### PR TITLE
fix: Standard 'See also' sections header

### DIFF
--- a/files/en-us/games/techniques/audio_for_web_games/index.html
+++ b/files/en-us/games/techniques/audio_for_web_games/index.html
@@ -447,7 +447,7 @@ function playTrack(audioBuffer) {
 
 <p>This is especially useful in a three-dimensional environment rendered using WebGL, where the Web Audio API makes it possible to tie audio to the objects and viewpoints.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API on MDN</a></li>

--- a/files/en-us/glossary/beacon/index.html
+++ b/files/en-us/glossary/beacon/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>There is a <a href="https://w3c.github.io/beacon/">W3C Draft Beacon Specification</a> to standardize the beacon as an interface to asynchronously transfer HTTP data from User Agent to a web server prior to page load without negative performance impact.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/Real_User_Monitoring">Real User Monitoring (RUM)</a></li>

--- a/files/en-us/glossary/client_hints/index.html
+++ b/files/en-us/glossary/client_hints/index.html
@@ -30,7 +30,7 @@ tags:
 
 <p><code>Vary: Accept, Width, Viewport-Width, Downlink</code></p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/HTTP/Headers#Client_hints">Client Hints headers</a></li>

--- a/files/en-us/glossary/code_splitting/index.html
+++ b/files/en-us/glossary/code_splitting/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>Code splitting is a feature supported by bundlers like <a href="https://webpack.js.org/">Webpack</a> and <a href="http://browserify.org/">Browserify</a> which can create multiple bundles that can be dynamically loaded at runtime.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>Bundling</li>

--- a/files/en-us/glossary/cssom/index.html
+++ b/files/en-us/glossary/cssom/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>The <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model</a> is also a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify the CSS style dynamically.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Performance/How_browsers_work">Populating the page: how browsers work</a></li>

--- a/files/en-us/glossary/domain_sharding/index.html
+++ b/files/en-us/glossary/domain_sharding/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>HTTP2 supports unlimited concurrent requests making domain sharding an obsolete requirement when HTTP/2 is enabled.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Archive/Security/SSL_and_TLS">Transport Layer Security (TLS)</a></li>

--- a/files/en-us/glossary/effective_connection_type/index.html
+++ b/files/en-us/glossary/effective_connection_type/index.html
@@ -59,7 +59,7 @@ tags:
 
 <pre class="brush: js notranslate">navigator.connection.effectiveType;</pre>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Network_Information_API">Network Information API</a></li>

--- a/files/en-us/glossary/first_contentful_paint/index.html
+++ b/files/en-us/glossary/first_contentful_paint/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p><dfn>The First Contentful Paint</dfn> time stamp is when the browser first rendered any text, image (including background images), non-white canvas or SVG. This excludes any content of iframes, but includes text with pending webfonts. This is the first time users could start consuming page content.</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/first_meaningful_paint">First Meaningful Paint</a></li>

--- a/files/en-us/glossary/first_input_delay/index.html
+++ b/files/en-us/glossary/first_input_delay/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>The time between when content is painted to the page and when all the functionality becomes responsive to human interaction often varies based on the size and complexity of the JavaScript needing to be downloaded, parsed, and executed on the main thread, and on the device speed or lack thereof (think low end mobile devices). The longer the delay, the worse the user experience. Reducing site initialization time and eliminating<a href="/en-US/docs/Web/API/Long_Tasks_API"> long tasks</a> can help eliminate first input delays.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Window/requestIdleCallback">requestIdleCallback </a></li>

--- a/files/en-us/glossary/first_meaningful_paint/index.html
+++ b/files/en-us/glossary/first_meaningful_paint/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><strong>First Meaningful Paint</strong> (FMP) is the paint after which the biggest above-the-fold layout change has happened and web fonts have loaded.  It is when the answer to "Is it useful?" becomes "yes", upon first meaningful paint completion.</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/First_contentful_paint">First contentful paint</a></li>

--- a/files/en-us/glossary/houdini/index.html
+++ b/files/en-us/glossary/houdini/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>While many of the features Houdini enables can be created with JavaScript, interacting directly with the CSSOM before JavaScript is enabled provides for faster parse times. Browsers create the CSSOM —  including layout, paint, and composite processes — before applying any style updates found in scripts: layout, paint, and composite processes are repeated for updated JavaScript styles to be implemented. Houdini code doesn't wait for that first rendering cycle to be complete. Rather, it is included in that first cycle, creating renderable, understandable styles.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Houdini">Houdini</a></li>

--- a/files/en-us/glossary/lazy_load/index.html
+++ b/files/en-us/glossary/lazy_load/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p><span class="seoSummary"><strong>Lazy loading</strong> is a strategy that delays the loading of some assets (e.g., images) until they are needed by the user based on the user's activity and navigation pattern; typically, these assets are only loaded when they are scrolled into view. </span>If correctly implemented, this delay in asset loading is seamless to the user experience and might help improve initial load performance, including <a href="/en-US/docs/Glossary/Time_to_interactive">time to interactive</a>, as fewer assets are required for the page to start working.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Performance/Lazy_loading">Lazy loading</a></li>

--- a/files/en-us/glossary/long_task/index.html
+++ b/files/en-us/glossary/long_task/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p><span class="seoSummary">A <strong>long task</strong>  is a task that takes more than 50ms to complete.</span> It is an uninterrupted period where the <a href="/en-US/docs/Glossary/Main_thread">main UI thread</a> is busy for 50 ms or longer. Common examples include long running event handlers, expensive <a href="/en-US/docs/Glossary/Reflow">reflows</a> and other re-renders, and work the browser does between different turns of the event loop that exceeds 50 ms.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Long_Tasks_API">Long task API</a></li>

--- a/files/en-us/glossary/lossy_compression/index.html
+++ b/files/en-us/glossary/lossy_compression/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>Although there is no obvious difference quality between the two images above, the size of the second image has been significantly reduced, using lossy compression.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/Lossless_compression">Lossless compression</a></li>

--- a/files/en-us/glossary/network_throttling/index.html
+++ b/files/en-us/glossary/network_throttling/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>Browser developer tools generally have network throttling options, to allow you to test your app under slow network conditions. Firefox's developer tools for example have a drop-down menu available in both the <a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a> and <a href="/en-US/docs/Tools/Responsive_Design_Mode">Responsive Design Mode</a> containing network speed options (e.g. wifi, good 3G, 2G...)</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/Synthetic_monitoring">Synthetic monitoring</a></li>

--- a/files/en-us/glossary/quic/index.html
+++ b/files/en-us/glossary/quic/index.html
@@ -31,7 +31,7 @@ tags:
  <li><a href="https://tools.ietf.org/html/draft-tsvwg-quic-protocol-02">IETF Draft</a></li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/HTTP_2">HTTP/2</a></li>

--- a/files/en-us/glossary/real_user_monitoring/index.html
+++ b/files/en-us/glossary/real_user_monitoring/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p><strong>Real User Monitoring</strong> or<strong> </strong>RUM measures the performance of a page from real users' machines. Generally, a third party script injects a script on each page to measure and report page load data for every request made. This technique monitors an application’s actual user interactions. In RUM, the third party script collects performance metrics from the real users' browsers. RUM helps identify how an application is being used, including the geographic distribution of users and the impact of that distribution on the end user experience.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Performance/Rum-vs-Synthetic">Real User Monitoring (RUM) versus Synthetic Monitoring</a></li>

--- a/files/en-us/glossary/round_trip_time_(rtt)/index.html
+++ b/files/en-us/glossary/round_trip_time_(rtt)/index.html
@@ -26,7 +26,7 @@ round-trip min/avg/max/stddev = 23.781/26.828/34.904/4.114 ms</pre>
 <p>In the above example, the average round trip time is shown on the final line as 26.8ms.</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/time_to_first_byte">Time to First Byte (TTFB)</a></li>

--- a/files/en-us/glossary/server_timing/index.html
+++ b/files/en-us/glossary/server_timing/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p><span class="seoSummary">The <a href="https://www.w3.org/TR/server-timing/" rel="noopener noreferrer">Server Timing specification</a> enables the server to communicate performance metrics from the request-response cycle to the user agent, and utilizes a JavaScript interface to allow applications to collect, process, and act on these metrics to optimize application delivery.</span></p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://www.w3.org/TR/server-timing/">https://www.w3.org/TR/server-timing/</a></li>

--- a/files/en-us/glossary/synthetic_monitoring/index.html
+++ b/files/en-us/glossary/synthetic_monitoring/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>Unlike <a href="/en-US/docs/Glossary/Real_User_Monitoring">RUM</a>, synthetic monitoring provides a narrow view of performance that doesn't account for user differences, making it useful in getting basic data about an application's performance and spot-checking performance in development environments. Combined with other tools, such as network throttling, can provide excellent insight into potential problem areas.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/Real_User_Monitoring">Real User Monitoring (RUM)</a></li>

--- a/files/en-us/glossary/tcp_slow_start/index.html
+++ b/files/en-us/glossary/tcp_slow_start/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>Congestion itself is a state that happens within a network layer when the message traffic is too busy it slows the network response time. T<span style="font-weight: 400;">he server sends data in TCP packets, the user's client then confirms delivery by returning acknoledgements, or ACKs. The connection has a limited capacity depending on hardware and network conditions. If the server sends too many packets too quickly, they will be dropped. Meaning, there will be no acknowledgement. The server registers this as missing ACKs. Congestion control algorithms use this flow of sent packets and ACKs to determine a send rate.</span></p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Performance/Populating_the_page:_how_browsers_work">Populating the page: how browsers work</a></li>

--- a/files/en-us/glossary/time_to_first_byte/index.html
+++ b/files/en-us/glossary/time_to_first_byte/index.html
@@ -13,7 +13,7 @@ tags:
 
 <pre>TTFB = <a href="/en-US/docs/Web/API/PerformanceResourceTiming/responseStart">responseStart</a> - <a href="/en-US/docs/Web/API/PerformanceResourceTiming/requestStart">requestStart</a></pre>
 
-<h2 id="See_Also">See Also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/HTTP/Session">A typical HTTP session</a></li>

--- a/files/en-us/glossary/webdav/index.html
+++ b/files/en-us/glossary/webdav/index.html
@@ -19,7 +19,7 @@ tags:
  <li>lock a document from being edited by more than one person at a time</li>
 </ul>
 
-<h2 id="See_also">Learn more</h2>
+<h2 id="See_also">See also</h2>
 
 <h3 id="General_Knowledge">General Knowledge</h3>
 

--- a/files/en-us/learn/accessibility/what_is_accessibility/index.html
+++ b/files/en-us/learn/accessibility/what_is_accessibility/index.html
@@ -212,7 +212,7 @@ tags:
  <li><a href="/en-US/docs/Learn/Accessibility/Accessibility_troubleshooting">Accessibility troubleshooting</a></li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG">WCAG</a>

--- a/files/en-us/learn/css/css_layout/grids/index.html
+++ b/files/en-us/learn/css/css_layout/grids/index.html
@@ -694,7 +694,7 @@ aside {
 
 <p>In this overview we have toured the main features of CSS Grid Layout. You should be able to start using it in your designs. To dig further into the specification, read our guides to Grid Layout, which can be found below.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout#Guides">CSS Grid guides</a></li>

--- a/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
+++ b/files/en-us/learn/css/css_layout/supporting_older_browsers/index.html
@@ -214,7 +214,7 @@ tags:
 
 <p>You now have the knowledge to confidently use techniques such as Grid and Flexbox, create fallbacks for older browsers, and make use of any new techniques that might come along in the future.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://hacks.mozilla.org/2016/08/using-feature-queries-in-css/">Using Feature Queries in CSS</a></li>

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.html
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.html
@@ -296,7 +296,7 @@ tags:
 
 <p>You now have all the knowledge you'll need to properly structure your web forms. We will cover many of the features introduced here in the next few articles, with the next article looking in more detail at using all the different types of form widgets you'll want to use to collect information from your users.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="http://www.alistapart.com/articles/sensibleforms/" rel="external" title="http://www.alistapart.com/articles/sensibleforms/">A List Apart: <em>Sensible Forms: A Form Usability Checklist</em></a></li>

--- a/files/en-us/learn/performance/css/index.html
+++ b/files/en-us/learn/performance/css/index.html
@@ -68,7 +68,7 @@ tags:
  <li><a href="/en-US/docs/Learn/Performance/business_case_for_performance">Focusing on performance</a></li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>

--- a/files/en-us/learn/performance/html/index.html
+++ b/files/en-us/learn/performance/html/index.html
@@ -63,7 +63,7 @@ tags:
  <li><a href="/en-US/docs/Learn/Performance/business_case_for_performance">Focusing on performance</a></li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/picture">The <code>&lt;picture&gt;</code> Element</a></li>

--- a/files/en-us/learn/performance/web_performance_basics/index.html
+++ b/files/en-us/learn/performance/web_performance_basics/index.html
@@ -81,7 +81,7 @@ tags:
  <li>  Use uncompressed media files</li>
 </ul>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://github.com/filamentgroup/loadCSS">https://github.com/filamentgroup/loadCSS</a></li>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.html
@@ -15,13 +15,6 @@ tags:
 
 <p>Functions to internationalize your extension. You can use these APIs to get localized strings from locale files packaged with your extension, find out the browser's current language, and find out the value of its <a href="/en-US/docs/Web/HTTP/Content_negotiation#The_Accept-Language_header">Accept-Language header</a>.</p>
 
-<p id="See_also">For more details on using i18n for your extension, see:</p>
-
-<ul>
- <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization">Internationalization</a>: a guide to using the WebExtension i18n system.</li>
- <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference">Locale-Specific Message reference</a>: extensions supply locale-specific strings in files called <code>messages.json</code>. This page describes the format of <code>messages.json</code>.</li>
-</ul>
-
 <h2 id="Types">Types</h2>
 
 <dl>
@@ -54,6 +47,13 @@ tags:
 
 <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization">Internationalization</a>: a guide to using the WebExtension i18n system.</li>
+ <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference">Locale-Specific Message reference</a>: extensions supply locale-specific strings in files called <code>messages.json</code>. This page describes the format of <code>messages.json</code>.</li>
+</ul>
 
 <div class="hidden">
 <pre>// Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/developer_guide/build_instructions/compiling_32-bit_firefox_on_a_linux_64-bit_os/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/compiling_32-bit_firefox_on_a_linux_64-bit_os/index.html
@@ -202,7 +202,7 @@ checking build system type... i686-pc-linux-gnu
 
 <p>Now, follow the <a href="/En/Developer_Guide/Build_Instructions" title="Build Instructions">build instructions</a> like normal and you should have 32-bit builds!</p>
 
-<h3 id="See_Also">See Also</h3>
+<h3 id="See_also">See also</h3>
 
 <ul>
  <li><a href="/en/Cross-Compiling_Mozilla" title="en/Cross-Compiling_Mozilla">Cross-Compiling Mozilla</a></li>

--- a/files/en-us/mozilla/developer_guide/build_instructions/global_deps/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/global_deps/index.html
@@ -3,7 +3,5 @@ title: GLOBAL DEPS
 slug: Mozilla/Developer_guide/Build_Instructions/GLOBAL_DEPS
 ---
 <p>Is a makefile variable that can be used to add dependencies on common sources (Makefile, Makefile.in, autoconf.mk) that will force targets to rebuild whenever they are changed.</p>
-<h3 class="editable" id="Set_By"><span>Set By</span></h3>
-<h3 class="editable" id="Example"><span>Example</span></h3>
-<h3 class="editable" id="See_Also"><span>See Also</span></h3>
+<h2 id="See_also">See also</h2>
 <p><a class=" external" href="http://bugzilla.mozilla.org/show_bug.cgi?id=680542">http://bugzilla.mozilla.org/show_bug.cgi?id=680542</a></p>

--- a/files/en-us/mozilla/developer_guide/rtl_guidelines/index.html
+++ b/files/en-us/mozilla/developer_guide/rtl_guidelines/index.html
@@ -209,7 +209,7 @@ tags:
  <li>If code is displayed as RTL (e.g., <code>;padding: 20px</code> - the semicolon should appear on the right side of the code). Code can still be aligned to the right if it appears in an RTL context</li>
 </ul>
 
-<h3 id="See_Also">See Also</h3>
+<h3 id="See_also">See also</h3>
 
 <ul>
  <li><a href="https://docs.google.com/document/d/1Rc8rvwsLI06xArFQouTinSh3wNte9Sqn9KWi1r7xY4Y/edit#heading=h.pw54h41h12ct">RTL Best Practices</a></li>

--- a/files/en-us/mozilla/developer_guide/source_code/getting_comm-central/index.html
+++ b/files/en-us/mozilla/developer_guide/source_code/getting_comm-central/index.html
@@ -142,7 +142,7 @@ date
 make -f client.mk build
 </pre>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/comm-central" title="en/comm-central">comm-central</a></li>

--- a/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.html
+++ b/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.html
@@ -52,7 +52,7 @@ tags:
 
 <p>The easiest way to do this is to use the provided user interface, by using the Feeds panel in the Preferences (or Options, depending on your platform) window.</p>
 
-<h3 id="See_Also">See Also</h3>
+<h3 id="See_also">See also</h3>
 
 <ul>
  <li>{{ domxref("window.navigator.registerContentHandler()") }}</li>

--- a/files/en-us/plugins/flash_to_html5/video/file_format_conversion/index.html
+++ b/files/en-us/plugins/flash_to_html5/video/file_format_conversion/index.html
@@ -42,7 +42,7 @@ tags:
  <li>The next step is to use a utility like <a href="https://github.com/axiomatic-systems/Bento4">Bento4</a>'s <code>mp4-dash.py</code> Python script to generate the corresponding MPD manifest file needed by clients to access the different resolution fragmented MP4s.</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <p>For more information about transcoding:</p>
 

--- a/files/en-us/plugins/roadmap/index.html
+++ b/files/en-us/plugins/roadmap/index.html
@@ -23,7 +23,7 @@ slug: Plugins/Roadmap
  <dd>In January 2021, Firefox 85 will completely remove Flash support. <a href="https://theblog.adobe.com/adobe-flash-update/">Adobe will stop shipping security updates for Flash at the end of 2020</a>.</dd>
 </dl>
 
-<h3 id="See_Also">See Also</h3>
+<h3 id="See_also">See also</h3>
 
 <h4 id="Mozilla_Firefox">Mozilla Firefox</h4>
 

--- a/files/en-us/tools/memory/dominators/index.html
+++ b/files/en-us/tools/memory/dominators/index.html
@@ -52,7 +52,7 @@ slug: Tools/Memory/Dominators
 <p><a id="multiple-paths">One slight subtlety here is that if an object A is referenced by two other objects B and C, then neither object is its dominator</a>, because you could remove either B or C from the graph, and A would still be retained by its other referrer. Instead, the immediate dominator of A would be its first common ancestor:<br>
  <img alt="" src="https://mdn.mozillademos.org/files/12331/memory-graph-dominator-multiple-references.svg" style="display: block; height: 283px; margin-left: auto; margin-right: auto; width: 211px;"></p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <p><a href="https://en.wikipedia.org/wiki/Dominator_%28graph_theory%29">Dominators in graph theory</a>.</p>
 

--- a/files/en-us/web/accessibility/accessibility_colon__what_users_can_to_to_browse_safely/index.html
+++ b/files/en-us/web/accessibility/accessibility_colon__what_users_can_to_to_browse_safely/index.html
@@ -99,7 +99,7 @@ tags:
 
 <p><img alt="Shows Windows 10 Accessibility Settings for GrayScale" src="https://mdn.mozillademos.org/files/16656/ColorFiltersGrayScaleInWindows.PNG"></p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility">Accessibilty</a></li>

--- a/files/en-us/web/accessibility/aria/aria_techniques/x-ms-aria-flowfrom/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/x-ms-aria-flowfrom/index.html
@@ -28,7 +28,7 @@ tags:
 <pre>&lt;div tabindex="0" class="foo" id="element2" role="option" aria-posinset="1" aria-setsize="15" aria-flowto="element8" x-ms-aria-flowfrom="element5"&gt;
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques">ARIA relationship attributes</a></li>

--- a/files/en-us/web/accessibility/aria/roles/article_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/article_role/index.html
@@ -108,7 +108,7 @@ tags:
 
 <p>This role corresponds to the <code>&lt;<a href="/en-US/docs/Web/HTML/Element/article">article</a>&gt;</code> element in HTML, and that element should be used instead, if possible. This role does not require any specific roles to be present among its children. It is the only role allowed as a direct child of an element with the <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Feed_Role">feed</a></code> role.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Feed_Role">feed role</a></li>

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.html
@@ -133,7 +133,7 @@ tags:
 
 <p>The first rule of ARIA is: if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding an ARIA role, state or property to make it accessible. As such, it is recommended to use the native <a href="/en-US/docs/Web/HTML/Element/input/checkbox">HTML checkbox</a>  using form control instead of recreating a checkbox's functionality with JavaScript and ARIA.</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><code><a href="/en-US/docs/Web/HTML/Element/input/checkbox">&lt;input type="checkbox"&gt;</a></code></li>

--- a/files/en-us/web/accessibility/aria/roles/gridcell_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/gridcell_role/index.html
@@ -155,7 +155,7 @@ tags:
 
 <p>The first rule of ARIA is: if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding an ARIA role, state or property to make it accessible. As such, it is recommended to use the utilize <a href="/en-US/docs/Web/HTML/Element/table">native HTML table markup</a> instead of recreating a table's form and functionality with ARIA and JavaScript.</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/table">The Table element</a></li>

--- a/files/en-us/web/accessibility/aria/roles/textbox_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/textbox_role/index.html
@@ -117,7 +117,7 @@ tags:
 	<li class="li1">Be sure to add the <code>contenteditable="true"</code> attribute to the HTML element to which this role is applied. Do so even if you set <code>aria-readonly</code> to <code>true</code>; in this way, you communicate that the content would be editable if it were not read-only.</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox">ARIA: search role</a></li>

--- a/files/en-us/web/accessibility/cognitive_accessibility/index.html
+++ b/files/en-us/web/accessibility/cognitive_accessibility/index.html
@@ -291,7 +291,7 @@ tags:
  <li>In the U.S., “intellectual disabilities” used to be called “mental retardation.” In the U.K., “intellectual disabilities” is commonly called “learning disabilities” or “learning difficulties”.</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Accessibility_guidelines">Accessibility Guidelines </a></li>

--- a/files/en-us/web/accessibility/seizure_disorders/index.html
+++ b/files/en-us/web/accessibility/seizure_disorders/index.html
@@ -574,7 +574,7 @@ tags:
 
 <p>The Web Animations model is intended to provide the features necessary for expressing CSS Transitions <strong><a href="https://drafts.csswg.org/web-animations/#biblio-css-transitions-1">[CSS-TRANSITIONS-1]</a></strong>, CSS Animations <strong><a href="https://drafts.csswg.org/web-animations/#biblio-css-animations-1">[CSS-ANIMATIONS-1]</a></strong>, and SVG <strong><a href="https://drafts.csswg.org/web-animations/#biblio-svg11">[SVG11]</a></strong>.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <h4 id="MDN">MDN</h4>
 

--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.html
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.html
@@ -235,7 +235,7 @@ em { color: rgba(100%, 0%, 0%, 100%); }
 
 <p>Luminance and reflected light are not the same.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <h4 id="MDN"><strong>MDN</strong></h4>
 

--- a/files/en-us/web/accessibility/understanding_wcag/operable/index.html
+++ b/files/en-us/web/accessibility/understanding_wcag/operable/index.html
@@ -299,7 +299,7 @@ tags:
 <p><strong>Note</strong>: Also see the WCAG description for <a href="https://www.w3.org/TR/WCAG21/#input-modalities">Guideline 2.5: Input Modalities: Make it easier for users to operate functionality through various inputs beyond keyboard</a>.</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="en-US/docs/Web/Accessibility/Understanding_WCAG">WCAG</a>

--- a/files/en-us/web/accessibility/understanding_wcag/perceivable/index.html
+++ b/files/en-us/web/accessibility/understanding_wcag/perceivable/index.html
@@ -338,7 +338,7 @@ tags:
 <p><strong>Note</strong>: Also see the WCAG description for <a href="https://www.w3.org/TR/WCAG21/#distinguishable">Guideline 1.4: Distinguishable: Make it easier for users to see and hear content including separating foreground from background.</a><a href="https://www.w3.org/TR/WCAG21/#distinguishable">.</a></p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="en-US/docs/Web/Accessibility/Understanding_WCAG">WCAG</a>

--- a/files/en-us/web/accessibility/understanding_wcag/robust/index.html
+++ b/files/en-us/web/accessibility/understanding_wcag/robust/index.html
@@ -66,7 +66,7 @@ tags:
 </div>
 
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="en-US/docs/Web/Accessibility/Understanding_WCAG">WCAG</a>

--- a/files/en-us/web/accessibility/understanding_wcag/understandable/index.html
+++ b/files/en-us/web/accessibility/understanding_wcag/understandable/index.html
@@ -243,7 +243,7 @@ tags:
 <p><strong>Note</strong>: Also see the WCAG description for <a href="https://www.w3.org/TR/WCAG21/#input-assistance">Guideline 3.3 Input Assistance: Help users avoid and correct mistakes</a>.</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="en-US/docs/Web/Accessibility/Understanding_WCAG">WCAG</a>

--- a/files/en-us/web/api/animation/cancel/index.html
+++ b/files/en-us/web/api/animation/cancel/index.html
@@ -59,7 +59,7 @@ tags:
 <p>{{Compat("api.Animation.cancel")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/commitstyles/index.html
+++ b/files/en-us/web/api/animation/commitstyles/index.html
@@ -65,7 +65,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 <p>{{Compat("api.Animation.commitStyles")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/currenttime/index.html
+++ b/files/en-us/web/api/animation/currenttime/index.html
@@ -83,7 +83,7 @@ animation.currentTime;
 <p>{{Compat("api.Animation.currentTime")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("Animation")}} for other methods and properties you can use to control web page animation.</li>

--- a/files/en-us/web/api/animation/effect/index.html
+++ b/files/en-us/web/api/animation/effect/index.html
@@ -49,7 +49,7 @@ tags:
 <p>{{Compat("api.Animation.effect")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/finish/index.html
+++ b/files/en-us/web/api/animation/finish/index.html
@@ -85,7 +85,7 @@ tags:
 <p>{{Compat("api.Animation.finish")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/finished/index.html
+++ b/files/en-us/web/api/animation/finished/index.html
@@ -68,7 +68,7 @@ tags:
 <p>{{Compat("api.Animation.finished")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("KeyframeEffect")}}</li>

--- a/files/en-us/web/api/animation/id/index.html
+++ b/files/en-us/web/api/animation/id/index.html
@@ -55,7 +55,7 @@ tags:
 <p>{{Compat("api.Animation.id")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("KeyframeEffect")}}</li>

--- a/files/en-us/web/api/animation/oncancel/index.html
+++ b/files/en-us/web/api/animation/oncancel/index.html
@@ -62,7 +62,7 @@ tags:
 <p>{{Compat("api.Animation.oncancel")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/onfinish/index.html
+++ b/files/en-us/web/api/animation/onfinish/index.html
@@ -78,7 +78,7 @@ bringUI.onfinish = function() {
 <p>{{Compat("api.Animation.onfinish")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/onremove/index.html
+++ b/files/en-us/web/api/animation/onremove/index.html
@@ -76,7 +76,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 <p>{{Compat("api.Animation.onremove")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/pause/index.html
+++ b/files/en-us/web/api/animation/pause/index.html
@@ -93,7 +93,7 @@ bottle.addEventListener("mouseup", stopPlayingAlice, false);
 <p>{{Compat("api.Animation.pause")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/pending/index.html
+++ b/files/en-us/web/api/animation/pending/index.html
@@ -47,7 +47,7 @@ tags:
 <p>{{Compat("api.Animation.pending")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("Animation")}} for other methods and properties you can use to control web page animation.</li>

--- a/files/en-us/web/api/animation/persist/index.html
+++ b/files/en-us/web/api/animation/persist/index.html
@@ -79,7 +79,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 <p>{{Compat("api.Animation.persist")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/play/index.html
+++ b/files/en-us/web/api/animation/play/index.html
@@ -87,7 +87,7 @@ cake.addEventListener("touchstart", growAlice, false);
 <p>{{Compat("api.Animation.play")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/playbackrate/index.html
+++ b/files/en-us/web/api/animation/playbackrate/index.html
@@ -105,7 +105,7 @@ document.addEventListener("touchstart", goFaster);
 <p>{{Compat("api.Animation.playbackRate")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/ready/index.html
+++ b/files/en-us/web/api/animation/ready/index.html
@@ -70,7 +70,7 @@ animation.play();
 <p>{{Compat("api.Animation.ready")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/replacestate/index.html
+++ b/files/en-us/web/api/animation/replacestate/index.html
@@ -80,7 +80,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 <p>{{Compat("api.Animation.replaceState")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/reverse/index.html
+++ b/files/en-us/web/api/animation/reverse/index.html
@@ -76,7 +76,7 @@ tags:
 <p>{{Compat("api.Animation.reverse")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/starttime/index.html
+++ b/files/en-us/web/api/animation/starttime/index.html
@@ -102,7 +102,7 @@ animation.startTime;
 <p>{{Compat("api.Animation.startTime")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/timeline/index.html
+++ b/files/en-us/web/api/animation/timeline/index.html
@@ -56,7 +56,7 @@ tags:
 <p>{{Compat("api.Animation.timeline")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/animation/updateplaybackrate/index.html
+++ b/files/en-us/web/api/animation/updateplaybackrate/index.html
@@ -75,7 +75,7 @@ tags:
 <p>{{Compat("api.Animation.updatePlaybackRate")}}</p>
 </div>
 
-<h2 id="See_also" style="line-height: 30px; font-size: 2.14285714285714rem;">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a></li>

--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -175,7 +175,7 @@ BarcodeDetector.getSupportedFormats()
 
 <p>{{Compat("api.BarcodeDetector")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://www.barcodefaq.com/">barcodefaq.com: A website with information about different barcodes and examples of the different types.</a></li>

--- a/files/en-us/web/api/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/index.html
@@ -95,7 +95,7 @@ BarcodeDetector.getSupportedFormats()
 
 <p>{{Compat("api.BarcodeDetector")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://www.barcodefaq.com/">barcodefaq.com: A website with information about different barcodes and examples of the different types.</a></li>

--- a/files/en-us/web/api/baseaudiocontext/audioworklet/index.html
+++ b/files/en-us/web/api/baseaudiocontext/audioworklet/index.html
@@ -57,7 +57,7 @@ tags:
 </div>
 </div>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web_Audio_API/Using_Web_Audio_API">Using Web Audio API</a></li>

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.html
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.html
@@ -80,7 +80,7 @@ audioCtx.currentTime;
 </div>
 </div>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web_Audio_API/Using_Web_Audio_API">Using Web Audio API</a></li>

--- a/files/en-us/web/api/beacon_api/using_the_beacon_api/index.html
+++ b/files/en-us/web/api/beacon_api/using_the_beacon_api/index.html
@@ -51,7 +51,7 @@ tags:
 };
 </pre>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("Beacon_API","Beacon API")}} (Overview)</li>

--- a/files/en-us/web/api/closeevent/initcloseevent/index.html
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.html
@@ -44,9 +44,9 @@ slug: Web/API/CloseEvent/initCloseEvent
 
 <p>{{Compat("api.CloseEvent.initCloseEvent")}}</p>
 
-<h2 id="See_Also"><span>S</span>ee Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
-	<li>{{domxref("CloseEvent.CloseEvent()","CloseEvent()")}} constructor, the modern standard way of creating a {{domxref("CloseEvent")}}</li>
-	<li>{{domxref("Event.initEvent()")}} is a simpler method serving a similar purpose. It is also obsolete and shouldn't be used any more.</li>
+  <li>{{domxref("CloseEvent.CloseEvent()","CloseEvent()")}} constructor, the modern standard way of creating a {{domxref("CloseEvent")}}</li>
+  <li>{{domxref("Event.initEvent()")}} is a simpler method serving a similar purpose. It is also obsolete and shouldn't be used any more.</li>
 </ul>

--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -115,7 +115,7 @@ async function getContacts() {
 
 <p>{{Compat("api.ContactsManager")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/contact-picker/">A Contact Picker for the Web</a></li>

--- a/files/en-us/web/api/contactsmanager/index.html
+++ b/files/en-us/web/api/contactsmanager/index.html
@@ -97,7 +97,7 @@ async function getContacts() {
 
 <p>{{Compat("api.ContactsManager")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/contact-picker/">A Contact Picker for the Web</a></li>

--- a/files/en-us/web/api/content_index_api/index.html
+++ b/files/en-us/web/api/content_index_api/index.html
@@ -214,7 +214,7 @@ const contentIndexItems = self.registration.index.getAll();
 
 <p>{{Compat("api.ContentIndex")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
   <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindex/add/index.html
+++ b/files/en-us/web/api/contentindex/add/index.html
@@ -139,7 +139,7 @@ self.registration.index.add(item);
 
 <p>{{Compat("api.ContentIndex.add")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindex/delete/index.html
+++ b/files/en-us/web/api/contentindex/delete/index.html
@@ -80,7 +80,7 @@ tags:
 
 <p>{{Compat("api.ContentIndex.delete")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindex/getall/index.html
+++ b/files/en-us/web/api/contentindex/getall/index.html
@@ -126,7 +126,7 @@ tags:
 
 <p>{{Compat("api.ContentIndex.getAll")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindex/index.html
+++ b/files/en-us/web/api/contentindex/index.html
@@ -177,7 +177,7 @@ const contentIndexItems = self.registration.index.getAll();
 
 <p>{{Compat("api.ContentIndex")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.html
@@ -70,7 +70,7 @@ ciEvent.id; // should return 'unique-content-id'
 
 <p>{{Compat("api.ContentIndexEvent.ContentIndexEvent")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindexevent/id/index.html
+++ b/files/en-us/web/api/contentindexevent/id/index.html
@@ -57,7 +57,7 @@ tags:
 
 <p>{{Compat("api.ContentIndexEvent.id")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
   <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/index.html
@@ -70,7 +70,7 @@ tags:
 
 <p>{{Compat("api.ContentIndexEvent")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
   <li><a href="https://web.dev/content-indexing-api/">An introductory article on the Content Index API</a></li>

--- a/files/en-us/web/api/css/index.html
+++ b/files/en-us/web/api/css/index.html
@@ -78,7 +78,7 @@ tags:
 
 <p>{{Compat("api.CSS", 1)}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Components.utils.importGlobalProperties">Components.utils.importGlobalProperties</a></li>

--- a/files/en-us/web/api/css/paintworklet/index.html
+++ b/files/en-us/web/api/css/paintworklet/index.html
@@ -56,7 +56,7 @@ tags:
 
 <p>{{Compat("api.CSS.paintWorklet")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>

--- a/files/en-us/web/api/css_painting_api/guide/index.html
+++ b/files/en-us/web/api/css_painting_api/guide/index.html
@@ -532,7 +532,7 @@ li:nth-of-type(3n+1) {
 
 <p>{{EmbedLiveSample("example5", 300, 300)}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API </a></li>

--- a/files/en-us/web/api/css_painting_api/index.html
+++ b/files/en-us/web/api/css_painting_api/index.html
@@ -186,7 +186,7 @@ li:nth-of-type(3n+1) {
 
 <p>See the browser compatibility data for each CSS Painting API Interfaces.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Houdini/Learn/CSS_Painting_API">Using the CSS Painting API</a></li>

--- a/files/en-us/web/api/css_properties_and_values_api/index.html
+++ b/files/en-us/web/api/css_properties_and_values_api/index.html
@@ -57,7 +57,7 @@ tags:
 
 <p>See individual interfaces</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li><a href="/en-US/docs/Web/API/CSS_Properties_and_Values_API/guide">Using the CSS properties and values API</a></li>

--- a/files/en-us/web/api/css_typed_om_api/guide/index.html
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.html
@@ -421,7 +421,7 @@ console.log( bgImage.toString() );  // url("https://mdn.mozillademos.org/files/1
 
 <p>This should get you started with understanding the CSS Typed OM. Take a look at all the <a href="/en-US/docs/Web/Houdini/learn/CSS_Typed_OM">CSS Typed OM</a> interfaces to learn more.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API/Guide">Using the CSS Painting API</a></li>

--- a/files/en-us/web/api/css_typed_om_api/index.html
+++ b/files/en-us/web/api/css_typed_om_api/index.html
@@ -132,7 +132,7 @@ tags:
 	<li><a href="/en-US/docs/Web/API/CSSKeywordValue#Browser_compatibility">CSSKeywordValue</a></li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>

--- a/files/en-us/web/api/cssimagevalue/index.html
+++ b/files/en-us/web/api/cssimagevalue/index.html
@@ -72,7 +72,7 @@ console.log( allComputedStyles.get('background-image').toString() );
 
 <p>{{Compat("api.CSSImageValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref('CSSKeywordValue')}}</li>

--- a/files/en-us/web/api/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/index.html
@@ -70,7 +70,7 @@ console.log( myElement.get('display').value);  // 'initial'</pre>
 
 <p>{{Compat("api.CSSKeywordValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref('CSSImageValue')}}</li>

--- a/files/en-us/web/api/cssnumericvalue/index.html
+++ b/files/en-us/web/api/cssnumericvalue/index.html
@@ -89,7 +89,7 @@ tags:
 
 <p>{{Compat("api.CSSNumericValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li>{{domxref('CSSImageValue')}}</li>

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
@@ -41,7 +41,7 @@ console.log(position.x.value, position.y.value);  // 5 10</pre>
 
 <p>{{Compat("api.CSSPositionValue.CSSPositionValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSPositionValue.x")}}</li>

--- a/files/en-us/web/api/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/index.html
@@ -64,7 +64,7 @@ console.log( replacedEl.computedStyleMap().get('object-position') );</pre>
 
 <p>{{Compat("api.CSSPositionValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref('CSSImageValue')}}</li>

--- a/files/en-us/web/api/csspositionvalue/x/index.html
+++ b/files/en-us/web/api/csspositionvalue/x/index.html
@@ -37,7 +37,7 @@ console.log(position.x.value, position.y.value);</pre>
 
 <p>{{Compat("api.CSSPositionValue.x")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSPositionValue.CSSPositionValue()")}}</li>

--- a/files/en-us/web/api/csspositionvalue/y/index.html
+++ b/files/en-us/web/api/csspositionvalue/y/index.html
@@ -37,7 +37,7 @@ console.log(position.x.value, position.y.value);</pre>
 
 <p>{{Compat("api.CSSPositionValue.y")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSPositionValue.CSSPositionValue")}}</li>

--- a/files/en-us/web/api/cssstylevalue/parse/index.html
+++ b/files/en-us/web/api/cssstylevalue/parse/index.html
@@ -62,7 +62,7 @@ tags:
 
 <p>{{Compat("api.CSSStyleValue.parse")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSStyleValue.parseAll()")}}</li>

--- a/files/en-us/web/api/cssstylevalue/parseall/index.html
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.html
@@ -53,7 +53,7 @@ tags:
 
 <p>{{Compat("api.CSSStyleValue.parseAll")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li>{{domxref("CSSStyleValue.parse()")}}</li>

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
@@ -57,7 +57,7 @@ tags:
 
 <p>{{Compat("api.CSSUnitValue.CSSUnitValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li>{{domxref('CSSUnitValue.unit')}}</li>

--- a/files/en-us/web/api/cssunitvalue/unit/index.html
+++ b/files/en-us/web/api/cssunitvalue/unit/index.html
@@ -56,7 +56,7 @@ console.log( pos.y.unit ); // "em"
 
 <p>{{Compat("api.CSSUnitValue.unit")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li>{{domxref('CSSUnitValue.value')}}</li>

--- a/files/en-us/web/api/cssunitvalue/value/index.html
+++ b/files/en-us/web/api/cssunitvalue/value/index.html
@@ -57,7 +57,7 @@ console.log( pos.y.value ); // 10
 
 <p>{{Compat("api.CSSUnitValue.value")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li>{{domxref('CSSUnitValue.unit')}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
@@ -56,7 +56,7 @@ console.log( values ); // CSSUnparsedValue {0: "1em", 1: "#445566", 2: "-45px", 
 
 <p>{{Compat("api.CSSUnparsedValue.CSSUnparsedValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSUnparsedValue.entries")}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.html
@@ -53,7 +53,7 @@ tags:
 
 <p>{{Compat("api.CSSUnparsedValue.entries")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSUnparsedValue.CSSUnparsedValue()")}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.html
@@ -68,7 +68,7 @@ tags:
 
 <p>{{Compat("api.CSSUnparsedValue.forEach")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSUnparsedValue.CSSUnparsedValue()")}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/index.html
@@ -65,7 +65,7 @@ tags:
 
 <p>{{Compat("api.CSSUnparsedValue")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref('CSSImageValue')}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.html
@@ -50,7 +50,7 @@ tags:
 
 <p>{{Compat("api.CSSUnparsedValue.keys")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSUnparsedValue.CSSUnparsedValue()")}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/length/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.html
@@ -54,7 +54,7 @@ console.log( values.length ) // 3</pre>
 
 <p>{{Compat("api.CSSUnparsedValue.length")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSUnparsedValue.CSSUnparsedValue()")}}</li>

--- a/files/en-us/web/api/cssunparsedvalue/values/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.html
@@ -50,7 +50,7 @@ tags:
 
 <p>{{Compat("api.CSSUnparsedValue.values")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("CSSUnparsedValue.CSSUnparsedValue()")}}</li>

--- a/files/en-us/web/api/document/forms/index.html
+++ b/files/en-us/web/api/document/forms/index.html
@@ -111,11 +111,11 @@ var selectFormElement = document.forms[index].elements[index];
  </tbody>
 </table>
 
-<h2 id="See_Also">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Document.forms")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Learn/HTML/Forms">HTML forms</a></li>

--- a/files/en-us/web/api/document/head/index.html
+++ b/files/en-us/web/api/document/head/index.html
@@ -74,7 +74,7 @@ tags:
 
 <p>{{Compat("api.Document.head")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("document.body")}}</li>

--- a/files/en-us/web/api/documentorshadowroot/mselementsfromrect/index.html
+++ b/files/en-us/web/api/documentorshadowroot/mselementsfromrect/index.html
@@ -45,7 +45,7 @@ var nodeList = document.msElementsFromPoint(x,y)
 
 <p>The returned nodeList is sorted by z-index so that you can tell the relative stacking order of the elements.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://testdrive-archive.azurewebsites.net/HTML5/HitTest/Default.html">Advanced Hit Testing APIs Demo for msElementsFromPoint() and msElementsFromRect() </a></li>

--- a/files/en-us/web/api/eckeygenparams/index.html
+++ b/files/en-us/web/api/eckeygenparams/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>Browsers that support the "ECDH" or "ECDSA" algorithms for the {{domxref("SubtleCrypto.generateKey()")}} method will support this type.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("SubtleCrypto.generateKey()")}}.</li>

--- a/files/en-us/web/api/element/mscontentzoom_event/index.html
+++ b/files/en-us/web/api/element/mscontentzoom_event/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>{{Compat("api.Element.msContentZoom_event")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSSStyleDeclaration">CSS Style Declaration</a></li>

--- a/files/en-us/web/api/element/msmanipulationstatechanged_event/index.html
+++ b/files/en-us/web/api/element/msmanipulationstatechanged_event/index.html
@@ -59,7 +59,7 @@ outerScroller.addEventListener("MSManipulationStateChanged", function(e) {
 
 <p>{{Compat("api.Element.MSManipulationStateChanged_event")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("MSManipulationEvent")}}</li>

--- a/files/en-us/web/api/element/mszoomto/index.html
+++ b/files/en-us/web/api/element/mszoomto/index.html
@@ -81,7 +81,7 @@ var args = {
 zoomer.msZoomTo(args);
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/event/msconverturl/index.html
+++ b/files/en-us/web/api/event/msconverturl/index.html
@@ -75,7 +75,7 @@ tags:
 
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/eventlistener/index.html
+++ b/files/en-us/web/api/eventlistener/index.html
@@ -59,12 +59,6 @@ buttonElement.addEventListener('click', {
 
 <p>{{EmbedLiveSample('Example')}}</p>
 
-<h3 id="See_Also">See Also:</h3>
-
-<ul>
- <li><a href="/en-US/docs/Web/API/EventTarget/addEventListener">addEventListener</a></li>
-</ul>
-
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
@@ -92,3 +86,9 @@ buttonElement.addEventListener('click', {
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.EventListener")}}</p>
+
+<h3 id="See_also">See also</h3>
+
+<ul>
+  <li><a href="/en-US/docs/Web/API/EventTarget/addEventListener">addEventListener</a></li>
+</ul>

--- a/files/en-us/web/api/fontface/index.html
+++ b/files/en-us/web/api/fontface/index.html
@@ -78,7 +78,7 @@ tags:
 
 <p>{{Compat("api.FontFace")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/@font-face/font-family">@font-face</a></li>

--- a/files/en-us/web/api/hmackeygenparams/index.html
+++ b/files/en-us/web/api/hmackeygenparams/index.html
@@ -52,7 +52,7 @@ tags:
 
 <p>Browsers that support the "HMAC" algorithm for the {{domxref("SubtleCrypto.generateKey()")}} method will support this type.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("SubtleCrypto.generateKey()")}}.</li>

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.html
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.html
@@ -217,7 +217,7 @@ dataProvider.prototype = {
 }
 </pre>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a class="internal" href="/Web/API/HTML_Drag_and_Drop_API" title="HTML Drag and Drop API">HTML Drag and Drop API (Overview)</a></li>

--- a/files/en-us/web/api/htmlaudioelement/msaudiodevicetype/index.html
+++ b/files/en-us/web/api/htmlaudioelement/msaudiodevicetype/index.html
@@ -48,7 +48,7 @@ tags:
 </table>
 
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/htmlcanvaselement/height/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/height/index.html
@@ -67,7 +67,7 @@ console.log(canvas.height); // 300
 
 <p>{{Compat("api.HTMLCanvasElement.height")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLCanvasElement")}}.</li>

--- a/files/en-us/web/api/htmlcanvaselement/mozopaque/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/mozopaque/index.html
@@ -45,7 +45,7 @@ canvas.mozOpaque = false;
 
 <p>{{Compat("api.HTMLCanvasElement.mozOpaque")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLCanvasElement")}}.</li>

--- a/files/en-us/web/api/htmlcanvaselement/width/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/width/index.html
@@ -67,7 +67,7 @@ console.log(canvas.width); // 300
 
 <p>{{Compat("api.HTMLCanvasElement.width")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLCanvasElement")}}.</li>

--- a/files/en-us/web/api/htmlelement/inert/index.html
+++ b/files/en-us/web/api/htmlelement/inert/index.html
@@ -63,7 +63,7 @@ slug: Web/API/HTMLElement/inert
 
 <p>{{Compat("api.HTMLElement.inert")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://github.com/WICG/inert">Inert Polyfill</a></li>

--- a/files/en-us/web/api/htmlelement/offsetheight/index.html
+++ b/files/en-us/web/api/htmlelement/offsetheight/index.html
@@ -60,7 +60,7 @@ tags:
 
 <p>{{Compat("api.HTMLElement.offsetHeight")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("Element.clientHeight")}}</li>

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
@@ -30,7 +30,7 @@ tags:
 <p>{{Compat("api.HTMLIFrameElement.allowPaymentRequest")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> </li>

--- a/files/en-us/web/api/htmlmediaelement/audiotracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/audiotracks/index.html
@@ -78,7 +78,7 @@ for (var i = 0; i &lt; video.audioTracks.length; i += 1) {
 
 <p>{{Compat("api.HTMLMediaElement.audioTracks")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/autoplay/index.html
+++ b/files/en-us/web/api/htmlmediaelement/autoplay/index.html
@@ -79,7 +79,7 @@ var <em>autoplay</em> = <em>HTMLMediaElement</em>.autoplay;</pre>
 
 <p>{{Compat("api.HTMLMediaElement.autoplay")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/buffered/index.html
+++ b/files/en-us/web/api/htmlmediaelement/buffered/index.html
@@ -55,7 +55,7 @@ console.log(obj.buffered); // TimeRanges { length: 0 }
 
 <p>{{Compat("api.HTMLMediaElement.buffered")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/canplay_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/canplay_event/index.html
@@ -111,7 +111,7 @@ video.oncanplay = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.html
@@ -113,7 +113,7 @@ video.oncanplaythrough = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/canplaytype/index.html
+++ b/files/en-us/web/api/htmlmediaelement/canplaytype/index.html
@@ -83,7 +83,7 @@ console.log(obj.canPlayType('video/mp4')); // "maybe"
 
 <p>{{Compat("api.HTMLMediaElement.canPlayType")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/controller/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controller/index.html
@@ -46,7 +46,7 @@ tags:
 
 <p>{{Compat("api.HTMLMediaElement.controller")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/controls/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controls/index.html
@@ -53,7 +53,7 @@ obj.controls = true;
 
 <p>{{Compat("api.HTMLMediaElement.controls")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/currentsrc/index.html
+++ b/files/en-us/web/api/htmlmediaelement/currentsrc/index.html
@@ -53,7 +53,7 @@ console.log(obj.currentSrc); // ""
 
 <p>{{Compat("api.HTMLMediaElement.currentSrc")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/currenttime/index.html
+++ b/files/en-us/web/api/htmlmediaelement/currenttime/index.html
@@ -76,7 +76,7 @@ console.log(video.currentTime);
 
 <p>{{Compat("api.HTMLMediaElement.currentTime")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/defaultmuted/index.html
+++ b/files/en-us/web/api/htmlmediaelement/defaultmuted/index.html
@@ -55,7 +55,7 @@ console.log(videoEle.outerHTML); // &lt;video muted=""&gt;&lt;/video&gt;
 
 <p>{{Compat("api.HTMLMediaElement.defaultMuted")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.html
@@ -54,7 +54,7 @@ console.log(obj.defaultPlaybackRate); // 1
 
 <p>{{Compat("api.HTMLMediaElement.defaultPlaybackRate")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/disableremoteplayback/index.html
+++ b/files/en-us/web/api/htmlmediaelement/disableremoteplayback/index.html
@@ -43,7 +43,7 @@ obj.disableRemotePlayback = true;</pre>
 <p>{{Compat("api.HTMLMediaElement.disableRemotePlayback")}}</p>
 </div>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/duration/index.html
+++ b/files/en-us/web/api/htmlmediaelement/duration/index.html
@@ -56,7 +56,7 @@ console.log(obj.duration); // NaN
 
 <p>{{Compat("api.HTMLMediaElement.duration")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Media">Web media technologies</a></li>

--- a/files/en-us/web/api/htmlmediaelement/durationchange_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/durationchange_event/index.html
@@ -111,7 +111,7 @@ video.ondurationchange = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/emptied_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/emptied_event/index.html
@@ -111,7 +111,7 @@ video.onemptied = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/ended/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ended/index.html
@@ -56,7 +56,7 @@ console.log(obj.ended); // false
 
 <p>{{Compat("api.HTMLMediaElement.ended")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.html
@@ -125,7 +125,7 @@ video.onended = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/error/index.html
+++ b/files/en-us/web/api/htmlmediaelement/error/index.html
@@ -62,7 +62,7 @@ videoElement.src = "https://example.com/bogusvideo.mp4";
 
 <p>{{Compat("api.HTMLMediaElement.error")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/initialtime/index.html
+++ b/files/en-us/web/api/htmlmediaelement/initialtime/index.html
@@ -35,7 +35,7 @@ tags:
 
 <p>{{Compat("api.HTMLMediaElement.initialTime")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.html
@@ -117,7 +117,7 @@ video.onloadeddata = (event) =&gt; {
 	<li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.html
@@ -142,7 +142,7 @@ video.onloadedmetadata = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/loop/index.html
+++ b/files/en-us/web/api/htmlmediaelement/loop/index.html
@@ -54,7 +54,7 @@ obj.loop = true; // true
 
 <p>{{Compat("api.HTMLMediaElement.loop")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.html
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.html
@@ -46,7 +46,7 @@ tags:
 
 <p>{{Compat("api.HTMLMediaElement.mediaGroup")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/mscleareffects/index.html
+++ b/files/en-us/web/api/htmlmediaelement/mscleareffects/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>This method does not return a value.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Touch">Touch API</a></li>

--- a/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.html
+++ b/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.html
@@ -35,7 +35,7 @@ tags:
 
 <p>This method does not return a value.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("HTMLMediaElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/muted/index.html
+++ b/files/en-us/web/api/htmlmediaelement/muted/index.html
@@ -53,7 +53,7 @@ console.log(obj.muted); // false
 
 <p>{{Compat("api.HTMLMediaElement.muted")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/networkstate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/networkstate/index.html
@@ -99,7 +99,7 @@ obj.addEventListener('playing', function() {
 
 <p>{{Compat("api.HTMLMediaElement.networkState")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/paused/index.html
+++ b/files/en-us/web/api/htmlmediaelement/paused/index.html
@@ -52,7 +52,7 @@ console.log(obj.paused); // true
 
 <p>{{Compat("api.HTMLMediaElement.paused")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/play_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/play_event/index.html
@@ -113,7 +113,7 @@ video.onplay = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/playbackrate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/playbackrate/index.html
@@ -62,7 +62,7 @@ console.log(obj.playbackRate); // Expected Output: 1</pre>
 
 <p>{{Compat("api.HTMLMediaElement.playbackRate")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/ratechange_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/ratechange_event/index.html
@@ -112,7 +112,7 @@ video.onratechange = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/readystate/index.html
+++ b/files/en-us/web/api/htmlmediaelement/readystate/index.html
@@ -106,7 +106,7 @@ obj.addEventListener('loadeddata', function() {
 
 <p>{{Compat("api.HTMLMediaElement.readyState")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/seekable/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seekable/index.html
@@ -71,7 +71,7 @@ for (let count = 0; count &lt; timeRangesObject.length; count ++) {
 <p>{{Compat("api.HTMLMediaElement.seekable")}}</p>
 </div>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/seeked_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seeked_event/index.html
@@ -112,7 +112,7 @@ video.onseeked = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/seeking_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seeking_event/index.html
@@ -112,7 +112,7 @@ video.onseeking = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/src/index.html
+++ b/files/en-us/web/api/htmlmediaelement/src/index.html
@@ -57,7 +57,7 @@ console.log(obj.src); // ""
 
 <p>{{Compat("api.HTMLMediaElement.src")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/stalled_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/stalled_event/index.html
@@ -112,7 +112,7 @@ video.onstalled = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/suspend_event/index.html
+++ b/files/en-us/web/api/htmlmediaelement/suspend_event/index.html
@@ -112,7 +112,7 @@ video.onsuspend = (event) =&gt; {
  <li>{{domxref("HTMLMediaElement.stalled_event", 'HTMLMediaElement: stalled event')}}</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLAudioElement")}}</li>

--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.html
@@ -111,7 +111,7 @@ for (var i = 0, L = tracks.length; i &lt; L; i++) { /* tracks.length == 10 */
 
 <p>{{Compat("api.HTMLMediaElement.textTracks")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{DOMxRef("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/videotracks/index.html
+++ b/files/en-us/web/api/htmlmediaelement/videotracks/index.html
@@ -51,7 +51,7 @@ tags:
 
 <p>{{Compat("api.HTMLMediaElement.videoTracks")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{DOMxRef("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlmediaelement/volume/index.html
+++ b/files/en-us/web/api/htmlmediaelement/volume/index.html
@@ -53,7 +53,7 @@ obj.volume = 0.75;</pre>
 
 <p>{{Compat("api.HTMLMediaElement.volume")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLMediaElement")}}.</li>

--- a/files/en-us/web/api/htmlselectelement/selectedoptions/index.html
+++ b/files/en-us/web/api/htmlselectelement/selectedoptions/index.html
@@ -126,7 +126,7 @@ orderButton.addEventListener("click", function() {
 
 <p>{{Compat("api.HTMLSelectElement.selectedOptions")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{SectionOnPage("/en-US/docs/Learn/HTML/Forms/The_native_form_widgets", "Drop-down content")}}</li>

--- a/files/en-us/web/api/htmltrackelement/src/index.html
+++ b/files/en-us/web/api/htmltrackelement/src/index.html
@@ -54,7 +54,7 @@ tags:
 
 <p>{{Compat("api.HTMLTrackElement.src")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("HTMLTrackElement")}}.</li>

--- a/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.html
+++ b/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.html
@@ -97,7 +97,7 @@ button<span class="punctuation token">.</span><span class="function function-var
 
 <p>{{Compat("api.HTMLVideoElement.enterpictureinpicture_event")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLVideoElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.html
+++ b/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.html
@@ -101,7 +101,7 @@ button<span class="punctuation token">.</span><span class="function function-var
 
 <p>{{Compat("api.HTMLVideoElement.leavepictureinpicture_event")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLVideoElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/msframestep/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msframestep/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>This method does not return a value.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("HTMLMediaElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.html
+++ b/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.html
@@ -41,7 +41,7 @@ tags:
     });
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("HTMLVideoElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.html
@@ -41,7 +41,7 @@ tags:
 oVideo1.msInsertVideoEffect("Windows.Media.VideoEffects.VideoStabilization", true, null);
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("HTMLVideoElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>*To enable Stereo 3D playback, <code>msIsLayoutOptimalForPlayback</code> must be true.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("HTMLVideoElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.html
@@ -29,7 +29,7 @@ tags:
 
 <p>{{Compat("api.HTMLVideoElement.msIsStereo3D")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("HTMLVideoElement")}}</li>

--- a/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.html
+++ b/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.html
@@ -39,7 +39,7 @@ tags:
 <pre class="brush: js">HTMLVideoElement.msSetVideoRectangle(left: 2, top: 0, right: 4, bottom: 4);
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
   <li><a href="/en-US/docs/Web/API/HTMLVideoElement">HTMLVideoElement</a></li>

--- a/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.html
@@ -29,7 +29,7 @@ tags:
  <li><code>sidebyside (2)</code>: Specifies sidebyside stereo 3-D content packing and that the views are packed top-to-bottom in a single frame.</li>
 </ul>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/HTMLVideoElement">HTMLVideoElement</a></li>

--- a/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.html
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.html
@@ -27,7 +27,7 @@ tags:
  <li><code>stereo (1)</code>: Specifies stereo mode is enabled.</li>
 </ul>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/HTMLVideoElement">HTMLVideoElement</a></li>

--- a/files/en-us/web/api/htmlvideoelement/mszoom/index.html
+++ b/files/en-us/web/api/htmlvideoelement/mszoom/index.html
@@ -39,7 +39,7 @@ tags:
        myVideo.play();
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/HTMLVideoElement">HTMLVideoElement</a></li>

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.html
@@ -43,7 +43,7 @@ tags:
  <li>val[in], type=function</li>
 </ul>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/HTMLVideoElement">HTMLVideoElement</a></li>

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.html
@@ -43,7 +43,7 @@ tags:
  <li>val[in], type=function</li>
 </ul>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/HTMLVideoElement">HTMLVideoElement</a></li>

--- a/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.html
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.html
@@ -54,7 +54,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/MsIsLayoutOptimalForPlayback">msIsLayoutOptimalForPlayback</a></li>

--- a/files/en-us/web/api/mediaerror/code/index.html
+++ b/files/en-us/web/api/mediaerror/code/index.html
@@ -90,7 +90,7 @@ obj.src="https://example.com/blahblah.mp4";
 
 <p>{{Compat("api.MediaError.code")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>The interface defining it, {{domxref("MediaError")}}.</li>

--- a/files/en-us/web/api/mediaerror/message/index.html
+++ b/files/en-us/web/api/mediaerror/message/index.html
@@ -94,7 +94,7 @@ tags:
 
 <p>{{Compat("api.MediaError.message")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{HTMLElement("video")}} and {{HTMLElement("audio")}}</li>

--- a/files/en-us/web/api/mediastream/id/index.html
+++ b/files/en-us/web/api/mediastream/id/index.html
@@ -47,8 +47,8 @@ p.then(function(stream) {
 
 <p>{{Compat("api.MediaStream.id")}}</p>
 
-<h2 id="See_Also"><span>S</span>ee Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
-	<li>{{domxref("MediaStream")}}, the interface this property belongs to.</li>
+  <li>{{domxref("MediaStream")}}, the interface this property belongs to.</li>
 </ul>

--- a/files/en-us/web/api/mediastreamtrack/ended_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/ended_event/index.html
@@ -89,7 +89,7 @@ tags:
 
 <p>{{Compat("api.MediaStreamTrack.ended_event")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("HTMLMediaElement.playing_event", 'HTMLMediaElement: playing event')}}</li>

--- a/files/en-us/web/api/mscaching/index.html
+++ b/files/en-us/web/api/mscaching/index.html
@@ -44,7 +44,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/msCachingEnabled">msCachingEnabled </a></li>

--- a/files/en-us/web/api/mscachingenabled/index.html
+++ b/files/en-us/web/api/mscachingenabled/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>Type: <strong>boolean</strong>. If true, <code>XMLHttpRequest </code>is cached to disk. If false, it is not written to disk.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/msCaching">msCaching property</a></li>

--- a/files/en-us/web/api/mscandidatewindowhide/index.html
+++ b/files/en-us/web/api/mscandidatewindowhide/index.html
@@ -54,7 +54,7 @@ slug: Web/API/MSCandidateWindowHide
 
 <p>Web applications need only register for this event once per element (the handler will remain valid for the lifetime of the element).</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/mscandidatewindowshow/index.html
+++ b/files/en-us/web/api/mscandidatewindowshow/index.html
@@ -71,7 +71,7 @@ function candidateWindowShowHandler(e) {
 
 <p>When the IME candidate window changes position or closes, it fires <code>MSCandidateWindowUpdate</code> or <code>MSCandidateWindowHide</code> events. Developers could listen to them and shift the suggestion UI accordingly.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/mscandidatewindowupdate/index.html
+++ b/files/en-us/web/api/mscandidatewindowupdate/index.html
@@ -59,7 +59,7 @@ tags:
 </ul>
 <p>Web applications need only register for this event once per element (the handler will remain valid for the lifetime of the element).</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/msgetpropertyenabled/index.html
+++ b/files/en-us/web/api/msgetpropertyenabled/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>If <em>false</em>, the property is not enabled. If <em>true</em>, the property is enabled.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/msgetregioncontent/index.html
+++ b/files/en-us/web/api/msgetregioncontent/index.html
@@ -32,7 +32,7 @@ tags:
 
 <p>Returned ranges are sorted by document position and do not overlap. If an element is not a region, this method throws a <code>DOMException</code> with the <code>InvalidAccessError</code> error code. This is only available to regions that are document elements and not to regions that are pseudo-elements.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/msmanipulationevent/index.html
+++ b/files/en-us/web/api/msmanipulationevent/index.html
@@ -73,7 +73,7 @@ tags:
 }
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("TouchEvent")}}</li>

--- a/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.html
+++ b/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.html
@@ -88,7 +88,7 @@ tags:
 }
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/MSManipulationEvent">MSManipulationEvent</a></li>

--- a/files/en-us/web/api/msplaytopreferredsourceuri/index.html
+++ b/files/en-us/web/api/msplaytopreferredsourceuri/index.html
@@ -36,7 +36,7 @@ ptr = object.msPlayToPreferredSourceUri;
   video.msPlayToPreferredSourceUri = "http://www.contoso.com/catalogid=1234";
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://docs.microsoft.com/en-us/playready/">Microsoft PlayReady</a> content access and protection technology is a set of technologies that can be used to distribute audio/video content more securely over a network, and help prevent the unauthorized use of this content.</li>

--- a/files/en-us/web/api/msplaytoprimary/index.html
+++ b/files/en-us/web/api/msplaytoprimary/index.html
@@ -35,7 +35,7 @@ ptr = object.msPlayToPrimary;
 
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/HTMLMediaElement">HTMLMediaElement</a></li>

--- a/files/en-us/web/api/msputpropertyenabled/index.html
+++ b/files/en-us/web/api/msputpropertyenabled/index.html
@@ -28,7 +28,7 @@ tags:
 
 <p>Type = HRESULT: If this method succeeds, it returns S_OK. Otherwise, it returns an HRESULT error code.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSSStyleDeclaration">CSS Style Declaration</a></li>

--- a/files/en-us/web/api/msregionoverflow/index.html
+++ b/files/en-us/web/api/msregionoverflow/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>When the region is an actual element, msRegionOverflow provides the ability to find out if content fully fits into the region or not. However, it is only available to regions that are document elements and not to regions that are pseudo-elements.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/mssitemodeevent/index.html
+++ b/files/en-us/web/api/mssitemodeevent/index.html
@@ -126,7 +126,7 @@ declare var MSSiteModeEvent: {
 }
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/mssitemodejumplistitemremoved/index.html
+++ b/files/en-us/web/api/mssitemodejumplistitemremoved/index.html
@@ -52,7 +52,7 @@ slug: Web/API/mssitemodejumplistitemremoved
 
 
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/msthumbnailclick/index.html
+++ b/files/en-us/web/api/msthumbnailclick/index.html
@@ -86,7 +86,7 @@ function onButtonClicked(e) {
  }
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/mswriteprofilermark/index.html
+++ b/files/en-us/web/api/mswriteprofilermark/index.html
@@ -49,7 +49,7 @@ tags:
 }
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Microsoft_API_extensions">Microsoft API extensions </a></li>

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -37,6 +37,6 @@ tags:
 
 <p>{{Compat("api.Navigator.canShare")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <p>{{domxref("navigator.share()")}}</p>

--- a/files/en-us/web/api/navigator/contacts/index.html
+++ b/files/en-us/web/api/navigator/contacts/index.html
@@ -50,7 +50,7 @@ tags:
 
 <p>{{Compat("api.Navigator.contacts")}}</p>
 
-<h2 id="See_also">See also:</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/contact-picker/">A Contact Picker for the Web</a></li>

--- a/files/en-us/web/api/navigator/mslaunchuri/index.html
+++ b/files/en-us/web/api/navigator/mslaunchuri/index.html
@@ -48,7 +48,7 @@ tags:
 
 <p>If the user's system does not have a program registered to handle a specific protocol, and a <code>noHandlerCallback</code> is provided, Windows Internet Explorer will invoke the <code>noHandlerCallback</code>. This enables developers to provide a custom fallback experience for the user. If a handler doesn't exist, and the developer doesn't provide a <code>noHandlerCallback</code>, then Internet Explorer displays a dialog that asks the user if they want to allow the action. If the user allows it, the user is then prompted to look in the Windows Store for an app to handle the protocol. If multiple programs are registered on the system for the given protocol and no default has been chosen, Windows prompts the user to choose one.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("MSLaunchUriCallback")}}</li>

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -99,7 +99,7 @@ btn.addEventListener('click', async () =&gt; {
 
 <p>{{Compat("api.Navigator.share")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("navigator.canShare()")}}</li>

--- a/files/en-us/web/api/networkinformation/effectivetype/index.html
+++ b/files/en-us/web/api/networkinformation/effectivetype/index.html
@@ -45,7 +45,7 @@ tags:
 <p>{{Compat("api.NetworkInformation.effectiveType")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Glossary/Effective_connection_type">Effective Connection Type</a></li>

--- a/files/en-us/web/api/paintworklet/devicepixelratio/index.html
+++ b/files/en-us/web/api/paintworklet/devicepixelratio/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>{{Compat("api.PaintWorkletGlobalScope.devicePixelRatio")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/PaintWorklet">PaintWorklet</a></li>

--- a/files/en-us/web/api/paintworklet/devicepizelratio/index.html
+++ b/files/en-us/web/api/paintworklet/devicepizelratio/index.html
@@ -47,7 +47,7 @@ tags:
 <p>{{Compat("api.PaintWorklet.PaintWorklet.devicePixelRatio")}}</p>
 
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>

--- a/files/en-us/web/api/paintworklet/index.html
+++ b/files/en-us/web/api/paintworklet/index.html
@@ -115,7 +115,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 
 <p>{{Compat("api.PaintWorkletGlobalScope")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>

--- a/files/en-us/web/api/paintworklet/paintworklet.devicepixelratio/index.html
+++ b/files/en-us/web/api/paintworklet/paintworklet.devicepixelratio/index.html
@@ -46,7 +46,7 @@ tags:
 
 <p>{{Compat("api.PaintWorklet.PaintWorklet.devicePixelRatio")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>

--- a/files/en-us/web/api/paintworklet/registerpaint/index.html
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.html
@@ -102,7 +102,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 
 <p>{{Compat("api.PaintWorkletGlobalScope.registerPaint")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>

--- a/files/en-us/web/api/paymentrequest/abort/index.html
+++ b/files/en-us/web/api/paymentrequest/abort/index.html
@@ -67,7 +67,7 @@ var paymentTimeout = window.setTimeout(() =&gt; {
 <p>{{Compat("api.PaymentRequest.abort")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref('PaymentRequest.abort','PaymentRequest.abort()')}}</li>

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.html
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.html
@@ -105,7 +105,7 @@ async function initPaymentRquest() {
 <p>{{Compat("api.PaymentRequest.canMakePayment")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref('PaymentRequest.show','PaymentRequest.show()')}}</li>

--- a/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.html
+++ b/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.html
@@ -75,7 +75,7 @@ function init() {
 
 <div>{{Compat("api.Performance.resourcetimingbufferfull_event")}}</div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("Performance.clearResourceTimings","Performance.clearResourceTimings()")}}</li>

--- a/files/en-us/web/api/performance_api/index.html
+++ b/files/en-us/web/api/performance_api/index.html
@@ -136,7 +136,7 @@ tags:
 
 <p>To test your browser's support for the {{domxref("Performance")}} interface, run the <code><a href="https://mdn.github.io/web-performance/perf-api-support.html">perf-api-support</a></code> application.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://w3c.github.io/perf-timing-primer/">A Primer for Web Performance Timing APIs</a></li>

--- a/files/en-us/web/api/performance_timeline/index.html
+++ b/files/en-us/web/api/performance_timeline/index.html
@@ -68,7 +68,7 @@ tags:
 
 <p>To test your browser's support for these interfaces, run the <code><a href="https://mdn.github.io/web-performance/perf-api-support.html">perf-api-support</a></code> application.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://siusin.github.io/perf-timing-primer/">A Primer for Web Performance Timing APIs</a></li>

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.html
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.html
@@ -189,7 +189,7 @@ function print_perf_entry(pe) {
  <li><a href="http://www.w3.org/TR/performance-timeline/">Performance Timeline</a>; W3C Recommendation 12 December 2013</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/Web/API/Performance_Timeline">Performance Timeline (Overview)</a></li>

--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -116,7 +116,7 @@ tags:
 <p>{{Compat("api.ReadableStream")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li><a href="https://whatwg-stream-visualizer.glitch.me/">WHATWG Stream Visualiser</a>, for a basic visualisation of readable, writable, and transform streams.</li>

--- a/files/en-us/web/api/resource_timing_api/index.html
+++ b/files/en-us/web/api/resource_timing_api/index.html
@@ -69,7 +69,7 @@ tags:
 
 <p>To test your browser's support for these interfaces, run the <code><a href="https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html">perf-api-support</a></code> application.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://w3c.github.io/resource-timing/">Resource Timing Standard</a>; W3C Editor's Draft</li>

--- a/files/en-us/web/api/stylepropertymapreadonly/get/index.html
+++ b/files/en-us/web/api/stylepropertymapreadonly/get/index.html
@@ -101,7 +101,7 @@ for ( let i = 0; i &lt; ofInterest.length; i++ ) {
 
 <p>{{Compat("api.StylePropertyMapReadOnly.get")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Houdini/CSS_Typed_OM">CSS Typed Object Model API</a></li>

--- a/files/en-us/web/api/svgaltglyphelement/format/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/format/index.html
@@ -95,7 +95,7 @@ slug: Web/API/SVGAltGlyphElement/format
 
 <p>{{Compat("api.SVGAltGlyphElement.format")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("SVGAltGlyphElement")}}</li>

--- a/files/en-us/web/api/svgaltglyphelement/glyphref/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/glyphref/index.html
@@ -51,7 +51,7 @@ tags:
 
 <p>{{Compat("api.SVGAltGlyphElement.glyphRef")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("<code>SVGGlyphRef</code>Element")}}</li>

--- a/files/en-us/web/api/svgaltglyphelement/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/index.html
@@ -49,7 +49,7 @@ tags:
 
 <p>{{Compat("api.SVGAltGlyphElement")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>SVG {{SVGElement("altglyph")}} Element</li>

--- a/files/en-us/web/api/touch/msmanipulationviewsenabled/index.html
+++ b/files/en-us/web/api/touch/msmanipulationviewsenabled/index.html
@@ -25,7 +25,7 @@ msManipulationViewsEnabled: true,
 }
 </pre>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Touch">Touch API</a></li>

--- a/files/en-us/web/api/touch/touch/index.html
+++ b/files/en-us/web/api/touch/touch/index.html
@@ -65,8 +65,7 @@ tags:
 
 <p>{{Compat("api.Touch.Touch")}}</p>
 
-<h2 id="See_also"><br>
- See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("TouchEvent")}}, the interface of the objects it constructs<br>

--- a/files/en-us/web/api/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/index.html
@@ -157,7 +157,7 @@ responses.reduce(
 <p>{{Compat("api.TransformStream")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://whatwg-stream-visualizer.glitch.me/">WHATWG Stream Visualiser</a>, for a basic visualisation of readable, writable, and transform streams.</li>

--- a/files/en-us/web/api/uievent/inituievent/index.html
+++ b/files/en-us/web/api/uievent/inituievent/index.html
@@ -76,7 +76,7 @@ e.initUIEvent("click", true, true, window, 1);
 
 <p>{{Compat("api.UIEvent.initUIEvent")}}</p>
 
-<h2 class="editable" id="See_also"><span>See also</span></h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{ domxref("UIEvent") }}</li>

--- a/files/en-us/web/api/user_timing_api/index.html
+++ b/files/en-us/web/api/user_timing_api/index.html
@@ -88,7 +88,7 @@ tags:
 
 <p>To test your browser's support for this API, run the <code><a href="https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html">perf-api-support</a></code> application.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://w3c.github.io/user-timing/">User Timing Standard</a>; W3C Editor's Draft</li>

--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.html
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.html
@@ -212,7 +212,7 @@ tags:
 
 <p>As shown in the {{domxref("Performance")}} interface's <a href="/Web/API/Performance#Browser_compatibility">Browser Compatibility</a> table, the <code>User Timing</code> methods are broadly implemented by desktop and mobile browsers (the only exceptions are no support for Desktop Safari and Mobile Safari).</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://w3c.github.io/user-timing/">User Timing Standard</a>; W3C Editor's Draft</li>

--- a/files/en-us/web/api/web_authentication_api/attestation_and_assertion/index.html
+++ b/files/en-us/web/api/web_authentication_api/attestation_and_assertion/index.html
@@ -16,7 +16,7 @@ tags:
 
 <div><span>When an authenticator registers a new key pair with a service, the authenticator signs the public key with an attestation certificate. The attestation certificate is built into the authenticator during manufacturing time and is specific to a device model. That is, all "Samsung Galaxy S8" phones, manufactured at a specific time or particular manufacturing run, have the same attestation certificate.</span></div>
 
-<div> </div>
+
 
 <div>
 <p><span>The attestation </span> <span>is returned through the WebAuthn API as the <a href="/en-US/docs/Web/API/AuthenticatorAttestationResponse">AuthenticatorAttestationResponse</a>. The attestation format contains two basic ArrayBuffers:</span></p>

--- a/files/en-us/web/api/webrtc_api/index.html
+++ b/files/en-us/web/api/webrtc_api/index.html
@@ -281,7 +281,7 @@ tags:
 
 <p>In additions to these specifications defining the API needed to use WebRTC, there are several protocols, listed under <a href="#Protocols">resources</a>.</p>
 
-<h2 class="Related_Topics" id="See_also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{DOMxRef("MediaDevices")}}</li>

--- a/files/en-us/web/api/window/onbeforeinstallprompt/index.html
+++ b/files/en-us/web/api/window/onbeforeinstallprompt/index.html
@@ -39,7 +39,7 @@ window.onbeforeinstallprompt = function(event) { ...};</pre>
 
 <p>{{Compat("api.Window.onbeforeinstallprompt")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("BeforeInstallPromptEvent.prompt")}}</li>

--- a/files/en-us/web/api/window/prompt/index.html
+++ b/files/en-us/web/api/window/prompt/index.html
@@ -79,7 +79,7 @@ sign = window.prompt('Are you feeling lucky', 'sure'); // open the window with T
  </tbody>
 </table>
 
-<h2 id="See_also">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.prompt")}}</p>
 

--- a/files/en-us/web/api/window/self/index.html
+++ b/files/en-us/web/api/window/self/index.html
@@ -62,7 +62,7 @@ var w4 = window.self;
 
 <p>{{Compat("api.Window.self")}}</p>
 
-<h2 class="noinclude" id="See_also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>Its <code>Worker</code> equivalent, {{domxref("WorkerGlobalScope.self")}}.</li>

--- a/files/en-us/web/api/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/index.html
@@ -144,7 +144,7 @@ sendMessage("Hello, world.", writableStream);</pre>
 <p>{{Compat("api.WritableStream")}}</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://whatwg-stream-visualizer.glitch.me/">WHATWG Stream Visualiser</a>, for a basic visualisation of readable, writable, and transform streams.</li>

--- a/files/en-us/web/css/@property/index.html
+++ b/files/en-us/web/css/@property/index.html
@@ -79,7 +79,7 @@ tags:
 
 <p>{{Compat("css.at-rules.property")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Properties_and_Values_API">CSS Properties and Values API</a></li>

--- a/files/en-us/web/css/box-orient/index.html
+++ b/files/en-us/web/css/box-orient/index.html
@@ -95,7 +95,7 @@ box-orient: unset;
 
 <p>{{Compat("css.properties.box-orient")}}</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{CSSxRef("box-direction")}}</li>

--- a/files/en-us/web/css/contain-intrinsic-size/index.html
+++ b/files/en-us/web/css/contain-intrinsic-size/index.html
@@ -39,7 +39,7 @@ contain-intrinsic-size: 10%;
 
 <p>{{Compat("css.properties.contain-intrinsic-size")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-visibility/">content-visibility: the new CSS property that boosts your rendering performance</a> (web.dev)</li>

--- a/files/en-us/web/css/content-visibility/index.html
+++ b/files/en-us/web/css/content-visibility/index.html
@@ -103,7 +103,7 @@ section {
 
 <p>{{Compat("css.properties.content-visibility")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="https://web.dev/content-visibility/">content-visibility: the new CSS property that boosts your rendering performance</a> (web.dev)</li>

--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.html
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.html
@@ -210,7 +210,7 @@ tags:
 
 <p>My suggestion when exploring flexbox alignment in depth is to do so alongside looking at alignment in Grid Layout. Both specifications use the alignment properties as detailed in the Box Alignment specification. You can see how these properties behave when working with a grid in the MDN article <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box Alignment in Grid Layout</a>, and I have also compared how alignment works in these specifications in my <a href="https://rachelandrew.co.uk/css/cheatsheets/box-alignment">Box Alignment Cheatsheet</a>.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Box_Alignment">Box Alignment</a></li>

--- a/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.html
+++ b/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.html
@@ -112,7 +112,7 @@ tags:
 
 <p>In this guide, we have looked at how elements display in normal flow, as block and inline elements. Due to the default behaviour of these elements, an HTML document with no CSS styling at all, will display in a readable way. By understanding how normal flow works you will find layout easier, as you understand the starting point for making changes to how elements are displayed.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Box_Model">CSS Basic Box Model</a></li>

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.html
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.html
@@ -76,7 +76,7 @@ tags:
 
 <p>In most cases, flow layout works as you would expect it to when changing the writing mode of the document or parts of the document. This can be used to properly typeset vertical languages or for creative reasons. CSS is making this easier by way of introducing logical properties and values so that when working in a vertical writing mode sizing can be based on element's inline and block size. This will be useful when creating components which can work in different writing-modes.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Writing_Modes">Writing Modes</a></li>

--- a/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.html
+++ b/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.html
@@ -64,7 +64,7 @@ tags:
 
 <p>In this guide we have covered the ways to take an element out of flow in order to achieve some very specific types of positioning. In the next guide we will look at a related issue, that of creating a <a href="/en-US/docs/Web/Guide/CSS/Block_formatting_context">Block Formatting Context</a>, in <a href="/en-US/docs/Web/CSS/CSS_Flow_Layout/Formatting_Contexts_Explained">Formatting Contexts Explained</a>.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>Learn Layout: <em><a href="/en-US/docs/Learn/CSS/CSS_layout/Positioning">Positioning</a></em></li>

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
@@ -566,7 +566,7 @@ tags:
 
 <p>As you can see from this guide, CSS Grid Layout is just one part of your toolkit. Don’t be afraid to mix it with other methods of doing layout to get the different effects you need.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox Guides</a></li>

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.html
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.html
@@ -111,7 +111,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>On the Mozilla Developer YouTube Channel, see the videos<a href="https://www.youtube.com/watch?v=gmQlK3kRft4"> Laying out forms using subgrid</a> and <a href="https://www.youtube.com/watch?v=lLnFtK1LNu4">Don't Wait To Use Subgrid For Better Card Layouts</a></li>

--- a/files/en-us/web/css/css_types/index.html
+++ b/files/en-us/web/css/css_types/index.html
@@ -162,7 +162,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Values_and_Units">CSS Units and Values</a></li>

--- a/files/en-us/web/css/inheritance/index.html
+++ b/files/en-us/web/css/inheritance/index.html
@@ -63,7 +63,7 @@ tags:
 
 <p>This reverts the style of the {{cssxref("font")}} property to the user agent's default unless a user stylesheet exists, in which case that is used instead. Then it doubles the font size and applies a {{cssxref("font-weight")}} of <code>"bold"</code>.</p>
 
-<h2 id="See_Also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>CSS values for controlling inheritance: {{ cssxref("inherit") }}, {{cssxref("initial")}}, {{cssxref("unset")}}, and {{cssxref("revert")}}</li>

--- a/files/en-us/web/css/string/index.html
+++ b/files/en-us/web/css/string/index.html
@@ -86,7 +86,7 @@ awesome string"
 
 <p>{{Compat("css.types.string")}}</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li><a href="/en-US/docs/Web/CSS/CSS_Values_and_Units">CSS Units and Values</a></li>

--- a/files/en-us/web/css/viewport_concepts/index.html
+++ b/files/en-us/web/css/viewport_concepts/index.html
@@ -149,7 +149,7 @@ body &gt; footer {
 
 <p>The <code>width</code> property controls the size of the viewport. It should preferably be set to <code>device-width</code>, which is the width of the screen in CSS pixels at a scale of 100%. There are other properties, including <code>maximum-scale</code>, <code>minimum-scale</code>, and <code>user-scalable</code>, which control whether users can zoom the page in or out, but the default values are the best for accessibility and user experience, so these can be omitted.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
 	<li><a href="/en-US/docs/Web/CSS/@viewport">@viewport CSS at-rule</a></li>

--- a/files/en-us/web/guide/ajax/index.html
+++ b/files/en-us/web/guide/ajax/index.html
@@ -66,7 +66,7 @@ An introduction to Ajax.</div>
  <dd>{{jsxref("Promise")}} based {{glossary("HTTP")}} client, which uses <code>XMLHttpRequest</code> internally.</dd>
 </dl>
 
-<h2 class="Other" id="See_also">See also</h2>
+<h2 id="See_also">See also</h2>
 
 <dl>
  <dt><a href="https://pdfs.semanticscholar.org/c440/ae765ff19ddd3deda24a92ac39cef9570f1e.pdf">Ajax: A New Approach to Web Applications</a></dt>

--- a/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.html
@@ -244,7 +244,7 @@ Currently, Opus is supported by Firefox desktop and mobile as well as the latest
 
 <p>Although you can install software like GStreamer, SHOUTcast and Icecast you will also find a lot of <a href="http://en.wikipedia.org/wiki/Comparison_of_streaming_media_systems">third-party streaming services</a> that will do much of the work for you.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul class="task-list">
 	<li><a href="http://en.wikipedia.org/wiki/HTTP_Live_Streaming">HTTP Live Streaming</a></li>

--- a/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.html
@@ -254,7 +254,7 @@ http://media.example.com/segment2.ts
 <p><strong>Note</strong>: Comprehensive information on how to encode media for Apple's HLS format can be found on <a href="https://developer.apple.com/streaming/">Apple's Developer Pages</a>.</p>
 </div>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <p>Further resources on adaptive streaming.</p>
 

--- a/files/en-us/web/guide/audio_and_video_delivery/webaudio_playbackrate_explained/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/webaudio_playbackrate_explained/index.html
@@ -91,7 +91,7 @@ myAudio.playbackRate = 0.5;</pre>
  <li>On iOS 7 you can only affect the <code>playbackRate</code> when the media is paused (not while it's playing).</li>
 </ul>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="http://hyperaud.io/lab/pbr-test/">Hyperaudio's Playback Rate Test</a></li>

--- a/files/en-us/web/html/element/listing/index.html
+++ b/files/en-us/web/html/element/listing/index.html
@@ -35,7 +35,7 @@ tags:
 <p><strong>Implementation note: </strong>up to Gecko 1.9.2 inclusive, Firefox implements the {{domxref('HTMLSpanElement')}} interface for this element.</p>
 </div>
 
-<h2 id="See_also">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("html.elements.listing")}}</p>
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -456,7 +456,7 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>In the past, specific plug-ins, add-ons or extensions added user agent parts to notify sites they were installed. The recommended way to do this, if it's absolutely necessary (remember that it slows down every request) is to <a href="/en/Setting_HTTP_request_headers">set a custom HTTP header</a>.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="http://lawrencemandel.com/2012/07/27/decision-made-firefox-os-user-agent-string/">Firefox OS User Agent String</a> (blog post w/<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=777710">bug 777710</a> reference)</li>

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.html
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.html
@@ -194,7 +194,7 @@ new WeakSet(function* () {
 }()).has(myObj);           // true
 </pre>
 
-<h4 id="See_Also">See Also</h4>
+<h4 id="See_also_1">See also</h4>
 
 <ul>
  <li>{{jsxref("Promise.all()", "Promise.all(<var>iterable</var>)")}}</li>
@@ -388,7 +388,7 @@ console.log(Symbol.iterator in aGeneratorObject)
  </tbody>
 </table>
 
-<h2 id="See_also">See also</h2>
+<h2 id="See_also_2">See also</h2>
 
 <ul>
  <li>To learn more about ES2015 generators, see:<br>

--- a/files/en-us/web/media/formats/containers/index.html
+++ b/files/en-us/web/media/formats/containers/index.html
@@ -1328,7 +1328,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="See_also"> See also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC API</a></li>

--- a/files/en-us/web/performance/how_browsers_work/index.html
+++ b/files/en-us/web/performance/how_browsers_work/index.html
@@ -208,7 +208,7 @@ tags:
 
 <p>In this example, the DOM content load process took over 1.5 seconds, and the main thread was fully occupied that entire time, unresponsive to click events or screen taps.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Performance">Web Performance</a></li>

--- a/files/en-us/web/performance/navigation_and_resource_timings/index.html
+++ b/files/en-us/web/performance/navigation_and_resource_timings/index.html
@@ -275,7 +275,7 @@ performance.getEntriesByType('frame').forEach((frame) =&gt; {
 
 <p>The main thing to look at for each resource.</p>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li>{{domxref("PerformanceNavigationTiming")}}</li>

--- a/files/en-us/web/svg/attribute/cx/index.html
+++ b/files/en-us/web/svg/attribute/cx/index.html
@@ -170,7 +170,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="See_Also">See Also</h2>
+<h2 id="See_also">See also</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/SVG/Attribute/cy">cy</a></li>


### PR DESCRIPTION
Make headers of "See also" sections consistent (match format `<h[123456] id="See_also">See also</h[123456]>`). Also, fix a couple mistakes along the way.