### PR TITLE
Change 'Property' tag to upper case

### DIFF
--- a/files/en-us/web/css/@property/index.html
+++ b/files/en-us/web/css/@property/index.html
@@ -6,7 +6,7 @@ tags:
   - CSS
   - Reference
   - Web
-  - property
+  - Property
   - Houdini
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>


### PR DESCRIPTION
The 'Property' tag is universally upper case.