### PR TITLE
Fix capitalization and style of TextMetrics reference

### DIFF
--- a/files/en-us/web/api/textmetrics/index.html
+++ b/files/en-us/web/api/textmetrics/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
-<p>The <strong><code>TextMetrics</code></strong> interface represents the dimensions of a piece of text in the canvas; a <code>textMetrics()</code> instance can be retrieved using the {{domxref("CanvasRenderingContext2D.measureText()")}} method.</p>
+<p>The <strong><code>TextMetrics</code></strong> interface represents the dimensions of a piece of text in the canvas; a <code>TextMetrics</code> instance can be retrieved using the {{domxref("CanvasRenderingContext2D.measureText()")}} method.</p>
 
 <h2 id="Properties">Properties</h2>
 


### PR DESCRIPTION
textMetrics() is not a method, and nothing with that capitalization exists on the platform.