### PR TITLE
remove unnecessary style attributes from <h3> tags

### DIFF
--- a/files/en-us/glossary/distributed_denial_of_service/index.html
+++ b/files/en-us/glossary/distributed_denial_of_service/index.html
@@ -30,9 +30,9 @@ tags:
  <li>Longterm denial of access to the Web or any internet services</li>
 </ul>
 
-<h3 id="Learn_more" style="line-height: 24px;"><strong style="font-size: 2.142857142857143rem; font-weight: 700; letter-spacing: -1px; line-height: 30px;">Learn more</strong></h3>
+<h3 id="Learn_more">Learn more</strong></h3>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{interwiki("wikipedia", "Denial-of-service_attack", "Denial-of-service attack")}} on Wikipedia</li>

--- a/files/en-us/glossary/microsoft_internet_explorer/index.html
+++ b/files/en-us/glossary/microsoft_internet_explorer/index.html
@@ -20,7 +20,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px; font-size: 1.71428571428571rem;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{interwiki("wikipedia", "Internet Explorer", "Internet Explorer")}} on Wikipedia</li>
@@ -28,7 +28,7 @@ tags:
  <li>{{interwiki("wikipedia", "Internet Explorer versions", "Internet Explorer versions")}} on Wikipedia</li>
 </ul>
 
-<h3 id="Learning_About_Internet_Explorer" style="line-height: 24px; font-size: 1.71428571428571rem;">Learning About Internet Explorer</h3>
+<h3 id="Learning_About_Internet_Explorer">Learning About Internet Explorer</h3>
 
 <ul>
  <li><a href="http://windows.microsoft.com/en-us/internet-explorer/download-ie">http://windows.microsoft.com/en-us/internet-explorer/download-ie</a></li>
@@ -37,7 +37,7 @@ tags:
  <li><a href="http://windows.microsoft.com/en-us/internet-explorer/make-ie-default-browser#ie=ie-11">http://windows.microsoft.com/en-us/internet-explorer/make-ie-default-browser#ie=ie-11</a></li>
 </ul>
 
-<h3 id="Technical_reference" style="line-height: 24px; font-size: 1.71428571428571rem;">Technical reference</h3>
+<h3 id="Technical_reference">Technical reference</h3>
 
 <ul>
  <li><a href="http://windows.microsoft.com/en-us/internet-explorer/products/ie-8/system-requirements">http://windows.microsoft.com/en-us/internet-explorer/products/ie-8/system-requirements</a></li>

--- a/files/en-us/glossary/nan/index.html
+++ b/files/en-us/glossary/nan/index.html
@@ -13,9 +13,9 @@ tags:
 
 <p>Practically speaking, if I divide two variables in a {{glossary("JavaScript")}} program, the result may be NaN, which is predefined in JavaScript as "undefined". Hence this division may break the program. Now, if this computation was a small part of a much larger algorithm, it would be really painful to figure out where the error actually occurs. Fortunately, since the result will be NaN and I know my divisor may turn out to be 0, I can set up testing conditions that prevent any such computations in the first place or notify me of where they happen.</p>
 
-<h2 id="Learn_more" style="line-height: 30px;">Learn more</h2>
+<h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "NaN")}} on Wikipedia</li>

--- a/files/en-us/glossary/openssl/index.html
+++ b/files/en-us/glossary/openssl/index.html
@@ -9,7 +9,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "OpenSSL")}} on Wikipedia</li>

--- a/files/en-us/glossary/statement/index.html
+++ b/files/en-us/glossary/statement/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p>In a computer programming language, a <strong>s</strong><strong>tatement</strong> is a line of code commanding a task. <span style="line-height: 1.5;">Every program consists of a sequence of statements.</span></p>
 
-<h2 id="Learn_more" style="line-height: 30px; font-size: 2.14285714285714rem;">Learn more</h2>
+<h2 id="Learn_more">Learn more</h2>
 
 <h3 id="General_knowledge">General knowledge</h3>
 

