### PR TITLE
Barcode supported formats updates

### DIFF
--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -13,13 +13,15 @@ tags:
 
 <p class="summary">The Barcode Detection API detects linear and two-dimensional barcodes in images.</p>
 
-<h2 id="Concepts_and_Usage">Concepts and Usage</h2>
+<h2 id="Concepts_and_usage">Concepts and usage</h2>
 
 <p>Support for barcode recognition within web apps unlocks a variety of use cases through supported barcode formats. QR codes can be used for online payments, web navigation or establishing social media connections, aztec codes can be used to scan boarding passes and shopping apps can use EAN or UPC barcodes to compare prices of physical items.</p>
 
 <p>Detection is achieved through the {{domxref('BarcodeDetector.detect()','detect()')}} method, which takes an image object; either an {{HTMLElement('img', ' element')}}, a {{domxref('Blob')}}, {{domxref('ImageData')}} or a {{domxref('CanvasImageSource')}}. Optional parameters can be passed to the {{domxref('BarcodeDetector')}} constructor to provide hints on which barcode formats to detect.</p>
 
-<p>The Barcode Detection API supports the following formats of barcodes:</p>
+<h3 id="Supported_barcode_formats">Supported barcode formats</h3>
+
+<p>The Barcode Detection API supports the following barcode formats:</p>
 
 <table class="standard-table">
  <thead>
@@ -33,67 +35,67 @@ tags:
   <tr>
    <td>aztec</td>
    <td>A square two-dimensional matrix following iso24778 and with a square bullseye pattern at their centre, thus resembling an Aztec pyramid. Does not require a surrounding blank zone.</td>
-   <td><img alt="A sample image of an aztec barcode. A square with smaller black and white squares inside" src="https://mdn.mozillademos.org/files/17417/aztec.gif" style="height: 200px; width: 200px;"></td>
+   <td><img alt="A sample image of an aztec barcode. A square with smaller black and white squares inside" src="https://mdn.mozillademos.org/files/17417/aztec.gif" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>code_128</td>
    <td>A linear (one-dimensional), bidirectionally-decodable, self-checking barcode following iso15417 and able to encode all 128 characters of ASCII (hence the naming).</td>
-   <td><img alt="An image of a code-128 barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17418/code-128.gif" style="height: 96px; width: 300px;"></td>
+   <td><img alt="An image of a code-128 barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17418/code-128.gif" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>code_39</td>
    <td>A linear (one-dimensional), self-checking barcode following iso16388. It is a discrete and variable-length barcode type.</td>
-   <td><img alt="An image of a code-39 barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17419/code-39.png" style="height: 120px; width: 300px;"></td>
+   <td><img alt="An image of a code-39 barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17419/code-39.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>code_93</td>
    <td>A linear, continuous symbology with a variable length following bc5. It offers a larger information density than Code 128 and the visually similar Code 39. Code 93 is used primarily by Canada Post to encode supplementary delivery information.</td>
-   <td><img alt="An image of a code 93 format barcode. A horizontal distribution of white and black horizontal lines" src="https://mdn.mozillademos.org/files/17421/code-93.png" style="height: 125px; width: 300px;"></td>
+   <td><img alt="An image of a code 93 format barcode. A horizontal distribution of white and black horizontal lines" src="https://mdn.mozillademos.org/files/17421/code-93.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>codabar</td>
    <td>A linear barcode representing characters 0-9, A-D and symbols - . $ / +</td>
-   <td><img alt="An image of a codabar format barcode. A horizontal distribution of black and white vertical lines" src="https://mdn.mozillademos.org/files/17420/codabar.png" style="height: 87px; width: 300px;"></td>
+   <td><img alt="An image of a codabar format barcode. A horizontal distribution of black and white vertical lines" src="https://mdn.mozillademos.org/files/17420/codabar.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>data_matrix</td>
    <td>An orientation-independent two-dimensional barcode composed of black and white modules arranged in either a square or rectangular pattern following iso16022.</td>
