### PR TITLE
Remove "irregardless" under operator precedence

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.html
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.html
@@ -34,7 +34,7 @@ console.log((3 + 10) * 2); // logs 26 because the parentheses change the order
 
 <p>with the expected result that <code>a</code> and <code>b</code> get the value 5. This is because the assignment operator returns the value that is assigned. First, <code>b</code> is set to 5. Then the <code>a</code> is also set to 5, the return value of <code>b = 5</code>, aka right operand of the assignment.</p>
 
-<p>As another example, the unique exponentiation operator has right-associativity, whereas other arithmetic operators have left-associativity. It is interesting to note that, the order of evaluation is always left-to-right irregardless of associativity and precedence.</p>
+<p>As another example, the unique exponentiation operator has right-associativity, whereas other arithmetic operators have left-associativity. It is interesting to note that the order of evaluation is always left-to-right, regardless of associativity and precedence.</p>
 
 <table class="standard-table">
  <tbody>


### PR DESCRIPTION
A colleague pointed this out, and once I knew, I couldn't just leave it there.