### PR TITLE
Fix typo in canvas element page

### DIFF
--- a/files/en-us/web/html/element/canvas/index.html
+++ b/files/en-us/web/html/element/canvas/index.html
@@ -152,7 +152,7 @@ ctx.fillRect(10, 10, 100, 100);</pre>
 <p>The <code>&lt;canvas&gt;</code> element on its own is just a bitmap and does not provide information about any drawn objects. Canvas content is not exposed to accessibility tools as semantic HTML is. In general, you should avoid using canvas in an accessible website or app. The following guides can help to make it more accessible.</p>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility">MDN Hit regions and accessability</a></li>
+ <li><a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility">Hit regions and accessibility</a></li>
  <li><a href="https://www.w3.org/WAI/PF/HTML/wiki/Canvas_Accessibility_Use_Cases">Canvas accessibility use cases</a></li>
  <li><a href="https://www.w3.org/html/wg/wiki/AddedElementCanvas">Canvas element accessibility issues</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2012/06/html5-canvas-accessibility-in-firefox-13/">HTML5 Canvas Accessibility in Firefox 13 – by Steve Faulkner</a></li>


### PR DESCRIPTION
This change fixes a misspelling in the hyperlink text for a link to the MDN “Hit regions and accessibility” tutorial. The change also drops the unnecessary “MDN” prefix from the hyperlink text. Fixes https://github.com/mdn/content/issues/462