### PR TITLE
Remove right-to-left attribute from code listing

### DIFF
--- a/files/en-us/learn/forms/your_first_form/index.html
+++ b/files/en-us/learn/forms/your_first_form/index.html
@@ -93,7 +93,7 @@ tags:
 
 <p>In terms of HTML code we need something like the following to implement these form widgets:</p>
 
-<pre class="brush:html; notranslate" dir="rtl">&lt;form action="/my-handling-form-page" method="post"&gt;
+<pre class="brush:html; notranslate">&lt;form action="/my-handling-form-page" method="post"&gt;
  &lt;ul&gt;
   &lt;li&gt;
     &lt;label for="name"&gt;Name:&lt;/label&gt;


### PR DESCRIPTION
Because of the dir="rtl" attribute, the code is rendered "smashed" to the right side. This attribute doesn't make sense for code listings. Remove it to make the code legible again.

### Screenshot

![Screenshot from 2020-12-16 14-53-21](https://user-images.githubusercontent.com/2905118/102358163-7b932680-3faf-11eb-8509-54507d965eab.png)
