### PR TITLE
Clarify what happens when th scope attribute is not specified

### DIFF
--- a/files/en-us/web/html/element/th/index.html
+++ b/files/en-us/web/html/element/th/index.html
@@ -78,10 +78,8 @@ tags:
   <li><code>col</code>: The header relates to all cells of the column it belongs to.</li>
   <li><code>rowgroup</code>: The header belongs to a rowgroup and relates to all of its cells. These cells can be placed to the right or the left of the header, depending on the value of the <code><a href="/en-US/docs/Web/HTML/Global_attributes/dir">dir</a></code> attribute in the {{HTMLElement("table")}} element.</li>
   <li><code>colgroup</code>: The header belongs to a colgroup and relates to all of its cells.</li>
-  <li><code>auto</code></li>
  </ul>
-
- <p>The default value when this attribute is not specified is <code>auto</code>.</p>
+ If the <code>scope</code> attribute is not specified, or its value is not <code>row</code>, <code>col</code>, or <code>rowgroup</code>, or <code>colgroup</code>, then browsers automatically select the set of cells to which the header cell applies.
  </dd>
 </dl>
 


### PR DESCRIPTION
This change refines the description of the `scope` attribute of the `th` element to explain what happens when no `scope` attribute is specified at all (what the HTML spec calls the *auto* state).

The change also corrects an existing error: `auto` isn’t actually an allowed value for the `scope` attribute; instead *auto* is just an abstract/internal value which the spec requires tools to use in the case where there’s no explicit value, or the value is invalid.

Fixes https://github.com/mdn/content/issues/362