### PR TITLE
Change images height to preserve aspect ratio

### DIFF
--- a/files/en-us/tools/accessibility_inspector/index.html
+++ b/files/en-us/tools/accessibility_inspector/index.html
@@ -51,7 +51,7 @@ tags:
 
 <p>The enabled accessibility panel looks like so:</p>
 
-<p><img alt='Shows issue checker toolbar with "contrast and "text label" options' src="https://mdn.mozillademos.org/files/17437/Accessibility-Inspector-tabbing_order.png" style="border-style: solid; border-width: 1px; height: 427px; width: 1055px;"></p>
+<p><img alt='Shows issue checker toolbar with "contrast and "text label" options' src="https://mdn.mozillademos.org/files/17437/Accessibility-Inspector-tabbing_order.png" style="border-style: solid; border-width: 1px; width: 1055px;"></p>
 
 <p>On the left-hand side, there is a tree diagram representing all the items in the accessibility tree for the current page. Items with nested children have arrows that can be clicked to reveal the children, so you can move deeper into the hierarchy. Each item has two properties listed:</p>
 
@@ -95,11 +95,11 @@ tags:
 
 <p>You can print the contents of the accessibility tree to json by right-clicking on an entry in the Accessibility tab and selecting <strong>Print to JSON:</strong></p>
 
-<p><strong><img alt="Print to JSON right-click menu in left panel" src="https://mdn.mozillademos.org/files/17438/Accessibility-Inspector-print_tree_to_json.png" style="border-style: solid; border-width: 1px; height: 320px; width: 1055px;"></strong></p>
+<p><strong><img alt="Print to JSON right-click menu in left panel" src="https://mdn.mozillademos.org/files/17438/Accessibility-Inspector-print_tree_to_json.png" style="border-style: solid; border-width: 1px; width: 1055px;"></strong></p>
 
 <p>When you do, you will get a new tab with the selected accessibility tree loaded into the JSON viewer:</p>
 
-<p><img alt="" src="https://mdn.mozillademos.org/files/16424/accessibility_json.png" style="display: block; height: 586px; margin: 0px auto; width: 800px;"></p>
+<p><img alt="" src="https://mdn.mozillademos.org/files/16424/accessibility_json.png" style="display: block; margin: 0px auto; width: 800px;"></p>
 
 <p>Once opened, you can save or copy the data as necessary. The JSON viewer can also show you the raw JSON data on a separate tab in the viewer.</p>
 
@@ -109,10 +109,10 @@ tags:
 
 <p>Firefox 84 and later can enable a visual overlay showing the tabbing order. This provides a high-level overview of how the page will be navigated using the <kbd>tab</kbd> key, which may highlight problems more effectively than simply tabbing through the elements. The overlay is toggled on/off using the <strong>Show Tabbing Order</strong> checkbox.</p>
 
-<p><img alt="Accessibility inspector and page with checkbox Show tab order selected." src="https://mdn.mozillademos.org/files/17440/Accessibility-Inspector-show_tab_order.png" style="border-style: solid; border-width: 1px; height: 642px; width: 993px;"></p>
+<p><img alt="Accessibility inspector and page with checkbox Show tab order selected." src="https://mdn.mozillademos.org/files/17440/Accessibility-Inspector-show_tab_order.png" style="border-style: solid; border-width: 1px; width: 993px;"></p>
 
 <p>All focussable items have a numbered marker and the currently focussed item is highlighted in a different color. In some cases the marker may be hidden by other elements, as is true for items 1 and 2 in the in the page below.<br>
- <img alt="A page where some of the markers for selection items are hidden" src="https://mdn.mozillademos.org/files/17442/Accessibility-Inspector-hidden_items.png" style="height: 161px; width: 767px;"><br>
+ <img alt="A page where some of the markers for selection items are hidden" src="https://mdn.mozillademos.org/files/17442/Accessibility-Inspector-hidden_items.png" style="width: 767px;"><br>
  These become visible in the overlay when the item is the current item.</p>
 
 <p><img alt="Sshows a hidden selection item in the tabbing order overlay when it is selected." src="https://mdn.mozillademos.org/files/17443/Accessibility-Inspector-hidden_item_revealed.png"></p>
@@ -136,7 +136,7 @@ tags:
 <p>When you one of the menu items, Firefox scans your document for the type of issues you selected. Depending on the size and complexity of your document, this may take a few seconds. When the scan is complete, the left side of the Accessibility Inspector panel displays only the items that have that type of issue. In the right side of the panel, the <em>Checks</em> subpanel lists the specific issue with the selected node. For each type of issue, there is a <strong>Learn more</strong> link to further information on <em>MDN Web Docs</em> about the issue.</p>
 
 <p><br>
- <img alt="Accessibility Inspector - Showing the options when you select the Check for Issues button" src="https://mdn.mozillademos.org/files/17439/Accessibility-Inspector-check_for_issues.png" style="border-style: solid; border-width: 1px; height: 290px; width: 704px;"></p>
+ <img alt="Accessibility Inspector - Showing the options when you select the Check for Issues button" src="https://mdn.mozillademos.org/files/17439/Accessibility-Inspector-check_for_issues.png" style="border-style: solid; border-width: 1px; width: 704px;"></p>
 
 <p>The menu items act as toggles. Select the item to view that type of issue; select the item again to clear the display of issues of that type.</p>
 
@@ -154,9 +154,9 @@ tags:
 
 <p>An extra context menu option is added, both for the general context menu on the web page when right/<kbd>Ctrl</kbd> + clicking a UI feature, and the HTML pane of the page inspector when right/<kbd>Ctrl</kbd> + clicking a DOM element:</p>
 
