### PR TITLE
fix: Do not use blockIndicator class

### DIFF
--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -14,11 +14,13 @@ tags:
 <p>This page attempts to be the complete intersection of every other page. No in terms of the text but in terms of the
 styles and macros. Let's start with some notes...</p>
 
-<div class="blockIndicator note">
+<div class="notecard note">
+  <h4>Note</h4>
   <p>Here's a block indicator note.</p>
 </div>
 
-<div class="blockIndicator warning">
+<div class="notecard warning">
+  <h4>Warning</h4>
   <p>Here's a block indicator warning.</p>
 </div>
 


### PR DESCRIPTION
There are two instances in the page that uses `blockIndicator` class but, we no longer support that so, updated it to use the appropriate classes that the macros now also do.