### PR TITLE
fix: IndexedDB broken links

### DIFF
--- a/files/en-us/web/api/indexeddb_api/basic_concepts_behind_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/basic_concepts_behind_indexeddb/index.html
@@ -132,7 +132,7 @@ tags:
 
  <p>Alternatively, you can also look up records in an object store using the <a href="#gloss_key"> key</a><em>.</em></p>
 
- <p>To learn more on using indexes, see <a href="/en/IndexedDB/Using_IndexedDB#Using_an_index" title="en/IndexedDB/Using_IndexedDB#Using_an_index">Using IndexedDB</a>. For the reference documentation on index, see <a href="/en-US/docs/Web/API/IDBKeyRange" rel="internal">IDBKeyRange</a>.</p>
+ <p>To learn more on using indexes, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#Using_an_index" title="en/IndexedDB/Using_IndexedDB#Using_an_index">Using IndexedDB</a>. For the reference documentation on index, see <a href="/en-US/docs/Web/API/IDBKeyRange" rel="internal">IDBKeyRange</a>.</p>
  </dd>
 </dl>
 
@@ -204,13 +204,13 @@ tags:
 
 <h2 id="next">Next steps</h2>
 
-<p>With these big concepts under our belts, we can get to more concrete stuff. For a tutorial on how to use the API, see <a href="/en/IndexedDB/Using_IndexedDB" title="en/IndexedDB/IndexedDB primer">Using IndexedDB</a>.</p>
+<p>With these big concepts under our belts, we can get to more concrete stuff. For a tutorial on how to use the API, see <a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB" title="en/IndexedDB/IndexedDB primer">Using IndexedDB</a>.</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="http://www.w3.org/TR/IndexedDB/"><span style="direction: ltr;">Indexed Database API Specification</span></a></li>
  <li><a href="/en/IndexedDB">IndexedDB API Reference</a></li>
- <li><a href="/en/IndexedDB/Using_IndexedDB" title="en/IndexedDB/IndexedDB primer">Using IndexedDB</a></li>
+ <li><a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB" title="en/IndexedDB/IndexedDB primer">Using IndexedDB</a></li>
  <li><a class="external" href="http://msdn.microsoft.com/en-us/scriptjunkie/gg679063.aspx">IndexedDB — The Store in Your Browser</a></li>
 </ul>


### PR DESCRIPTION
- Changed links from `/en/IndexedDB/Using_IndexedDB` to `/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB`
- Did not change url fragments as they are still correct
- `title` attributes are left untouched