### PR TITLE
Fix typo in padding doc

### DIFF
--- a/files/en-us/web/css/padding/index.html
+++ b/files/en-us/web/css/padding/index.html
@@ -29,7 +29,7 @@ tags:
 <ul>
  <li>{{cssxref("padding-bottom")}}</li>
  <li>{{cssxref("padding-left")}}</li>
- <li>{{cssxref("padding-right")}}}</li>
+ <li>{{cssxref("padding-right")}}</li>
  <li>{{cssxref("padding-top")}}</li>
 </ul>
 


### PR DESCRIPTION
Remove redundant bracket after "padding right".