### PR TITLE
updating release notes now 84 is latest release version

### DIFF
--- a/files/en-us/mozilla/firefox/releases/84/index.html
+++ b/files/en-us/mozilla/firefox/releases/84/index.html
@@ -9,7 +9,11 @@ tags:
 ---
 <p>{{FirefoxSidebar}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 84 that will affect developers. Firefox 84 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">December 15, 2020</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 84 that will affect developers. Firefox 84 was released on December 15, 2020.</p>
+
+<div class="notecard note">
+<p class="summary"><strong>Note</strong>: See also <a href="https://hacks.mozilla.org/2020/12/and-now-for-firefox-84/">And now for … Firefox 84</a> on Mozilla hacks</p>
+</div>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -1,15 +1,15 @@
 ---
-title: Firefox 85 for developers
-slug: Mozilla/Firefox/Releases/85
+title: Firefox 86 for developers
+slug: Mozilla/Firefox/Releases/86
 tags:
-  - '85'
+  - '86'
   - Firefox
   - Mozilla
   - Release
 ---
 <p>{{FirefoxSidebar}}{{draft}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 85 that will affect developers. Firefox 85 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">January 26, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 86 that will affect developers. Firefox 86 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">February 23, 2021</a>.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 
@@ -22,10 +22,6 @@ tags:
 <h4 id="Removals_2">Removals</h4>
 
 <h3 id="CSS">CSS</h3>
-
-<ul>
-  <li>The {{cssxref(":focus-visible")}} pseudo-class is now enabled. ({{bug(1445482)}}). </li>
-</ul>
 
 <h4 id="Removals_3">Removals</h4>
 
@@ -59,4 +55,4 @@ tags:
 
 <h2 id="Older_versions">Older versions</h2>
 
-<p>{{Firefox_for_developers(84)}}</p>
+<p>{{Firefox_for_developers(85)}}</p>


### PR DESCRIPTION
Updating Fx 84 rel notes to say it is the release version, and adding link to hacks post.
Updating Fx 85 rel notes to say it is the current beta.
Adding Fx 86 rel notes, and saying it is the current nightly.