### PR TITLE
Warn that legacy URL params/suffixes from Kuma are no longer supported

### DIFF
--- a/files/en-us/mdn/tools/document_parameters/index.html
+++ b/files/en-us/mdn/tools/document_parameters/index.html
@@ -11,6 +11,10 @@ tags:
 ---
 <div>{{MDNSidebar}}</div>
 
+<div class="notecard deprecated">
+<p>MDN no longer supports the URL parameters and URL suffixes documented in this article. They were part of the legacy Kuma wiki platform which MDN used previously, but are not part of the <a href="https://github.com/mdn/yari">Yari platform</a> which MDN now uses.</p>
+</div>
+
 <section id="intro">
 <p id="Introduction"><span class="seoSummary">MDN's Kuma wiki platform doesn't have a central API. Instead, our general approach is to offer ways to turn human-accessible resources into machine-friendly data.</span></p>
 </section>


### PR DESCRIPTION
This change adds a warning to the article that documented URL parameters (such as the `raw` parameter) and URL suffixes (such as the `$json`, `$history`, and `$compare` suffixes) that were exposed by the Kuma wiki platform but as yet have no equivalents in the current Yari platform.