### PR TITLE
Fix "auto" subsection link

### DIFF
--- a/files/en-us/web/css/margin/index.html
+++ b/files/en-us/web/css/margin/index.html
@@ -42,7 +42,7 @@ margin: initial;
 margin: unset;
 </pre>
 
-<p>The <code>margin</code> property may be specified using one, two, three, or four values. Each value is a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or the keyword <code><a href="#auto">auto</a></code>. Negative values draw the element closer to its neighbors than it would be by default.</p>
+<p>The <code>margin</code> property may be specified using one, two, three, or four values. Each value is a {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}}, or the keyword <code>auto</code>. Negative values draw the element closer to its neighbors than it would be by default.</p>
 
 <ul>
  <li>When <strong>one</strong> value is specified, it applies the same margin to <strong>all four sides</strong>.</li>

--- a/files/en-us/web/css/margin/index.html
+++ b/files/en-us/web/css/margin/index.html
@@ -58,7 +58,7 @@ margin: unset;
  <dd>The size of the margin as a fixed value.</dd>
  <dt>{{cssxref("percentage")}}</dt>
  <dd>The size of the margin as a percentage, relative to the <em>width</em> of the <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block">containing block</a>.</dd>
- <dt><code>auto</code></dt>
+ <dt id="auto"><code>auto</code></dt>
  <dd>The browser selects a suitable margin to use. For example, in certain cases this value can be used to center an element.</dd>
 </dl>
 

--- a/files/en-us/web/css/margin/index.html
+++ b/files/en-us/web/css/margin/index.html
@@ -58,7 +58,7 @@ margin: unset;
  <dd>The size of the margin as a fixed value.</dd>
  <dt>{{cssxref("percentage")}}</dt>
  <dd>The size of the margin as a percentage, relative to the <em>width</em> of the <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block">containing block</a>.</dd>
- <dt id="auto"><code>auto</code></dt>
+ <dt><code>auto</code></dt>
  <dd>The browser selects a suitable margin to use. For example, in certain cases this value can be used to center an element.</dd>
 </dl>
 


### PR DESCRIPTION
The "auto" subsection didn't have an id attribute so the link was broken.