### PR TITLE
Clarify EmbedLiveSample behavior with page_slug

### DIFF
--- a/files/en-us/mdn/structures/live_samples/index.html
+++ b/files/en-us/mdn/structures/live_samples/index.html
@@ -68,7 +68,12 @@ tags:
  <dt>screenshot_URL</dt>
  <dd>The URL of a screenshot that shows what the live sample should look like. This is optional, but can be useful for new technologies that may not work in the user's browser, so they can see what the sample would look like if it were supported by their browser. If you include this parameter, the screenshot is shown next to the live sample, with appropriate headings.</dd>
  <dt>page_slug</dt>
- <dd>The slug of the page containing the sample; this is optional, and if it's not provided, the sample is pulled from the same page on which the macro is used.</dd>
+ <dd>
+   <p>The slug of the page containing the sample; this is optional, and if it's not provided, the sample is pulled from the same page on which the macro is used.</p>
+   <div class="warning">
+   <strong>Warning:</strong>To show a live sample from one code-containing page in a different, target page, the code-containing page must itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro to embed a live sample in its own page. Otherwise, if the code-containing page doesn't itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro its own page, the live sample will fail to display at all on the target page. (See <a href="https://github.com/mdn/yari/issues/2243">Yari issue #2243</a>.)
+   </div>
+ </dd>
 </dl>
 
 <ol>

--- a/files/en-us/mdn/structures/live_samples/index.html
+++ b/files/en-us/mdn/structures/live_samples/index.html
@@ -71,7 +71,7 @@ tags:
  <dd>
    <p>The slug of the page containing the sample; this is optional, and if it's not provided, the sample is pulled from the same page on which the macro is used.</p>
    <div class="notecard warning">
-   <strong>Warning:</strong>To show a live sample from one code-containing page in a different, target page, the code-containing page must itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro to embed a live sample in its own page. Otherwise, if the code-containing page doesn't itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro its own page, the live sample will fail to display at all on the target page. (See <a href="https://github.com/mdn/yari/issues/2243">Yari issue #2243</a>.)
+   <strong>Warning:</strong> To show a live sample from one code-containing page in a different, target page, the code-containing page must itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro to embed a live sample in its own page. Otherwise, if the code-containing page doesn't itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro its own page, the live sample will fail to display at all on the target page. (See <a href="https://github.com/mdn/yari/issues/2243">Yari issue #2243</a>.)
    </div>
  </dd>
 </dl>

--- a/files/en-us/mdn/structures/live_samples/index.html
+++ b/files/en-us/mdn/structures/live_samples/index.html
@@ -70,7 +70,7 @@ tags:
  <dt>page_slug</dt>
  <dd>
    <p>The slug of the page containing the sample; this is optional, and if it's not provided, the sample is pulled from the same page on which the macro is used.</p>
-   <div class="warning">
+   <div class="notecard warning">
    <strong>Warning:</strong>To show a live sample from one code-containing page in a different, target page, the code-containing page must itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro to embed a live sample in its own page. Otherwise, if the code-containing page doesn't itself use the <span class="templateLink"><code><a href="https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs">EmbedLiveSample</a></code></span> macro its own page, the live sample will fail to display at all on the target page. (See <a href="https://github.com/mdn/yari/issues/2243">Yari issue #2243</a>.)
    </div>
  </dd>


### PR DESCRIPTION
This change adds a warning to the *Document structures » Live samples* article, to make clear that when using the *page_slug* parameter with the `EmbedLiveSample` macro, it’s necessary for the *page_slug* page itself to use the `EmbedLiveSample` macro in its own page. Relates to https://github.com/mdn/yari/issues/2243.