-   <td><img alt="An example of a data matrix barcode. A square filled with smaller black and white squares" src="https://mdn.mozillademos.org/files/17422/data-matrix.png" style="height: 307px; width: 300px;"></td>
+   <td><img alt="An example of a data matrix barcode. A square filled with smaller black and white squares" src="https://mdn.mozillademos.org/files/17422/data-matrix.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>ean_13</td>
    <td>A linear barcode based on the UPC-A standard and defined in iso15420.</td>
-   <td><img alt="An image of an EAN-13 format barcode. A horizontal distribution of white and black lines" src="https://mdn.mozillademos.org/files/17424/EAN-13.png" style="height: 164px; width: 300px;"></td>
+   <td><img alt="An image of an EAN-13 format barcode. A horizontal distribution of white and black lines" src="https://mdn.mozillademos.org/files/17424/EAN-13.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>ean_8</td>
    <td>A linear barcode defined in iso15420 and derived from EAN-13.</td>
-   <td><img alt="An image of an EAN-8 format barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17423/EAN-8.png" style="height: 241px; width: 300px;"></td>
+   <td><img alt="An image of an EAN-8 format barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17423/EAN-8.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>itf</td>
    <td>A continuous, self-checking, bidirectionally decodable barcode. It will always encode 14 digits.</td>
-   <td><img alt="An image of an ITF Barcode. A horizontal distribution of white and black lines" src="https://mdn.mozillademos.org/files/17425/ift.png" style="height: 148px; width: 300px;"></td>
+   <td><img alt="An image of an ITF Barcode. A horizontal distribution of white and black lines" src="https://mdn.mozillademos.org/files/17425/ift.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>pdf417</td>
    <td>A continuous two-dimensional barcode symbology format with multiple rows and columns. It's bi-directionally decodable and uses the iso15438 standard.</td>
-   <td><img alt="An example of a pdf417 barcode format. A rectangle of smaller black and white squares" src="https://mdn.mozillademos.org/files/17426/pdf417.png" style="height: 131px; width: 300px;"></td>
+   <td><img alt="An example of a pdf417 barcode format. A rectangle of smaller black and white squares" src="https://mdn.mozillademos.org/files/17426/pdf417.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>qr_code</td>
    <td>A two-dimensional barcode that uses the iso18004 standard. The information encoded can be text, URL or other data.</td>
-   <td><img alt="An example of a QR code. A square of smaller black and white squares" src="https://mdn.mozillademos.org/files/17427/qr-code.png" style="height: 302px; width: 302px;"></td>
+   <td><img alt="An example of a QR code. A square of smaller black and white squares" src="https://mdn.mozillademos.org/files/17427/qr-code.png" style="width: 302px;"></td>
   </tr>
   <tr>
    <td>upc_a</td>
    <td>One of the most common linear barcode types and is widely applied to retail in the United States. Defined in iso15420, it represents digits by strips of bars and spaces, each digit being associated to a unique pattern of 2 bars and 2 spaces, both of variable width. UPC-A can encode 12 digits that are uniquely assigned to each trade item, and it’s technically a subset of EAN-13 (UPC-A codes are represented in EAN-13 with the first character set to 0).</td>
-   <td><img alt="An image of a upc-a barcode. A rectangle of black and white vertical lines with numbers underneath" src="https://mdn.mozillademos.org/files/17428/upc-a.png" style="height: 164px; width: 300px;"></td>
+   <td><img alt="An image of a upc-a barcode. A rectangle of black and white vertical lines with numbers underneath" src="https://mdn.mozillademos.org/files/17428/upc-a.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>upc_e</td>
    <td>A variation of UPC-A defined in iso15420, compressing out unnecessary zeros for a more compact barcode.</td>
-   <td><img alt="An image of a upc-e barcode. A rectangle of black and white vertical lines" src="https://mdn.mozillademos.org/files/17429/upc-e.png" style="height: 210px; width: 300px;"></td>
+   <td><img alt="An image of a upc-e barcode. A rectangle of black and white vertical lines" src="https://mdn.mozillademos.org/files/17429/upc-e.png" style="width: 300px;"></td>
   </tr>
   <tr>
    <td>unknown</td>

