### PR TITLE
GitHub Actions: remove get-diff-action from preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,7 @@ on:
     paths:
     - package.json
     - yarn.lock
-    - preview.yml
+    - .github/workflows/preview.yml
 
 jobs:
   build:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,6 +2,10 @@ name: Preview
 
 on:
   pull_request:
+    paths:
+    - package.json
+    - yarn.lock
+    - preview.yml
 
 jobs:
   build:
@@ -10,25 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: technote-space/get-diff-action@v4
-        with:
-          FILES: |
-            package.json
-            yarn.lock
-            preview.yml
-
       - name: Setup Node.js environment
-        if: env.MATCHED_FILES
         uses: actions/setup-node@v2.1.2
         with:
           node-version: "12"
 
       - name: Get yarn cache directory path
-        if: env.MATCHED_FILES
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2.1.3
-        if: env.MATCHED_FILES
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -37,16 +31,13 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install all yarn packages
-        if: env.MATCHED_FILES
         run: yarn --frozen-lockfile
 
       - name: Start the Yari server
-        if: env.MATCHED_FILES
         run: |
           yarn start &
 
       - name: Wait for server
-        if: env.MATCHED_FILES
         run: |
           curl --retry-connrefused --retry 5 http://localhost:5000
 


### PR DESCRIPTION
This Action does not use the diff, just the fact that at least one of three specific files changed, so it's possible to use only built-in scripting tool [`on.pull_request.paths`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths).