### PR TITLE
fix: Double slashes in URLs

### DIFF
--- a/files/en-us/learn/forms/basic_native_form_controls/index.html
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.html
@@ -110,7 +110,7 @@ tags:
 
 <h2 id="Checkable_items_checkboxes_and_radio_buttons">Checkable items: checkboxes and radio buttons</h2>
 
-<p>Checkable items are controls whose state you can change by clicking on them or their associated labels. There are two kinds of checkable item: the check box and the radio button. Both use the <a href="/en-US/docs/Web/HTML/Attributes//checked"><code>checked</code></a> attribute to indicate whether the widget is checked by default or not.</p>
+<p>Checkable items are controls whose state you can change by clicking on them or their associated labels. There are two kinds of checkable item: the check box and the radio button. Both use the <a href="/en-US/docs/Web/HTML/Attributes/checked"><code>checked</code></a> attribute to indicate whether the widget is checked by default or not.</p>
 
 <p>It's worth noting that these widgets do not behave exactly like other form widgets. For most form widgets, once the form is submitted all widgets that have a <a href="/en-US/docs/Web/HTML/Attributes/name"><code>name</code></a> attribute are sent, even if no value has been filled out. In the case of checkable items, their values are sent only if they are checked. If they are not checked, nothing is sent, not even their name. If they are checked but have no value, the name is sent with a value of <em>on.</em></p>
 

--- a/files/en-us/learn/server-side/django/authentication/index.html
+++ b/files/en-us/learn/server-side/django/authentication/index.html
@@ -699,7 +699,7 @@ def my_view(request):
 
 <ul>
  <li><a href="https://docs.djangoproject.com/en/3.1/topics/auth/">User authentication in Django</a> (Django docs)</li>
- <li><a href="https://docs.djangoproject.com/en/3.1/topics/auth/default//">Using the (default) Django authentication system</a> (Django docs)</li>
+ <li><a href="https://docs.djangoproject.com/en/3.1/topics/auth/default/">Using the (default) Django authentication system</a> (Django docs)</li>
  <li><a href="https://docs.djangoproject.com/en/3.1/topics/class-based-views/intro/#decorating-class-based-views">Introduction to class-based views &gt; Decorating class-based views</a> (Django docs)</li>
 </ul>
 

--- a/files/en-us/mdn/editor/basics/page_info/index.html
+++ b/files/en-us/mdn/editor/basics/page_info/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="New_pages">New pages</h2>
 
-<p>If you have the <a href="/MDN/Contribute/Howto/Create_and_edit_pages#Getting_page_creation_permission">page-creation permission</a>, you can create new pages. See <a href="/en-US/docs//MDN/Contribute/Howto/Create_and_edit_pages#Creating_a_new_page">How to create and edit pages</a> for various techniques for creating pages. For a new page, the page info fields look like this:</p>
+<p>If you have the <a href="/MDN/Contribute/Howto/Create_and_edit_pages#Getting_page_creation_permission">page-creation permission</a>, you can create new pages. See <a href="/en-US/docs/MDN/Contribute/Howto/Create_and_edit_pages#Creating_a_new_page">How to create and edit pages</a> for various techniques for creating pages. For a new page, the page info fields look like this:</p>
 
 <p><img alt="Page info fields for a new page" src="https://mdn.mozillademos.org/files/15265/New-page-info.png" style="border-style: solid; border-width: 2px; height: 214px; width: 739px;"></p>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/building_on_os2_using_mercurial/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/building_on_os2_using_mercurial/index.html
@@ -9,7 +9,7 @@ tags:
   - OS/2
 ---
 <h2 id="Required_Packages">Required Packages</h2>
-<p>To build code from Mercurial, you need all the tools listed in sections <a class="internal" href="/En/Developer_Guide/Build_Instructions/OS//2_Build_Prerequisites#Required_packages" title="OS/2 Build Prerequisites: Required Packages">Requires Packages</a> and <a class="internal" href="/En/Developer_Guide/Build_Instructions/OS//2_Build_Prerequisites#Compiler" title="OS/2 Build Prerequisites: Compiler">Compiler</a> of the <a class="internal" href="/En/Developer_Guide/Build_Instructions/OS//2_Build_Prerequisites#Required_packages" title="OS/2 Build Prerequisites">OS/2 Build Prerequisites</a>.</p>
+<p>To build code from Mercurial, you need all the tools listed in sections <a class="internal" href="/En/Developer_Guide/Build_Instructions/OS/2_Build_Prerequisites#Required_packages" title="OS/2 Build Prerequisites: Required Packages">Requires Packages</a> and <a class="internal" href="/En/Developer_Guide/Build_Instructions/OS/2_Build_Prerequisites#Compiler" title="OS/2 Build Prerequisites: Compiler">Compiler</a> of the <a class="internal" href="/En/Developer_Guide/Build_Instructions/OS/2_Build_Prerequisites#Required_packages">OS/2 Build Prerequisites</a>.</p>
 <ul> <li>Mercurial<br> The OS/2 version of this version control system is available from <a class="external" href="http://members.pcug.org.au/~andymac/packages/">Andrew McIntyres's</a> webpage.</li>
 </ul>
 <h2 id="Compiler" name="Compiler">Compiler</h2>

