### PR TITLE
focus-visible release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/85/index.html
+++ b/files/en-us/mozilla/firefox/releases/85/index.html
@@ -23,6 +23,10 @@ tags:
 
 <h3 id="CSS">CSS</h3>
 
+<ul>
+  <li>The {{cssxref(":focus-visible")}} pseudo-class is now enabled. ({{bug(1445482)}}). </li>
+</ul>
+
 <h4 id="Removals_3">Removals</h4>
 
 <h3 id="JavaScript">JavaScript</h3>

--- a/files/en-us/web/css/_colon_focus-visible/index.html
+++ b/files/en-us/web/css/_colon_focus-visible/index.html
@@ -5,7 +5,6 @@ tags:
   - ':focus'
   - ':focus-visible'
   - CSS
-  - Experimental
   - Layout
   - Pseudo-class
   - Reference
@@ -54,7 +53,7 @@ tags:
 
 <h3 id="Selectively_showing_the_focus_indicator">Selectively showing the focus indicator</h3>
 
-<p>A custom control, such as a <a href="/en-US/docs/User:Andreas_Wuest/Custom_Elements">custom element</a> button, can use <code>:focus-visible</code> to selectively apply a focus indicator only on keyboard-focus. This matches the native focus behavior for controls like {{htmlelement("button")}}.</p>
+<p>A custom control, such as a custom element button, can use <code>:focus-visible</code> to selectively apply a focus indicator only on keyboard-focus. This matches the native focus behavior for controls like {{htmlelement("button")}}.</p>
 
 <pre class="brush: html notranslate">&lt;custom-button tabindex="0" role="button"&gt;Click Me&lt;/custom-button&gt;</pre>
 


### PR DESCRIPTION
Adding `:focus-visible` to the 5 release notes, removing a link to a user page which was broken from the docs for the pseudo-class.

https://github.com/mdn/content/issues/292