### PR TITLE
Fixing getBoundingClientRect demo image's ratio

### DIFF
--- a/files/en-us/web/api/element/getboundingclientrect/index.html
+++ b/files/en-us/web/api/element/getboundingclientrect/index.html
@@ -35,7 +35,7 @@ tags:
 
 <p>The returned value is a {{domxref("DOMRect")}} object which is the smallest rectangle which contains the entire element, including its padding and border-width. The <code>left</code>, <code>top</code>, <code>right</code>, <code>bottom</code>, <code>x</code>, <code>y</code>, <code>width</code>, and <code>height</code> properties describe the position and size of the overall rectangle in pixels. Properties other than <code>width</code> and <code>height</code> are relative to the top-left of the viewport.</p>
 
-<p style="display: block;"><img alt="" src="https://mdn.mozillademos.org/files/17155/element-box-diagram.png" style="height: 1099px; width: 1466px;"></p>
+<p style="display: block;"><img alt="" src="https://mdn.mozillademos.org/files/17155/element-box-diagram.png"></p>
 
 <p>The <code>width</code> and <code>height</code> properties of the {{domxref("DOMRect")}} object returned by the method include the <code>padding</code> and <code>border-width</code>, not only the content width/height. In the standard box model, this would be equal to the <code>width</code> or <code>height</code> property of the element + <code>padding</code> + <code>border-width</code>. But if <code><a href="/en-US/docs/Web/CSS/box-sizing">box-sizing: border-box</a></code> is set for the element this would be directly equal to its <code>width</code> or <code>height</code>.</p>
 


### PR DESCRIPTION
Because of the `max-width: 100%;` rule (from "_reset.scss") on all `img` elements, the demo image gets distorted.  
It shoud be better to let the image dimensions be ruled with the `height: auto;` rule on all `img` elements from "_base.scss"

Here is how [the getBoundingClientRect page](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) currently looks:

![image](https://user-images.githubusercontent.com/3054920/102684813-18d2a280-41dc-11eb-8e6d-554ecab69e62.png)