--- a/files/en-us/mozilla/firefox/releases/51/index.html
+++ b/files/en-us/mozilla/firefox/releases/51/index.html
@@ -121,7 +121,7 @@ tags:
  <li>Support for SHA-1 certificates from publicly-trusted certificate authorities has been removed ({{bug(1302140)}}). See also <a href="https://blog.mozilla.org/security/2016/10/18/phasing-out-sha-1-on-the-public-web/">Phasing Out SHA-1 on the Public Web</a> for more information.</li>
  <li>New WoSign and StartCom certificates will no longer be accepted ({{bug(1309707)}}), see <a href="https://blog.mozilla.org/security/2016/10/24/distrusting-new-wosign-and-startcom-certificates/">Distrusting New WoSign and StartCom Certificates</a> for more information.</li>
  <li>
-  <p>The <a href="/en-US/docs/Mozilla/Projects/Necko/Proxy_Auto-Configuration_(PAC)_file">PAC</a> <code>FindProxyForURL(url, host)</code> function now strips paths and queries from https:// URLs to avoid information leakage (see {{bug(1255474)}}, <a href="https://www.contextis.com//resources/blog/leaking-https-urls-20-year-old-vulnerability/">Sniffing HTTPS URLS with malicious PAC files</a>, or <code>CVE-2017-5384</code>).</p>
+  <p>The <a href="/en-US/docs/Mozilla/Projects/Necko/Proxy_Auto-Configuration_(PAC)_file">PAC</a> <code>FindProxyForURL(url, host)</code> function now strips paths and queries from https:// URLs to avoid information leakage (see {{bug(1255474)}}, <a href="https://www.contextis.com/resources/blog/leaking-https-urls-20-year-old-vulnerability/">Sniffing HTTPS URLS with malicious PAC files</a>, or <code>CVE-2017-5384</code>).</p>
  </li>
 </ul>
 

--- a/files/en-us/web/accessibility/aria/aria_screen_reader_implementors_guide/index.html
+++ b/files/en-us/web/accessibility/aria/aria_screen_reader_implementors_guide/index.html
@@ -24,4 +24,4 @@ tags:
  <li>Allow global settings to turn off the presentation of live changes, present all live changes, use markup, or be "smart" (use heuristics)</li>
 </ol>
 <h3 id="Details_for_Processing_via_Platform_Accessibility_APIs">Details for Processing via Platform Accessibility APIs</h3>
-<p>We hope browser manufacturers will work to provide consistent implementations. The most complete implementation of live regions currently is in Firefox 3.  Here is how <a href="/en/AJAX/WAI_ARIA_Live_Regions//API_Support" title="http://developer.mozilla.org/editor/fckeditor/core/editor/en/AJAX/WAI_ARIA_Live_Regions//API_Support">WAI-ARIA live regions are exposed in Firefox 3</a>.</p>
+<p>We hope browser manufacturers will work to provide consistent implementations. The most complete implementation of live regions currently is in Firefox 3.  Here is how <a href="/en/AJAX/WAI_ARIA_Live_Regions/API_Support">WAI-ARIA live regions are exposed in Firefox 3</a>.</p>

--- a/files/en-us/web/api/css_object_model/determining_the_dimensions_of_elements/index.html
+++ b/files/en-us/web/api/css_object_model/determining_the_dimensions_of_elements/index.html
@@ -38,5 +38,5 @@ tags:
 
 <ul>
  <li><a class="external" href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a></li>
- <li><a href="https://docs.microsoft.com/en-us/previous-versions//hh781509(v=vs.85)">MSDN: Measuring Element Dimension and Location</a></li>
+ <li><a href="https://docs.microsoft.com/en-us/previous-versions/hh781509(v=vs.85)">MSDN: Measuring Element Dimension and Location</a></li>
 </ul>

