### PR TITLE
Update index.html: Mobile accessibility checklist

### DIFF
--- a/files/en-us/web/accessibility/mobile_accessibility_checklist/index.html
+++ b/files/en-us/web/accessibility/mobile_accessibility_checklist/index.html
@@ -12,27 +12,27 @@ tags:
 <p><span class="seoSummary">This document provides a concise checklist of accessibility requirements for mobile app developers. It is intended to continuously evolve as more patterns arise.</span></p>
 </div>
 
-<h2 id="Colour">Colour</h2>
+<h2 id="Colour">Color</h2>
 
 <ul>
-	<li>Colour contrast <strong>MUST</strong> comply with <a href="https://www.w3.org/TR/WCAG/#contrast-minimum">WCAG 2.1 AA level requirements</a>:
+	<li>Color contrast must comply with <a href="https://www.w3.org/TR/WCAG/#contrast-minimum">WCAG 2.1 AA level requirements</a>:
 
 	<ul>
 		<li>Contrast ratio of 4.5:1 for normal text (less than 18 point or 14 point bold.)</li>
 		<li>Contrast ratio of 3:1 for large text (at least 18 point or 14 point bold.)</li>
 	</ul>
 	</li>
-	<li>Information conveyed via colour <strong>MUST</strong> be also available by other means too (underlined text for links, etc.)</li>
+	<li>Information conveyed via color must be also available by other means too (underlined text for links, etc.)</li>
 </ul>
 
 <h2 id="Visibility">Visibility</h2>
 
 <ul>
-	<li>Content hiding techniques such as zero opacity, z-index order and off-screen placement <strong>MUST NOT</strong> be used exclusively to handle visibility.</li>
-	<li>Everything other than the currently visible screen <strong>MUST</strong> be <em>truly</em> invisible (especially relevant for single page apps with multiple <em>cards</em>):
+	<li>Content hiding techniques such as zero opacity, z-index order and off-screen placement must not be used exclusively to handle visibility.</li>
+	<li>Everything other than the currently visible screen must be <em>truly</em> invisible (especially relevant for single page apps with multiple <em>cards</em>):
 	<ul>
-		<li><strong>USE</strong> the <code>hidden</code> attribute or <code>visibility</code> or <code>display</code> style properties.</li>
-		<li>Unless absolutely unavoidable, <code>aria-hidden</code> attribute <strong>SHOULD NOT</strong> be used.</li>
+		<li>Use the <code>hidden</code> attribute or <code>visibility</code> or <code>display</code> style properties.</li>
+		<li>Unless absolutely unavoidable, <code>aria-hidden</code> attribute should not be used.</li>
 	</ul>
 	</li>
 </ul>
@@ -40,32 +40,32 @@ tags:
 <h2 id="Focus">Focus</h2>
 
 <ul>
-	<li>All activatable elements <strong>MUST</strong> be focusable:
+	<li>All activatable elements must be focusable:
 
 	<ul>
 		<li>Standard controls such as links, buttons, and form fields are focusable by default.</li>
-		<li>Non-standard controls <strong>MUST</strong> have an appropriate <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">ARIA Role</a> assigned to them, such as <code>button</code>, <code>link</code>, or <code>checkbox</code>.</li>
+		<li>Non-standard controls must have an appropriate <a href="/en-US/docs/Web/Accessibility/ARIA/Roles">ARIA Role</a> assigned to them, such as <code>button</code>, <code>link</code>, or <code>checkbox</code>.</li>
 	</ul>
 	</li>
 	<li>Focus should be handled in a logical order and consistent manner.</li>
 </ul>
 
-<h2 id="Text_Equivalents">Text Equivalents</h2>
+<h2 id="Text_Equivalents">Text equivalents</h2>
 
 <ul>
