### PR TITLE
Add docs for EXT_texture_norm16

### DIFF
--- a/files/en-us/web/api/ext_texture_norm16/index.html
+++ b/files/en-us/web/api/ext_texture_norm16/index.html
@@ -9,12 +9,12 @@ tags:
 ---
 <div>{{APIRef("WebGL")}}</div>
 
-<p>The <code><strong>EXT_texture_norm16</strong></code> extension is part of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> and provides a set of new 16-bit signed normalized and unsigned normalized fixed point texture, renderbuffer and texture buffer formats.</p>
+<p>The <code><strong>EXT_texture_norm16</strong></code> extension is part of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> and provides a set of new 16-bit signed normalized and unsigned normalized formats (fixed-point texture, renderbuffer and texture buffer).</p>
 
 <p>When this extension is enabled:</p>
 <ul>
   <li>The {{domxref("WebGLRenderingContext.texImage2D()")}} and {{domxref("WebGLRenderingContext.texSubImage2D()")}} methods accept new formats provided by this extension.</li>
-  <li>The 16-bit normalized fixed point types <code>ext.R16_EXT</code>, <code>ext.RG16_EXT</code> and <code>ext.RGBA16_EXT</code> become available as color-renderable formats and renderbuffers and be created in these formats.</li>
+  <li>The 16-bit normalized fixed-point types <code>ext.R16_EXT</code>, <code>ext.RG16_EXT</code> and <code>ext.RGBA16_EXT</code> become available as color-renderable formats and renderbuffers and be created in these formats.</li>
 </ul>
 
 <p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
@@ -53,7 +53,7 @@ let ext = gl.getExtension('EXT_texture_norm16');
 
 <h3>Texture formats</h3>
 
-<p>The {{domxref("WebGLRenderingContext.texImage2D()")}} accepts new formats when <code>EXT_texture_norm16</code> is enabled. Example calls:</p>
+<p>The {{domxref("WebGLRenderingContext.texImage2D()")}} method accepts new formats when <code>EXT_texture_norm16</code> is enabled. Example calls:</p>
 
 <pre class="brush:js">
 // imageData = Uint16Array

