### PR TITLE
no need for the BUILD_FILES env var

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,19 +37,25 @@ jobs:
           node-version: "12"
 
       - name: Get yarn cache directory path
-        if: steps.git_diff_content.outputs.diff
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2.1.3
-        if: steps.git_diff_content.outputs.diff
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          # TODO: Is this correct?! We wanna make sure it's the yarn.lock
-          # from ./yari/ and not ./ which is just the content.
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: DEBUG yarn packages
+        run: |
+          echo "steps.yarn-cache-dir-path.outputs.dir"
+          echo ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          echo
+
+          find . -type d -name node_modules
+          echo ""
+          yarn cache dir
 
       - name: Install all yarn packages
         if: steps.git_diff_content.outputs.diff

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: "12"
 
-      - name: Restore node_modules
+      - name: Cache node_modules
         uses: actions/cache@v2.1.3
         id: cached-node_modules
         with:
@@ -56,15 +56,12 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-yarn-
 
-      # - name: DEBUG yarn packages
-      #   run: |
-      #     echo "steps.yarn-cache-dir-path.outputs.dir"
-      #     echo ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     echo
-
-      #     find . -type d -name node_modules
-      #     echo ""
-      #     yarn cache dir
+      - name: DEBUG yarn packages
+        run: |
+          echo "Where all the node_modules at?!"
+          find . -type d -name node_modules
+          echo ""
+          # yarn cache dir
 
       - name: Install all yarn packages
         if: steps.git_diff_content.outputs.diff && steps.cached-node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -99,12 +99,11 @@ jobs:
           export BUILD_OUT_ROOT=/tmp/
 
           export BUILD_NO_PROGRESSBAR=true
-          export BUILD_FILES="${{ env.GIT_DIFF }}"
           # The reason this script isn't in `package.json` is because
           # you don't need that script as a writer. It's only used in CI
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
-          node node_modules/@mdn/yari/build/cli.js
+          node node_modules/@mdn/yari/build/cli.js ${{ env.GIT_DIFF }}
 
   check_redirects:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,29 +36,38 @@ jobs:
         with:
           node-version: "12"
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Restore node_modules
+        uses: actions/cache@v2.1.3
+        id: cached-node_modules
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: DEBUG yarn packages
-        run: |
-          echo "steps.yarn-cache-dir-path.outputs.dir"
-          echo ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          echo
+      # - name: Get yarn cache directory path
+      #   id: yarn-cache-dir-path
+      #   run: echo "::set-output name=dir::$(yarn cache dir)"
+      # - uses: actions/cache@v2.1.3
+      #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
 
-          find . -type d -name node_modules
-          echo ""
-          yarn cache dir
+      # - name: DEBUG yarn packages
+      #   run: |
+      #     echo "steps.yarn-cache-dir-path.outputs.dir"
+      #     echo ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     echo
+
+      #     find . -type d -name node_modules
+      #     echo ""
+      #     yarn cache dir
 
       - name: Install all yarn packages
-        if: steps.git_diff_content.outputs.diff
+        if: steps.git_diff_content.outputs.diff && steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |
           yarn --frozen-lockfile
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,19 +42,7 @@ jobs:
         with:
           path: |
             node_modules
-            */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
-      # - name: Get yarn cache directory path
-      #   id: yarn-cache-dir-path
-      #   run: echo "::set-output name=dir::$(yarn cache dir)"
-      # - uses: actions/cache@v2.1.3
-      #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
 
       - name: DEBUG yarn packages
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,13 +44,6 @@ jobs:
             node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: DEBUG yarn packages
-        run: |
-          echo "Where all the node_modules at?!"
-          find . -type d -name node_modules
-          echo ""
-          # yarn cache dir
-
       - name: Install all yarn packages
         if: steps.git_diff_content.outputs.diff && steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -363,3 +363,5 @@ rect2.bind("EnterFrame", function () {
 {{Non-standard_Header}}
 {{Obsolete_Header}}
 {{Deprecated_Header}}
+
+<p>Sample change</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -363,5 +363,3 @@ rect2.bind("EnterFrame", function () {
 {{Non-standard_Header}}
 {{Obsolete_Header}}
 {{Deprecated_Header}}
-
-<p>Sample change..</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -364,4 +364,4 @@ rect2.bind("EnterFrame", function () {
 {{Obsolete_Header}}
 {{Deprecated_Header}}
 
-<p>Sample change.</p>
+<p>Sample change..</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -364,4 +364,4 @@ rect2.bind("EnterFrame", function () {
 {{Obsolete_Header}}
 {{Deprecated_Header}}
 
-<p>Sample change</p>
+<p>Sample change.</p>


### PR DESCRIPTION
Here's the problem, it seems the yarn install stuff isn't getting cached at all. 
<img width="1162" alt="Screen Shot 2020-11-20 at 10 19 17 AM" src="https://user-images.githubusercontent.com/26739/99816640-ef115780-2b19-11eb-9f14-596636fe7477.png">

Cool! It totally works. 
<img width="1160" alt="Screen Shot 2020-11-20 at 10 47 26 AM" src="https://user-images.githubusercontent.com/26739/99819724-d2771e80-2b1d-11eb-9260-10a48507f95d.png">

Now, taking care of `yarn` and `node_modules` takes ~7s on a warm cache. And a warm cache is extremely likely on this repo because 9 out of 10 PRs are expected to be edits to the `files/**/index.html` files. 

Unlike the ["default suggestion for Node Yarn"](https://github.com/actions/cache/blob/master/examples.md#node---yarn) I opted for the same solution we're doing for [the poetry install in Yari](https://github.com/mdn/yari/pull/1767/files).
And this is actually the recommended way for ["Node - Lerna"](https://github.com/actions/cache/blob/master/examples.md#node---lerna). 
The net effect is that we cache the whole `node_modules` directory. And it's keyed by OS and by `yarn.lock` so it's very unlikely that a cache hit is stale. 