### PR TITLE
use node_modules/@mdn/yari to build PR builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -30,12 +30,6 @@ jobs:
           SUFFIX_FILTER: .html
           PREFIX_FILTER: files/
 
-      - uses: actions/checkout@v2
-        if: steps.git_diff_content.outputs.diff
-        with:
-          repository: mdn/yari
-          path: yari
-
       - name: Setup Node.js environment
         if: steps.git_diff_content.outputs.diff
         uses: actions/setup-node@v2.1.2
@@ -60,15 +54,12 @@ jobs:
       - name: Install all yarn packages
         if: steps.git_diff_content.outputs.diff
         run: |
-          cd yari
           yarn --frozen-lockfile
 
       - name: Build changed content
         if: steps.git_diff_content.outputs.diff
         run: |
           export CONTENT_ROOT=$(pwd)/files
-          # Need to run from the yari we've cleanly cloned.
-          cd yari
 
           # Some day, when our number of flaws have reached 0 we'll change
           # this to "*:error" which means the slightest flaw in the build
@@ -102,10 +93,18 @@ jobs:
           # This environment variable will disable that functionality entirely.
           export REACT_APP_DISABLE_AUTH=true
 
+          # If we don't do this the built files will end up in
+          # `node_modules/@mdn/yari/client/build/` and we don't want that
+          # to get pushed into the cache.
+          export BUILD_OUT_ROOT=/tmp/
+
           export BUILD_NO_PROGRESSBAR=true
           export BUILD_FILES="${{ env.GIT_DIFF }}"
-          yarn prepare-build
-          yarn build
+          # The reason this script isn't in `package.json` is because
+          # you don't need that script as a writer. It's only used in CI
+          # and it can't use the default CONTENT_ROOT that gets set in
+          # package.json.
+          node node_modules/@mdn/yari/build/cli.js
 
   check_redirects:
     runs-on: ubuntu-latest

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -364,4 +364,4 @@ rect2.bind("EnterFrame", function () {
 {{Obsolete_Header}}
 {{Deprecated_Header}}
 
-<p>Peter test change</p>
+<p>Peter test changex</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -363,3 +363,5 @@ rect2.bind("EnterFrame", function () {
 {{Non-standard_Header}}
 {{Obsolete_Header}}
 {{Deprecated_Header}}
+
+<p>Peter test change</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -363,5 +363,3 @@ rect2.bind("EnterFrame", function () {
 {{Non-standard_Header}}
 {{Obsolete_Header}}
 {{Deprecated_Header}}
-
-<p>Peter test changex</p>


### PR DESCRIPTION
Fixes #1604

BEFORE:
<img width="1160" alt="Screen Shot 2020-11-16 at 10 04 33 AM" src="https://user-images.githubusercontent.com/26739/99268464-31255b00-27f3-11eb-869f-6478f7293786.png">

[AFTER (Cold cache)](https://github.com/mdn/content/pull/111/checks?check_run_id=1406997467)
<img width="1162" alt="Screen Shot 2020-11-16 at 10 06 52 AM" src="https://user-images.githubusercontent.com/26739/99268917-c0327300-27f3-11eb-9366-d19a98112f90.png">

[AFTER (Warm cache)](https://github.com/mdn/content/pull/111/checks?check_run_id=1407020436)
<img width="1160" alt="Screen Shot 2020-11-16 at 10 07 41 AM" src="https://user-images.githubusercontent.com/26739/99268977-d17b7f80-27f3-11eb-8b41-3beb2c8f6cdb.png">

So, if we get 19.2 PRs (just for en-US) per day, that means it would have cost 19.2 * 1m21s of total `yarn install` time every day. Now it's 19.2 * 17s instead. 
This stuff matters. It's much better for the environment and it gives much speedier feedback to the PR creator to know if her PR passes CI. 