### PR TITLE
fix: Bad value for text-align

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -383,7 +383,7 @@ console.log(g.__proto__.hasOwnProperty('addVertex'));
 
 <p>Here are all 4 ways and their pros/cons. All of the examples listed below create exactly the same resulting <code>inst</code> object (thus logging the same results to the console), except in different ways for the purpose of illustration.</p>
 
-<table class="standard-table" style="text-align: top;">
+<table class="standard-table" style="vertical-align: top;">
 	<tbody>
 		<tr>
 			<td style="width: 1%;">Name</td>


### PR DESCRIPTION
There seems to be some funny inline styles for the table, but this value wasn't a valid value for `text-align`