### PR TITLE
Removed dev-addons reference

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/index.html
@@ -25,7 +25,7 @@ tags:
 </dl>
 
 <div class="notecard note">
-<p><strong>Note:</strong> If you have ideas or questions or need help, you can reach us on the <a href="https://mail.mozilla.org/listinfo/dev-addons">dev-addons mailing list</a> or in the <a href="https://matrix.to/#/!CuzZVoCbeoDHsxMCVJ:mozilla.org?via=mozilla.org&amp;via=matrix.org&amp;via=humanoids.be">Add-ons Room</a> on <a href="https://wiki.mozilla.org/Matrix">Matrix</a>.</p>
+<p><strong>Note:</strong> If you have ideas or questions or need help, you can reach us on the <a href="https://discourse.mozilla.org/c/add-ons">community forum</a> or in the <a href="https://matrix.to/#/!CuzZVoCbeoDHsxMCVJ:mozilla.org?via=mozilla.org&amp;via=matrix.org&amp;via=humanoids.be">Add-ons Room</a> on <a href="https://wiki.mozilla.org/Matrix">Matrix</a>.</p>
 </div>
 
 <div class="topicpage-table">


### PR DESCRIPTION
* Removes mention of dev-addons mailing list (retired) from ways of contacting the add-ons team. 