### PR TITLE
Typo in SPA Glossary entry

### DIFF
--- a/files/en-us/glossary/spa/index.html
+++ b/files/en-us/glossary/spa/index.html
@@ -6,7 +6,7 @@ tags:
   - SPA
   - single-page app
 ---
-<p>An SPA (Single-page application) is a web app implemention that loads only a single web document, and then updates the body content of that single document via JavaScript APIs such as {{domxref("XMLHttpRequest")}} and <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> when different content is to be shown.</p>
+<p>An SPA (Single-page application) is a web app implementation that loads only a single web document, and then updates the body content of that single document via JavaScript APIs such as {{domxref("XMLHttpRequest")}} and <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> when different content is to be shown.</p>
 
 <p>This therefore allows users to use websites without loading whole new pages from the server, which can result in performance gains and a more dynamic experience, with some tradeoff disadvantages such as SEO, more effort required to maintain state, implement navigation, and do meaningful performance monitoring.</p>
 


### PR DESCRIPTION
The main description of an SPA in the Glossary has a type:
implemention -> implementation