### PR TITLE
Add docs for Canvas2D.getContextAttributes

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.html
@@ -1,0 +1,81 @@
+---
+title: CanvasRenderingContext2D.getContextAttributes()
+slug: Web/API/CanvasRenderingContext2D/getContextAttributes
+tags:
+  - API
+  - Method
+  - Reference
+  - Canvas
+  - CanvasRenderingContext2D
+---
+<div>{{APIRef("WebGL")}}</div>
+
+<p>The <code><strong>CanvasRenderingContext2D.getContextAttributes()</strong></code> method 
+returns an object that contains the actual context parameters. Context attributes can be requested with 
+<a href="/en-US/docs/Web/API/HTMLCanvasElement/getContext"><code>HTMLCanvasElement.getContext()</code></a>
+on context creation.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox"><var><em>ctx</em></var>.getContextAttributes();</pre>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>A <code>CanvasRenderingContext2DSettings</code> object that contains the actual context parameters.
+It has the following members:</p>
+<dl>
+    <dt><code>alpha</code></dt>
+    <dd>A Boolean indicating if the canvas contains an alpha channel. 
+        If <code>false</code>, the backdrop is always opaque, which can speed up drawing 
+        of transparent content and images.</dd>
+    <dt><code>desynchronized</code></dt>
+    <dd>A Boolean indicating the user agent reduced the latency by desynchronizing 
+        the canvas paint cycle from the event loop.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Given context attributes were provided on context creation using
+<a href="/en-US/docs/Web/API/HTMLCanvasElement/getContext"><code>HTMLCanvasElement.getContext()</code></a></p>
+
+<pre class="brush: js">
+let canvas = document.createElement('canvas');
+let ctx = canvas.getContext('2d', {alpha: false});
+</pre>
+
+<p>the <code>getContextAttributes()</code> method lets you read back actual attributes used by
+the user agent:</p>
+
+<pre class="brush: js">
+ctx.getContextAttributes();
+// returns {alpha: false, desynchronized: false}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName("HTML WHATWG", "#dom-context-2d-canvas-getcontextattributes", "CanvasRenderingContext2D.getContextAttributes")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p class="hidden">The compatibility table in this page is generated from structured data. 
+If you'd like to contribute to the data, please check out 
+<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+and send us a pull request.</p>
+
+<p>{{Compat("api.CanvasRenderingContext2D.getContextAttributes")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTMLCanvasElement/getContext"><code>HTMLCanvasElement.getContext()</code></a></li>
+ <li><a href="/en-US/docs/Web/API/WebGLRenderingContext/getContextAttributes"><code>WebGLRenderingContext.getContextAttributes()</code></a></li>
+</ul>

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.html
@@ -271,6 +271,8 @@ ctx.stroke();
  <dd>Restores the drawing style state to the last element on the 'state stack' saved by <code>save()</code>.</dd>
  <dt>{{domxref("CanvasRenderingContext2D.canvas")}}</dt>
  <dd>A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be {{jsxref("null")}} if it is not associated with a {{HTMLElement("canvas")}} element.</dd>
+ <dt>{{domxref("CanvasRenderingContext2D.getContextAttributes()")}}</dt>
+ <dd>Returns an object containing the actual context attributes. Context attributes can be requested with {{domxref("HTMLCanvasElement.getContext()")}}.</dd>
 </dl>
 
 <h3 id="Hit_regions">Hit regions</h3>

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.html
@@ -139,6 +139,8 @@ console.log(ctx); // CanvasRenderingContext2D { ... }
 <h2 id="See_also">See also</h2>
 
 <ul>
+ <li>{{domxref("CanvasRenderingContext2D.getContextAttributes()")}}</li>
+ <li>{{domxref("WebGLRenderingContext.getContextAttributes()")}}</li>
  <li>The interface defining it, {{domxref("HTMLCanvasElement")}}.</li>
  <li>{{domxref("OffscreenCanvas.getContext()")}}</li>
  <li>Available rendering contexts: {{domxref("CanvasRenderingContext2D")}}, {{domxref("WebGLRenderingContext")}} and {{domxref("WebGL2RenderingContext")}} and {{domxref("ImageBitmapRenderingContext")}}.</li>

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.html
@@ -82,5 +82,6 @@ gl.getContextAttributes();
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{domxref("WebGLRenderingContext")}}</li>
+ <li>{{domxref("HTMLCanvasElement.getContext()")}}</li>
+ <li>{{domxref("CanvasRenderingContext2D.getContextAttributes()")}}</li>
 </ul>


### PR DESCRIPTION
Spec: https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-canvas-getcontextattributes
I'm correcting the compat data in https://github.com/mdn/browser-compat-data/pull/7983