### PR TITLE
fix: use notecard for appcache page

### DIFF
--- a/files/en-us/web/api/window/applicationcache/index.html
+++ b/files/en-us/web/api/window/applicationcache/index.html
@@ -14,8 +14,9 @@ tags:
 ---
 <p>{{DefaultAPISidebar("App Cache")}}{{Deprecated_Header}}{{SecureContext_Header}}{{Draft}}</p>
 
-<div class="warning">
-<p><strong>Important</strong>: Application Cache is deprecated as of Firefox 44, and is no longer available in insecure contexts from Firefox 60 onwards ({{bug(1354175)}}, currently Nightly/Beta only). Don't use it to offline websites — consider using <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a> instead.</p>
+<div class="notecard warning">
+<h4>Important</h4>
+<p>Application Cache is deprecated as of Firefox 44, and is no longer available in insecure contexts from Firefox 60 onwards ({{bug(1354175)}}, currently Nightly/Beta only). Don't use it to offline websites — consider using <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a> instead.</p>
 </div>
 
 <p> </p>


### PR DESCRIPTION
Change to using notecard style for adhoc warning message on `applicationCache` page

fix #98