### PR TITLE
meta: Add docs on choosing how a PR gets merged

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -58,6 +58,8 @@ And the effect of appending the pull-request number to the commit subject line i
 
 However, in the case of some pull requests, using the **Rebase and merge** option makes more sense. You should choose that option when the commit author has intentionally constructed the pull request as a set of related commits, and has written an informative commit message for each commit in the pull request.
 
+You should also choose the **Rebase and merge** option when a pull request was created from separate commits by multiple authors, and you want to preserve the authorship of the commits — that is, to ensure that in the commit history, each commit is attributed to the right author. Otherwise, using the **Squash and merge** option would cause the commits to all be attributed to a single author, obscuring the actual authorship.
+
 ## Topic review owners
 
 The following specific topic areas are being reviewed by the kind souls listed underneath them. Be kind to them, and thank them for all the help they give to this project. If you would like to help with MDN content reviews, [get in touch with us](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Getting_started#Step_4_Ask_for_help).

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -34,7 +34,7 @@ If you are reviewing mdn content changes, read through the following guidelines.
 
 ### Choosing how a pull request gets merged
 
-When you're ready to merge a pull request to the main branch, you can use the green button in GitHub to perform the actual merge.
+When you're ready to merge a pull request to the `main` branch, you can use the green button in GitHub to perform the actual merge.
 
 As explained in [Merging a pull request on GitHub](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request#merging-a-pull-request-on-github), GitHub provides multiple options for controlling how pull requests gets merged. The MDN content repo doesn't allow the *"Merge all of the commits into the base branch"* option, so you're left with a choice between two options:
 
@@ -42,13 +42,13 @@ As explained in [Merging a pull request on GitHub](https://docs.github.com/en/fr
 
 * Rebase the commits individually onto the base branch by clicking the merge drop down menu next to the green button, selecting **Rebase and merge** and then clicking the green button (which will now say **Rebase and merge**).
 
-For most pull requests, you generally want to use the **Squash and merge** option, to squash all the commits in the pull-request branch into one commit.
+For most pull requests, you generally want to use the **Squash and merge** option, to squash all the commits in the pull request branch into one commit.
 
-Especially you should be careful to choose the **Squash and merge** option when your review of a pull request has resulted in the pull-request author making a series of small commits in response to your review suggestions.
+Especially you should be careful to choose the **Squash and merge** option when your review of a pull request has resulted in the pull request author making a series of small commits in response to your review suggestions.
 
-Using that **Squash and merge** option helps significantly to keep the [commit history for the repo](https://github.com/mdn/content/commits/main) more readable. Otherwise, we end up with a commit history that's less clear, with multiple commit messages that are less informative, making it all a lot more work to read through later
+Using that **Squash and merge** option helps significantly to keep the [commit history for the repo](https://github.com/mdn/content/commits/main) more readable. Otherwise, we end up with a commit history that's less clear, with multiple commit messages that are less informative, making it all a lot more work to read through later.
 
-That said, you should still prefer the **Squash and merge** option even for the normal case where a pull request consists of a single commit; that is, when there's nothing to actually squash. Even in those single-commit cases, the **Squash and merge** option is better; that's because it has the effect of appending the pull-request number to the commit subject line, like this:
+That said, you should still prefer the **Squash and merge** option even for the normal case where a pull request consists of a single commit; that is, when there's nothing to actually squash. Even in those single-commit cases, the **Squash and merge** option is better; that's because it has the effect of appending the pull request number to the commit subject line, like this:
 
 ```
 No longer mark WebGL 2 as experimental (#304)

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -32,6 +32,23 @@ If you are reviewing mdn content changes, read through the following guidelines.
 1. If you don't understand a content change that you've been selected to review, or feel that it is too large and complex for you to deal with, don't panic! Feel free to reach out to someone else to ask for help, like a colleague, or someone else in your group of topic review owners (if you know who they are). If you are not sure who to approach for help, then ping our @core-yari-content group to ask for help.
 1. Related to the above point, it is rare that you'll be required to review a large, complex content change with no warning, like a complete page rewrite, or the addition of several new reference pages or tutorials. Usually such changes are done as part of specific work streams where the content has been approved for addition, and reviewer(s) have been assigned already. In such cases, the PR should be linked to an issue that explains all these details. If you are not sure, ask the submitter if they need a review of the content, and where the rationale behnd the change is explained. Ping our [@core-yari-content](https://github.com/orgs/mdn/teams/core-yari-content) team to ask for help if you are still not sure, or if you think the content is suspicious.
 
+### Choosing how a pull request gets merged
+
+When you're ready to merge a pull request to the main branch, you can use the green button in GitHub to perform the actual merge.
+
+As explained in [Merging a pull request on GitHub](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request#merging-a-pull-request-on-github), GitHub provides multiple options for controlling how pull requests gets merged. The MDN content repo doesn't allow the *"Merge all of the commits into the base branch"* option, so you're left with a choice between two options:
+
+* Squash the commits into one commit by clicking the merge drop down menu next to the green button, selecting **Squash and merge** and then clicking the green button (which will now say **Squash and merge**).
+
+* Rebase the commits individually onto the base branch by clicking the merge drop down menu next to the green button, selecting **Rebase and merge** and then clicking the green button (which will now say **Rebase and merge**).
+
+For most pull requests, you generally want to use the **Squash and merge** option, to squash all the commits in the pull-request branch into one commit.
+
+Especially you should be careful to choose the **Squash and merge** option when your review of a pull request has resulted in the pull-request author making a series of small commits in response to your review suggestions.
+
+Using that **Squash and merge** option helps significantly to keep the [commit history for the repo](https://github.com/mdn/content/commits/main) more readable. Otherwise, we end up with a commit history that's less clear, with multiple commit messages that are less informative, making it all a lot more work to read through later
+
+However, in the case of some pull requests, using the **Rebase and merge** option makes more sense. You should choose that option when the commit author has intentionally constructed the pull request as a set of related commits, and has written an informative commit message for each commit in the pull request.
 
 ## Topic review owners
 

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -48,6 +48,14 @@ Especially you should be careful to choose the **Squash and merge** option when 
 
 Using that **Squash and merge** option helps significantly to keep the [commit history for the repo](https://github.com/mdn/content/commits/main) more readable. Otherwise, we end up with a commit history that's less clear, with multiple commit messages that are less informative, making it all a lot more work to read through later
 
+That said, you should still prefer the **Squash and merge** option even for the normal case where a pull request consists of a single commit; that is, when there's nothing to actually squash. Even in those single-commit cases, the **Squash and merge** option is better; that's because it has the effect of appending the pull-request number to the commit subject line, like this:
+
+```
+No longer mark WebGL 2 as experimental (#304)
+```
+
+And the effect of appending the pull-request number to the commit subject line is: when you view the [commit history for the repo](https://github.com/mdn/content/commits/main) in GitHub, the pull-request number becomes a hyperlink to the actual pull request. And that can be very helpful to anyone who browses through the commit history later.
+
 However, in the case of some pull requests, using the **Rebase and merge** option makes more sense. You should choose that option when the commit author has intentionally constructed the pull request as a set of related commits, and has written an informative commit message for each commit in the pull request.
 
 ## Topic review owners


### PR DESCRIPTION
This change adds guidance to the REVIEWING.md file to recommend to reviewers that the "Squash and merge" option is preferred in most cases, but to also make clear to reviewers when they should consider choosing the "Rebase and merge" option instead.