### PR TITLE
Deleted

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     branches:
       - main
+    paths: files/**/*.html
 
 jobs:
   build:
@@ -96,45 +97,3 @@ jobs:
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
           node node_modules/@mdn/yari/build/cli.js ${{ env.GIT_DIFF }}
-
-  check_redirects:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: technote-space/get-diff-action@v3
-        id: git_diff_content
-        with:
-          SUFFIX_FILTER: _redirects.txt
-          PREFIX_FILTER: files/
-
-      - name: Setup Node.js environment
-        if: steps.git_diff_content.outputs.diff
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: "12"
-
-      - name: Get yarn cache directory path
-        if: steps.git_diff_content.outputs.diff
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.3
-        if: steps.git_diff_content.outputs.diff
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install all yarn packages
-        if: steps.git_diff_content.outputs.diff
-        run: yarn --frozen-lockfile
-
-      - name: Check redirects file(s)
-        if: steps.git_diff_content.outputs.diff
-        run: |
-          echo ${{ env.GIT_DIFF }}
-          echo ${{ env.MATCHED_FILES }}
-          yarn content validate-redirects

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1,5 +1,5 @@
 # FROM-URL	TO-URL
-/en-US/docs/%3Cimg%3E	/en-US/docs/Web/HTML/Element/img
+/en-US/docs/%3Cimg%3E	/en-US/docs/Web/HTML/Element
 /en-US/docs/%7B%7Bdomxref(%22/Input.setSelectionRange	/en-US/docs/Web/API/HTMLInputElement/setSelectionRange
 /en-US/docs/%7B%7Bdomxref(%22/TouchList.item	/en-US/docs/Web/API/TouchList/item
 /en-US/docs/%D9%88%D8%A7%D8%B5%D9%81%D8%A9_SpellCheck_%D8%A7%D9%84%D8%AC%D8%AF%D9%8A%D8%AF%D8%A9_%D9%81%D9%8A_HTML5	/ar/docs/واصفة_SpellCheck_الجديدة_في_HTML5


### PR DESCRIPTION
Please disregard this PR (made by mistake). I was tying to add `on.*.paths` to GitHub Actions and was testing regex matching (treatment of dots) by creating PRs on my own fork. I used my own fork, but after a !dozon PRs accidentally ended up filing PR against upstream.