### PR TITLE
remove useless IncludeSubnav macro calls

### DIFF
--- a/files/en-us/games/anatomy/index.html
+++ b/files/en-us/games/anatomy/index.html
@@ -9,8 +9,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<p>{{IncludeSubnav("/en-US/docs/Games")}}</p>
-
 <div class="summary">
 <p><span class="seoSummary">This article looks at the anatomy and workflow of the average video game from a technical point of view, in terms of how the main loop should run. It helps beginners to the modern game development arena understand what is required when building a game and how web standards like JavaScript lend themselves as tools.</span> Experienced game programmers who are new to web development could also benefit, too.</p>
 </div>

--- a/files/en-us/games/examples/index.html
+++ b/files/en-us/games/examples/index.html
@@ -7,7 +7,7 @@ tags:
   - Games
   - Web
 ---
-<div>{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p class="summary"><span class="seoSummary">This page lists a number of impressive web technology demos for you to get inspiration from, and generally have fun with. A testament to what can be done with JavaScript, WebGL, and related technologies.</span> The first two sections list playable games, while the second is a catch-all area to list demos that aren't necessarily interactive/games.</p>
 

--- a/files/en-us/games/index/index.html
+++ b/files/en-us/games/index/index.html
@@ -4,6 +4,6 @@ slug: Games/Index
 tags:
   - Meta
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{Index("/en-US/docs/Games")}}</p>

--- a/files/en-us/games/introduction/index.html
+++ b/files/en-us/games/introduction/index.html
@@ -11,8 +11,6 @@ tags:
 
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>The modern web has quickly become a viable platform not only for creating stunning, high quality games, but also for distributing those games. </p>
 
 <p>The range of games that can be created is on par with desktop and native OS counterparts. With modern Web technologies and a recent browser, it's entirely possible to make stunning, top-notch games for the Web. And we're not talking about simple card games or multi-player social games that have in the olden days been done using Flash®. We're talking about kick-ass 3D action shooters, RPGs, and more. Thanks to massive performance improvements in <a href="/en-US/docs/JavaScript" title="/en-US/docs/JavaScript">JavaScript</a> just-in-time compiler technology and new APIs, you can build games that run in the browser (or on <a href="/en-US/docs/HTML/HTML5" title="/en-US/docs/HTML/HTML5">HTML5</a>-powered devices like those based on <a href="/en-US/docs/Mozilla/Firefox_OS" title="/en-US/docs/Mozilla/Firefox_OS">Firefox OS</a>) without making compromises.</p>

--- a/files/en-us/games/introduction_to_html5_game_development_(summary)/index.html
+++ b/files/en-us/games/introduction_to_html5_game_development_(summary)/index.html
@@ -7,7 +7,7 @@ tags:
   - HTML5
   - Mobile
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div>
 <h2 id="Advantages" style="line-height: 30px;">Advantages</h2>

--- a/files/en-us/games/techniques/2d_collision_detection/index.html
+++ b/files/en-us/games/techniques/2d_collision_detection/index.html
@@ -9,8 +9,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<p>{{IncludeSubnav("/en-US/docs/Games")}}</p>
-
 <div class="summary">
 <p>Algorithms to detect collision in 2D games depend on the type of shapes that can collide (e.g. Rectangle to Rectangle, Rectangle to Circle, Circle to Circle). Generally you will have a simple generic shape that covers the entity known as a "hitbox" so even though collision may not be pixel perfect, it will look good enough and be performant across multiple entities. This article provides a review of the most common techniques used to provide collision detection in 2D games.</p>
 </div>

--- a/files/en-us/games/techniques/async_scripts/index.html
+++ b/files/en-us/games/techniques/async_scripts/index.html
@@ -7,7 +7,7 @@ tags:
   - asm.js
   - async
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div class="summary">
 <p><span class="seoSummary">Every medium or large game should compile <a href="/en-US/docs/Games/Tools/asm.js">asm.js</a> code as part of an async script to give the browser the maximum flexibility to optimize the compilation process. In Gecko, async compilation allows the JavaScript engine to compile the asm.js off the main thread when the game is loading and cache the generated machine code so that the game doesn't need to be compiled on subsequent loads (starting in Firefox 28). To see the difference, toggle <code>javascript.options.parallel_parsing</code> in <code>about:config</code>.</span></p>

