### PR TITLE
Drop stray IncludeSubnav("/en-US/docs/MDN")

### DIFF
--- a/files/en-us/mdn/about/index.html
+++ b/files/en-us/mdn/about/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{MDNSidebar}}</div>
 
-<div>{{IncludeSubNav("/en-US/docs/MDN")}}</div>
-
 <p>MDN Web Docs (previously known as MDN — the Mozilla Developer Network) is an evolving learning platform for Web technologies and the software that powers the Web, including <a href="/en-US/docs/CSS">CSS</a>, <a href="/en-US/docs/HTML">HTML</a>, and <a href="/en-US/docs/JavaScript">JavaScript</a>. We also have a detailed set of beginner's learning material — see <a href="/en-US/docs/Learn">Learn Web development</a>.</p>
 
 <h2 id="Our_mission">Our mission</h2>


### PR DESCRIPTION
This change drops a stray `{{IncludeSubnav("/en-US/docs/MDN")}}` macro instance that for some reason didn’t get included in the patch for https://github.com/mdn/content/pull/210. Fixes https://github.com/mdn/content/issues/510