### PR TITLE
Small grammar fix in for-await...of doc

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.html
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.html
@@ -122,7 +122,7 @@ getResponseSize('https://jsonplaceholder.typicode.com/photos');</pre>
 
 <h3 id="Iterating_over_sync_iterables_and_generators">Iterating over sync iterables and generators</h3>
 
-<p><code>for await...of</code> loop also consumes sync iterables and generators. In that case it internally awaits emitted values before assign them to the loop control variable.</p>
+<p><code>for await...of</code> loop also consumes sync iterables and generators. In that case it internally awaits emitted values before assigning them to the loop control variable.</p>
 
 <pre class="brush: js notranslate">function* generator() {
   yield 0;


### PR DESCRIPTION
Modifies content in "Iterating over sync iterables and generators" example from "emitted values before _assign_ them..." to "emitted values before _assigning_ them..."