### PR TITLE
Drop references to now-unspecified DPR HTTP header

### DIFF
--- a/files/en-us/glossary/client_hints/index.html
+++ b/files/en-us/glossary/client_hints/index.html
@@ -8,17 +8,17 @@ tags:
   - Reference
   - Web Performance
 ---
-<p><span class="seoSummary"><strong>Client Hints </strong>are a set of <a href="/en-US/docs/Web/HTTP/Headers">HTTP request header</a> fields for proactive content negotiation allowing clients to indicate a list of device and agent specific preferences. </span><a href="/en-US/docs/Web/HTTP/Headers#Client_hints">Client Hints</a> enable automated delivery of optimized assets like the automatic negotiation of image <abbr title="device pixel ratio">DPR</abbr> resolution. </p>
+<p><span class="seoSummary"><strong>Client Hints </strong>are a set of <a href="/en-US/docs/Web/HTTP/Headers">HTTP request header</a> fields for proactive content negotiation allowing clients to indicate a list of device and agent specific preferences.</span></p>
 
 <p>Use of client hints isn't automatic: rather, servers must announce that they support client hints. Servers announce support for Client Hints using the <code><a href="https://tools.ietf.org/html/draft-grigorik-http-client-hints-03#section-2.2.1">Accept-CH</a></code> (accept client hints) header or an equivalent HTML meta element with the <code><a href="/en-US/docs/Web/HTML/Element/meta#Attributes">http-equiv</a></code> attribute.</p>
 
-<p><code>Accept-CH: <abbr title="device pixel ratio">DPR</abbr>, Width, Viewport-Width, Downlink</code></p>
+<p><code>Accept-CH: Width, Viewport-Width, Downlink</code></p>
 
 <p>and / or</p>
 
-<p><code>&lt;meta http-equiv="Accept-CH" content="<abbr title="device pixel ratio">DPR</abbr>, Width, Viewport-Width, Downlink</code><code>"&gt;</code></p>
+<p><code>&lt;meta http-equiv="Accept-CH" content="Width, Viewport-Width, Downlink</code><code>"&gt;</code></p>
 
-<p>When a client receives the <code>Accept-CH</code> header, if supported, it appends Client Hint headers that match the advertised field-values. For example, based on Accept-CH example above, the client could append DPR, Width, Viewport-Width, and Downlink headers to all subsequent requests. In the second example, the server gives the browser the hints by setting the Accept-CH meta tag.</p>
+<p>When a client receives the <code>Accept-CH</code> header, if supported, it appends Client Hint headers that match the advertised field-values. For example, based on Accept-CH example above, the client could append Width, Viewport-Width, and Downlink headers to all subsequent requests. In the second example, the server gives the browser the hints by setting the Accept-CH meta tag.</p>
 
 <p>Basically, with the Client Hints header, the developer or application can tell the browser to advertise information about itself to the server, such as the device pixel ratio, the viewport width, and the display width. The client can then give the server information about the client's environment, and the server can determine which resources to send based on that information.</p>
 
@@ -28,7 +28,7 @@ tags:
 
 <p id="Example_varying_response">Example varying response:</p>
 
-<p><code>Vary: Accept, <abbr title="device pixel ratio">DPR</abbr>, Width, Viewport-Width, Downlink</code></p>
+<p><code>Vary: Accept, Width, Viewport-Width, Downlink</code></p>
 
 <h2 id="See_Also">See Also</h2>
 

--- a/files/en-us/web/http/content_negotiation/index.html
+++ b/files/en-us/web/http/content_negotiation/index.html
@@ -75,10 +75,6 @@ tags:
    <td>Indicates the approximate amount of device RAM. This value is an approximation given by rounding to the nearest power of 2 and dividing that number by 1024. For example, 512 megabytes will be reported as <code>0.5</code>.</td>
   </tr>
   <tr>
