### PR TITLE
Mark DeviceLightEvent as obsolete

### DIFF
--- a/files/en-us/web/api/devicelightevent/index.html
+++ b/files/en-us/web/api/devicelightevent/index.html
@@ -4,12 +4,12 @@ slug: Web/API/DeviceLightEvent
 tags:
   - API
   - Ambient Light Events
-  - Experimental
+  - Obsolete
   - Interface
   - NeedsBetterSpecLink
   - NeedsMarkupWork
 ---
-<div>{{apiref("Ambient Light Events")}}{{SeeCompatTable}}</div>
+<div>{{obsolete_header}}{{apiref("Ambient Light Events")}}{{SeeCompatTable}}</div>
 
 <p>The <code>DeviceLightEvent</code> provides web developers with information from photo sensors or similiar detectors about ambient light levels near the device. For example this may be useful to adjust the screen's brightness based on the current ambient light level in order to save energy or provide better readability.</p>
 


### PR DESCRIPTION
The event was removed in https://github.com/w3c/ambient-light/commit/ead8612846d81e959bbda952c8d25e5bbe14201c
part of #80