### PR TITLE
fix: "beforeinput" feature detection example function

### DIFF
--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.html
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.html
@@ -56,7 +56,7 @@ tags:
 <p>The following function returns true if <code>beforeinput</code> is supported.</p>
 
 <pre class="brush: js notranslate">function isBeforeInputEventAvailable() {
-  return typeof InputEvent.prototype.getTargetRanges === "function";
+  return window.InputEvent && typeof InputEvent.prototype.getTargetRanges === "function";
 }
 </pre>
 

--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.html
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.html
@@ -53,7 +53,7 @@ tags:
 
 <h3 id="Feature_Detection">Feature Detection</h3>
 
-<p>The following function returns true if <code>beforeinput</code> is supported.</p>
+<p>The following function returns true if <code>beforeinput</code>, and thus <code>getTargetRanges</code>, is supported.</p>
 
 <pre class="brush: js notranslate">function isBeforeInputEventAvailable() {
   return window.InputEvent && typeof InputEvent.prototype.getTargetRanges === "function";

--- a/files/en-us/web/api/inputevent/gettargetranges/index.html
+++ b/files/en-us/web/api/inputevent/gettargetranges/index.html
@@ -34,7 +34,7 @@ tags:
 <p>The following function returns true if <code>beforeinput</code>, and thus <code>getTargetRanges</code>, is supported.</p>
 
 <pre class="brush: js notranslate">function isBeforeInputEventAvailable() {
-  return typeof InputEvent.prototype.getTargetRanges === "function";
+  return window.InputEvent && typeof InputEvent.prototype.getTargetRanges === "function";
 }
 </pre>
 


### PR DESCRIPTION
The function provided in the example throws an error when executed in a browser lacking _InputEvent_ API support.

This pull request fixes #381.