-   <td><code>DPR</code></td>
-   <td>Indicates the client's device pixel ratio.</td>
-  </tr>
-  <tr>
    <td><code>Viewport-Width</code></td>
    <td>Indicates the layout viewport width in CSS pixels.</td>
   </tr>

--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.html
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.html
@@ -34,7 +34,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre>Accept-CH: Viewport-Width, DPR
+<pre>Accept-CH: Viewport-Width
 Accept-CH-Lifetime: 86400
 </pre>
 

--- a/files/en-us/web/http/headers/accept-ch/index.html
+++ b/files/en-us/web/http/headers/accept-ch/index.html
@@ -34,10 +34,10 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre>Accept-CH: DPR, Viewport-Width
+<pre>Accept-CH: Viewport-Width
 Accept-CH: Width
 Accept-CH-Lifetime: 86400
-Vary: DPR, Viewport-Width, Width
+Vary: Viewport-Width, Width
 </pre>
 
 <div class="notecard note">

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -5,10 +5,14 @@ tags:
   - Client hints
   - HTTP
   - HTTP Header
+  - Obsolete
+  - Non-standard
 ---
+<div>{{Obsolete_header}}{{Non-standard_header}}</div>
+
 <div>{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> headers which represents the client device pixel ratio ({{Glossary("DPR")}}), which is the number of physical device pixels corresponding to every CSS pixel.</p>
+<p>The <strong><code>DPR</code></strong> header is a <a href="/en-US/docs/Glossary/Client_hints">Client Hints</a> header which represents the client device pixel ratio ({{Glossary("DPR")}}), which is the number of physical device pixels corresponding to every CSS pixel.</p>
 
 <table class="properties">
  <tbody>

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -85,10 +85,6 @@ tags:
  <dd>Servers can ask the client to remember the set of Client Hints that the server supports for a specified period of time, to enable delivery of Client Hints on subsequent requests to the server’s origin (<a href="https://httpwg.org/http-extensions/client-hints.html#RFC6454"><cite>[RFC6454]</cite></a>).</dd>
  <dt>{{HTTPHeader("Early-Data")}} {{experimental_inline}}</dt>
  <dd>Indicates that the request has been conveyed in early data.</dd>
- <dt>{{HTTPHeader("Content-DPR")}} {{experimental_inline}}</dt>
- <dd>A number that indicates the ratio between physical pixels over CSS pixels of the selected image response.</dd>
- <dt>{{HTTPHeader("DPR")}} {{experimental_inline}}</dt>
- <dd>A number that indicates the client’s current Device Pixel Ratio (DPR), which is the ratio of physical pixels over CSS pixels (Section 5.2 of <a href="https://httpwg.org/http-extensions/client-hints.html#CSSVAL"><cite>[CSSVAL]</cite></a>) of the layout viewport (Section 9.1.1 of <a href="https://httpwg.org/http-extensions/client-hints.html#CSS2"><cite>[CSS2]</cite></a>) on the device.</dd>
  <dt>{{HTTPHeader("Device-Memory")}} {{experimental_inline}}</dt>
  <dd>Technically a part of Device Memory API, this header represents an approximate amount of RAM client has.</dd>
  <dt>{{HTTPHeader("Save-Data")}} {{experimental_inline}}</dt>


### PR DESCRIPTION
This change drops all references in all MDN content to the DPR HTTP header. The DPR HTTP header is now completely unspecified; that is, it is no longer defined in any current specification.

So this change also marks the web/http/headers/dpr article with Obsolete and Non-standard notices and tags.

---

DPR was specified in the “HTTP Client Hints” Internet Draft up to version 06:

https://tools.ietf.org/html/draft-ietf-httpbis-client-hints-06#section-6.4

But https://tools.ietf.org/html/draft-ietf-httpbis-client-hints-07 and later versions of that dropped the DPR header completely — and I can’t find any other current specification that it might have been moved to. Maybe @igrigorik can clarify.

So also now https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR should probably be archived — but we can deal with that in a follow-up PR.