### PR TITLE
Remove array from ImageCapture.takephoto signature

### DIFF
--- a/files/en-us/web/api/imagecapture/takephoto/index.html
+++ b/files/en-us/web/api/imagecapture/takephoto/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">const <em>blobPromise</em> = <em>imageCaptureObj</em>.takePhoto([<em>photoSettings</em>])</pre>
+<pre class="syntaxbox">const <em>blobPromise</em> = <em>imageCaptureObj</em>.takePhoto(<em>photoSettings</em>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/imagecapture/takephoto/index.html
+++ b/files/en-us/web/api/imagecapture/takephoto/index.html
@@ -18,7 +18,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">const <em>blobPromise</em> = <em>imageCaptureObj</em>.takePhoto(<em>photoSettings</em>)</pre>
+<pre class="syntaxbox">
+const <em>blobPromise</em> = <em>imageCaptureObj</em>.takePhoto()
+const <em>blobPromise</em> = <em>imageCaptureObj</em>.takePhoto(<em>photoSettings</em>)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 


### PR DESCRIPTION
Currently, it seems like takephoto takes in an array of photosettings, but this does not adhere to the [spec](https://w3c.github.io/mediacapture-image/#imagecaptureapi). takephoto should only take an object of photosettings.