### PR TITLE
Document WEBGL_multi_draw extension

### DIFF
--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.html
@@ -96,4 +96,5 @@ ext.drawArraysInstancedANGLE(gl.POINTS, 0, 8, 4);
  <li>{{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.drawElementsInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.vertexAttribDivisor()")}}</li>
+ <li>{{domxref("WEBGL_multi_draw.multiDrawArraysInstancedWEBGL()")}}</li>
 </ul>

--- a/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.html
@@ -108,4 +108,5 @@ ext.drawElementsInstancedANGLE(gl.POINTS, 2, gl.UNSIGNED_SHORT, 0, 4);
  <li>{{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.drawElementsInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.vertexAttribDivisor()")}}</li>
+ <li>{{domxref("WEBGL_multi_draw.multiDrawElementsInstancedWEBGL()")}}</li>
 </ul>

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
@@ -85,4 +85,5 @@ tags:
 
 <ul>
  <li>{{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()")}}</li>
+ <li>{{domxref("WEBGL_multi_draw.multiDrawArraysInstancedWEBGL()")}}</li>
 </ul>

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
@@ -111,4 +111,5 @@ tags:
  <li>{{domxref("WebGLRenderingContext.drawElements()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.vertexAttribDivisor()")}}</li>
+ <li>{{domxref("WEBGL_multi_draw.multiDrawElementsInstancedWEBGL()")}}</li>
 </ul>

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -92,6 +92,7 @@ tags:
  <li>{{domxref("WEBGL_depth_texture")}}</li>
  <li>{{domxref("WEBGL_draw_buffers")}}</li>
  <li>{{domxref("WEBGL_lose_context")}}</li>
+ <li>{{domxref("WEBGL_multi_draw")}}</li>
 </ul>
 </div>
 

--- a/files/en-us/web/api/webgl_multi_draw/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/index.html
@@ -1,0 +1,157 @@
+---
+title: WEBGL_multi_draw
+slug: Web/API/WEBGL_multi_draw
+tags:
+  - API
+  - Reference
+  - WebGL
+  - WebGL extension
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>WEBGL_multi_draw</strong></code> extension is part of the
+<a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> and allows to render more
+than one primitive with a single function call. This can improve a WebGL application's performance
+as it reduces binding costs in the renderer and speeds up GPU thread time with uniform data.</p>
+
+<p>When this extension is enabled:</p>
+<ul>
+  <li>New methods that handle multiple lists of arguments in one call are added 
+    (see method list below).</li>
+  <li>The <code>gl_DrawID</code> built-in is added to the shading language.</li>
+</ul>
+
+<div class="note">
+  <p><strong>Availability:</strong> This extension is available to both, 
+  {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} and 
+  {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.
+  <p>In shader code, the directive <code>#extension GL_ANGLE_multi_draw</code>
+  needs to be called to enable the extension.</p>
+  <p>This extension enables the {{domxref("ANGLE_instanced_arrays")}} extension implicitly.</p>
+</p>
+</div>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+ <dt><a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL"><code>ext.multiDrawArraysWEBGL()</code></a></dt>
+ <dd>Renders multiple primitives from array data (identical to multiple calls to 
+   <a href="/en-US/docs/Web/API/WebGLRenderingContext/drawArrays"><code>drawArrays</code></a>).</dd>
+ <dt><a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawElementsWEBGL"><code>ext.multiDrawElementsWEBGL()</code></a></dt>
+ <dd>Renders multiple primitives from element array data (identical to multiple calls to 
+   <a href="en-US/docs/Web/API/WebGLRenderingContext/drawElements"><code>drawElements</code></a>).</dd>
+ <dt><a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawArraysInstancedWEBGL"><code>ext.multiDrawArraysInstancedWEBGL()</code></a></dt>
+ <dd>Renders multiple primitives from array data (identical to multiple calls to 
+   <a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawArraysInstanced"><code>drawArraysInstanced</code></a>).</dd>
+ <dt><a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawElementsInstancedWEBGL"><code>ext.multiDrawElementsInstancedWEBGL()</code></a></dt>
+ <dd>Renders multiple primitives from element array data (identical to multiple calls to 
+   <a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawElementsInstanced"><code>drawElementsInstanced</code></a>).</dd>
+</dl>
+
+<h2 id="Shader_extension">Shader extension</h2>
+
+<p>Note: Although the extension name is named <code>WEBGL_multi_draw</code>, 
+the extension must be enabled with the <code>#extension GL_ANGLE_multi_draw</code>
+directive to use the extension in a shader.</p>
+
+<p>When this extension is enabled, the <code>gl_DrawID</code> built-in can be used
+in shader code. For any <code>multi*</code> draw call variant, 
+the index of the draw <code>i</code> may be read by the vertex shader 
+as <code>gl_DrawID</code>. For non-<code>multi*</code> calls, the value of 
+<code>gl_DrawID</code> is <code>0</code>.</p>
+
+<pre class="brush: html">&lt;script type="x-shader/x-vertex"&gt;
+#extension GL_ANGLE_multi_draw : require
+void main() {
+  gl_Position = vec4(gl_DrawID, 0, 0, 1);
+}
+&lt;/script&gt;</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Enabling the extension</h3>
+
+<p>WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. 
+  For more information, see also <a href="/en-US/docs/Web/API/WebGL_API/Using_Extensions">Using Extensions</a>
+  in the <a href="/en-US/docs/Web/API/WebGL_API/Tutorial">WebGL tutorial</a>.</p>
+
+<pre class="brush:js">
+let ext = gl.getExtension('WEBGL_multi_draw');
+</pre>
+
+<h3>Drawing multiple arrays</h3>
+
+<p>Example calls for <a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL"><code>ext.multiDrawArraysWEBGL()</code></a>
+and <a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawArraysInstancedWEBGL"><code>ext.multiDrawArraysInstancedWEBGL()</code></a>:</p>
+
+<pre class="brush:js">
+// multiDrawArrays variant
+// let firsts = new Int32Array(...);
+// let counts = new Int32Array(...);
+ext.multiDrawArraysWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, firsts.length);
+
+// multiDrawArraysInstanced variant
+// let firsts = new Int32Array(...);
+// let counts = new Int32Array(...);
+// let instanceCounts = new Int32Array(...);
+ext.multiDrawArraysInstancedWEBGL(
+  gl.TRIANGLES, firsts, 0, counts, 0, instanceCounts, 0, firsts.length);
+</pre>
+
+<h3>Drawing multiple elements</h3>
+
+<p>Example calls for <a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawElementsWEBGL"><code>ext.multiDrawElementsWEBGL()</code></a>
+and <a href="/en-US/docs/Web/API/WEBGL_multi_draw/multiDrawElementsInstancedWEBGL"><code>ext.multiDrawElementsInstancedWEBGL()</code></a>.</p>
+<p>Assumes that the indices which have been previously uploaded to the 
+<code>ELEMENT_ARRAY_BUFFER</code> are to be treated as <code>UNSIGNED_SHORT</code>.</p>
+
+<pre class="brush:js">
+// multiDrawElements variant
+// let counts = new Int32Array(...);
+// let offsets = new Int32Array(...);
+ext.multiDrawElementsWEBGL(
+  gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, counts.length);
+}
+
+// multiDrawElementsInstanced variant
+// let counts = new Int32Array(...);
+// let offsets = new Int32Array(...);
+// let instanceCounts = new Int32Array(...);
+ext.multiDrawElementsInstancedWEBGL(
+    gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, instanceCounts, 0,
+    counts.length);
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('WEBGL_multi_draw', "", "WEBGL_multi_draw")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. 
+If you'd like to contribute to the data, please check out 
+<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+and send us a pull request.</p>
+
+<p>{{Compat("WEBGL_multi_draw")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{domxref("WebGLRenderingContext.drawArrays()")}}</li>
+ <li>{{domxref("WebGLRenderingContext.drawElements()")}}</li>
+ <li>{{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()")}} or 
+     in WebGL 2: {{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}</li>
+ <li>{{domxref("ANGLE_instanced_arrays.drawElementsInstancedANGLE()")}} or
+     in WebGL 2: {{domxref("WebGL2RenderingContext.drawElementsInstanced()")}}</li>
+</ul>

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
@@ -1,0 +1,124 @@
+---
+title: WEBGL_multi_draw.multiDrawArraysInstancedWEBGL()
+slug: Web/API/WEBGL_multi_draw/multiDrawArraysInstancedWEBGL
+tags:
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>WEBGL_multi_draw.multiDrawArraysInstancedWEBGL()</strong></code> method of the 
+<a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> renders multiple primitives from array data. It is
+identical to multiple calls to the 
+<a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawArraysInstanced"><code>gl.drawArraysInstanced()</code></a> method.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">void <var>ext</var>.multiDrawArraysWEBGL(<var>mode</var>, 
+    <var>firstsList</var>, <var>firstsOffset</var>,
+    <var>countsList</var>, <var>countsOffset</var>,
+    <var>instanceCountsList</var>, <var>instanceCountsOffset</var>,
+    <var>drawCount</var>);
+</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+ <dt><code>mode</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLenum</code></a> 
+    specifying the type primitive to render. Possible values are:
+ <ul>
+  <li><code>gl.POINTS</code>: Draws a single dot.</li>
+  <li><code>gl.LINE_STRIP</code>: Draws a straight line to the next vertex.</li>
+  <li><code>gl.LINE_LOOP</code>: Draws a straight line to the next vertex, and connects the 
+    last vertex back to the first.</li>
+  <li><code>gl.LINES</code>: Draws a line between a pair of vertices.</li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_strip">gl.TRIANGLE_STRIP</a></code></li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_fan">gl.TRIANGLE_FAN</a></code></li>
+  <li><code>gl.TRIANGLES</code>: Draws a triangle for a group of three vertices.</li>
+ </ul>
+ </dd>
+ <dt><code>firstsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLint</code></a>)
+    specifying a list of starting indices for the arrays of vector points.</dd>
+ <dt><code>firstsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+    defining the starting point into the <code>firstsLists</code> array.</dd>
+ <dt><code>countsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a>)
+    specifying a list of numbers of indices to be rendered.</dd>
+ <dt><code>countsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+    defining the starting point into the <code>countsList</code> array.</dd>
+ <dt><code>instanceCountsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a>)
+  specifying a list of number sof instances of the range of elements to execute.</dd>
+ <dt><code>instanceCountsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+    defining the starting point into the <code>instanceCountsList</code> array.</dd>
+ <dt><code>drawCount</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a> 
+    specifying the number of instances of the range of elements to execute.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>None.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<ul>
+  <li>If <code>mode</code> is not one of the accepted values, a <code>gl.INVALID_ENUM</code> error is thrown.</li>
+  <li>If <code>drawCount</code> or items in <code>firstsList</code>, <code>countsList</code>, or <code>instanceCountsList</code> are negative, 
+    a <code>gl.INVALID_VALUE</code> error is thrown.</li>
+  <li>if <code>gl.CURRENT_PROGRAM</code> is 
+    <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/null"><code>null</code></a>, 
+    a <code>gl.INVALID_OPERATION</code> error is thrown.</li>
+</ul>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">
+// let firsts = new Int32Array(...);
+// let counts = new Int32Array(...);
+// let instanceCounts = new Int32Array(...);
+ext.multiDrawArraysInstancedWEBGL(
+   gl.TRIANGLES, firsts, 0, counts, 0, instanceCounts, 0, firsts.length);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. 
+If you'd like to contribute to the data, please check out 
+<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+and send us a pull request.</p>
+
+<p>{{Compat("api.WEBGL_multi_draw.multiDrawArraysWEBGL")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/WebGLRenderingContext/drawArrays"><code>WebGLRenderingContext.drawArrays()</code></a></li>
+  <li><a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawArraysInstanced"><code>WebGL2RenderingContext.drawArraysInstanced()</code></a></li>
+</ul>  

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.html
@@ -1,0 +1,113 @@
+---
+title: WEBGL_multi_draw.multiDrawArraysWEBGL()
+slug: Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL
+tags:
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>WEBGL_multi_draw.multiDrawArraysWEBGL()</strong></code> method of the 
+<a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> renders multiple primitives from array data. It is
+identical to multiple calls to the 
+<a href="/en-US/docs/Web/API/WebGLRenderingContext/drawArrays"><code>gl.drawArrays()</code></a> method.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">void <var>ext</var>.multiDrawArraysWEBGL(<var>mode</var>, 
+    <var>firstsList</var>, <var>firstsOffset</var>,
+    <var>countsList</var>, <var>countsOffset</var>,
+    <var>drawCount</var>);
+</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+ <dt><code>mode</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLenum</code></a> 
+    specifying the type primitive to render. Possible values are:
+ <ul>
+  <li><code>gl.POINTS</code>: Draws a single dot.</li>
+  <li><code>gl.LINE_STRIP</code>: Draws a straight line to the next vertex.</li>
+  <li><code>gl.LINE_LOOP</code>: Draws a straight line to the next vertex, and connects the 
+    last vertex back to the first.</li>
+  <li><code>gl.LINES</code>: Draws a line between a pair of vertices.</li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_strip">gl.TRIANGLE_STRIP</a></code></li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_fan">gl.TRIANGLE_FAN</a></code></li>
+  <li><code>gl.TRIANGLES</code>: Draws a triangle for a group of three vertices.</li>
+ </ul>
+ </dd>
+ <dt><code>firstsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLint</code></a>)
+    specifying a list of starting indices for the arrays of vector points.</dd>
+ <dt><code>firstsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+    defining the starting point into the <code>firstsLists</code> array.</dd>
+ <dt><code>countsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a>)
+    specifying a list of numbers of indices to be rendered.</dd>
+ <dt><code>countsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+    defining the starting point into the <code>countsList</code> array.</dd>
+ <dt><code>drawCount</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a> 
+    specifying the number of instances of the range of elements to execute.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>None.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<ul>
+  <li>If <code>mode</code> is not one of the accepted values, a <code>gl.INVALID_ENUM</code> error is thrown.</li>
+  <li>If <code>drawCount</code> or items in <code>firstsList</code> and <code>countsList</code> are negative, 
+    a <code>gl.INVALID_VALUE</code> error is thrown.</li>
+  <li>if <code>gl.CURRENT_PROGRAM</code> is 
+    <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/null"><code>null</code></a>, 
+    a <code>gl.INVALID_OPERATION</code> error is thrown.</li>
+</ul>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">
+// let firsts = new Int32Array(...);
+// let counts = new Int32Array(...);
+ext.multiDrawArraysWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, firsts.length);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. 
+If you'd like to contribute to the data, please check out 
+<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+and send us a pull request.</p>
+
+<p>{{Compat("api.WEBGL_multi_draw.multiDrawArraysWEBGL")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/WebGLRenderingContext/drawArrays"><code>WebGLRenderingContext.drawArrays()</code></a></li>
+  <li><a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawArraysInstanced"><code>WebGL2RenderingContext.drawArraysInstanced()</code></a></li>
+</ul>  

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
@@ -1,0 +1,136 @@
+---
+title: WEBGL_multi_draw.multiDrawElementsInstancedWEBGL()
+slug: Web/API/WEBGL_multi_draw/multiDrawElementsInstancedWEBGL
+tags:
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>WEBGL_multi_draw.multiDrawElementsWEBGL()</strong></code> method of the 
+<a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> renders multiple primitives from array data. It is
+identical to multiple calls to the 
+<a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawElementsInstanced"><code>gl.drawElementsInstanced()</code></a> method.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">void <var>ext</var>.multiDrawElementsInstancedWEBGL(<var>mode</var>, 
+    <var>countsList</var>, <var>countsOffset</var>,
+    <var>type</var>,
+    <var>firstsList</var>, <var>firstsOffset</var>,
+    <var>instanceCountsList</var>, <var>instanceCountsOffset</var>,
+    <var>drawCount</var>);
+</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+ <dt><code>mode</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLenum</code></a> 
+    specifying the type primitive to render. Possible values are:
+ <ul>
+  <li><code>gl.POINTS</code>: Draws a single dot.</li>
+  <li><code>gl.LINE_STRIP</code>: Draws a straight line to the next vertex.</li>
+  <li><code>gl.LINE_LOOP</code>: Draws a straight line to the next vertex, and connects the 
+    last vertex back to the first.</li>
+  <li><code>gl.LINES</code>: Draws a line between a pair of vertices.</li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_strip">gl.TRIANGLE_STRIP</a></code></li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_fan">gl.TRIANGLE_FAN</a></code></li>
+  <li><code>gl.TRIANGLES</code>: Draws a triangle for a group of three vertices.</li>
+ </ul>
+ </dd>
+ <dt><code>countsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLint</code></a>)
+    specifying a list of numbers of indices to be rendered.</dd>
+ <dt><code>countsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLUint</code></a> 
+    defining the starting point into the <code>countsList</code> array.</dd>
+  <dt>type</dt>
+  <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLenum</code></a> specifying the type of the values in the element array buffer. Possible values are:
+   <ul>
+    <li><code>gl.UNSIGNED_BYTE</code></li>
+    <li><code>gl.UNSIGNED_SHORT</code></li>
+    <li>When using the <a href="/en-US/docs/Web/API/OES_element_index_uint"><code>OES_element_index_uint</code></a> extension:
+    <ul>
+    <li><code>gl.UNSIGNED_INT</code></li>
+    </ul>
+    </li>
+   </ul>
+ </dd>
+ <dt><code>offsetsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a>)
+    specifying a list of starting indices for the arrays of vector points.</dd>
+ <dt><code>offsetsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+     defining the starting point into the <code>offsetsList</code> array.</dd>
+ <dt><code>instanceCountsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+     or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+     (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a>)
+     specifying a list of number sof instances of the range of elements to execute.</dd>
+ <dt><code>instanceCountsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+     defining the starting point into the <code>instanceCountsList</code> array.</dd>
+ <dt><code>drawCount</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a> 
+     specifying the number of instances of the range of elements to execute.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>None.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<ul>
+  <li>If <code>mode</code> is not one of the accepted values, a <code>gl.INVALID_ENUM</code> error is thrown.</li>
+  <li>If <code>drawCount</code> or items in <code>countsList</code>, <code>offsetsList</code>, or <code>instanceCountsList</code> are negative, 
+    a <code>gl.INVALID_VALUE</code> error is thrown.</li>
+</ul>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">
+// let counts = new Int32Array(...);
+// let offsets = new Int32Array(...);
+// let instanceCounts = new Int32Array(...);
+ext.multiDrawElementsInstancedWEBGL(
+    gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, instanceCounts, 0,
+    counts.length);
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. 
+If you'd like to contribute to the data, please check out 
+<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+and send us a pull request.</p>
+
+<p>{{Compat("api.WEBGL_multi_draw.multiDrawElementsWEBGL")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/WebGLRenderingContext/drawElements"><code>WebGLRenderingContext.drawElements()</code></a></li>
+  <li><a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawElementsInstanced"><code>WebGL2RenderingContext.drawElementsInstanced()</code></a></li>
+</ul>

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.html
@@ -1,0 +1,125 @@
+---
+title: WEBGL_multi_draw.multiDrawElementsWEBGL()
+slug: Web/API/WEBGL_multi_draw/multiDrawElementsWEBGL
+tags:
+  - Method
+  - Reference
+  - WebGL
+  - WebGL extension
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>WEBGL_multi_draw.multiDrawElementsWEBGL()</strong></code> method of the 
+<a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> renders multiple primitives from array data. It is
+identical to multiple calls to the 
+<a href="/en-US/docs/Web/API/WebGLRenderingContext/drawElements"><code>gl.drawElements()</code></a> method.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">void <var>ext</var>.multiDrawElementsWEBGL(<var>mode</var>, 
+    <var>countsList</var>, <var>countsOffset</var>,
+    <var>type</var>,
+    <var>firstsList</var>, <var>firstsOffset</var>,
+    <var>drawCount</var>);
+</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+ <dt><code>mode</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLenum</code></a> 
+    specifying the type primitive to render. Possible values are:
+ <ul>
+  <li><code>gl.POINTS</code>: Draws a single dot.</li>
+  <li><code>gl.LINE_STRIP</code>: Draws a straight line to the next vertex.</li>
+  <li><code>gl.LINE_LOOP</code>: Draws a straight line to the next vertex, and connects the 
+    last vertex back to the first.</li>
+  <li><code>gl.LINES</code>: Draws a line between a pair of vertices.</li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_strip">gl.TRIANGLE_STRIP</a></code></li>
+  <li><code><a href="https://en.wikipedia.org/wiki/Triangle_fan">gl.TRIANGLE_FAN</a></code></li>
+  <li><code>gl.TRIANGLES</code>: Draws a triangle for a group of three vertices.</li>
+ </ul>
+ </dd>
+ <dt><code>countsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLint</code></a>)
+    specifying a list of numbers of indices to be rendered.</dd>
+ <dt><code>countsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLUint</code></a> 
+    defining the starting point into the <code>countsList</code> array.</dd>
+  <dt>type</dt>
+  <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLenum</code></a> specifying the type of the values in the element array buffer. Possible values are:
+   <ul>
+    <li><code>gl.UNSIGNED_BYTE</code></li>
+    <li><code>gl.UNSIGNED_SHORT</code></li>
+    <li>When using the <a href="/en-US/docs/Web/API/OES_element_index_uint"><code>OES_element_index_uint</code></a> extension:
+    <ul>
+    <li><code>gl.UNSIGNED_INT</code></li>
+    </ul>
+    </li>
+   </ul>
+ </dd>
+ <dt><code>offsetsList</code></dt>
+ <dd>An <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array"><code>Int32Array</code></a> 
+    or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a>
+    (of <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a>)
+    specifying a list of starting indices for the arrays of vector points.</dd>
+ <dt><code>offsetsOffset</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLuint</code></a> 
+    defining the starting point into the <code>offsetsList</code> array.</dd>
+ <dt><code>drawCount</code></dt>
+ <dd>A <a href="/en-US/docs/Web/API/WebGL_API/Types"><code>GLsizei</code></a> 
+    specifying the number of instances of the range of elements to execute.</dd>
+</dl>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>None.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<ul>
+  <li>If <code>mode</code> is not one of the accepted values, a <code>gl.INVALID_ENUM</code> error is thrown.</li>
+  <li>If <code>drawCount</code> or items in <code>countsList</code> or <code>offsetsList</code> are negative, 
+    a <code>gl.INVALID_VALUE</code> error is thrown.</li>
+</ul>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">
+// let counts = new Int32Array(...);
+// let offsets = new Int32Array(...);
+ext.multiDrawElementsWEBGL(
+    gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, counts.length);
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('WEBGL_multi_draw', '', 'WEBGL_multi_draw')}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. 
+If you'd like to contribute to the data, please check out 
+<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+and send us a pull request.</p>
+
+<p>{{Compat("api.WEBGL_multi_draw.multiDrawElementsWEBGL")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/WebGLRenderingContext/drawElements"><code>WebGLRenderingContext.drawElements()</code></a></li>
+  <li><a href="/en-US/docs/Web/API/WebGL2RenderingContext/drawElementsInstanced"><code>WebGL2RenderingContext.drawElementsInstanced()</code></a></li>
+</ul>

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
@@ -93,4 +93,5 @@ tags:
  <li>{{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.drawElementsInstanced()")}}</li>
  <li>{{domxref("WebGL2RenderingContext.vertexAttribDivisor()")}}</li>
+ <li>{{domxref("WEBGL_multi_draw.multiDrawArraysWEBGL()")}}</li>
 </ul>

--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
@@ -100,4 +100,5 @@ tags:
 <ul>
  <li>{{domxref("WebGLRenderingContext.drawArrays()")}}</li>
  <li>{{domxref("OES_element_index_uint")}}</li>
+ <li>{{domxref("WEBGL_multi_draw.multiDrawElementsWEBGL()")}}</li>
 </ul>


### PR DESCRIPTION
This PR adds documentation for the WebGL extension `WEBGL_multi_draw`

Spec: https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/
BCD: https://github.com/mdn/browser-compat-data/pull/7634
SpecData addition: https://github.com/mdn/yari/pull/2160