### PR TITLE
fix: Remove empty titles

### DIFF
--- a/files/en-us/glossary/forbidden_header_name/index.html
+++ b/files/en-us/glossary/forbidden_header_name/index.html
@@ -10,34 +10,34 @@ tags:
 ---
 <p>A <dfn>forbidden header name</dfn> is the name of any <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> that cannot be modified programmatically; specifically, an HTTP <strong>request</strong> header name (in contrast with a {{Glossary("Forbidden response header name")}}).</p>
 
-<p>Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `<code title="">Sec-</code>` are reserved for creating new headers safe from {{glossary("API","APIs")}} using <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.</p>
+<p>Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `<code>Sec-</code>` are reserved for creating new headers safe from {{glossary("API","APIs")}} using <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.</p>
 
 <p>Forbidden header names start with <code>Proxy-</code> or <code>Sec-</code>, or are one of the following names:</p>
 
 <ul class="brief">
- <li><code title="">Accept-Charset</code></li>
- <li><code title="">Accept-Encoding</code></li>
- <li><code title="">Access-Control-Request-Headers</code></li>
- <li><code title="">Access-Control-Request-Method</code></li>
- <li><code title="">Connection</code></li>
- <li><code title="">Content-Length</code></li>
- <li><code title="">Cookie</code></li>
- <li><code title="">Cookie2</code></li>
- <li><code title="">Date</code></li>
- <li><code title="">DNT</code></li>
- <li><code title="">Expect</code></li>
- <li><code title="">Feature-Policy</code></li>
- <li><code title="">Host</code></li>
- <li><code title="">Keep-Alive</code></li>
- <li><code title="http-origin">Origin</code></li>
- <li><code title="http-origin">Proxy-</code></li>
- <li><code title="http-origin">Sec-</code></li>
- <li><code title="">Referer</code></li>
- <li><code title="">TE</code></li>
- <li><code title="">Trailer</code></li>
- <li><code title="">Transfer-Encoding</code></li>
- <li><code title="">Upgrade</code></li>
- <li><code title="">Via</code></li>
+ <li><code>Accept-Charset</code></li>
+ <li><code>Accept-Encoding</code></li>
+ <li><code>Access-Control-Request-Headers</code></li>
+ <li><code>Access-Control-Request-Method</code></li>
+ <li><code>Connection</code></li>
+ <li><code>Content-Length</code></li>
+ <li><code>Cookie</code></li>
+ <li><code>Cookie2</code></li>
+ <li><code>Date</code></li>
+ <li><code>DNT</code></li>
+ <li><code>Expect</code></li>
+ <li><code>Feature-Policy</code></li>
+ <li><code>Host</code></li>
+ <li><code>Keep-Alive</code></li>
+ <li><code>Origin</code></li>
+ <li><code>Proxy-</code></li>
+ <li><code>Sec-</code></li>
+ <li><code>Referer</code></li>
+ <li><code>TE</code></li>
+ <li><code>Trailer</code></li>
+ <li><code>Transfer-Encoding</code></li>
+ <li><code>Upgrade</code></li>
+ <li><code>Via</code></li>
 </ul>
 
 <div class="note">

--- a/files/en-us/glossary/forbidden_response_header_name/index.html
+++ b/files/en-us/glossary/forbidden_response_header_name/index.html
@@ -7,7 +7,7 @@ tags:
   - Response
   - forbidden
 ---
-<p>A <dfn>forbidden response header name</dfn> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> name (either `<code title="">Set-Cookie</code>` or `<code title="">Set-Cookie2</code>`) that cannot be modified programmatically.</p>
+<p>A <dfn>forbidden response header name</dfn> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> name (either `<code>Set-Cookie</code>` or `<code>Set-Cookie2</code>`) that cannot be modified programmatically.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/mdn/contribute/howto/write_interface_reference_documentation/sample_interface_document/index.html
+++ b/files/en-us/mdn/contribute/howto/write_interface_reference_documentation/sample_interface_document/index.html
@@ -106,7 +106,7 @@ A make-believe interface that eats and enjoys cookies. This is an example of wha
 </div>
 
 <div style="background: #eee; padding: 2px;">
-Inherits from: <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieFan" title="">nsICookieFan</a></code>
+Inherits from: <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieFan">nsICookieFan</a></code>
 <span style="text-align: right; float: right;">Last changed in Gecko 2.0 (Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1)</span></div>
 </div>
 
@@ -123,7 +123,7 @@ Inherits from: <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface
 <table class="standard-table">
  <tbody>
   <tr>
