### PR TITLE
AmbientLightEvents/PointerEvents: Move not-supported-in-threads note

### DIFF
--- a/files/en-us/web/api/ambient_light_events/index.html
+++ b/files/en-us/web/api/ambient_light_events/index.html
@@ -6,11 +6,11 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Ambient Light Events")}}{{SeeCompatTable}}</div>
 
-<div class="blockIndicator note">
-<p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (it is accessed in the main thread using {{domxref("window")}}, but is not included in the <a href="/en-US/docs/Web/API/Web_Workers_API#Worker_global_contexts_and_functions">worker global context</a>).</p>
-</div>
-
 <p>The ambient light events are a handy way to make a web page or an application aware of any change in the light intensity. It allows them to react to such a change, for example by changing the color contrast of the User Interface (UI) or by changing the exposure necessary to take a picture.</p>
+
+<div class="blockIndicator note">
+<p><strong>Note:</strong> This API is <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (it is not exposed in the <a href="/en-US/docs/Web/API/Web_Workers_API#Worker_global_contexts_and_functions">worker global context</a>).</p>
+</div>
 
 <h2 id="Light_Events">Light Events</h2>
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -14,6 +14,11 @@ tags:
 
 <p>Much of today's web content assumes the user's pointing device will be a mouse. However, since many devices support other types of pointing input devices, such as pen/stylus and touch surfaces, extensions to the existing pointing device event models are needed. <em><a href="#term_pointer_event">Pointer events</a></em> address that need.</p>
 
+<div class="blockIndicator note">
+<p><strong>Note:</strong> Pointer events are <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a>.</p>
+</div>
+
+
 <p>Pointer events are DOM events that are fired for a pointing device. They are designed to create a single DOM event model to handle pointing input devices such as a mouse, pen/stylus or touch (such as one or more fingers).</p>
 
 <p>The <em><a href="#term_pointer">pointer</a></em> is a hardware-agnostic device that can target a specific set of screen coordinates. Having a single event model for pointers can simplify creating Web sites and applications and provide a good user experience regardless of the user's hardware. However, for scenarios when device-specific handling is desired, pointer events defines a {{domxref("PointerEvent.pointerType","pointerType property")}} to inspect the device type which produced the event.</p>
@@ -21,10 +26,6 @@ tags:
 <p>The events needed to handle generic pointer input are analogous to {{domxref("MouseEvent","mouse events")}} (<code>mousedown</code>/<code>pointerdown</code>, <code>mousemove</code>/<code>pointermove</code>, etc.). Consequently, pointer event types are intentionally similar to mouse event types.</p>
 
 <p>Additionally, a pointer event contains the usual properties present in mouse events (client coordinates, target element, button states, etc.) in addition to new properties for other forms of input: pressure, contact geometry, tilt, etc. In fact, the {{domxref("PointerEvent")}} interface inherits all of the {{domxref("MouseEvent")}} properties, thus facilitating the migration of content from mouse events to pointer events.</p>
-
-<div class="blockIndicator note">
-<p><strong>Note:</strong> Pointer events are <em>not available</em> in <a href="/en-US/docs/Web/API/Web_Workers_API">Web Workers</a> (along with {{domxref("Document")}} and most other <a href="/en-US/docs/Web/API/HTML_DOM_API">DOM API</a>-related functionality). </p>
-</div>
 
 <h2 id="Terminology">Terminology</h2>
 


### PR DESCRIPTION
As discussed with @chrisdavidmills , info on "supported in web workers" should be after the first paragraph. This also reduces the info about why it isn't supported.