### PR TITLE
Fix URLs for IndexedDB examples

### DIFF
--- a/files/en-us/web/api/idbindex/count/index.html
+++ b/files/en-us/web/api/idbindex/count/index.html
@@ -70,7 +70,7 @@ var <em>request</em> = <em>myIndex</em>.count(<em>key</em>);</pre>
 
 <p><code>myIndex.count()</code> is then used to count the number of records in the index, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/count/index.html
+++ b/files/en-us/web/api/idbindex/count/index.html
@@ -70,7 +70,7 @@ var <em>request</em> = <em>myIndex</em>.count(<em>key</em>);</pre>
 
 <p><code>myIndex.count()</code> is then used to count the number of records in the index, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/get/index.html
+++ b/files/en-us/web/api/idbindex/get/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p><code>myIndex.get('Bungle')</code> is then used to retrieve the record with an <code>lName</code> of <code>Bungle</code>, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js;highlight[7]">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/get/index.html
+++ b/files/en-us/web/api/idbindex/get/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p><code>myIndex.get('Bungle')</code> is then used to retrieve the record with an <code>lName</code> of <code>Bungle</code>, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre class="brush: js;highlight[7]">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/getkey/index.html
+++ b/files/en-us/web/api/idbindex/getkey/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p><code>myIndex.getKey('Bungle')</code> is then used to retrieve the primary key of the record with an <code>lName</code> of <code>Bungle</code>, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindexidbindex/">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/getkey/index.html
+++ b/files/en-us/web/api/idbindex/getkey/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p><code>myIndex.getKey('Bungle')</code> is then used to retrieve the primary key of the record with an <code>lName</code> of <code>Bungle</code>, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex/">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/getkey/index.html
+++ b/files/en-us/web/api/idbindex/getkey/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p><code>myIndex.getKey('Bungle')</code> is then used to retrieve the primary key of the record with an <code>lName</code> of <code>Bungle</code>, and the result of that request is logged to the console when its success callback returns.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindexidbindex/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -66,7 +66,7 @@ tags:
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindex">IndexedDB-examples demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -66,7 +66,7 @@ tags:
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindex/">IndexedDB-examples demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindexidbindex/">IndexedDB-examples demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex/tree/master/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -66,7 +66,7 @@ tags:
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindex/">IDBIndex-example demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindex/">IndexedDB-examples demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -66,7 +66,7 @@ tags:
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindexidbindex/">IndexedDB-examples demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex/tree/master/idbindex">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://mdn.github.io/indexeddb-examples/idbindex">IndexedDB-examples demo repo</a> (<a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>The key path of the current index is logged to the console: it should be returned as <code>lName</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindexidbindex/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>The key path of the current index is logged to the console: it should be returned as <code>lName</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex/">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -33,7 +33,7 @@ tags:
 
 <p>The key path of the current index is logged to the console: it should be returned as <code>lName</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindexidbindex/">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/multientry/index.html
+++ b/files/en-us/web/api/idbindex/multientry/index.html
@@ -52,7 +52,7 @@ tags:
 
 <p>The multi-entry status of the index is logged to the console: it should be returned as <code>false</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/multientry/index.html
+++ b/files/en-us/web/api/idbindex/multientry/index.html
@@ -52,7 +52,7 @@ tags:
 
 <p>The multi-entry status of the index is logged to the console: it should be returned as <code>false</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/name/index.html
+++ b/files/en-us/web/api/idbindex/name/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>The name of the index is logged to the console: it should be returned as <code>lName</code>.</p>
 
-<p>Finally, we iterate through each record, inserting the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>).</p>
+<p>Finally, we iterate through each record, inserting the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>).</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/name/index.html
+++ b/files/en-us/web/api/idbindex/name/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>The name of the index is logged to the console: it should be returned as <code>lName</code>.</p>
 
-<p>Finally, we iterate through each record, inserting the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>).</p>
+<p>Finally, we iterate through each record, inserting the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>).</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/objectstore/index.html
+++ b/files/en-us/web/api/idbindex/objectstore/index.html
@@ -35,7 +35,7 @@ tags:
 
 <pre class="brush: json">IDBObjectStore { name: "contactsList", keyPath: "id", indexNames: DOMStringList[7], transaction: IDBTransaction, autoIncrement: false }</pre>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/objectstore/index.html
+++ b/files/en-us/web/api/idbindex/objectstore/index.html
@@ -35,7 +35,7 @@ tags:
 
 <pre class="brush: json">IDBObjectStore { name: "contactsList", keyPath: "id", indexNames: DOMStringList[7], transaction: IDBTransaction, autoIncrement: false }</pre>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js" style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/opencursor/index.html
+++ b/files/en-us/web/api/idbindex/opencursor/index.html
@@ -87,7 +87,7 @@ var <em>request</em> = <em>myIndex</em>.openCursor(range, direction);</pre>
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using <code>openCursor()</code> — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/opencursor/index.html
+++ b/files/en-us/web/api/idbindex/opencursor/index.html
@@ -87,7 +87,7 @@ var <em>request</em> = <em>myIndex</em>.openCursor(range, direction);</pre>
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using <code>openCursor()</code> — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/unique/index.html
+++ b/files/en-us/web/api/idbindex/unique/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>The unique status of the index is logged to the console: it should be returned as <code>false</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbindex/unique/index.html
+++ b/files/en-us/web/api/idbindex/unique/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>The unique status of the index is logged to the console: it should be returned as <code>false</code>.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre style="font-size: 14px;">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbobjectstore/index/index.html
+++ b/files/en-us/web/api/idbobjectstore/index/index.html
@@ -63,7 +63,7 @@ tags:
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples/tree/master/idbindex">IDBIndex example in IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/idbindex">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';

--- a/files/en-us/web/api/idbobjectstore/index/index.html
+++ b/files/en-us/web/api/idbobjectstore/index/index.html
@@ -63,7 +63,7 @@ tags:
 
 <p>In the following example we open a transaction and an object store, then get the index <code>lName</code> from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an <code>ObjectStore</code> using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.</p>
 
-<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/IDBIndex-example">IDBIndex-example demo repo</a> (<a href="https://mdn.github.io/IDBIndex-example/">View the example live</a>.)</p>
+<p>Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our <a href="https://github.com/mdn/indexeddb-examples">IndexedDB-examples demo repo</a> (<a href="https://mdn.github.io/indexeddb-examples/">View the example live</a>.)</p>
 
 <pre class="brush: js">function displayDataByIndex() {
   tableEntry.innerHTML = '';


### PR DESCRIPTION
URLs used to point to https://github.com/mdn/IDBIndex-example , but apparently have moved since. The new location is https://github.com/mdn/indexeddb-examples .