### PR TITLE
fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "content",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "https://github.com/mdn/yari/issues/408",
+  "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "node": ">=12.0.0"
   },


### PR DESCRIPTION
Per https://docs.npmjs.com/files/package.json#license:

> If you are using a license that hasn’t been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one:
> 
> ```json
> { "license" : "SEE LICENSE IN <filename>" }
> ```
> 
> Then include a file named <filename> at the top level of the package.
