### PR TITLE
GitHub Actions: split pr-build.yml, update get-diff-action

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,6 +15,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - files/**/*.html
+      - .github/workflows/pr-build.yml
 
 jobs:
   build:
@@ -23,14 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: technote-space/get-diff-action@v3
-        id: git_diff_content
+      - uses: technote-space/get-diff-action@v4.0.2
         with:
-          SUFFIX_FILTER: .html
-          PREFIX_FILTER: files/
+          PATTERNS: files/**/*.html
 
       - name: Setup Node.js environment
-        if: steps.git_diff_content.outputs.diff
         uses: actions/setup-node@v2.1.2
         with:
           node-version: "12"
@@ -44,12 +44,11 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install all yarn packages
-        if: steps.git_diff_content.outputs.diff && steps.cached-node_modules.outputs.cache-hit != 'true'
+        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         run: |
           yarn --frozen-lockfile
 
       - name: Build changed content
-        if: steps.git_diff_content.outputs.diff
         run: |
           export CONTENT_ROOT=$(pwd)/files
 
@@ -96,45 +95,3 @@ jobs:
           # and it can't use the default CONTENT_ROOT that gets set in
           # package.json.
           node node_modules/@mdn/yari/build/cli.js ${{ env.GIT_DIFF }}
-
-  check_redirects:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: technote-space/get-diff-action@v3
-        id: git_diff_content
-        with:
-          SUFFIX_FILTER: _redirects.txt
-          PREFIX_FILTER: files/
-
-      - name: Setup Node.js environment
-        if: steps.git_diff_content.outputs.diff
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: "12"
-
-      - name: Get yarn cache directory path
-        if: steps.git_diff_content.outputs.diff
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.3
-        if: steps.git_diff_content.outputs.diff
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install all yarn packages
-        if: steps.git_diff_content.outputs.diff
-        run: yarn --frozen-lockfile
-
-      - name: Check redirects file(s)
-        if: steps.git_diff_content.outputs.diff
-        run: |
-          echo ${{ env.GIT_DIFF }}
-          echo ${{ env.MATCHED_FILES }}
-          yarn content validate-redirects

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -1,0 +1,38 @@
+name: Check Redirects
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - files/**/_redirects.txt
+      - .github/workflows/pr-check_redirects.yml
+
+jobs:
+  check_redirects:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "12"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2.1.3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Check redirects file(s)
+        run: yarn content validate-redirects


### PR DESCRIPTION
This PR is a follow-up to #137.

Highlights:
 - Extract `check_redirects` job into a separate file for clarity and to specify separate `on.pull_request.paths`.
 - Remove `technote-space/get-diff-action` from `check_redirects` job (because it's no longer needed)
 - Update `technote-space/get-diff-action` in `build` job, remove all the `if: steps.git_diff_content.outputs.diff` because if job is run either there is a diff or the GitHub Action was updated and should to be tested.

This PR makes these GitHub Actions run only if they need to (as opposed to using > 10 seconds per job on setting up the job, checking out the repo, finding no diff and skipping all the checks).

(Force-pushed to add a commit signature.)