--- a/files/en-us/web/api/element/scrollheight/index.html
+++ b/files/en-us/web/api/element/scrollheight/index.html
@@ -167,7 +167,7 @@ onload = function () {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="https://docs.microsoft.com/en-us/previous-versions//hh781509(v=vs.85)">MSDN: Measuring Element Dimension and Location with CSSOM in Windows Internet Explorer 9</a></li>
+ <li><a href="https://docs.microsoft.com/en-us/previous-versions/hh781509(v=vs.85)">MSDN: Measuring Element Dimension and Location with CSSOM in Windows Internet Explorer 9</a></li>
  <li>{{domxref("Element.clientHeight")}}</li>
  <li>{{domxref("HTMLElement.offsetHeight")}}</li>
  <li><a href="/en-US/docs/Determining_the_dimensions_of_elements">Determining the dimensions of elements</a></li>

--- a/files/en-us/web/api/htmlelement/offsetheight/index.html
+++ b/files/en-us/web/api/htmlelement/offsetheight/index.html
@@ -69,5 +69,5 @@ tags:
  <li>{{domxref("Element.scrollHeight")}}</li>
  <li>{{domxref("HTMLElement.offsetWidth")}}</li>
  <li><a href="/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements" title="en/Determining_the_dimensions_of_elements">Determining the dimensions of elements</a></li>
- <li><a href="https://docs.microsoft.com/en-us/previous-versions//hh781509(v=vs.85)">MSDN Measuring Element Dimension and Location</a></li>
+ <li><a href="https://docs.microsoft.com/en-us/previous-versions/hh781509(v=vs.85)">MSDN Measuring Element Dimension and Location</a></li>
 </ul>

--- a/files/en-us/web/api/texttracklist/addtrack_event/index.html
+++ b/files/en-us/web/api/texttracklist/addtrack_event/index.html
@@ -78,7 +78,7 @@ mediaElement.textTracks.onaddtrack = (event) =&gt; {
 
 <ul>
  <li>Related events: <code><a href="/en-US/docs/Web/API/VideoTrackList/removetrack_event">removetrack</a></code>, <code><a href="/en-US/docs/Web/API/VideoTrackList/change_event">change</a></code></li>
- <li>This event on <code><a href="/en-US/docs/Web/API//VideoTrackList">VideoTrackList</a></code> targets: <code><a href="/en-US/docs/Web/API/VideoTrackList/addtrack_event">addtrack</a></code></li>
+ <li>This event on <code><a href="/en-US/docs/Web/API/VideoTrackList">VideoTrackList</a></code> targets: <code><a href="/en-US/docs/Web/API/VideoTrackList/addtrack_event">addtrack</a></code></li>
  <li>This event on <code><a href="/en-US/docs/Web/API/AudioTrackList">AudioTrackList</a></code> targets: <code><a href="/en-US/docs/Web/API/AudioTrackList/addtrack_event">addtrack</a></code></li>
  <li>This event on <code><a href="/en-US/docs/Web/API/MediaStream">MediaStream</a></code> targets: <code><a href="/en-US/docs/Web/API/MediaStream/addtrack_event">addtrack</a></code></li>
  <li><a href="/en-US/docs/Web/API/Media_Streams_API">Media Streams API</a></li>

--- a/files/en-us/web/css/css_columns/styling_columns/index.html
+++ b/files/en-us/web/css/css_columns/styling_columns/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="The_column-gap_property">The <code>column-gap</code> property</h2>
 
-<p>The gap between our columns is controlled by the <code>column-gap</code> property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in <a href="/en-US/docs//Web/CSS/CSS_Box_Alignment">Box Alignment</a> in order to unify gaps between boxes in other specifications such as <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">CSS Grid Layout</a>.</p>
+<p>The gap between our columns is controlled by the <code>column-gap</code> property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in <a href="/en-US/docs/Web/CSS/CSS_Box_Alignment">Box Alignment</a> in order to unify gaps between boxes in other specifications such as <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">CSS Grid Layout</a>.</p>
 
 <p>The initial value of <code>column-gap</code> in multicol is <code>1em</code>. This means your columns will not run into each other. In other layout methods the initial value for <code>column-gap</code> is 0. If you use the keyword value “normal” the gap will be set to 1em.</p>
 

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.html
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/flow/overflow/overflow.html", '100%', 700)}}</p>
 
-<p>The content goes into the box. Once it fills the box, it continues to overflow in a visible way, displaying content outside the box, potentially displaying under subsequent content. The property that controls how overflow behaves is the <code><a href="/en-US/docs//Web/CSS/overflow">overflow</a></code> property which has an initial value of <code>visible</code>. This is why we can see the overflow content.</p>
+<p>The content goes into the box. Once it fills the box, it continues to overflow in a visible way, displaying content outside the box, potentially displaying under subsequent content. The property that controls how overflow behaves is the <code><a href="/en-US/docs/Web/CSS/overflow">overflow</a></code> property which has an initial value of <code>visible</code>. This is why we can see the overflow content.</p>
 
 <h2 id="Controlling_overflow">Controlling overflow</h2>
 

--- a/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.html
+++ b/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.html
@@ -106,7 +106,7 @@ var newFragment = processor.transformToFragment(domToBeTransformed, ownerDocumen
 <h3 id="See_also" name="See_also">See also</h3>
 
 <ul>
- <li><a href="/en/The_XSLT//JavaScript_Interface_in_Gecko" title="en/The_XSLT//JavaScript_Interface_in_Gecko">The XSLT JavaScript Interface in Gecko</a></li>
+ <li><a href="/en/The_XSLT/JavaScript_Interface_in_Gecko">The XSLT JavaScript Interface in Gecko</a></li>
  <li><a href="/en/DOM/document.load" title="en/DOM/document.load">document.load()</a> regarding the loading of XML documents (as used above)</li>
 </ul>
 


### PR DESCRIPTION
Removed some duplicate titles when changing affected links