### PR TITLE
fix: Remove <header> tag

### DIFF
--- a/files/en-us/games/techniques/efficient_animation_for_web_games/index.html
+++ b/files/en-us/games/techniques/efficient_animation_for_web_games/index.html
@@ -8,13 +8,7 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<header class="entry-header">
-<div class="summary">
-<div class="entry-meta"><span class="seoSummary">This article covers techniques and advice for creating efficient animation for web games, with a slant towards supporting lower end devices such as mobile phones. We touch on <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_transitions">CSS transitions</a> and <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_animations">CSS animations</a>, and JavaScript loops involving {{ domxref("window.requestAnimationFrame") }}.</span></div>
-</div>
-
-<div class="entry-meta"></div>
-</header>
+<p><span class="seoSummary">This article covers techniques and advice for creating efficient animation for web games, with a slant towards supporting lower end devices such as mobile phones. We touch on <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_transitions">CSS transitions</a> and <a href="/en-US/docs/Web/Guide/CSS/Using_CSS_animations">CSS animations</a>, and JavaScript loops involving {{ domxref("window.requestAnimationFrame") }}.</span></p>
 
 <p>There are several techniques worth knowing that will improve the performance of your game or application whilst also using less battery life, especially on low-end devices. It is worth documenting some of these things, as there is evidence to suggest (in popular and widely-used UI libraries, for example) that they aren’t necessarily common knowledge. First off, let us discuss some basic ideas.</p>
 


### PR DESCRIPTION
Tag `<header>` is not well-represented by Markdown, so let's follow the convention of using simple `<p>` and `<span>` like on all other pages.