--- a/files/en-us/web/api/ext_texture_norm16/index.html
+++ b/files/en-us/web/api/ext_texture_norm16/index.html
@@ -1,0 +1,108 @@
+---
+title: EXT_texture_norm16
+slug: Web/API/EXT_texture_norm16
+tags:
+  - API
+  - Reference
+  - WebGL
+  - WebGL extension
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>EXT_texture_norm16</strong></code> extension is part of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> and provides a set of new 16-bit signed normalized and unsigned normalized fixed point texture, renderbuffer and texture buffer formats.</p>
+
+<p>When this extension is enabled:</p>
+<ul>
+  <li>The {{domxref("WebGLRenderingContext.texImage2D()")}} and {{domxref("WebGLRenderingContext.texSubImage2D()")}} methods accept new formats provided by this extension.</li>
+  <li>The 16-bit normalized fixed point types <code>ext.R16_EXT</code>, <code>ext.RG16_EXT</code> and <code>ext.RGBA16_EXT</code> become available as color-renderable formats and renderbuffers and be created in these formats.</li>
+</ul>
+
+<p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a> in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
+
+<div class="note">
+<p><strong>Availability:</strong> This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.</p>
+</div>
+
+<h2 id="Constants">Constants</h2>
+
+<dl>
+ <dt><code>ext.R16_EXT</code></dt>
+ <dd>Red 16-bit unsigned format. Color-renderable.</dd>
+ <dt><code>ext.RG16_EXT</code></dt>
+ <dd>RG 16-bit unsigned format. Color-renderable.</dd>
+ <dt><code>ext.RGB16_EXT</code></dt>
+ <dd>RGB 16-bit unsigned format.</dd>
+ <dt><code>ext.RGBA16_EXT</code></dt>
+ <dd>RGBA 16-bit unsigned format. Color-renderable.</dd>
+ <dt><code>ext.R16_SNORM_EXT</code></dt>
+ <dd>Red 16-bit signed normalized format.</dd>
+ <dt><code>ext.RG16_SNORM__EXT</code></dt>
+ <dd>RG 16-bit signed normalized format.</dd>
+ <dt><code>ext.RGB16_SNORM__EXT</code></dt>
+ <dd>RGB 16-bit signed normalized format.</dd>
+ <dt><code>ext.RGBA16_SNORM__EXT</code></dt>
+ <dd>RGBA 16-bit signed normalized format.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Enabling the extension</h3>
+<pre class="brush:js">
+let ext = gl.getExtension('EXT_texture_norm16');
+</pre>
+
+<h3>Texture formats</h3>
+
+<p>The {{domxref("WebGLRenderingContext.texImage2D()")}} accepts new formats when <code>EXT_texture_norm16</code> is enabled. Example calls:</p>
+
+<pre class="brush:js">
+// imageData = Uint16Array
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.R16_EXT, 1, 1, 0, gl.RED, gl.UNSIGNED_SHORT, imageData);
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.RG16_EXT, 1, 1, 0, gl.RG, gl.UNSIGNED_SHORT, imageData);
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.RGB16_EXT, 1, 1, 0, gl.RGB, gl.UNSIGNED_SHORT, imageData);
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.RGBA16_EXT, 1, 1, 0, gl.RGBA, gl.UNSIGNED_SHORT, imageData);
+
+// imageData = Int16Array
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.R16_SNORM_EXT, 1, 1, 0, gl.RED, gl.SHORT, imageData);
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.RG16_SNORM_EXT, 1, 1, 0, gl.RG, gl.SHORT, imageData);
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.RGB16_SNORM_EXT, 1, 1, 0, gl.RGB, gl.SHORT, imageData);
+gl.texImage2D(gl.TEXTURE_2D, 0, ext.RGBA16_SNORM_EXT, 1, 1, 0, gl.RGBA, gl.SHORT, imageData);
+</pre>
+
+<h3>Renderbuffer formats</h3>
+
+<p>The {{domxref("WebGLRenderingContext.renderbufferStorage()")}} method accepts <code>ext.R16_EXT</code>, 
+<code>ext.RG16_EXT</code> and <code>ext.RGBA16_EXT</code> as internal formats to create renderbuffers in these formats. Example calls:</p>
+
+<pre class="brush:js">
+gl.renderbufferStorage(gl.RENDERBUFFER, ext.R16_EXT, 1, 1);
+gl.renderbufferStorage(gl.RENDERBUFFER, ext.RG16_EXT, 1, 1);
+gl.renderbufferStorage(gl.RENDERBUFFER, ext.RGBA16_EXT, 1, 1);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('EXT_texture_norm16', "", "EXT_texture_norm16")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
+
+<p>{{Compat("api.EXT_texture_norm16")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{domxref("WebGLRenderingContext.getExtension()")}}</li>
+ <li>{{domxref("WebGLRenderingContext.texImage2D()")}}</li>
+ <li>{{domxref("WebGLRenderingContext.renderbufferStorage()")}}</li>
+</ul>

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -68,6 +68,7 @@ tags:
  <li>{{domxref("EXT_texture_compression_bptc")}}</li>
  <li>{{domxref("EXT_texture_compression_rgtc")}}</li>
  <li>{{domxref("EXT_texture_filter_anisotropic")}}</li>
+ <li>{{domxref("EXT_texture_norm16")}}</li>
  <li>{{domxref("KHR_parallel_shader_compile")}}</li>
  <li>{{domxref("OES_element_index_uint")}}</li>
  <li>{{domxref("OES_fbo_render_mipmap")}}</li>

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.html
@@ -156,4 +156,5 @@ tags:
  <li>{{domxref("WEBGL_color_buffer_float")}}</li>
  <li>{{domxref("EXT_sRGB")}}</li>
  <li>{{domxref("EXT_color_buffer_float")}}</li>
+ <li>{{domxref("EXT_texture_norm16")}}</li>
 </ul>

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
@@ -876,5 +876,6 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
  <li>{{domxref("WEBGL_depth_texture")}}</li>
  <li>{{domxref("OES_texture_float")}}</li>
  <li>{{domxref("OES_texture_half_float")}}</li>
+ <li>{{domxref("EXT_texture_norm16")}}</li>
  <li>{{domxref("EXT_sRGB")}}</li>
 </ul>

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.html
@@ -203,4 +203,5 @@ void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, ty
  <li>{{domxref("OES_texture_float")}}</li>
  <li>{{domxref("OES_texture_half_float")}}</li>
  <li>{{domxref("EXT_sRGB")}}</li>
+ <li>{{domxref("EXT_texture_norm16")}}</li>
 </ul>


### PR DESCRIPTION
Hi! I'd like to contribute new documentation for this new WebGL extension.

Spec: https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/
BCD: https://github.com/mdn/browser-compat-data/pull/7634

Question: This requires a new spec to be added for specData. Do I open a PR against https://github.com/mdn/yari/blob/master/kumascript/macros/SpecData.json or is it https://github.com/mdn/kumascript/blob/master/macros/SpecData.json?

Cheers and good luck for the launch today!