--- a/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
-<p class="summary">The <strong><code>getSupportedFormats()</code></strong> method of the {{domxref("BarcodeDetector")}} interface returns a {{jsxref('Promise')}} which fulfills with an {{jsxref('Array')}} of supported barcode format types.</p>
+<p class="summary">The <strong><code>getSupportedFormats()</code></strong> static method of the {{domxref("BarcodeDetector")}} interface returns a {{jsxref('Promise')}} which fulfills with an {{jsxref('Array')}} of supported barcode format types.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -22,91 +22,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>An {{jsxref('Array')}} of supported format types.</p>
-
-<p>Below is a list of supported barcode formats:</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Format</th>
-   <th>Description</th>
-   <th>Image</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>aztec</td>
-   <td>A square two-dimensional matrix following iso24778 and with a square bullseye pattern at their centre, thus resembling an Aztec pyramid. Does not require a surrounding blank zone.</td>
-   <td><img alt="A sample image of an aztec barcode. A square with smaller black and white squares inside" src="https://mdn.mozillademos.org/files/17417/aztec.gif" style="height: 200px; width: 200px;"></td>
-  </tr>
-  <tr>
-   <td>code_128</td>
-   <td>A linear (one-dimensional), bidirectionally-decodable, self-checking barcode following iso15417 and able to encode all 128 characters of ASCII (hence the naming).</td>
-   <td><img alt="An image of a code-128 barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17418/code-128.gif" style="height: 96px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>code_39</td>
-   <td>A linear (one-dimensional), self-checking barcode following iso16388. It is a discrete and variable-length barcode type.</td>
-   <td><img alt="An image of a code-39 barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17419/code-39.png" style="height: 120px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>code_93</td>
-   <td>A linear, continuous symbology with a variable length following bc5. It offers a larger information density than Code 128 and the visually similar Code 39. Code 93 is used primarily by Canada Post to encode supplementary delivery information.</td>
-   <td><img alt="An image of a code 93 format barcode. A horizontal distribution of white and black horizontal lines" src="https://mdn.mozillademos.org/files/17421/code-93.png" style="height: 125px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>codabar</td>
-   <td>A linear barcode representing characters 0-9, A-D and symbols - . $ / +</td>
-   <td><img alt="An image of a codabar format barcode. A horizontal distribution of black and white vertical lines" src="https://mdn.mozillademos.org/files/17420/codabar.png" style="height: 87px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>data_matrix</td>
-   <td>An orientation-independent two-dimensional barcode composed of black and white modules arranged in either a square or rectangular pattern following iso16022.</td>
-   <td><img alt="An example of a data matrix barcode. A square filled with smaller black and white squares" src="https://mdn.mozillademos.org/files/17422/data-matrix.png" style="height: 307px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>ean_13</td>
-   <td>A linear barcode based on the UPC-A standard and defined in iso15420.</td>
-   <td><img alt="An image of an EAN-13 format barcode. A horizontal distribution of white and black lines" src="https://mdn.mozillademos.org/files/17424/EAN-13.png" style="height: 164px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>ean_8</td>
-   <td>A linear barcode defined in iso15420 and derived from EAN-13.</td>
-   <td><img alt="An image of an EAN-8 format barcode. A horizontal distribution of vertical black and white lines" src="https://mdn.mozillademos.org/files/17423/EAN-8.png" style="height: 241px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>itf</td>
-   <td>A continuous, self-checking, bidirectionally decodable barcode. It will always encode 14 digits.</td>
-   <td><img alt="An image of an ITF Barcode. A horizontal distribution of white and black lines" src="https://mdn.mozillademos.org/files/17425/ift.png" style="height: 148px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>pdf417</td>
-   <td>A continuous two-dimensional barcode symbology format with multiple rows and columns. It's bi-directionally decodable and uses the iso15438 standard.</td>
-   <td><img alt="An example of a pdf417 barcode format. A rectangle of smaller black and white squares" src="https://mdn.mozillademos.org/files/17426/pdf417.png" style="height: 131px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>qr_code</td>
-   <td>A two-dimensional barcode that uses the iso18004 standard. The information encoded can be text, URL or other data.</td>
-   <td><img alt="An example of a QR code. A square of smaller black and white squares" src="https://mdn.mozillademos.org/files/17427/qr-code.png" style="height: 302px; width: 302px;"></td>
-  </tr>
-  <tr>
-   <td>upc_a</td>
-   <td>One of the most common linear barcode types and is widely applied to retail in the United States. Defined in iso15420, it represents digits by strips of bars and spaces, each digit being associated to a unique pattern of 2 bars and 2 spaces, both of variable width. UPC-A can encode 12 digits that are uniquely assigned to each trade item, and it’s technically a subset of EAN-13 (UPC-A codes are represented in EAN-13 with the first character set to 0).</td>
-   <td><img alt="An image of a upc-a barcode. A rectangle of black and white vertical lines with numbers underneath" src="https://mdn.mozillademos.org/files/17428/upc-a.png" style="height: 164px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>upc_e</td>
-   <td>A variation of UPC-A defined in iso15420, compressing out unnecessary zeros for a more compact barcode.</td>
-   <td><img alt="An image of a upc-e barcode. A rectangle of black and white vertical lines" src="https://mdn.mozillademos.org/files/17429/upc-e.png" style="height: 210px; width: 300px;"></td>
-  </tr>
-  <tr>
-   <td>unknown</td>
-   <td>This value is used by the platform to signify that it does not know or specify which barcode format is being detected or supported.</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>An {{jsxref('Array')}} of <a href="/en-US/docs/Web/API/Barcode_Detection_API#Supported_barcode_formats">supported barcode format types</a>.</p>
 
 <h3 id="Exceptions">Exceptions</h3>
 
