### PR TITLE
ignore _githistory.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 yarn-debug.log*
 yarn-error.log*
+_githistory.json


### PR DESCRIPTION
This doesn't really matter in production (or dev or stage) builds because there it doesn't matter what's left after the build. BUt it's inconvenient to have to see this after you run `yarn dev` in Yari based on your CONTENT_ROOT. 