### PR TITLE
Add article about unsupported GET API (index.json)

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7719,6 +7719,7 @@
 /en-US/docs/MDN/Structures/Content_blocks	/en-US/docs/MDN/Guidelines/CSS_style_guide
 /en-US/docs/MDN/Tools/Kuma_API	/en-US/docs/Project:MDN/Kuma/API
 /en-US/docs/MDN/Tools/MDN-related_projects	/en-US/docs/MDN/Tools/Add-ons_and_plug-ins
+/en-US/docs/MDN/Tools/Document_parameters	/en-US/docs/MDN/Tools/Unsupported_GET_API
 /en-US/docs/MDN/User_guide	/en-US/docs/MDN/Tools
 /en-US/docs/MDN/User_guide/Advanced_search	/en-US/docs/MDN/Tools/Search
 /en-US/docs/MDN/User_guide/Deleting_pages	/en-US/docs/MDN/Tools/Page_deletion

--- a/files/en-us/mdn/tools/unsupported_get_api/index.html
+++ b/files/en-us/mdn/tools/unsupported_get_api/index.html
@@ -1,0 +1,30 @@
+---
+title: Unsupported GET API
+slug: MDN/Tools/Unsupported_GET_API
+tags:
+  - Advanced
+  - Automation
+  - Documentation
+  - Draft
+  - Guide
+  - MDN Meta
+  - PUT API
+  - Page-level
+  - Tools
+---
+<div>{{MDNSidebar}}</div>
+
+<p><span class="seoSummary">MDN's platform, <a href="https://github.com/mdn/yari">Yari</a>, doesn't provide a supported GET API. However, Yari does currently provide an unsupported mechanism that exposes JSON resources which you can retrieve with HTTP <code>GET</code> requests and then consume programatically.</span></p>
+
+<h2>index.json resources</h2>
+
+<p>Given the URL for a particular MDN article, by making an HTTP GET request to the corresponding URL with <code>/index.json</code> appended, you can retrieve associated JSON data.</p>
+
+<p>For example, for the MDN article at:</p>
+<p><a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch">https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch</a></p>
+<p>...you can retrieve its associated JSON data at:</p>
+<p><a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch/index.json">https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch/index.json</a></p>
+
+<div class="warning">
+<p><strong>Warning:</strong> The format used for the JSON data in the MDN <code>index.json</code> resources is unversioned and intentionally undocumented. Any part of the format is subject to possible change, including the structure and the key names. It's even possible that Yari may change in such a way that the <code>index.json</code> resources are no longer provided at all.</p>
+</div>


### PR DESCRIPTION
This change adds a new article about the (unsupported) `index.json` resources that Yari provides for programmatic HTTP GET use. Related to https://github.com/mdn/content/pull/201 and https://github.com/mdn/content/issues/202

---

Note that the redirect I attempted to also set up with the changes in this PR does not actually work as expected for me locally. I get a 404 when I navigate to http://localhost:3000/en-US/docs/mdn/tools/Document_parameters or http://localhost:5000/en-US/docs/mdn/tools/Document_parameters