-	<li>Text equivalent <strong>MUST</strong> be provided for every non-strictly presentational non-text element within the app.
+	<li>Text equivalent must be provided for every non-strictly presentational non-text element within the app.
 
 	<ul>
 		<li>Use <em>alt</em> and <em>title</em> where appropriate (<em>s</em>ee Steve Faulkner's post about <a href="http://blog.paciellogroup.com/2013/01/using-the-html-title-attribute-updated/">Using the HTML title attribute</a> for a good guide.)</li>
 		<li>If the above attributes are not applicable, use appropriate <a href="https://www.w3.org/TR/wai-aria-1.1/#state_prop_def">ARIA States and Properties</a> such as <code>aria-label</code>, <code>aria-labelledby</code>, or <code>aria-describedby</code>.</li>
 	</ul>
 	</li>
-	<li>Images of text <strong>MUST</strong> be avoided.</li>
+	<li>Images of text must be avoided.</li>
 	<li>All user interface components with visible text (or image of text) as labels must have the same text available in the programmatic <a href="https://www.w3.org/TR/WCAG21/#dfn-name">name</a> of the component. <a href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">WCAG 2.1: Label in name.</a></li>
-	<li>All form controls <strong>MUST</strong> have labels ({{ htmlelement("label") }} elements) for the benefit of screen reader users.</li>
+	<li>All form controls must have labels ({{ htmlelement("label") }} elements) for the benefit of screen reader users.</li>
 </ul>
 
-<h2 id="Handling_State">Handling State</h2>
+<h2 id="Handling_State">Handling state</h2>
 
 <ul>
 	<li>Standard controls such as radio buttons and checkboxes are handled by the operating system. However, for other custom controls state changes must be provided via <a href="https://www.w3.org/TR/wai-aria-1.1/#state_prop_def">ARIA States</a> such as<code> aria-checked</code>, <code>aria-disabled</code>, <code>aria-selected</code>, <code>aria-expanded</code>, and <code>aria-pressed</code>.</li>
@@ -77,22 +77,22 @@ tags:
 	<li>Content should not be restricted to a single orientation, such as portrait or landscape, unless essential. <a href="https://www.w3.org/WAI/WCAG21/Understanding/orientation.html">WCAG 2.1: Orientation</a>
 
 	<ul>
-		<li>Examples of when an orientation is esssential is a piano application or a bank cheque.</li>
+		<li>Examples of when an orientation is esssential is a piano application or a bank check.</li>
 	</ul>
 	</li>
 </ul>
 
-<h2 id="General_Guidelines">General Guidelines</h2>
+<h2 id="General_Guidelines">General guidelines</h2>
 
 <ul>
-	<li>An app title <strong>MUST</strong> be provided.</li>
-	<li>Headings <strong>MUST</strong> not break hierarchical structure
+	<li>An app title must be provided.</li>
+	<li>Headings must not break hierarchical structure
 	<pre class="brush: html notranslate">&lt;h1&gt;Top level heading&lt;/h1&gt;
   &lt;h2&gt;Secondary heading&lt;/h2&gt;
   &lt;h2&gt;Another secondary heading&lt;/h2&gt;
     &lt;h3&gt;Low level heading&lt;/h3&gt;</pre>
 	</li>
-	<li><a href="https://www.washington.edu/accessibility/web/landmarks/">ARIA Landmark Roles</a> <strong>SHOULD</strong> be used to describe an app or document structure, such as <code>banner</code>, <code>complementary</code>, <code>contentinfo</code>, <code>main</code>, <code>navigation</code>, <code>search</code>.</li>
+	<li><a href="https://www.washington.edu/accessibility/web/landmarks/">ARIA Landmark Roles</a> should be used to describe an app or document structure, such as <code>banner</code>, <code>complementary</code>, <code>contentinfo</code>, <code>main</code>, <code>navigation</code>, <code>search</code>.</li>
 	<li>For touch events, at least one of the following must be true (<a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html">WCAG 2.1: Pointer Cancellation</a>):
 	<ul>
 		<li>The down-event should not be used to trigger any action</li>
@@ -101,7 +101,7 @@ tags:
 		<li>It is essential to trigger the action on the down event. For example, playing a game or a piano application.</li>
 	</ul>
 	</li>
-	<li>Touch targets <strong>MUST</strong> be large enough for the user to interact with (see the <a href="http://www.bbc.co.uk/guidelines/futuremedia/accessibility/mobile/design/touch-target-size">BBC Mobile Accessibility Guidelines</a> for useful touch target size guidelines).</li>
+	<li>Touch targets must be large enough for the user to interact with (see the <a href="http://www.bbc.co.uk/guidelines/futuremedia/accessibility/mobile/design/touch-target-size">BBC Mobile Accessibility Guidelines</a> for useful touch target size guidelines).</li>
 </ul>
 
 <div class="note">


### PR DESCRIPTION
changes:

- revised text to US spelling (color, check) 
- revised the capitalization of second words in two-word headings  
- removed numerous cases of capitalization and bold formatting for emphasis in the wording of sentences 
 (example: <strong>MUST NOT</strong>)