### PR TITLE
Remove useless class spectable

### DIFF
--- a/files/en-us/web/api/document/body/index.html
+++ b/files/en-us/web/api/document/body/index.html
@@ -37,7 +37,7 @@ alert(document.body.id); // "newBodyElement"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/document/createattribute/index.html
+++ b/files/en-us/web/api/document/createattribute/index.html
@@ -47,7 +47,7 @@ console.log(node.getAttribute("my_attrib")); // "newVal"
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -148,7 +148,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/document/head/index.html
+++ b/files/en-us/web/api/document/head/index.html
@@ -43,7 +43,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/document/onvisibilitychange/index.html
+++ b/files/en-us/web/api/document/onvisibilitychange/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/document/readystate/index.html
+++ b/files/en-us/web/api/document/readystate/index.html
@@ -87,7 +87,7 @@ document.onreadystatechange = function () {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/document/url/index.html
+++ b/files/en-us/web/api/document/url/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/filereader/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.html
@@ -54,7 +54,7 @@ canvas.toBlob(function (blob) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/globaleventhandlers.onloadstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/globaleventhandlers.onloadstart/index.html
@@ -26,7 +26,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadstart;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onabort/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.html
@@ -38,7 +38,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
@@ -172,7 +172,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -41,7 +41,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
@@ -159,7 +159,7 @@ box.onanimationiteration = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
@@ -174,7 +174,7 @@ box.onanimationend = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
@@ -58,7 +58,7 @@ button.onauxclick = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onblur/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onblur/index.html
@@ -60,7 +60,7 @@ function inputFocus() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/oncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncancel/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncanplay;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
@@ -25,7 +25,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncanplaythrough;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onchange/index.html
@@ -53,7 +53,7 @@ function handleChange(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.html
@@ -76,7 +76,7 @@ function inputChange(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onclose/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclose/index.html
@@ -35,7 +35,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
@@ -111,7 +111,7 @@ window.onpointerdown = play;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
 	<tbody>
 		<tr>
 			<th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
@@ -29,7 +29,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncuechange;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
@@ -51,7 +51,7 @@ function logDoubleClick(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.ondurationchange;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onemptied/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onemptied/index.html
@@ -26,7 +26,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onemptied;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onended/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onended/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onended;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onerror/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.html
@@ -92,7 +92,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onfocus/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onfocus/index.html
@@ -62,7 +62,7 @@ function inputFocus() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onformdata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onformdata/index.html
@@ -58,7 +58,7 @@ formElem.onformdata = (e) =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
@@ -68,7 +68,7 @@ function submit(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
@@ -50,7 +50,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
@@ -123,7 +123,7 @@ input.onpaste = event =&gt; false;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
@@ -49,7 +49,7 @@ function logKey(e) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadeddata;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadedmetadata;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
@@ -90,7 +90,7 @@ document.onmouseup = hideView;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmouseenter;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmouseleave;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
@@ -87,7 +87,7 @@ links.forEach(link =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
@@ -48,7 +48,7 @@ function logMouseOut() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
@@ -48,7 +48,7 @@ function logMouseOut() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
@@ -94,7 +94,7 @@ document.onmouseup = release;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onpause/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpause/index.html
@@ -24,7 +24,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onpause;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplay/index.html
@@ -41,7 +41,7 @@ function alertPlay() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onplaying/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplaying/index.html
@@ -24,7 +24,7 @@ var <var>handlerFunction</var> = <var>element</var>.onplaying;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onreset/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onreset/index.html
@@ -53,7 +53,7 @@ form.onreset = logReset;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onresize/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onresize/index.html
@@ -47,7 +47,7 @@ window.onresize = resize;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onselect/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselect/index.html
@@ -50,7 +50,7 @@ textarea.onselect = logSelection;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -40,7 +40,7 @@ document.onselectionchange = function() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
@@ -42,7 +42,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
@@ -68,7 +68,7 @@ function submit(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -101,7 +101,7 @@ box.ontransitionend = function(event) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/globaleventhandlers/onwheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onwheel/index.html
@@ -86,7 +86,7 @@ document.onwheel = zoom;</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/htmlmediaelement/onerror/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onerror/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/htmlvideoelement/onenterpictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onenterpictureinpicture/index.html
@@ -52,7 +52,7 @@ button.onclick = function() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/htmlvideoelement/onleavepictureinpicture/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onleavepictureinpicture/index.html
@@ -54,7 +54,7 @@ button.onclick = function() =&gt; {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/node/comparedocumentposition/index.html
+++ b/files/en-us/web/api/node/comparedocumentposition/index.html
@@ -88,7 +88,7 @@ if (head.compareDocumentPosition(body) &amp; Node.DOCUMENT_POSITION_FOLLOWING) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/node/insertbefore/index.html
+++ b/files/en-us/web/api/node/insertbefore/index.html
@@ -130,7 +130,7 @@ parentElement.insertBefore(newElement, theFirstChild)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/node/textcontent/index.html
+++ b/files/en-us/web/api/node/textcontent/index.html
@@ -81,7 +81,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
 	<thead>
 		<tr>
 			<th scope="col">Specification</th>

--- a/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
@@ -52,7 +52,7 @@ video.requestPictureInPicture()
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/window/blur/index.html
+++ b/files/en-us/web/api/window/blur/index.html
@@ -25,7 +25,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/window/focus/index.html
+++ b/files/en-us/web/api/window/focus/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/window/frames/index.html
+++ b/files/en-us/web/api/window/frames/index.html
@@ -38,7 +38,7 @@ for (var i = 0; i &lt; frames.length; i++) {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/window/length/index.html
+++ b/files/en-us/web/api/window/length/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/api/window/stop/index.html
+++ b/files/en-us/web/api/window/stop/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <tbody>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.html
@@ -64,7 +64,7 @@ console.log(o.gimmeFive); // 5
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.html
@@ -56,7 +56,7 @@ Object.getOwnPropertyDescriptor(obj, "foo").get;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.html
@@ -56,7 +56,7 @@ Object.getOwnPropertyDescriptor(obj, 'foo').set;
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
+<table class="standard-table">
  <thead>
   <tr>
    <th scope="col">Specification</th>


### PR DESCRIPTION
All tables in "Specifications" sections have class `standard-table`. Prior to this commit some tables (70 out of over 7700) also had a useless class `spectable`, which could confuse people. Class `spectable` does not add any CSS and is not mentioned in JS in Yari.