### PR TITLE
Align “CORS-safelisted request-header” def w/ spec

### DIFF
--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -78,10 +78,6 @@ tags:
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (but note the additional requirements below)</li>
-   <li>{{HTTPHeader("Downlink")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>The only allowed values for the {{HTTPHeader("Content-Type")}} header are:


### PR DESCRIPTION
This change aligns the definition of “CORS-safelisted request-header” in https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS with the current definition in the Fetch spec; specifically, it drops the Client Hints headers Save-Data, Viewport-Width, and Width (the DPR header was dropped in a previous revision). Fixes https://github.com/mdn/content/issues/399