-   <td><code>void <a href="#eatCookie.28.29">eatCookie</a>(in <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookie" title="">nsICookie</a></code> cookieToEat);</code></td>
+   <td><code>void <a href="#eatCookie.28.29">eatCookie</a>(in <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookie">nsICookie</a></code> cookieToEat);</code></td>
   </tr>
   <tr>
    <td><code>AString <a href="#getFunnySaying.28.29">getFunnySaying</a>(in integer number);</code> </td>
@@ -314,6 +314,6 @@ Inherits from: <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookie" title="">nsICookie</a></code></li>
- <li><code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieManager" title="">nsICookieManager</a></code></li>
+ <li><code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookie">nsICookie</a></code></li>
+ <li><code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieManager">nsICookieManager</a></code></li>
 </ul>

--- a/files/en-us/mozilla/firefox/releases/21/index.html
+++ b/files/en-us/mozilla/firefox/releases/21/index.html
@@ -22,7 +22,7 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/E4X" title="E4X">E4X</a>, an ancient JavaScript extension, has been removed. Implemented only in Gecko, it never got significant traction ({{bug("788293")}}).</li>
- <li><a href="/en-US/docs/JavaScript/Reference/Global_Objects/parseInt" title="">parseInt</a> no longer treats strings with leading "0" as octal ({{bug("786135")}}).</li>
+ <li><a href="/en-US/docs/JavaScript/Reference/Global_Objects/parseInt">parseInt</a> no longer treats strings with leading "0" as octal ({{bug("786135")}}).</li>
 </ul>
 
 <h3 id="CSS">CSS</h3>

--- a/files/en-us/mozilla/firefox/releases/42/index.html
+++ b/files/en-us/mozilla/firefox/releases/42/index.html
@@ -168,7 +168,7 @@ install Firefox Developer Edition</a> Firefox 42 was released on November 3, 201
 <h4 id="nsIContentPolicy">nsIContentPolicy</h4>
 
 <ul>
- <li>The <code><strong>TYPE_EMBED</strong></code> constant has been added to <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIContentPolicy" title="">nsIContentPolicy</a></code> to allow Gecko internals and add-on code to better differentiate different types of requests. Previously, <code><strong>TYPE_OBJECT</strong></code> was used for these cases ({{bug(1148030)}}).</li>
+ <li>The <code><strong>TYPE_EMBED</strong></code> constant has been added to <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIContentPolicy">nsIContentPolicy</a></code> to allow Gecko internals and add-on code to better differentiate different types of requests. Previously, <code><strong>TYPE_OBJECT</strong></code> was used for these cases ({{bug(1148030)}}).</li>
  <li>Similarly, the <strong><code>TYPE_SUBDOCUMENT</code></strong> constants has been split into <code><strong>TYPE_FRAME</strong></code> and <strong><code>TYPE_IFRAME</code></strong> ({{bug(1148044)}}).</li>
 </ul>
 

--- a/files/en-us/tools/browser_toolbox/index.html
+++ b/files/en-us/tools/browser_toolbox/index.html
@@ -26,7 +26,7 @@ tags:
 
 <h2 id="Opening_the_Browser_Toolbox"><span style="font-size: 2.14285714285714rem;">Opening</span> the Browser Toolbox</h2>
 
-<p><span style="line-height: 1.5;">Open the Browser Toolbox through the </span><span style="line-height: 1.5;">menu button </span><img alt="new fx menu" class="frameless wiki-image" src="https://support.cdn.mozilla.net/media/uploads/gallery/images/2014-01-10-13-08-08-f52b8c.png" style="line-height: 1.5;" title=""><span style="line-height: 1.5;"> and the menu items "Developer" then "Browser Toolbox".</span><span style="line-height: 1.5;"> </span></p>
+<p><span style="line-height: 1.5;">Open the Browser Toolbox through the </span><span style="line-height: 1.5;">menu button </span><img alt="new fx menu" class="frameless wiki-image" src="https://support.cdn.mozilla.net/media/uploads/gallery/images/2014-01-10-13-08-08-f52b8c.png" style="line-height: 1.5;"><span style="line-height: 1.5;"> and the menu items "Developer" then "Browser Toolbox".</span><span style="line-height: 1.5;"> </span></p>
 
 <p><span style="line-height: 1.5;">You can also open it with the </span><kbd>Ctrl</kbd> + <kbd>Alt</kbd> +<kbd>Shift</kbd> + <kbd>I</kbd>  key combination ( <kbd>Cmd</kbd> + <kbd>Opt</kbd> +<kbd>Shift</kbd> + <kbd>I</kbd> on a Mac).</p>
 

--- a/files/en-us/tools/debugger/how_to/open_the_debugger/index.html
+++ b/files/en-us/tools/debugger/how_to/open_the_debugger/index.html
@@ -11,7 +11,7 @@ slug: Tools/Debugger/How_to/Open_the_debugger
  <li>
   <p>Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> on Windows and Linux, or <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>Z</kbd> on macOS (starting in Firefox 71; prior to Firefox 66, the letter in this shortcut was S).</p>
  </li>
- <li>Press the menu button ( <img alt="new fx menu" class="frameless wiki-image" src="https://mdn.mozillademos.org/files/12712/hamburger.png" style="height: 20px; width: 22px;" title=""> ), select "Developer", then "Debugger".</li>
+ <li>Press the menu button ( <img alt="new fx menu" class="frameless wiki-image" src="https://mdn.mozillademos.org/files/12712/hamburger.png" style="height: 20px; width: 22px;"> ), select "Developer", then "Debugger".</li>
 </ul>
 
 <p>{{EmbedYouTube("yI5SlVQiZtI")}}</p>

--- a/files/en-us/tools/network_monitor/index.html
+++ b/files/en-us/tools/network_monitor/index.html
@@ -30,7 +30,7 @@ tags:
 
 <p>Either action causes the Network Monitor to begin monitoring network activity. Once the tool is monitoring network requests, the display looks like this:</p>
 
-<p><img alt="" src="https://mdn.mozillademos.org/files/16245/network_monitor.png" style="border: 1px solid black; display: block; height: 541px; margin: 0px auto; width: 800px;" title=""></p>
+<p><img alt="" src="https://mdn.mozillademos.org/files/16245/network_monitor.png" style="border: 1px solid black; display: block; height: 541px; margin: 0px auto; width: 800px;"></p>
 
 <p>When it is actively monitoring activity, the Network Monitor records network requests any time the Toolbox is open, even if the Network Monitor itself is not selected. This means you can start debugging a page in, for example, the Web Console, then switch to the Network Monitor to see network activity without having to reload the page.</p>
 
@@ -42,13 +42,13 @@ tags:
  <li>The main screen contains the <a href="/en-US/docs/Tools/Network_Monitor/Toolbar">toolbar</a>, the <a href="/en-US/docs/Tools/Network_Monitor/request_list">network request list</a>, and the <a href="/en-US/docs/Tools/Network_Monitor/request_details">network request details pane</a>:</li>
 </ul>
 
-<p><img alt="" src="https://mdn.mozillademos.org/files/16246/Network_Monitor_Closeup.png" style="border: 1px solid black; display: block; height: 747px; margin: 0px auto; width: 800px;" title=""></p>
+<p><img alt="" src="https://mdn.mozillademos.org/files/16246/Network_Monitor_Closeup.png" style="border: 1px solid black; display: block; height: 747px; margin: 0px auto; width: 800px;"></p>
 
 <ul>
  <li>The <a href="/en-US/docs/Tools/Network_Monitor/Performance_analysis">performance analysis</a> view is a separate screen:</li>
 </ul>
 
-<p><img alt="Performance analysis view" src="https://mdn.mozillademos.org/files/16276/network_performance.png" style="border: 1px solid black; display: block; height: 1176px; margin-left: auto; margin-right: auto; width: 1382px;" title=""></p>
+<p><img alt="Performance analysis view" src="https://mdn.mozillademos.org/files/16276/network_performance.png" style="border: 1px solid black; display: block; height: 1176px; margin-left: auto; margin-right: auto; width: 1382px;"></p>
 
 <h2 id="Working_with_the_network_monitor">Working with the network monitor</h2>
 

--- a/files/en-us/web/api/accelerometer/index.html
+++ b/files/en-us/web/api/accelerometer/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p><span class="seoSummary">The <strong><code>Accelerometer</code></strong> interface of the <a href="/docs/Web/API/Sensor_APIs">Sensor APIs</a> provides on each reading the acceleration applied to the device along all three axes. </span></p>
 
-<p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code>, device sensor through the <a href="/en-US/docs/Web/API/Permissions" title=""><code>Permissions</code></a> API.</p>
+<p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code>, device sensor through the <a href="/en-US/docs/Web/API/Permissions"><code>Permissions</code></a> API.</p>
 
 <p>If a feature policy blocks the use of a feature, it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
 

--- a/files/en-us/web/api/fetch_api/basic_concepts/index.html
+++ b/files/en-us/web/api/fetch_api/basic_concepts/index.html
@@ -67,7 +67,7 @@ tags:
 <p>A header's guard affects the {{domxref("Headers.set","set()")}}, {{domxref("Headers.delete","delete()")}}, and {{domxref("Headers.append","append()")}} methods which change the header's contents. A <code>TypeError</code> is thrown if you try to modify a {{domxref("Headers")}} object whose guard is <code>immutable</code>. However, the operation will work if</p>
 
 <ul>
- <li>guard is <code title="">request</code> and the header <var>name</var> isn't a {{Glossary("forbidden header name")}} .</li>
- <li>guard is <code title="">request-no-cors</code> and the header <var>name</var>/<var>value</var> is a {{Glossary("simple header")}} .</li>
- <li>guard is <code title="">response</code> and the header <var>name</var> isn't a {{Glossary("forbidden response header name")}} .</li>
+ <li>guard is <code>request</code> and the header <var>name</var> isn't a {{Glossary("forbidden header name")}} .</li>
+ <li>guard is <code>request-no-cors</code> and the header <var>name</var>/<var>value</var> is a {{Glossary("simple header")}} .</li>
+ <li>guard is <code>response</code> and the header <var>name</var> isn't a {{Glossary("forbidden response header name")}} .</li>
 </ul>

--- a/files/en-us/web/api/textdecoder/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>The <code><strong>TextDecoder()</strong></code> constructor returns a newly created {{DOMxRef("TextDecoder")}} object for the encoding specified in parameter.</p>
 
-<p>If the value for <em>utfLabel</em> is unknown, or is one of the two values leading to a <code>'replacement'</code> decoding algorithm ( "<code title="">iso-2022-cn</code>" or "<code title="">iso-2022-cn-ext</code>"), a {{DOMxRef("DOMException")}} with the <code>"TypeError"</code> value is thrown.</p>
+<p>If the value for <em>utfLabel</em> is unknown, or is one of the two values leading to a <code>'replacement'</code> decoding algorithm ( "<code>iso-2022-cn</code>" or "<code>iso-2022-cn-ext</code>"), a {{DOMxRef("DOMException")}} with the <code>"TypeError"</code> value is thrown.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -34,144 +34,144 @@ tags:
   </thead>
   <tbody>
    <tr>
-    <td>"<code title="">unicode-1-1-utf-8</code>", "<code title="">utf-8</code>", "<code>utf8</code>"</td>
+    <td>"<code>unicode-1-1-utf-8</code>", "<code>utf-8</code>", "<code>utf8</code>"</td>
     <td><code>'utf-8'</code></td>
    </tr>
    <tr>
-    <td>"<code title="">866</code>", "<code title="">cp866</code>", "<code title="">csibm866</code>", "<code title="">ibm866</code>"</td>
+    <td>"<code>866</code>", "<code>cp866</code>", "<code>csibm866</code>", "<code>ibm866</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Code_page_866', "'ibm866'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatin2</code>", "<code title="">iso-8859-2</code>", "<code title="">iso-ir-101</code>", "<code title="">iso8859-2</code>", "<code title="">iso88592</code>", "<code title="">iso_8859-2</code>", "<code title="">iso_8859-2:1987</code>", "<code title="">l2</code>", "<code title="">latin2</code>"</td>
+    <td>"<code>csisolatin2</code>", "<code>iso-8859-2</code>", "<code>iso-ir-101</code>", "<code>iso8859-2</code>", "<code>iso88592</code>", "<code>iso_8859-2</code>", "<code>iso_8859-2:1987</code>", "<code>l2</code>", "<code>latin2</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-2', "'iso-8859-2'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatin3</code>", "<code title="">iso-8859-3</code>", "<code title="">iso-ir-109</code>", "<code title="">iso8859-3</code>", "<code title="">iso88593</code>", "<code title="">iso_8859-3</code>", "<code title="">iso_8859-3:1988</code>", "<code title="">l3</code>", "<code title="">latin3</code>"</td>
+    <td>"<code>csisolatin3</code>", "<code>iso-8859-3</code>", "<code>iso-ir-109</code>", "<code>iso8859-3</code>", "<code>iso88593</code>", "<code>iso_8859-3</code>", "<code>iso_8859-3:1988</code>", "<code>l3</code>", "<code>latin3</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-3', "'iso-8859-3'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatin4</code>", "<code title="">iso-8859-4</code>", "<code title="">iso-ir-110</code>", "<code title="">iso8859-4</code>", "<code title="">iso88594</code>", "<code title="">iso_8859-4</code>", "<code title="">iso_8859-4:1988</code>", "<code title="">l4</code>", "<code title="">latin4</code>"</td>
+    <td>"<code>csisolatin4</code>", "<code>iso-8859-4</code>", "<code>iso-ir-110</code>", "<code>iso8859-4</code>", "<code>iso88594</code>", "<code>iso_8859-4</code>", "<code>iso_8859-4:1988</code>", "<code>l4</code>", "<code>latin4</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-4', "'iso-8859-4'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatincyrillic</code>", "<code title="">cyrillic</code>", "<code title="">iso-8859-5</code>", "<code title="">iso-ir-144</code>", "<code title="">iso88595</code>", "<code title="">iso_8859-5</code>", "<code title="">iso_8859-5:1988</code>"</td>
+    <td>"<code>csisolatincyrillic</code>", "<code>cyrillic</code>", "<code>iso-8859-5</code>", "<code>iso-ir-144</code>", "<code>iso88595</code>", "<code>iso_8859-5</code>", "<code>iso_8859-5:1988</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-5', "'iso-8859-5'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">arabic</code>", "<code title="">asmo-708</code>", "<code title="">csiso88596e</code>", "<code title="">csiso88596i</code>", "<code title="">csisolatinarabic</code>", "<code title="">ecma-114</code>", "<code title="">iso-8859-6</code>", "<code title="">iso-8859-6-e</code>", "<code title="">iso-8859-6-i</code>", "<code title="">iso-ir-127</code>", "<code title="">iso8859-6</code>", "<code title="">iso88596</code>", "<code title="">iso_8859-6</code>", "<code title="">iso_8859-6:1987</code>"</td>
+    <td>"<code>arabic</code>", "<code>asmo-708</code>", "<code>csiso88596e</code>", "<code>csiso88596i</code>", "<code>csisolatinarabic</code>", "<code>ecma-114</code>", "<code>iso-8859-6</code>", "<code>iso-8859-6-e</code>", "<code>iso-8859-6-i</code>", "<code>iso-ir-127</code>", "<code>iso8859-6</code>", "<code>iso88596</code>", "<code>iso_8859-6</code>", "<code>iso_8859-6:1987</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-6', "'iso-8859-6'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatingreek</code>", "<code title="">ecma-118</code>", "<code title="">elot_928</code>", "<code title="">greek</code>", "<code title="">greek8</code>", "<code title="">iso-8859-7</code>", "<code title="">iso-ir-126</code>", "<code title="">iso8859-7</code>", "<code title="">iso88597</code>", "<code title="">iso_8859-7</code>", "<code title="">iso_8859-7:1987</code>", "<code title="">sun_eu_greek</code>"</td>
+    <td>"<code>csisolatingreek</code>", "<code>ecma-118</code>", "<code>elot_928</code>", "<code>greek</code>", "<code>greek8</code>", "<code>iso-8859-7</code>", "<code>iso-ir-126</code>", "<code>iso8859-7</code>", "<code>iso88597</code>", "<code>iso_8859-7</code>", "<code>iso_8859-7:1987</code>", "<code>sun_eu_greek</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-7', "'iso-8859-7'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csiso88598e</code>", "<code title="">csisolatinhebrew</code>", "<code title="">hebrew</code>", "<code title="">iso-8859-8</code>", "<code title="">iso-8859-8-e</code>", "<code title="">iso-ir-138</code>", "<code title="">iso8859-8</code>", "<code title="">iso88598</code>", "<code title="">iso_8859-8</code>", "<code title="">iso_8859-8:1988</code>", "<code title="">visual</code>"</td>
+    <td>"<code>csiso88598e</code>", "<code>csisolatinhebrew</code>", "<code>hebrew</code>", "<code>iso-8859-8</code>", "<code>iso-8859-8-e</code>", "<code>iso-ir-138</code>", "<code>iso8859-8</code>", "<code>iso88598</code>", "<code>iso_8859-8</code>", "<code>iso_8859-8:1988</code>", "<code>visual</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-8', "'iso-8859-8'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csiso88598i</code>", "<code title="">iso-8859-8-i</code>", "<code title="">logical</code>"</td>
+    <td>"<code>csiso88598i</code>", "<code>iso-8859-8-i</code>", "<code>logical</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO-8859-8-I', "'iso-8859-8i'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatin6</code>", "<code title="">iso-8859-10</code>", "<code title="">iso-ir-157</code>", "<code title="">iso8859-10</code>", "<code title="">iso885910</code>", "<code title="">l6</code>", "<code title="">latin6</code>"</td>
+    <td>"<code>csisolatin6</code>", "<code>iso-8859-10</code>", "<code>iso-ir-157</code>", "<code>iso8859-10</code>", "<code>iso885910</code>", "<code>l6</code>", "<code>latin6</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-10', "'iso-8859-10'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">iso-8859-13</code>", "<code title="">iso8859-13</code>", "<code title="">iso885913</code>"</td>
+    <td>"<code>iso-8859-13</code>", "<code>iso8859-13</code>", "<code>iso885913</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-13', "'iso-8859-13'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">iso-8859-14</code>", "<code title="">iso8859-14</code>", "<code title="">iso885914</code>"</td>
+    <td>"<code>iso-8859-14</code>", "<code>iso8859-14</code>", "<code>iso885914</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-14', "'iso-8859-14'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csisolatin9</code>", "<code title="">iso-8859-15</code>", "<code title="">iso8859-15</code>", "<code title="">iso885915</code>", "<code title="">l9</code>", "<code title="">latin9</code>"</td>
+    <td>"<code>csisolatin9</code>", "<code>iso-8859-15</code>", "<code>iso8859-15</code>", "<code>iso885915</code>", "<code>l9</code>", "<code>latin9</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-15', "'iso-8859-15'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">iso-8859-16</code>"</td>
+    <td>"<code>iso-8859-16</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-16', "'iso-8859-16'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cskoi8r</code>", "<code title="">koi</code>", "<code title="">koi8</code>", "<code title="">koi8-r</code>", "<code title="">koi8_r</code>"</td>
+    <td>"<code>cskoi8r</code>", "<code>koi</code>", "<code>koi8</code>", "<code>koi8-r</code>", "<code>koi8_r</code>"</td>
     <td><code>{{interwiki('wikipedia', 'KOI8-R', "'koi8-r'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">koi8-u</code>"</td>
+    <td>"<code>koi8-u</code>"</td>
     <td><code>{{interwiki('wikipedia', 'KOI8-U', "'koi8-u'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csmacintosh</code>", "<code title="">mac</code>", "<code title="">macintosh</code>", "<code title="">x-mac-roman</code>"</td>
+    <td>"<code>csmacintosh</code>", "<code>mac</code>", "<code>macintosh</code>", "<code>x-mac-roman</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Mac OS Roman', "'macintosh'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">dos-874</code>", "<code title="">iso-8859-11</code>", "<code title="">iso8859-11</code>", "<code title="">iso885911</code>", "<code title="">tis-620</code>", "<code title="">windows-874</code>"</td>
+    <td>"<code>dos-874</code>", "<code>iso-8859-11</code>", "<code>iso8859-11</code>", "<code>iso885911</code>", "<code>tis-620</code>", "<code>windows-874</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-874', "'windows-874'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1250</code>", "<code title="">windows-1250</code>", "<code title="">x-cp1250</code>"</td>
+    <td>"<code>cp1250</code>", "<code>windows-1250</code>", "<code>x-cp1250</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1250', "'windows-1250'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1251</code>", "<code title="">windows-1251</code>", "<code title="">x-cp1251</code>"</td>
+    <td>"<code>cp1251</code>", "<code>windows-1251</code>", "<code>x-cp1251</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1251', "'windows-1251'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">ansi_x3.4-1968</code>", "<code title="">ascii</code>", "<code title="">cp1252</code>", "<code title="">cp819</code>", "<code title="">csisolatin1</code>", "<code title="">ibm819</code>", "<code title="">iso-8859-1</code>", "<code title="">iso-ir-100</code>", "<code title="">iso8859-1</code>", "<code title="">iso88591</code>", "<code title="">iso_8859-1</code>", "<code title="">iso_8859-1:1987</code>", "<code title="">l1</code>", "<code title="">latin1</code>", "<code title="">us-ascii</code>", "<code title="">windows-1252</code>", "<code title="">x-cp1252</code>"</td>
+    <td>"<code>ansi_x3.4-1968</code>", "<code>ascii</code>", "<code>cp1252</code>", "<code>cp819</code>", "<code>csisolatin1</code>", "<code>ibm819</code>", "<code>iso-8859-1</code>", "<code>iso-ir-100</code>", "<code>iso8859-1</code>", "<code>iso88591</code>", "<code>iso_8859-1</code>", "<code>iso_8859-1:1987</code>", "<code>l1</code>", "<code>latin1</code>", "<code>us-ascii</code>", "<code>windows-1252</code>", "<code>x-cp1252</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1252', "'windows-1252'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1253</code>", "<code title="">windows-1253</code>", "<code title="">x-cp1253</code>"</td>
+    <td>"<code>cp1253</code>", "<code>windows-1253</code>", "<code>x-cp1253</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1253', "'windows-1253'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1254</code>", "<code title="">csisolatin5</code>", "<code title="">iso-8859-9</code>", "<code title="">iso-ir-148</code>", "<code title="">iso8859-9</code>", "<code title="">iso88599</code>", "<code title="">iso_8859-9</code>", "<code title="">iso_8859-9:1989</code>", "<code title="">l5</code>", "<code title="">latin5</code>", "<code title="">windows-1254</code>", "<code title="">x-cp1254</code>"</td>
+    <td>"<code>cp1254</code>", "<code>csisolatin5</code>", "<code>iso-8859-9</code>", "<code>iso-ir-148</code>", "<code>iso8859-9</code>", "<code>iso88599</code>", "<code>iso_8859-9</code>", "<code>iso_8859-9:1989</code>", "<code>l5</code>", "<code>latin5</code>", "<code>windows-1254</code>", "<code>x-cp1254</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1254', "'windows-1254'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1255</code>", "<code title="">windows-1255</code>", "<code title="">x-cp1255</code>"</td>
+    <td>"<code>cp1255</code>", "<code>windows-1255</code>", "<code>x-cp1255</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1255', "'windows-1255'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1256</code>", "<code title="">windows-1256</code>", "<code title="">x-cp1256</code>"</td>
+    <td>"<code>cp1256</code>", "<code>windows-1256</code>", "<code>x-cp1256</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1256', "'windows-1256'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1257</code>", "<code title="">windows-1257</code>", "<code title="">x-cp1257</code>"</td>
+    <td>"<code>cp1257</code>", "<code>windows-1257</code>", "<code>x-cp1257</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1257', "'windows-1257'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cp1258</code>", "<code title="">windows-1258</code>", "<code title="">x-cp1258</code>"</td>
+    <td>"<code>cp1258</code>", "<code>windows-1258</code>", "<code>x-cp1258</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Windows-1258', "'windows-1258'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">x-mac-cyrillic</code>", "<code title="">x-mac-ukrainian</code>"</td>
+    <td>"<code>x-mac-cyrillic</code>", "<code>x-mac-ukrainian</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Macintosh Cyrillic encoding', "'x-mac-cyrillic'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">chinese</code>", "<code title="">csgb2312</code>", "<code title="">csiso58gb231280</code>", "<code title="">gb2312</code>", "<code title="">gb_2312</code>", "<code title="">gb_2312-80</code>", "<code title="">gbk</code>", "<code title="">iso-ir-58</code>", "<code title="">x-gbk</code>"</td>
+    <td>"<code>chinese</code>", "<code>csgb2312</code>", "<code>csiso58gb231280</code>", "<code>gb2312</code>", "<code>gb_2312</code>", "<code>gb_2312-80</code>", "<code>gbk</code>", "<code>iso-ir-58</code>", "<code>x-gbk</code>"</td>
     <td><code>{{interwiki('wikipedia', 'GBK', "'gbk'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">gb18030</code>"</td>
+    <td>"<code>gb18030</code>"</td>
     <td><code>{{interwiki('wikipedia', 'GB_18030', "'gb18030'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">hz-gb-2312</code>"</td>
+    <td>"<code>hz-gb-2312</code>"</td>
     <td><code>{{interwiki('wikipedia', 'HZ_(character_encoding)', "'hz-gb-2312'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">big5</code>", "<code title="">big5-hkscs</code>", "<code title="">cn-big5</code>", "<code title="">csbig5</code>", "<code title="">x-x-big5</code>"</td>
+    <td>"<code>big5</code>", "<code>big5-hkscs</code>", "<code>cn-big5</code>", "<code>csbig5</code>", "<code>x-x-big5</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Big5', "'big5'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cseucpkdfmtjapanese</code>", "<code title="">euc-jp</code>", "<code title="">x-euc-jp</code>"</td>
+    <td>"<code>cseucpkdfmtjapanese</code>", "<code>euc-jp</code>", "<code>x-euc-jp</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-JP', "'euc-jp'")}}</code></td>
    </tr>
    <tr>
     <td>
-     <p>"<code title="">csiso2022jp</code>", "<code title="">iso-2022-jp</code>"</p>
+     <p>"<code>csiso2022jp</code>", "<code>iso-2022-jp</code>"</p>
 
      <div class="note">
      <p><strong>Note</strong>: Firefox used to accept <code>iso-2022-jp-2</code> sequences silently when an <code>iso-2022-jp</code> decoder was instantiated, however this was removed in version 56 to simplify the API, as no other browsers support it and no pages seem to use it.</p>
@@ -180,31 +180,31 @@ tags:
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-JP', "'iso-2022-jp'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csshiftjis</code>", "<code title="">ms_kanji</code>", "<code title="">shift-jis</code>", "<code title="">shift_jis</code>", "<code title="">sjis</code>", "<code title="">windows-31j</code>", "<code title="">x-sjis</code>"</td>
+    <td>"<code>csshiftjis</code>", "<code>ms_kanji</code>", "<code>shift-jis</code>", "<code>shift_jis</code>", "<code>sjis</code>", "<code>windows-31j</code>", "<code>x-sjis</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Shift JIS', "'shift-jis'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">cseuckr</code>", "<code title="">csksc56011987</code>", "<code title="">euc-kr</code>", "<code title="">iso-ir-149</code>", "<code title="">korean</code>", "<code title="">ks_c_5601-1987</code>", "<code title="">ks_c_5601-1989</code>", "<code title="">ksc5601</code>", "<code title="">ksc_5601</code>", "<code title="">windows-949</code>"</td>
+    <td>"<code>cseuckr</code>", "<code>csksc56011987</code>", "<code>euc-kr</code>", "<code>iso-ir-149</code>", "<code>korean</code>", "<code>ks_c_5601-1987</code>", "<code>ks_c_5601-1989</code>", "<code>ksc5601</code>", "<code>ksc_5601</code>", "<code>windows-949</code>"</td>
     <td><code>{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-KR', "'euc-kr'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">csiso2022kr</code>", "<code title="">iso-2022-kr</code>"</td>
+    <td>"<code>csiso2022kr</code>", "<code>iso-2022-kr</code>"</td>
     <td><code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-KR', "'iso-2022-kr'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">utf-16be</code>"</td>
+    <td>"<code>utf-16be</code>"</td>
     <td><code>{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16be'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">utf-16</code>", "<code title="">utf-16le</code>"</td>
+    <td>"<code>utf-16</code>", "<code>utf-16le</code>"</td>
     <td><code>{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16le'")}}</code></td>
    </tr>
    <tr>
-    <td>"<code title="">x-user-defined</code>"</td>
+    <td>"<code>x-user-defined</code>"</td>
     <td><code>'x-user-defined'</code></td>
    </tr>
    <tr>
-    <td>"<code title="">iso-2022-cn</code>", "<code title="">iso-2022-cn-ext</code>"</td>
+    <td>"<code>iso-2022-cn</code>", "<code>iso-2022-cn-ext</code>"</td>
     <td><code>'replacement'</code></td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/worklet/index.html
+++ b/files/en-us/web/api/worklet/index.html
@@ -93,7 +93,7 @@ tags:
 
 <ul>
  <li><a href="https://developers.google.com/web/updates/2016/05/houdini">Houdini: Demystifying CSS</a> on Google Developers (May 2016)</li>
- <li><a href="https://www.youtube.com/watch?v=g1L4O1smMC0&amp;t=1m33s" title="">AudioWorklet :: What, Why, and How</a> on YouTube (November 2017)</li>
+ <li><a href="https://www.youtube.com/watch?v=g1L4O1smMC0&amp;t=1m33s">AudioWorklet :: What, Why, and How</a> on YouTube (November 2017)</li>
  <li><a href="https://developers.google.com/web/updates/2017/12/audio-worklet">Enter AudioWorklet</a> on Google Developers (December 2017)</li>
- <li><a href="https://www.youtube.com/watch?v=ZPkMMShYxKU&amp;t=0m19s" title="">Animation Worklet - HTTP203 Advent</a> on YouTube (December 2017)</li>
+ <li><a href="https://www.youtube.com/watch?v=ZPkMMShYxKU&amp;t=0m19s">Animation Worklet - HTTP203 Advent</a> on YouTube (December 2017)</li>
 </ul>

--- a/files/en-us/web/api/xmlhttprequest/channel/index.html
+++ b/files/en-us/web/api/xmlhttprequest/channel/index.html
@@ -13,4 +13,4 @@ tags:
 ---
 <p>{{draft}}{{APIRef('XMLHttpRequest')}}</p>
 
-<p>XMLHttpRequest.channel is an <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIChannel" title="">nsIChannel</a></code> that used by the object when performing the request. This is <code>null</code> if the channel hasn't been created yet. In the case of a multi-part request, this is the initial channel, not the different parts in the multi-part request. <strong>Requires elevated privileges to access.</strong></p>
+<p>XMLHttpRequest.channel is an <code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIChannel">nsIChannel</a></code> that used by the object when performing the request. This is <code>null</code> if the channel hasn't been created yet. In the case of a multi-part request, this is the initial channel, not the different parts in the multi-part request. <strong>Requires elevated privileges to access.</strong></p>

--- a/files/en-us/web/css/quotes/index.html
+++ b/files/en-us/web/css/quotes/index.html
@@ -83,15 +83,15 @@ q::after {
 <h4 id="HTML_2">HTML</h4>
 
 <pre class="brush: html notranslate">&lt;div lang="fr"&gt;
-  &lt;q&gt;<span class="tlid-translation translation" lang="fr"><span title="">Ceci est une citation française.</span></span>&lt;/q&gt;
+  &lt;q&gt;<span class="tlid-translation translation" lang="fr">Ceci est une citation française.</span>&lt;/q&gt;
 &lt;div&gt;
 &lt;hr&gt;
 &lt;div lang="ru"&gt;
-  &lt;q&gt;<span class="tlid-translation translation" lang="ru"><span title="">Это русская цитата</span></span>&lt;/q&gt;
+  &lt;q&gt;<span class="tlid-translation translation" lang="ru">Это русская цитата</span>&lt;/q&gt;
 &lt;div&gt;
 &lt;hr&gt;
 &lt;div lang="de"&gt;
-  &lt;q&gt;<span class="tlid-translation translation" lang="de"><span title="">Dies ist ein deutsches Zitat</span></span>&lt;/q&gt;
+  &lt;q&gt;<span class="tlid-translation translation" lang="de">Dies ist ein deutsches Zitat</span>&lt;/q&gt;
 &lt;div&gt;
 &lt;hr&gt;
 &lt;div lang="en"&gt;


### PR DESCRIPTION
Left one instance were it was used in an example for no tootlips when it's specifically empty