### PR TITLE
chore: Push devDepenencies and mark private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "content",
   "version": "1.0.0",
-  "main": "index.js",
+  "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "node": ">=12.0.0"
@@ -13,9 +13,7 @@
   },
   "dependencies": {
     "@mdn/yari": "0.1.458",
+    "cross-env": "7.0.3",
     "env-cmd": "10.1.0"
-  },
-  "devDependencies": {
-    "cross-env": "7.0.3"
   }
 }


### PR DESCRIPTION
Since this is currently all content, I don't think the difference between devDependencies and dependencies is a big deal. Also marked `private` since it's not a published package