--- a/files/en-us/games/techniques/audio_for_web_games/index.html
+++ b/files/en-us/games/techniques/audio_for_web_games/index.html
@@ -11,8 +11,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p class="summary">Audio is an important part of any game; it adds feedback and atmosphere. Web-based audio is maturing fast, but there are still many browser differences to navigate. We often need to decide which audio parts are essential to our games' experience and which are nice to have but not essential, and devise a strategy accordingly. This article provides a detailed guide to implementing audio for web games, looking at what works currently across as wide a range of platforms as possible.</p>
 
 <h2 id="Mobile_audio_caveats">Mobile audio caveats</h2>

--- a/files/en-us/games/techniques/efficient_animation_for_web_games/index.html
+++ b/files/en-us/games/techniques/efficient_animation_for_web_games/index.html
@@ -8,8 +8,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <header class="entry-header">
 <div class="summary">
 <div class="entry-meta"><span class="seoSummary">This article covers techniques and advice for creating efficient animation for web games, with a slant towards supporting lower end devices such as mobile phones. We touch on <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_transitions">CSS transitions</a> and <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_animations">CSS animations</a>, and JavaScript loops involving {{ domxref("window.requestAnimationFrame") }}.</span></div>

--- a/files/en-us/games/techniques/index.html
+++ b/files/en-us/games/techniques/index.html
@@ -5,7 +5,7 @@ tags:
   - Games
   - Guide
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div class="summary">
 <p><span class="seoSummary">This page lists essential core techniques for anyone wanting to develop games using open web technologies.</span></p>

--- a/files/en-us/games/techniques/webrtc_data_channels/index.html
+++ b/files/en-us/games/techniques/webrtc_data_channels/index.html
@@ -10,7 +10,7 @@ tags:
   - WebRTC
   - data channels
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>The <a href="/en-US/docs/WebRTC" title="/en-US/docs/WebRTC">WebRTC</a> (Web Real-Time Communications) API is primarily known for its support for audio and video communications; however, it also offers peer-to-peer data channels. This article explains more about this, and shows you how to use libraries to implement data channels in your game.</p>
 

--- a/files/en-us/games/tools/asm.js/index.html
+++ b/files/en-us/games/tools/asm.js/index.html
@@ -10,8 +10,6 @@ tags:
 
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <div class="summary">
 <p><span class="seoSummary"><a href="http://asmjs.org/">Asm.js</a> is a specification defining a subset of JavaScript that is highly optimizable. This article looks at exactly what is permitted in the asm.js subset, what improvements it confers, where and how you can make use of it, and further resources and examples.</span></p>
 </div>

