### PR TITLE
fix: Unescaped gt in IDs

### DIFF
--- a/files/en-us/web/css/flex-basis/index.html
+++ b/files/en-us/web/css/flex-basis/index.html
@@ -45,7 +45,7 @@ flex-basis: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="&lt;'width'>">&lt;'width'&gt;</code></dt>
+ <dt><code id="&lt;'width'&gt;">&lt;'width'&gt;</code></dt>
  <dd>An absolute {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}} of the parent flex container's main size property, or the keyword <code>auto</code>. Negative values are invalid. Defaults to <code>auto</code>.</dd>
  <dt><code id="content">content</code></dt>
  <dd>Indicates automatic sizing, based on the flex item’s content.</dd>

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -99,11 +99,11 @@ flex: unset;
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties, but grows to absorb any extra free space in the flex container, and shrinks to its minimum size to fit the container. This is equivalent to setting "<code>flex: 1 1 auto</code>".</dd>
  <dt id="none"><code>none</code></dt>
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties. It is fully inflexible: it neither shrinks nor grows in relation to the flex container. This is equivalent to setting "<code>flex: 0 0 auto</code>".</dd>
- <dt id="&lt;'flex-grow'>"><code>&lt;'flex-grow'&gt;</code></dt>
+ <dt id="&lt;'flex-grow'&gt;"><code>&lt;'flex-grow'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-grow")}} of the flex item. Negative values are considered invalid. Defaults to <code>1</code> when omitted. (initial is <code>0</code>)</dd>
- <dt id="&lt;'flex-shrink'>"><code>&lt;'flex-shrink'&gt;</code></dt>
+ <dt id="&lt;'flex-shrink'&gt;"><code>&lt;'flex-shrink'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-shrink")}} of the flex item. Negative values are considered invalid. Defaults to <code>1</code> when omitted. (initial is <code>1</code>)</dd>
- <dt id="&lt;'flex-basis'>"><code>&lt;'flex-basis'&gt;</code></dt>
+ <dt id="&lt;'flex-basis'&gt;"><code>&lt;'flex-basis'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-basis")}} of the flex item. A preferred size of <code>0</code> must have a unit to avoid being interpreted as a flexibility. Defaults to <code>0</code> when omitted. (initial is <code>auto</code>)</dd>
 </dl>
 

--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -66,19 +66,19 @@ tags:
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="&lt;'font-style'>"><code>&lt;'font-style'&gt;</code></dt>
+ <dt id="&lt;'font-style'&gt;"><code>&lt;'font-style'&gt;</code></dt>
  <dd>See the {{cssxref("font-style")}} CSS property.</dd>
- <dt id="&lt;'font-variant'>"><code>&lt;'font-variant'&gt;</code></dt>
+ <dt id="&lt;'font-variant'&gt;"><code>&lt;'font-variant'&gt;</code></dt>
  <dd>See the {{cssxref("font-variant")}} CSS property.</dd>
- <dt id="&lt;'font-weight'>"><code>&lt;'font-weight'&gt;</code></dt>
+ <dt id="&lt;'font-weight'&gt;"><code>&lt;'font-weight'&gt;</code></dt>
  <dd>See the {{cssxref("font-weight")}} CSS property.</dd>
- <dt id="&lt;'font-stretch'>"><code>&lt;'font-stretch'&gt;</code></dt>
+ <dt id="&lt;'font-stretch'&gt;"><code>&lt;'font-stretch'&gt;</code></dt>
  <dd>See the {{cssxref("font-stretch")}} CSS property.</dd>
- <dt id="&lt;'font-size'>"><code>&lt;'font-size'&gt;</code></dt>
+ <dt id="&lt;'font-size'&gt;"><code>&lt;'font-size'&gt;</code></dt>
  <dd>See the {{cssxref("font-size")}} CSS property.</dd>
- <dt id="&lt;'line-height'>"><code>&lt;'line-height'&gt;</code></dt>
+ <dt id="&lt;'line-height'&gt;"><code>&lt;'line-height'&gt;</code></dt>
  <dd>See the {{cssxref("line-height")}} CSS property.</dd>
- <dt id="&lt;'font-family'>"><code>&lt;'font-family'&gt;</code></dt>
+ <dt id="&lt;'font-family'&gt;"><code>&lt;'font-family'&gt;</code></dt>
  <dd>See the {{cssxref("font-family")}} CSS property.</dd>
 </dl>
 


### PR DESCRIPTION
Might be better to replace these IDs without the special characters later, but I think that might required some redirects