### PR TITLE
fix: Google Structured Data link

### DIFF
--- a/files/en-us/web/html/microdata/index.html
+++ b/files/en-us/web/html/microdata/index.html
@@ -158,7 +158,7 @@ tags:
 <p>{{ EmbedLiveSample('HTML', '', '100', '', 'Web/HTML/Microdata') }}</p>
 
 <div class="note">
-<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/structured-data/testing-tool/ Structured Data Testing Tool">Structured Data Testing Tool</a>. Try it on the HTML shown above.</p>
+<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/search/docs/guides/intro-structured-data">Structured Data Testing Tool</a>. Try it on the HTML shown above.</p>
 </div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>


### PR DESCRIPTION
This now redirects to a general page with some other tool links