### PR TITLE
update bigint example with octal

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.html
@@ -27,6 +27,9 @@ const hugeString = BigInt("9007199254740991")
 const hugeHex = BigInt("0x1fffffffffffff")
 // ↪ 9007199254740991n
 
+const hugeOctal = BigInt("0o377777777777777777")
+// ↪ 9007199254740991n
+
 const hugeBin = BigInt("0b11111111111111111111111111111111111111111111111111111")
 // ↪ 9007199254740991n
 </pre>


### PR DESCRIPTION
According to the ECMA 262 specification a "0o" prefix for octal numbers is also valid.
Just add an example to let people know that it is possible.