### PR TITLE
Unbreak link to legacy generator function article

### DIFF
--- a/files/en-us/web/javascript/reference/operators/yield/index.html
+++ b/files/en-us/web/javascript/reference/operators/yield/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>The <code>yield</code> keyword is used to pause and resume a generator function ({{jsxref("Statements/function*", "function*")}} or <a href="/en-US/docs/Web/JavaScript/Reference/Statements/Legacy_generator_function">legacy generator function</a>).</p>
+<p>The <code>yield</code> keyword is used to pause and resume a generator function ({{jsxref("Statements/function*", "function*")}} or <a href="/en-US/docs/Archive/Web/JavaScript/Legacy_generator_function_statement">legacy generator function</a>).</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-yield.html", "taller")}}</div>
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/345

---

Alternatively, we can just remove the entire *or \_legacy generator function\_* part.