### PR TITLE
GitHub Actions: Cache node_modules

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -20,16 +20,13 @@ jobs:
         with:
           node-version: "12"
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Cache node_modules
+        uses: actions/cache@v2.1.3
+        id: cached-node_modules
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile

--- a/.github/workflows/pr-filecheck.yml
+++ b/.github/workflows/pr-filecheck.yml
@@ -45,18 +45,13 @@ jobs:
         with:
           node-version: "12"
 
-      - name: Get yarn cache directory path
-        if: steps.git_diff_content.outputs.diff
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.3
-        if: steps.git_diff_content.outputs.diff
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Cache node_modules
+        uses: actions/cache@v2.1.3
+        id: cached-node_modules
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install all yarn packages
         if: steps.git_diff_content.outputs.diff

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,16 +19,13 @@ jobs:
         with:
           node-version: "12"
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Cache node_modules
+        uses: actions/cache@v2.1.3
+        id: cached-node_modules
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile


### PR DESCRIPTION
Background: https://github.com/mdn/content/pull/153#discussion_r538613196

Cache `node_modules` in all GitHub Actions the same way it's already done in [`pr-build`](https://github.com/mdn/content/blob/8256a02936c5e9ddb07253fc8856e1a9545b1085/.github/workflows/pr-build.yml#L38).