### PR TITLE
Normalize on “stylable” (not “styleable”)

### DIFF
--- a/files/en-us/learn/css/building_blocks/styling_tables/index.html
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.html
@@ -77,7 +77,7 @@ tags:
   &lt;/tfoot&gt;
 &lt;/table&gt;</pre>
 
-<p>The table is nicely marked up, easily styleable, and accessible, thanks to features such as {{htmlattrxref("scope","th")}}, {{htmlelement("caption")}}, {{htmlelement("thead")}}, {{htmlelement("tbody")}}, etc. Unfortunately, it doesn't look good when rendered on the screen (see it live at <a href="https://mdn.github.io/learning-area/css/styling-boxes/styling-tables/punk-bands-unstyled.html">punk-bands-unstyled.html</a>):</p>
+<p>The table is nicely marked up, easily stylable, and accessible, thanks to features such as {{htmlattrxref("scope","th")}}, {{htmlelement("caption")}}, {{htmlelement("thead")}}, {{htmlelement("tbody")}}, etc. Unfortunately, it doesn't look good when rendered on the screen (see it live at <a href="https://mdn.github.io/learning-area/css/styling-boxes/styling-tables/punk-bands-unstyled.html">punk-bands-unstyled.html</a>):</p>
 
 <p><img alt="" src="https://mdn.mozillademos.org/files/13064/table-unstyled.png" style="display: block; margin: 0 auto;"></p>
 

--- a/files/en-us/learn/forms/advanced_form_styling/index.html
+++ b/files/en-us/learn/forms/advanced_form_styling/index.html
@@ -462,7 +462,7 @@ button {
 
 <p>Inputs of type file are generally OK — as you saw in our example, it is fairly easy to create something that fits in OK with the rest of the page — the output line that is part of the control will inherit the parent font if you tell the input to do so, and you can style the custom list of file names and sizes in any way you want; we created it after all.</p>
 
-<p>The only problem with file pickers is that the button provided that you press to open the file picker is completely unstyleable — it can't be sized or colored, and it won't even accept a different font.</p>
+<p>The only problem with file pickers is that the button provided that you press to open the file picker is completely unstylable — it can't be sized or colored, and it won't even accept a different font.</p>
 
 <p>One way around this is to take advantage of the fact that if you have a label associated with a form control, clicking the label will activate the control. So you could hide the actual from input using something like this:</p>
 

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.html
@@ -262,13 +262,13 @@ button:active {
 <p><strong>Note</strong>: Sitepoint's <span class="l-d-i l-pa2 t-bg-white"><a href="https://www.sitepoint.com/web-foundations/internet-explorer-conditional-comments/">Internet Explorer Conditional Comments</a> provides a useful beginner's tutorial/reference that explains the conditional comment syntax in detail.</span></p>
 </div>
 
-<p>As you can see, this is especially useful for applying code fixes to old versions of IE. The use case we mentioned earlier (making modern semantic elements styleable in old versions of IE) can be achieved easily using conditional comments, for example you could put something like this in your IE stylesheet:</p>
+<p>As you can see, this is especially useful for applying code fixes to old versions of IE. The use case we mentioned earlier (making modern semantic elements stylable in old versions of IE) can be achieved easily using conditional comments, for example you could put something like this in your IE stylesheet:</p>
 
 <pre class="brush: css">aside, main, article, section, nav, figure, figcaption {
   display: block;
 }</pre>
 
-<p>It isn't that simple, however — you also need to create a copy of each element you want to style in the DOM via JavaScript, for them to be styleable; this is a strange quirk, and we won't bore you with the details here. For example:</p>
+<p>It isn't that simple, however — you also need to create a copy of each element you want to style in the DOM via JavaScript, for them to be stylable; this is a strange quirk, and we won't bore you with the details here. For example:</p>
 
 <pre class="brush: js">const asideElem = document.createElement('aside');
  ...</pre>


### PR DESCRIPTION
This change replaces all instances of “styleable” in MDN content with “stylable”. Otherwise, without this change, the content is inconsistent in that some articles have “stylable” while others have “styleable” (and we even have one article which uses both “stylable” and “unstyleable” within the same article).

---

https://developer.mozilla.org/en-US/docs/Learn/Forms/Advanced_form_styling is the article that has both “stylable” and “unstyleable”. (I noticed it while looking at https://github.com/mdn/content/issues/396.)

I don’t have any strong opinion about “stylable” being better than “styleable” — so this patch could actually be amended to do the reverse, if we decide that’s better.

The reasons I chose “styleable” is that there are slightly more instances of it in existing MDN content, and also because we have a standard (though obsolete) interface, https://developer.mozilla.org/en-US/docs/Web/API/SVGStylable that has “stylable” in its name.