--- a/files/en-us/glossary/tld/index.html
+++ b/files/en-us/glossary/tld/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;"><strong>General knowledge</strong></h3>
+<h3 id="General_knowledge"><strong>General knowledge</strong></h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "TLD")}} on Wikipedia</li>

--- a/files/en-us/glossary/urn/index.html
+++ b/files/en-us/glossary/urn/index.html
@@ -11,7 +11,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "URN")}} on Wikipedia</li>

--- a/files/en-us/glossary/usenet/index.html
+++ b/files/en-us/glossary/usenet/index.html
@@ -9,7 +9,7 @@ tags:
 
 <h2 id="Learn_more" style="line-height: 30px;">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;"><strong>General knowledge</strong></h3>
+<h3 id="General_knowledge"><strong>General knowledge</strong></h3>
 
 <div> </div>
 

--- a/files/en-us/glossary/validator/index.html
+++ b/files/en-us/glossary/validator/index.html
@@ -10,7 +10,7 @@ tags:
 
 <h2 id="Learn_more"><strong style="font-size: 2.142857142857143rem; font-weight: 700; letter-spacing: -1px; line-height: 30px;">Learn more</strong></h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "Validator")}} on Wikipedia</li>

--- a/files/en-us/glossary/w3c/index.html
+++ b/files/en-us/glossary/w3c/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li><a href="https://www.w3.org/">W3C website</a></li>

--- a/files/en-us/glossary/wcag/index.html
+++ b/files/en-us/glossary/wcag/index.html
@@ -21,7 +21,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "Web Content Accessibility Guidelines", "WCAG")}} on Wikipedia</li>

--- a/files/en-us/glossary/web_standards/index.html
+++ b/files/en-us/glossary/web_standards/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "Web standards")}} on Wikipedia</li>

--- a/files/en-us/glossary/webgl/index.html
+++ b/files/en-us/glossary/webgl/index.html
@@ -18,14 +18,14 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "WebGL")}} on Wikipedia</li>
  <li><a href="http://get.webgl.org/">Check for WebGL support</a></li>
 </ul>
 
-<h3 id="Technical_Article" style="line-height: 24px;">Technical Article</h3>
+<h3 id="Technical_Article">Technical Article</h3>
 
 <ul>
  <li><a href="/en-US/docs/Web/WebGL">WebGL on MDN</a></li>

--- a/files/en-us/glossary/webkit/index.html
+++ b/files/en-us/glossary/webkit/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "WebKit")}} on Wikipedia</li>

--- a/files/en-us/glossary/websockets/index.html
+++ b/files/en-us/glossary/websockets/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "Websocket")}} on Wikipedia</li>

--- a/files/en-us/glossary/whatwg/index.html
+++ b/files/en-us/glossary/whatwg/index.html
@@ -15,7 +15,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_Knowledge" style="line-height: 24px;">General Knowledge</h3>
+<h3 id="General_Knowledge">General Knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "WHATWG")}} on Wikipedia</li>

--- a/files/en-us/glossary/world_wide_web/index.html
+++ b/files/en-us/glossary/world_wide_web/index.html
@@ -32,7 +32,7 @@ tags:
  <li><a href="https://learning.mozilla.org/web-literacy">Web literacy map</a> (an inventory of skills needed in Web development)</li>
 </ul>
 
-<h3 id="General_knowledge" style="line-height: 24px;">General knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "World Wide Web")}} on Wikipedia</li>

--- a/files/en-us/glossary/xslt/index.html
+++ b/files/en-us/glossary/xslt/index.html
@@ -13,7 +13,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="Technical_reference" style="line-height: 24px;">Technical reference</h3>
+<h3 id="Technical_reference">Technical reference</h3>
 
 <ul>
  <li>{{Interwiki("wikipedia", "XSLT")}} on Wikipedia</li>

