### PR TITLE
don't dir="rtl" on the en-US pre content

### DIFF
--- a/files/en-us/web/css/css_images/using_css_gradients/index.html
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.html
@@ -28,7 +28,7 @@ tags:
 <p>To create the most basic type of gradient, all you need is to specify two colors. These are called <em>color stops</em>. You must have at least two, but you can have as many as you want.</p>
 
 <div class="hidden">
-<pre class="brush: html notranslate" dir="rtl">&lt;div class="simple-linear"&gt;&lt;/div&gt;</pre>
+<pre class="brush: html notranslate">&lt;div class="simple-linear"&gt;&lt;/div&gt;</pre>
 
 <pre class="brush: css notranslate">div {
   width: 120px;
@@ -191,7 +191,7 @@ tags:
 <p>By default, the gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark.</p>
 
 <div class="hidden">
-<pre class="brush: html notranslate" dir="rtl">&lt;div class="color-hint"&gt;&lt;/div&gt;
+<pre class="brush: html notranslate">&lt;div class="color-hint"&gt;&lt;/div&gt;
 &lt;div class="simple-linear"&gt;&lt;/div&gt;</pre>
 
 <pre class="brush: css notranslate">div {

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.html
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.html
@@ -738,7 +738,7 @@ and so is foo.'
 
 <p>ECMAScript 2015 introduces a new type of literal, namely <a href="/en-US/docs/Web/JavaScript/Reference/template_strings"><strong>template literals</strong></a>. This allows for many new features, including multiline strings!</p>
 
-<pre class="brush: js notranslate" dir="rtl">var poem =
+<pre class="brush: js notranslate">var poem =
 `Roses are red,
 Violets are blue.
 Sugar is sweet,

--- a/files/en-us/web/javascript/reference/global_objects/math/abs/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/abs/index.html
@@ -42,7 +42,7 @@ tags:
 
 <p>Passing an empty object, an array with more than one member, a non-numeric string or {{jsxref("undefined")}}/empty variable returns {{jsxref("NaN")}}. Passing {{jsxref("null")}}, an empty string or an empty array returns 0.</p>
 
-<pre class="brush: js notranslate" dir="rtl">Math.abs('-1');     // 1
+<pre class="brush: js notranslate">Math.abs('-1');     // 1
 Math.abs(-2);       // 2
 Math.abs(null);     // 0
 Math.abs('');       // 0

--- a/files/en-us/web/javascript/reference/global_objects/number/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.html
@@ -140,7 +140,7 @@ console.log(Number(d))
 
 <h3 id="Convert_numeric_strings_and_null_to_numbers">Convert numeric strings and null to numbers</h3>
 
-<pre class="brush: js notranslate" dir="rtl">Number('123')     // 123
+<pre class="brush: js notranslate">Number('123')     // 123
 Number('123') === 123 /// true
 Number('12.3')    // 12.3
 Number('12.00')   // 12


### PR DESCRIPTION
For example, on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
<img width="1125" alt="Screen Shot 2020-12-18 at 5 05 35 PM" src="https://user-images.githubusercontent.com/26739/102665706-4a535b80-4153-11eb-80f8-6b63c466dff8.png">
