### PR TITLE
Remove RTL direction in a code block

### DIFF
--- a/files/en-us/web/javascript/reference/operators/this/index.html
+++ b/files/en-us/web/javascript/reference/operators/this/index.html
@@ -132,7 +132,7 @@ new Bad(); // ReferenceError</pre>
 
 <h3 id="this_in_function_contexts">this in function contexts</h3>
 
-<pre class="brush:js" dir="rtl">// An object can be passed as the first argument to call or apply and this will be bound to it.
+<pre class="brush:js">// An object can be passed as the first argument to call or apply and this will be bound to it.
 var obj = {a: 'Custom'};
 
 // We declare a variable and the variable is assigned to the global window as its property.


### PR DESCRIPTION
A single code block was tagged with a RTL text direction in the english version of this document under [this in Function Contexts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#this_in_function_contexts). This removes the dir="rtl" attribute to allow the code to flow the default ltr.