### PR TITLE
fix: OL start values

### DIFF
--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.html
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.html
@@ -80,9 +80,6 @@ browserType.length;</pre>
  <li>Try this:
   <pre class="brush: js notranslate">browserType.indexOf('zilla');</pre>
   This gives us a result of 2, because the substring "zilla" starts at position 2 (0, 1, 2  — so 3 characters in) inside "mozilla". Such code could be used to filter strings. For example, we may have a list of web addresses and only want to print out the ones that contain "mozilla".</li>
-</ol>
-
-<ol start="2">
  <li>This can be done in another way, which is possibly even more effective. Try the following:
   <pre class="brush: js notranslate">browserType.indexOf('vanilla');</pre>
   This should give you a result of <code>-1</code> — this is returned when the substring, in this case 'vanilla', is not found in the main string.<br>

--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.html
@@ -55,9 +55,6 @@ tags:
  <li>Create the folder where you want to save the program, for example, <code>test-node</code> and then enter it by entering the following command into your terminal:
   <pre class="notranslate">cd test-node</pre>
  </li>
-</ol>
-
-<ol start="3">
  <li>Using your favorite text editor, create a file called <code>hello.js</code> and paste the following code into it:<br>
 
   <pre class="brush: js notranslate">// Load HTTP module
@@ -82,9 +79,6 @@ server.listen(port, hostname, () =&gt; {
 })
 </pre>
  </li>
-</ol>
-
-<ol start="4">
  <li>Save the file in the folder you created above.</li>
  <li>Go back to the terminal and type the following command:
   <pre class="brush: bash notranslate">node hello.js</pre>

--- a/files/en-us/mdn/contribute/howto/recruit_a_technical_reviewer/index.html
+++ b/files/en-us/mdn/contribute/howto/recruit_a_technical_reviewer/index.html
@@ -43,12 +43,9 @@ tags:
 <p>Once you've finished writing and are ready for a technical review, make sure the "Technical Review Requested" flag is set on every page that needs to be reviewed. Now it's time to ask for the review. There are several ways to find someone to get a review; typically, you should start with the first one and work your way down the list if you fail to find someone to do the review.</p>
 
 <ol>
- <li>Start by posting a comment in the bug asking for someone to do a technical review. List all the changed pages and sections of pages, complete with links. The easier it is to find the stuff that needs reviewing, the more likely you are to get a review. If you can see who the most likely candidate is, use Bugzilla's "Need more information" option (commonly referred to as "needinfo" or "NI") to get their attention.</li>
-</ol>
-
-<p><img alt="Screen shot of the needinfo option on Bugzilla" src="https://mdn.mozillademos.org/files/11347/bz-ni-annotated.png" style="display: block; height: 366px; margin-left: auto; margin-right: auto; width: 950px;"></p>
-
-<ol start="2">
+ <li>Start by posting a comment in the bug asking for someone to do a technical review. List all the changed pages and sections of pages, complete with links. The easier it is to find the stuff that needs reviewing, the more likely you are to get a review. If you can see who the most likely candidate is, use Bugzilla's "Need more information" option (commonly referred to as "needinfo" or "NI") to get their attention.
+  <p><img alt="Screen shot of the needinfo option on Bugzilla" src="https://mdn.mozillademos.org/files/11347/bz-ni-annotated.png" style="display: block; height: 366px; margin-left: auto; margin-right: auto; width: 950px;"></p>
+ </li>
  <li>If that doesn't get any action in a reasonable amount of time (at least an "I'll do it in a couple days" comment within a day or two, depending on the urgency) follow up by directly emailing the person or people that contributed the patch(es).</li>
  <li>If that doesn't work, follow up by asking in the appropriate Matrix room. Say something like "Hi everyone. We've got new/updated docs for X, and could really use someone who knows X well to read it over and make sure we got it right. Check out bug X, comment Y &lt;link&gt; for a list of what needs looking at. Anyone able to help?"</li>
  <li>If that doesn't work, that's when you politely send email to ask <a href="https://wiki.mozilla.org/Modules">the manager of the team responsible for the technology</a> in question to suggest someone to do the review. "Hi ManagerNameHere! We just finished documenting X and could use a review. Do you know who would be a good person to read it over and let us know where I got things wrong? Thanks so much in advance!"</li>

--- a/files/en-us/mozilla/developer_guide/build_instructions/compiling_32-bit_firefox_on_a_linux_64-bit_os/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/compiling_32-bit_firefox_on_a_linux_64-bit_os/index.html
@@ -67,16 +67,10 @@ ac_add_options --disable-optimize
  <li>Install mercurial or git and fetch a copy of mozilla-central.</li>
  <li>Run <code>./mach bootstrap</code> to install some dependencies. Note that this will install some amd64 packages that are not needed to build 32-bit Firefox.</li>
  <li>Run <code>rustup target install i686-unknown-linux-gnu</code> to install the 32-bit Rust target.</li>
- <li>Install 32-bit dependencies with the following command (this may uninstall some unneeded/conflicting packages that were installed by mach bootstrap):</li>
-</ol>
-
+ <li>Install 32-bit dependencies with the following command (this may uninstall some unneeded/conflicting packages that were installed by mach bootstrap):
 <pre class="syntaxbox">sudo apt install gcc-multilib g++-multilib libdbus-glib-1-dev:i386 \