-<p><img alt="context menu in the browser viewport, with a highlighted option: Inspect Accessibility Properties" src="https://mdn.mozillademos.org/files/16028/web-page-context-menu.png" style="border-style: solid; border-width: 1px; height: 798px; width: 1200px;"></p>
+<p><img alt="context menu in the browser viewport, with a highlighted option: Inspect Accessibility Properties" src="https://mdn.mozillademos.org/files/16028/web-page-context-menu.png" style="border-style: solid; border-width: 1px; width: 1200px;"></p>
 
-<p><img alt="context menu in the DOM inspector, with a highlighted option: Show Accessibility Properties" src="https://mdn.mozillademos.org/files/16020/dom-inspector-context-menu.png" style="border-style: solid; border-width: 1px; height: 803px; width: 1200px;"></p>
+<p><img alt="context menu in the DOM inspector, with a highlighted option: Show Accessibility Properties" src="https://mdn.mozillademos.org/files/16020/dom-inspector-context-menu.png" style="border-style: solid; border-width: 1px; width: 1200px;"></p>
 
 <p>When you choose the <em>Inspect Accessibility Properties</em>/<em>Show Accessibility Properties</em> context menu options, the <em>Accessibility</em> tab is immediately opened to show the corresponding accessibility tree item and its properties.</p>
 
@@ -184,7 +184,7 @@ tags:
 
 <p>As of Firefox 65, viewing this information for some foreground text that has a complex background image (e.g. a gradient) gives you a range of color contrast values. For example:</p>
 
-<p><img alt="A screenshot of colour contrast highlighter where for text over gradient background with contrast satisfying the AAA WCAG guidelines." src="https://mdn.mozillademos.org/files/16460/Screen_Shot_2019-01-29_at_10.21.07.png" style="display: block; height: 434px; margin: 0px auto; width: 1484px;"></p>
+<p><img alt="A screenshot of colour contrast highlighter where for text over gradient background with contrast satisfying the AAA WCAG guidelines." src="https://mdn.mozillademos.org/files/16460/Screen_Shot_2019-01-29_at_10.21.07.png" style="display: block; margin: 0px auto; width: 1484px;"></p>
 
 <p>In this example, the contrast ranges from 4.72 to 5.98. The numbers are followed by AAA and a checkmark in green, indicating that the large text has a contrast ratio of 4.5:1 or more, meeting the criteria for enhanced contrast, or Level AAA.</p>
 
@@ -196,9 +196,9 @@ tags:
 
 <p>The accessibility tab element picker looks slightly different from the Page Inspector HTML pane picker, as shown below:</p>
 
-<p><img alt="highlighted dom inspector picker button, with a tooltip saying Pick an element from the page" src="https://mdn.mozillademos.org/files/16024/dom-inspector-picker.png" style="border-style: solid; border-width: 1px; height: 677px; width: 1716px;"></p>
+<p><img alt="highlighted dom inspector picker button, with a tooltip saying Pick an element from the page" src="https://mdn.mozillademos.org/files/16024/dom-inspector-picker.png" style="border-style: solid; border-width: 1px; width: 1716px;"></p>
 
-<p><img alt="highlighted accessibility inspector button, with a tooltip saying Pick accessible object from the page" src="https://mdn.mozillademos.org/files/16023/accessibility-inspector-picker.png" style="border-style: solid; border-width: 1px; height: 677px; width: 1717px;"></p>
+<p><img alt="highlighted accessibility inspector button, with a tooltip saying Pick accessible object from the page" src="https://mdn.mozillademos.org/files/16023/accessibility-inspector-picker.png" style="border-style: solid; border-width: 1px; width: 1717px;"></p>
 
 <p>When you "perform a pick", you see the accessibility object highlighted in the accessibility tree, and the picker is then deactivated. Note, however, that if you hold the <kbd>Shift</kbd> key down when "performing a pick", you can "preview" the accessibility object in the tree (and its properties in the right-hand pane), but then continue picking as many times as you like (the picker does not get cancelled) until you release the <kbd>Shift</kbd> key.</p>
 
@@ -208,11 +208,11 @@ tags:
 
 <p>The Accessibility Inspector is very useful for spotting accessibility problems at a glance. For a start, you can investigate items that don't have a proper text equivalent — images without <code>alt</code> text and form elements without proper labels have a <code>name</code> property of <code>null</code>, for example.</p>
 
-<p><img alt="A form input highlighted in the UI, with information about it shown in the accessibility inspector to reveal that it has no label — it has a name property of null" src="https://mdn.mozillademos.org/files/16027/use-case-no-label.png" style="border-style: solid; border-width: 1px; height: 1180px; width: 1182px;"></p>
+<p><img alt="A form input highlighted in the UI, with information about it shown in the accessibility inspector to reveal that it has no label — it has a name property of null" src="https://mdn.mozillademos.org/files/16027/use-case-no-label.png" style="border-style: solid; border-width: 1px; width: 1182px;"></p>
 
 <p>It is also very handy for verifying semantics — you can use the <em>Inspect Accessibility Properties</em> context menu option to quickly see whether an item has the correct role set on it (e.g., whether a button is really a button, or a link is really a link).</p>
 
-<p><img alt="A UI element that looks like a button, with information about it shown in the accessibility inspector to reveal that it isn't a button, it is a section element. It has a name property of null" src="https://mdn.mozillademos.org/files/16026/use-case-fake-button.png" style="border-style: solid; border-width: 1px; height: 1180px; width: 1182px;"></p>
+<p><img alt="A UI element that looks like a button, with information about it shown in the accessibility inspector to reveal that it isn't a button, it is a section element. It has a name property of null" src="https://mdn.mozillademos.org/files/16026/use-case-fake-button.png" style="border-style: solid; border-width: 1px; width: 1182px;"></p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
The images on this page are stretched because their height is not match their aspect ratio. By removing their height, it fixed them.