### PR TITLE
Drop reference to DPR HTTP header in CORS article

### DIFF
--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -78,7 +78,6 @@ tags:
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (but note the additional requirements below)</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
    <li>{{HTTPHeader("Downlink")}}</li>
    <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
    <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>


### PR DESCRIPTION
This change removes the `DPR` HTTP header from the set of headers which the https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS article cites as being defined as “CORS-safelisted request-headers” — because at https://fetch.spec.whatwg.org/#cors-safelisted-request-header, the Fetch spec no longer includes the `DPR` header among that set. Fixes https://github.com/mdn/content/issues/399