### PR TITLE
Main tag under incorrect heading

### DIFF
--- a/files/en-us/web/html/element/main/index.html
+++ b/files/en-us/web/html/element/main/index.html
@@ -4,7 +4,6 @@ slug: Web/HTML/Element/main
 tags:
   - Element
   - HTML
-  - HTML grouping content
   - HTML sections
   - Reference
   - main


### PR DESCRIPTION
Removed the tag `HTML grouping content` from the `en-us/web/html/element/main/index.html` file as it is only referenced in `en-us/web/html/element/index.html`. This removes a duplicate `<main>` entry that was placed under the `Text Content` heading.