-  libgtk2.0-dev:i386 libgtk-3-dev:i386 libpango1.0-dev:i386 libxt-dev:i386</pre>
-
-<ol start="7">
- <li>Create a <code>.mozconfig</code> file containing at least the following:</li>
-</ol>
-
+  libgtk2.0-dev:i386 libgtk-3-dev:i386 libpango1.0-dev:i386 libxt-dev:i386</pre></li>
+ <li>Create a <code>.mozconfig</code> file containing at least the following:
 <pre class="syntaxbox">ac_add_options --target=i686-pc-linux
 
 CFLAGS="$CFLAGS -march=pentium-m -msse -msse2 -mfpmath=sse"
@@ -84,8 +78,7 @@ CXXFLAGS="$CXXFLAGS -march=pentium-m -msse -msse2 -mfpmath=sse"
 
 export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
 </pre>
-
-<ol start="8">
+ </li>
  <li>Run <code>./mach build</code>.</li>
 </ol>
 

--- a/files/en-us/tools/debugger/set_a_logpoint/index.html
+++ b/files/en-us/tools/debugger/set_a_logpoint/index.html
@@ -19,12 +19,9 @@ tags:
 <p>To create a logpoint:</p>
 
 <ol>
- <li>Right click on a line number in the Debugger panel and pick <strong>Add log</strong> action from the context menu.</li>
-</ol>
-
+ <li>Right click on a line number in the Debugger panel and pick <strong>Add log</strong> action from the context menu.
 <p><span style="background-color: transparent; color: #000000; font-family: Arial; font-size: 11pt; font-style: normal; font-variant: normal; font-weight: 400; text-decoration: none; vertical-align: baseline; white-space: pre-wrap;"><img alt="" src="https://mdn.mozillademos.org/files/16601/add_logpoint.png" style="display: block; height: 121px; margin: 0px auto; width: 241px;"></span></p>
-
-<ol start="2">
+ </li>
  <li>Create an expression inline. The result is logged in the console panel every time the line with the logpoint executes. You can use any variable or function available in the current scope.</li>
 </ol>
 

--- a/files/en-us/web/css/containing_block/index.html
+++ b/files/en-us/web/css/containing_block/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>When a user agent (such as your browser) lays out a document, it generates a box for every element. Each box is divided into four areas:</p>
 
-<ol start="1">
+<ol>
  <li>Content area</li>
  <li>Padding area</li>
  <li>Border area</li>
@@ -40,12 +40,12 @@ tags:
 
 <p>The process for identifying the containing block depends entirely on the value of the element's {{cssxref("position")}} property:</p>
 
-<ol start="1">
+<ol>
  <li>If the <code>position</code> property is <code><strong>static</strong></code>, <code><strong>relative</strong></code>, or <strong><code>sticky</code></strong>, the containing block is formed by the edge of the <em>content box</em> of the nearest ancestor element that is either <strong>a block container</strong> (such as an inline-block, block, or list-item element) or <strong>establishes a formatting context</strong> (such as a table container, flex container, grid container, or the block container itself).</li>
  <li>If the <code>position</code> property is <code><strong>absolute</strong></code>, the containing block is formed by the edge of the <em>padding box</em> of the nearest ancestor element that has a <code>position</code> value other than <code>static</code> (<code>fixed</code>, <code>absolute</code>, <code>relative</code>, or <code>sticky</code>).</li>
  <li>If the <code>position</code> property is <code><strong>fixed</strong></code>, the containing block is established by the {{glossary("viewport")}} (in the case of continuous media) or the page area (in the case of paged media).</li>
  <li>If the <code>position</code> property is <code><strong>absolute</strong></code> or <code><strong>fixed</strong></code>, the containing block may also be formed by the edge of the <em>padding box</em> of the nearest ancestor element that has the following:
-  <ol start="1">
+  <ol>
    <li>A {{cssxref("transform")}} or {{cssxref("perspective")}} value other than <code>none</code></li>
    <li>A {{cssxref("will-change")}} value of <code>transform</code> or <code>perspective</code></li>
    <li>A {{cssxref("filter")}} value other than <code>none</code> or a <code>will-change</code> value of <code>filter</code> (only works on Firefox).</li>
@@ -62,7 +62,7 @@ tags:
 
 <p>As noted above, when certain properties are given a percentage value, the computed value depends on the element's containing block. The properties that work this way are <strong>box model properties</strong> and <strong>offset properties</strong>:</p>
 
-<ol start="1">
+<ol>
  <li>The {{cssxref("height")}}, {{cssxref("top")}}, and {{cssxref("bottom")}} properties compute percentage values from the <code>height</code> of the containing block.</li>
  <li>The {{cssxref("width")}}, {{cssxref("left")}}, {{cssxref("right")}}, {{cssxref("padding")}}, and {{cssxref("margin")}} properties compute percentage values from the <code>width</code> of the containing block.</li>
 </ol>


### PR DESCRIPTION
- Remove start="1"
- Fold down split lists

There were also some `start="0"` in files/en-us/web/api/web_authentication_api/index.html that I left