### PR TITLE
Fix image aspect ratio

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.html
@@ -109,7 +109,7 @@ npm run dev</pre>
 
 <p>After running <code>npm run dev</code>, Svelte will compile and build your application. It will start a local server at <code>localhost:5000</code>. Svelte will watch for file updates, and automatically recompile and refresh the app for you when changes are made to the source files. Your browser will display something like this:</p>
 
-<p><img alt="A simple start page that says hello world, and gives a link to the official svelte tutorials" src="https://mdn.mozillademos.org/files/17338/01-svelte-starter-app.png" style="border-style: solid; border-width: 1px; height: 529px; width: 1166px;"></p>
+<p><img alt="A simple start page that says hello world, and gives a link to the official svelte tutorials" src="https://mdn.mozillademos.org/files/17338/01-svelte-starter-app.png" style="border-style: solid; border-width: 1px; height: auto;"></p>
 
 <h3 id="Application_structure">Application structure</h3>
 
@@ -270,7 +270,7 @@ npm run dev</pre>
 
 <p>You can see this in action by opening <code>localhost:5000</code> in a new browser tab, right/<kbd>Ctrl</kbd>-clicking on the <em>HELLO WORLD!</em> label, and choosing <em>Inspect</em>:</p>
 
-<p><img alt="Svelte starter app with devtools open, showing classes for scoped styles" src="https://mdn.mozillademos.org/files/17339/02-svelte-component-scoped-styles.png" style="height: 878px; width: 1117px;"></p>
+<p><img alt="Svelte starter app with devtools open, showing classes for scoped styles" src="https://mdn.mozillademos.org/files/17339/02-svelte-component-scoped-styles.png" style="height: auto;"></p>
 
 <p>When compiling the app, Svelte changes our <code>h1</code> styles definition to <code>h1.svelte-1tky8bj</code>, and then modifies every <code>&lt;h1&gt;</code> element in our component to <code>&lt;h1 class="svelte-1tky8bj"&gt;</code>, so that it picks up the styles as required.</p>
 
@@ -414,7 +414,7 @@ npm run dev</pre>
 
 <p>Let's have a quick look at the Svelte REPL and how you'd use it. It looks like so:</p>
 
-<p><img alt="the svelte repl in action, showing component code on the left, and output on the right" src="https://mdn.mozillademos.org/files/17340/03-svelte-repl-in-action.png" style="height: 946px; width: 1284px;"></p>
+<p><img alt="the svelte repl in action, showing component code on the left, and output on the right" src="https://mdn.mozillademos.org/files/17340/03-svelte-repl-in-action.png" style="height: auto;"></p>
 
 <p>To start a REPL, open your browser and navigate to <a href="https://svelte.dev/repl">https://svelte.dev/repl</a>.</p>
 


### PR DESCRIPTION
There's `max-width: 100%;` in the global CSS that's causing abnormal aspect ratio when used together with fixed width and height of images. Setting the height to `auto` should fix that.