### PR TITLE
Fix “Older versions” in Firefox for developers pages starting with page version

### DIFF
--- a/files/en-us/mozilla/firefox/releases/64/index.html
+++ b/files/en-us/mozilla/firefox/releases/64/index.html
@@ -211,4 +211,4 @@ tags:
 
 <h2 id="Older_versions">Older versions</h2>
 
-<p>{{Firefox_for_developers(64)}}</p>
+<p>{{Firefox_for_developers(63)}}</p>

--- a/files/en-us/mozilla/firefox/releases/65/index.html
+++ b/files/en-us/mozilla/firefox/releases/65/index.html
@@ -242,4 +242,4 @@ tags:
 
 <h2 id="Older_versions">Older versions</h2>
 
-<p>{{Firefox_for_developers(65)}}</p>
+<p>{{Firefox_for_developers(64)}}</p>


### PR DESCRIPTION
Pages [Firefox/Releases/64#Older_versions](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/64#Older_versions) and [Firefox/Releases/65#Older_versions](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65#Older_versions) start their “Older versions” section with the same page that’s described in the page (that is, the first link point to the page itself), instead of starting the most recent previous version like other “Firefox for developers” pages. This fixes it.