--- a/files/en-us/games/tools/index.html
+++ b/files/en-us/games/tools/index.html
@@ -9,8 +9,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <div class="summary">
 <p><span class="seoSummary">On this page you can find links to our game development tools articles, which eventually aims to cover frameworks, compilers, and debugging tools.</span></p>
 </div>

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.html
@@ -12,7 +12,7 @@ tags:
   - Tutorial
   - tween
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Extra_lives", "Games/Workflows/2D_Breakout_game_Phaser/Buttons")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - bouncing
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Physics", "Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/build_the_brick_field/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/build_the_brick_field/index.html
@@ -10,7 +10,7 @@ tags:
   - Phaser
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Game_over", "Games/Workflows/2D_Breakout_game_Phaser/Collision_detection")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/buttons/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/buttons/index.html
@@ -11,7 +11,7 @@ tags:
   - Phaser
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens", "Games/Workflows/2D_Breakout_game_Phaser/Randomizing_gameplay")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/collision_detection/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/collision_detection/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - collision detection
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field", "Games/Workflows/2D_Breakout_game_Phaser/The_score")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/extra_lives/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/extra_lives/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - lives
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Win_the_game", "Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/game_over/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/game_over/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - game over
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls", "Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{Next("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework")}}</p>
 
 <p class="summary">In this step-by-step tutorial, we create a simple mobile <strong>MDN Breakout</strong> game written in JavaScript, using the <a href="http://phaser.io/">Phaser</a> framework.</p>

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.html
@@ -11,7 +11,7 @@ tags:
   - Phaser
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser", "Games/Workflows/2D_Breakout_game_Phaser/Scaling")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/load_the_assets_and_print_them_on_screen/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/load_the_assets_and_print_them_on_screen/index.html
@@ -12,7 +12,7 @@ tags:
   - Sprites
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Scaling", "Games/Workflows/2D_Breakout_game_Phaser/Move the ball")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - moving
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen", "Games/Workflows/2D_Breakout_game_Phaser/Physics")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/physics/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/physics/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - physics
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Move_the_ball", "Games/Workflows/2D_Breakout_game_Phaser/Bounce_off_the_walls")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.html
@@ -10,7 +10,7 @@ tags:
   - Phaser
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Bounce_off_the_walls", "Games/Workflows/2D_Breakout_game_Phaser/Game_over")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/randomizing_gameplay/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/randomizing_gameplay/index.html
@@ -10,7 +10,7 @@ tags:
   - Phaser
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{Previous("Games/Workflows/2D_Breakout_game_Phaser/Buttons")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/scaling/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/scaling/index.html
@@ -10,7 +10,7 @@ tags:
   - Phaser
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework", "Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/the_score/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/the_score/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - scoring
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Collision_detection", "Games/Workflows/2D_Breakout_game_Phaser/Win_the_game")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/win_the_game/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/win_the_game/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
   - winning
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/The_score", "Games/Workflows/2D_Breakout_game_Phaser/Extra_lives")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.html
@@ -12,7 +12,7 @@ tags:
   - collision
   - detection
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Move_the_ball", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.html
@@ -11,8 +11,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Game_over", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Collision_detection")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Build_the_brick_field", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.html
@@ -11,7 +11,7 @@ tags:
   - JavaScript
   - Tutorial
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Move_the_ball")}}</p>
 

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{Previous("Games/Workflows/2D_Breakout_game_pure_JavaScript/Mouse_controls")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Build_the_brick_field")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/index.html
@@ -11,8 +11,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{Next("Games/Workflows/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it")}}</p>
 
 <p class="summary">In this step-by-step tutorial we create a simple <strong>MDN Breakout</strong> game written entirely in pure JavaScript and rendered on HTML5 {{htmlelement("canvas")}}.</p>

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Finishing_up")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.html
@@ -13,8 +13,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.html
@@ -13,8 +13,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Game_over")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.html
+++ b/files/en-us/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Collision_detection", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Mouse_controls")}}</p>
 
 <div class="summary">

--- a/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.html
+++ b/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.html
@@ -11,8 +11,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <div class="summary">
 <p>In this tutorial we’ll go through the process of building an HTML5 mobile game that uses the <a href="https://developer.mozilla.org/en-US/Apps/Build/gather_and_modify_data/responding_to_device_orientation_changes">Device Orientation</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/API/Vibration">Vibration</a><strong> APIs</strong> to enhance the gameplay and is built using the <a class="external external-icon" href="http://phaser.io/">Phaser</a> framework. Basic JavaScript knowledge is recommended to get the most from this tutorial.</p>
 </div>

--- a/files/en-us/games/tutorials/index.html
+++ b/files/en-us/games/tutorials/index.html
@@ -8,7 +8,7 @@ tags:
   - Web
   - Workflows
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>This page contains multiple tutorial series that highlight different workflows for effectively creating different types of web games.</p>
 

--- a/files/en-us/games/tutorials/touch_event_horizon/index.html
+++ b/files/en-us/games/tutorials/touch_event_horizon/index.html
@@ -5,7 +5,7 @@ tags:
   - NeedsContent
   - NeedsExample
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p><span class="seoSummary">This article is for Touch Event Horizon and A Game Related To It</span></p>
 


### PR DESCRIPTION
I made this same update already in the Wiki, so when we refresh this repository with the content from the Wiki, https://github.com/mdn/yari/issues/1187 will be resolved, but until then I thought I'd get rid of the useless `{{IncludeSubnav("/en-US/docs/Games")}}` calls so we don't have to think about this any longer.