### PR TITLE
Update protocol_handlers examples to suggest using ext+ for protocols not on allowed list

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -69,6 +69,16 @@ tags:
   }
 ]</pre>
 
+<p>If the protocol is not in the allowed list then it has to start with 'ext+'</p>
+
+<pre class="brush: json  no-line-numbers">"protocol_handlers": [
+  {
+    "protocol": "ext+foo",
+    "name": "Foo Extension",
+    "uriTemplate": "https://example.com/#!/%s"
+  }
+]</pre>
+
 <p>Handlers can also be <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages">extension pages</a>.</p>
 
 <pre class="brush: json  no-line-numbers">"protocol_handlers": [


### PR DESCRIPTION
Add an example that makes it clear that protocols not on the allowed list have to have the prefix "ext+"