### PR TITLE
Add warmup function in WebExtensions browser.tabs page

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
@@ -26,10 +26,10 @@ tags:
    <li>In Firefox, this also means you need <code>"tabs"</code> to {{WebExtAPIRef("tabs.query()")}} by URL.</li>
   </ul>
  </li>
- <li>To use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}}, you must have the <a href="/en-US/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions">host permission</a> for the tab</li>
+ <li>To use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}}, you must have the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions">host permission</a> for the tab</li>
 </ul>
 
-<p>Alternatively, you can get these permissions temporarily, only for the currently active tab and only in response to an explicit user action, by asking for the <a href="/en-US/Add-ons/WebExtensions/manifest.json/permissions#activeTab_permission"><code>"activeTab"</code> permission</a>.</p>
+<p>Alternatively, you can get these permissions temporarily, only for the currently active tab and only in response to an explicit user action, by asking for the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activeTab_permission"><code>"activeTab"</code> permission</a>.</p>
 
 <p>Many tab operations use a Tab <code>id</code>. Tab <code>id</code>s are guaranteed to be unique to a single tab only within a browser session. If the browser is restarted, then it can and will reuse tab <code>id</code>s. To associate information with a tab across browser restarts, use {{WebExtAPIRef("sessions.setTabValue()")}}.</p>
 
@@ -89,7 +89,7 @@ tags:
  <dt>{{WebExtAPIRef("tabs.getAllInWindow()")}} {{deprecated_inline}}</dt>
  <dd>Gets details about all tabs in the specified window.</dd>
  <dt>{{WebExtAPIRef("tabs.getCurrent()")}}</dt>
- <dd>Gets information about the tab that this script is running in, as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Tabs/Tab" title="This type contains information about a tab."><code>tabs.Tab</code></a> object.</dd>
+ <dd>Gets information about the tab that this script is running in, as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab" title="This type contains information about a tab."><code>tabs.Tab</code></a> object.</dd>
  <dt>{{WebExtAPIRef("tabs.getSelected()")}} {{deprecated_inline}}</dt>
  <dd>Gets the tab that is selected in the specified window. <strong>Deprecated: use <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query" title="Gets all tabs that have the specified properties, or all tabs if no properties are specified."><code>tabs.query({active: true})</code></a> instead.</strong></dd>
  <dt>{{WebExtAPIRef("tabs.getZoom()")}}</dt>
@@ -171,6 +171,8 @@ tags:
  <dd>Fired when a tab is updated.</dd>
  <dt>{{WebExtAPIRef("tabs.onZoomChange")}}</dt>
  <dd>Fired when a tab is zoomed.</dd>
+ <dt>{{WebExtAPIRef("tabs.warmup")}}</dt>
+ <dd>Warm up a tab.</dd>
 </dl>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
@@ -26,10 +26,10 @@ tags:
    <li>In Firefox, this also means you need <code>"tabs"</code> to {{WebExtAPIRef("tabs.query()")}} by URL.</li>
   </ul>
  </li>
- <li>To use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}}, you must have the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions">host permission</a> for the tab</li>
+ <li>To use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}}, you must have the <a href="/en-US/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions">host permission</a> for the tab</li>
 </ul>
 
-<p>Alternatively, you can get these permissions temporarily, only for the currently active tab and only in response to an explicit user action, by asking for the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activeTab_permission"><code>"activeTab"</code> permission</a>.</p>
+<p>Alternatively, you can get these permissions temporarily, only for the currently active tab and only in response to an explicit user action, by asking for the <a href="/en-US/Add-ons/WebExtensions/manifest.json/permissions#activeTab_permission"><code>"activeTab"</code> permission</a>.</p>
 
 <p>Many tab operations use a Tab <code>id</code>. Tab <code>id</code>s are guaranteed to be unique to a single tab only within a browser session. If the browser is restarted, then it can and will reuse tab <code>id</code>s. To associate information with a tab across browser restarts, use {{WebExtAPIRef("sessions.setTabValue()")}}.</p>
 
@@ -140,6 +140,8 @@ tags:
  <dd>Toggles Reader mode for the specified tab.</dd>
  <dt>{{WebExtAPIRef("tabs.update()")}}</dt>
  <dd>Navigate the tab to a new URL, or modify other properties of the tab.</dd>
+ <dt>{{WebExtAPIRef("tabs.warmup")}}</dt>
+ <dd>Prepare the tab to make a potential following switch faster.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>
@@ -171,8 +173,6 @@ tags:
  <dd>Fired when a tab is updated.</dd>
  <dt>{{WebExtAPIRef("tabs.onZoomChange")}}</dt>
  <dd>Fired when a tab is zoomed.</dd>
- <dt>{{WebExtAPIRef("tabs.warmup")}}</dt>
- <dd>Warm up a tab.</dd>
 </dl>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.html
@@ -6,7 +6,6 @@ tags:
   - Add-ons
   - Extensions
   - Method
-  - Non-standard
   - Reference
   - WebExtensions
   - tabs

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.html
@@ -6,6 +6,7 @@ tags:
   - Add-ons
   - Extensions
   - Method
+  - Non-standard
   - Reference
   - WebExtensions
   - tabs


### PR DESCRIPTION
[`tabs.warmup()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/warmup) is not in the page for [`tabs`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs) right now, this fixes it.

- Fix links with flaw autofixer
- Also add “Non-standard” tag to `tabs.warmup` page