--- a/files/en-us/web/api/idbcursorwithvalue/value/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/value/index.html
@@ -24,7 +24,7 @@ tags:
 
 <pre class="syntaxbox" style="font-size: 14px;">var value = myIDBCursorWithValue.value;</pre>
 
-<h3 id="Value" style="line-height: 24px; font-size: 1.71428571428571rem;">Value</h3>
+<h3 id="Value">Value</h3>
 
 <p>The value of the current cursor.</p>
 

--- a/files/en-us/web/api/idbfactory/open/index.html
+++ b/files/en-us/web/api/idbfactory/open/index.html
@@ -35,7 +35,7 @@ tags:
 var <em>IDBOpenDBRequest</em> = <em>indexedDB</em>.open(<em>name</em>, <em>version</em>);
 </pre>
 
-<h3 id="Parameters" style="line-height: 30px; font-size: 2.14286rem;">Parameters</h3>
+<h3 id="Parameters">Parameters</h3>
 
 <dl>
  <dt>name</dt>

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.html
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>This would be easy if we were just comparing two {{jsxref("Global_Objects/Date", "Date")}} objects, but of course humans don't want to enter deadline information in the same format JavaScript understands. Human-readable dates are quite different, with a number of different representations.</p>
 
-<h3 id="Recording_the_date_information" style="">Recording the date information</h3>
+<h3 id="Recording_the_date_information">Recording the date information</h3>
 
 <p>To provide a reasonable user experience on mobile devices, and to cut down on ambiguities, I decided to create an HTML form with:</p>
 

--- a/files/en-us/web/api/webvr_api/concepts/index.html
+++ b/files/en-us/web/api/webvr_api/concepts/index.html
@@ -129,7 +129,7 @@ tags:
 
 <p><img alt="How to create stereoscopic 3D images" src="https://mdn.mozillademos.org/files/11095/createStereoscopicImages.png" style="width: 100%;"></p>
 
-<h3 id="Head_tracking" style="line-height: 24px; font-size: 1.71428571428571rem;">Head tracking</h3>
+<h3 id="Head_tracking">Head tracking</h3>
 
 <p>The primary technology used to make you feel present in a 360º scene, thanks to the gyroscope, accelerometer, and magnetometer (compass) included in the HMD.<br>
  It has primary relevance because it makes our eyes believe we are in front of a spherical screen, giving users realistic immersion inside the app canvas.</p>

--- a/files/en-us/web/media/formats/containers/index.html
+++ b/files/en-us/web/media/formats/containers/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>In other cases, a particular codec, stored in a certain container type, is so ubiquitous that the pairing is treated in a unique fashion. A good example of this is the MP3 audio file, which is in fact an MPEG-1 container with a single audio track encoded using MPEG-1 Audio Layer III encoding. These files use the <code>audio/mp3</code> MIME type and the <code>.mp3</code> extension, even though their containers are just MPEG.</p>
 
-<h3 id="Index_of_media_container_formats_file_types" style="font-size: 1.4em;">Index of media container formats (file types)</h3>
+<h3 id="Index_of_media_container_formats_file_types">Index of media container formats (file types)</h3>
 
 <p>To learn more about a specific container format, find it in this list and click through to the details, which include information about what the container is typically useful for, what codecs it supports, and which browsers support it, among other specifics.</p>
 


### PR DESCRIPTION
Before:
<img width="999" alt="Screen Shot 2020-12-17 at 4 48 18 PM" src="https://user-images.githubusercontent.com/26739/102548699-08f67980-4089-11eb-85e2-f31660481431.png">


After:
<img width="811" alt="Screen Shot 2020-12-17 at 4 57 48 PM" src="https://user-images.githubusercontent.com/26739/102548680-0136d500-4089-11eb-9b6c-f7b9a709422b.png">

Yeah, virtually no difference. But most importantly, we shouldn't be using these inline styles in the first place. It's just weird and it's best to control that from a global stylesheet. 