### PR TITLE
Do not escape hyphens in escape regex function

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.html
@@ -127,7 +127,7 @@ tags:
 <p>If escape strings are not already part of your pattern you can add them using {{jsxref('String.replace')}}:</p>
 
 <pre class="brush: js notranslate">function escapeRegExp(string) {
-  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&amp;'); // $&amp; means the whole matched string
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&amp;'); // $&amp; means the whole matched string
 }
 </pre>
 


### PR DESCRIPTION
Escaping hyphens does not seem necessary, as hyphens only have to be escaped within character classes (https://stackoverflow.com/questions/9589074/regex-should-hyphens-be-escaped), and character classes won't exist after escaping as we escape [ and ] already.
In fact, escaping hyphens causes problems when the regex uses the unicode flag as `\-` is an invalid escape sequence then.