### PR TITLE
moved example to css-examples

### DIFF
--- a/files/en-us/web/css/font-variant-numeric/index.html
+++ b/files/en-us/web/css/font-variant-numeric/index.html
@@ -85,34 +85,7 @@ font-variant-numeric: unset;
 
 <h3 id="Setting_ordinal_numeric_forms">Setting ordinal numeric forms</h3>
 
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html notranslate">&lt;p class="ordinal"&gt;1st, 2nd, 3rd, 4th, 5th&lt;/p&gt;</pre>
-
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css notranslate">/*
-This example uses the Source Sans Pro OpenType font, developed by Adobe
-and used here under the terms of the SIL Open Font License, Version 1.1:
-http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web
-*/
-
-@font-face {
-  font-family: "Source Sans Pro";
-  font-style: normal;
-  font-weight: 400;
-  src: url("https://mdn.mozillademos.org/files/15757/SourceSansPro-Regular.otf") format("opentype");
-}
-
-.ordinal {
-  font-variant-numeric: ordinal;
-  font-family: "Source Sans Pro";
-}
-</pre>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample('Setting_ordinal_numeric_forms')}}</p>
+<p>{{EmbedGHLiveSample("css-examples/font-features/font-variant-numeric-example.html", '100%', 600)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes #340 

Example was showing a CORS error so recreated the example in the css-examples repo and this PR embeds it.