@@ -114,11 +30,11 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example calls the <code>getSupportFormat()</code> method and logs the results to the console.</p>
+<p>The following example calls the <code>getSupportFormat()</code> static method and logs the results to the console.</p>
 
 <pre class="brush: js notranslate">// check supported types
-barcodeDetector.getSupportedFormats()
-  .then(formats =&gt; {
+BarcodeDetector.getSupportedFormats()
+  .then(supportedFormats =&gt; {
     supportedFormats.forEach(format =&gt; console.log(format));
   });</pre>
 

--- a/files/en-us/web/api/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/index.html
@@ -32,7 +32,7 @@ tags:
  </ul>
  </dd>
  <dt>{{domxref('BarcodeDetector.getSupportedFormats', 'getSupportedFormats()')}}</dt>
- <dd>Returns a {{jsxref('Promise')}} which fulfills with an {{jsxref('Array')}} of supported barcode format types.</dd>
+ <dd>Returns a {{jsxref('Promise')}} which fulfills with an {{jsxref('Array')}} of supported <a href="/en-US/docs/Web/API/Barcode_Detection_API#Supported_barcode_formats">barcode format types</a>.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -53,10 +53,10 @@ if (barcodeDetector) {
 
 <h3 id="Getting_Supported_Formats">Getting Supported Formats</h3>
 
-<p>The following example calls the <code>getSupportFormat()</code> method and logs the results to the console.</p>
+<p>The following example calls the <code>getSupportFormat()</code> static method and logs the results to the console.</p>
 
 <pre class="brush: js notranslate">// check supported types
-barcodeDetector.getSupportedFormats()
+BarcodeDetector.getSupportedFormats()
   .then(formats =&gt; {
     supportedFormats.forEach(format =&gt; console.log(format));
   });</pre>


### PR DESCRIPTION
This fixes/improves Barcode Detection API docs:
- Adds heading in the API level docs for supported formats. 
- Duplicate table of formats removed from getSupportedFormats() doc, whih now links to above barcode API doc (as do other areas that mention the supported formats).
- Examples of gettingsupported formats now refer to the static method.

Note that the redirects in some pages aren't working from the sidebar "Barcode Detector API" macro. I have asked for a rename in https://github.com/mdn/yari/pull/2202