### PR TITLE
Fixes #464 small error in text of positioning learn material 

### DIFF
--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.html
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.html
@@ -160,7 +160,7 @@ body {
 
 <p>The next job is to style our panels. Let's get going!</p>
 
-<p>First, of all, add the following rule to style the <code>.panels</code> {{htmlelement("div")}} container. Here we set a fixed {{cssxref("height")}} to make sure the panels fit snugly inside the info-box, {{cssxref("position")}} <code>relative</code> to set the {{htmlelement("div")}} as the positioning context, so you can then place positioned child elements relative to it and not the {{htmlelement("html")}} element, and finally we {{cssxref("clear")}} the float set in the CSS above so that it doesn't interfere with the remainder of the layout.</p>
+<p>First, of all, add the following rule to style the <code>.panels</code> {{htmlelement("div")}} container. Here we set a fixed {{cssxref("height")}} to make sure the panels fit snugly inside the info-box, {{cssxref("position")}} <code>relative</code> to set the {{htmlelement("div")}} as the positioning context, so you can then place positioned child elements relative to it and not the initial viewport, and finally we {{cssxref("clear")}} the float set in the CSS above so that it doesn't interfere with the remainder of the layout.</p>
 
 <pre class="brush: css">.info-box .panels {
   height: 352px;


### PR DESCRIPTION
Fixes #464 the text suggested that the initial containing block was the html element, it's really the root element which is the size of the viewport https://www.w3.org/TR/CSS2/visudet.html#containing-block-details