### PR TITLE
Add HTMLTableElement.createTBody() page

### DIFF
--- a/files/en-us/web/api/htmltableelement/createtbody/index.html
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p>The <code><strong>HTMLTableElement.createTBody()</strong></code> method creates and returns a new {{HTMLElement("tbody")}} element associated with a given {{HtmlElement("table")}}.</p>
+<p>The <code><strong>createTBody()</strong></code> method of {{domxref("HTMLTableElement")}} objects creates and returns a new {{HTMLElement("tbody")}} element associated with a given {{HtmlElement("table")}}.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> Unlike {{domxref("HTMLTableElement.createTHead()")}} and {{domxref("HTMLTableElement.createTFoot()")}}, <code>createTBody()</code> systematically creates a new <code>&lt;tbody&gt;</code> element, even if the table already contains one or more bodies. If so, the new one is inserted after the existing ones.</p>

--- a/files/en-us/web/api/htmltableelement/createtbody/index.html
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.html
@@ -1,0 +1,58 @@
+---
+title: HTMLTableElement.createTBody()
+slug: Web/API/HTMLTableElement/createTBody
+tags:
+  - API
+  - HTML DOM
+  - HTMLTableElement
+  - Method
+  - NeedsSpecTable
+  - Reference
+---
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p>The <code><strong>HTMLTableElement.createTBody()</strong></code> method creates and returns a new {{HTMLElement("tbody")}} element associated with a given {{HtmlElement("table")}}.</p>
+
+<div class="notecard note">
+<p><strong>Note:</strong> Unlike {{domxref("HTMLTableElement.createTHead()")}} and {{domxref("HTMLTableElement.createTFoot()")}}, <code>createTBody()</code> systematically creates a new <code>&lt;tbody&gt;</code> element, even if the table already contains one or more bodies. If so, the new one is inserted after the existing ones.</p>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox"><em>HTMLTableSectionElement</em> = <em>table</em>.createTBody();</pre>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>{{domxref("HTMLTableSectionElement")}}</p>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush:js">let mybody = mytable.createTBody();
+// Now this should be true: mybody == mytable.tBodies.item(mytable.tBodies.length - 1)</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('HTML WHATWG', '#dom-table-createtbody', 'HTMLTableElement: createTBody')}}</td>
+   <td>{{Spec2('HTML WHATWG')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>
+
+
+<p>{{Compat("api.HTMLTableElement.createTBody")}}</p>
+</div>

--- a/files/en-us/web/api/htmltableelement/createtbody/index.html
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.html
@@ -1,5 +1,5 @@
 ---
-title: HTMLTableElement.createTBody()
+title: 'HTMLTableElement: createTBody()'
 slug: Web/API/HTMLTableElement/createTBody
 tags:
   - API
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><em>HTMLTableSectionElement</em> = <em>table</em>.createTBody();</pre>
+<pre class="syntaxbox"><var>table</var>.createTBody();</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p>The <code><strong>HTMLTableElement.createTFoot()</strong></code> method returns the {{HTMLElement("tfoot")}} element associated with a given {{HtmlElement("table")}}. If no footer exists in the table, this methods creates it, and then returns it.</p>
+<p>The <code><strong>HTMLTableElement.createTFoot()</strong></code> method returns the {{HTMLElement("tfoot")}} element associated with a given {{HtmlElement("table")}}. If no footer exists in the table, this method creates it, and then returns it.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> If no footer exists, <code>createTFoot()</code> inserts a new footer directly into the table. The footer does not need to be added separately as would be the case if {{domxref("Document.createElement()")}} had been used to create the new <code>&lt;tfoot&gt;</code> element.</p>

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.html
@@ -1,5 +1,5 @@
 ---
-title: HTMLTableElement.createTFoot()
+title: 'HTMLTableElement: createTFoot()'
 slug: Web/API/HTMLTableElement/createTFoot
 tags:
   - API
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p>The <code><strong>HTMLTableElement.createTFoot()</strong></code> method returns the {{HTMLElement("tfoot")}} element associated with a given {{HtmlElement("table")}}. If no footer exists in the table, this method creates it, and then returns it.</p>
+<p>The <code><strong>createTFoot()</strong></code> method of {{domxref("HTMLTableElement")}} objects returns the {{HTMLElement("tfoot")}} element associated with a given {{HtmlElement("table")}}. If no footer exists in the table, this method creates it, and then returns it.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> If no footer exists, <code>createTFoot()</code> inserts a new footer directly into the table. The footer does not need to be added separately as would be the case if {{domxref("Document.createElement()")}} had been used to create the new <code>&lt;tfoot&gt;</code> element.</p>
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><em>HTMLTableSectionElement</em> = <em>table</em>.createTFoot();</pre>
+<pre class="syntaxbox"><var>table</var>.createTFoot();</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/api/htmltableelement/createthead/index.html
+++ b/files/en-us/web/api/htmltableelement/createthead/index.html
@@ -1,5 +1,5 @@
 ---
-title: HTMLTableElement.createTHead()
+title: 'HTMLTableElement: createTHead()'
 slug: Web/API/HTMLTableElement/createTHead
 tags:
   - API
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p>The <code><strong>HTMLTableElement.createTHead()</strong></code> method returns the {{HTMLElement("thead")}} element associated with a given {{HtmlElement("table")}}. If no header exists in the table, this method creates it, and then returns it.</p>
+<p>The <code><strong>createTHead()</strong></code> method of {{domxref("HTMLTableElement")}} objects returns the {{HTMLElement("thead")}} element associated with a given {{HtmlElement("table")}}. If no header exists in the table, this method creates it, and then returns it.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> If no header exists, <code>createTHead()</code> inserts a new header directly into the table. The header does not need to be added separately as would be the case if {{domxref("Document.createElement()")}} had been used to create the new <code>&lt;thead&gt;</code> element.</p>
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><em>HTMLTableSectionElement</em> = <em>table</em>.createTHead();</pre>
+<pre class="syntaxbox"><var>table</var>.createTHead();</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/api/htmltableelement/createthead/index.html
+++ b/files/en-us/web/api/htmltableelement/createthead/index.html
@@ -9,7 +9,7 @@ tags:
   - NeedsSpecTable
   - Reference
 ---
-<div>{{APIRef}}</div>
+<div>{{APIRef("HTML DOM")}}</div>
 
 <p>The <code><strong>HTMLTableElement.createTHead()</strong></code> method returns the {{HTMLElement("thead")}} element associated with a given {{HtmlElement("table")}}. If no header exists in the table, this method creates it, and then returns it.</p>
 

--- a/files/en-us/web/api/htmltableelement/index.html
+++ b/files/en-us/web/api/htmltableelement/index.html
@@ -65,13 +65,15 @@ tags:
 
 <dl>
  <dt>{{DOMxRef("HTMLTableElement.createTHead()")}}</dt>
- <dd>Returns an {{DOMxRef("HTMLElement")}} representing the first {{HTMLElement("thead")}} that is a child of the element. If none is found, a new one is created and inserted in the tree immediately before the first element that is neither a {{HTMLElement("caption")}}, nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element.</dd>
+ <dd>Returns an {{DOMxRef("HTMLTableSectionElement")}} representing the first {{HTMLElement("thead")}} that is a child of the element. If none is found, a new one is created and inserted in the tree immediately before the first element that is neither a {{HTMLElement("caption")}}, nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element.</dd>
  <dt>{{DOMxRef("HTMLTableElement.deleteTHead()")}}</dt>
  <dd>Removes the first {{HTMLElement("thead")}} that is a child of the element.</dd>
  <dt>{{DOMxRef("HTMLTableElement.createTFoot()")}}</dt>
- <dd>Returns an {{DOMxRef("HTMLElement")}} representing the first {{HTMLElement("tfoot")}} that is a child of the element. If none is found, a new one is created and inserted in the tree immediately before the first element that is neither a {{HTMLElement("caption")}}, a {{HTMLElement("colgroup")}}, nor a {{HTMLElement("thead")}}, or as the last child if there is no such element.</dd>
+ <dd>Returns an {{DOMxRef("HTMLTableSectionElement")}} representing the first {{HTMLElement("tfoot")}} that is a child of the element. If none is found, a new one is created and inserted in the tree as the last child.</dd>
  <dt>{{DOMxRef("HTMLTableElement.deleteTFoot()")}}</dt>
  <dd>Removes the first {{HTMLElement("tfoot")}} that is a child of the element.</dd>
+ <dt>{{DOMxRef("HTMLTableElement.createTBody()")}}</dt>
+ <dd>Returns a {{DOMxRef("HTMLTableSectionElement")}} representing a new {{HTMLElement("tbody")}} that is a child of the element. It is inserted in the tree after the last element that is a {{HTMLElement("tbody")}}, or as the last child if there is no such element.</dd>
  <dt>{{DOMxRef("HTMLTableElement.createCaption()")}}</dt>
  <dd>Returns an {{DOMxRef("HTMLElement")}} representing the first {{HTMLElement("caption")}} that is a child of the element. If none is found, a new one is created and inserted in the tree as the first child of the {{HTMLElement("table")}} element.</dd>
  <dt>{{DOMxRef("HTMLTableElement.deleteCaption()")}}</dt>


### PR DESCRIPTION
This PR adds a page about the `HTMLTableElement.createTBody()` method, and a link to it in the `HTMLTableElement` page.

This also fixes the description of the `HTMLTableElement.createTFoot()`.

The compatibility table about the `HTMLTableElement.createTBody()` method was already available.