### PR TITLE
fix: obsolete_build_caveats_and_tips

### DIFF
--- a/files/en-us/mozilla/developer_guide/introduction/obsolete_build_caveats_and_tips/index.html
+++ b/files/en-us/mozilla/developer_guide/introduction/obsolete_build_caveats_and_tips/index.html
@@ -21,8 +21,9 @@ tags:
 <dl>
  <dt><a href="/En/Developer_Guide/Source_Code/CVS">Older Mozilla Source Code via CVS</a></dt>
  <dd>Those who need to work with the code for Firefox 3/Mozilla 1.9 and earlier can check out the latest source using CVS. In reality, you should probably not need to do this, since that code is very obsolete.</dd>
- <dt>This note below seems redundant as this is true by default https://msdn.microsoft.com/en-us/library/dh8che7s%28v=vs.110%29.aspx</dt>
 </dl>
+
+<p>This note below seems redundant as this is true by default https://msdn.microsoft.com/en-us/library/dh8che7s%28v=vs.110%29.aspx</p>
 
 <div class="note">
 <p><strong>Note:</strong> Starting with {{Gecko("7.0")}}, you should no longer include "-Zc:wchar_t-" in the command line when building on Windows. If you're using Visual Studio, go to Project Properties &gt; C/C++ &gt; Language &gt; Treat wchar_t as Built-in Type and set it to "yes".</p>
@@ -179,8 +180,8 @@ cd 191src
 <div class="warning">If you want to enable jemalloc, you must be using Visual Studio 2012, Visual Studio 2010 SP1, Visual Studio 2010, Visual Studio 2008 SP1, or <a class="external" href="http://www.microsoft.com/downloads/details.aspx?familyid=bb4a75ab-e2d4-4c96-b39d-37baf6b5b1dc&amp;displaylang=en">Visual Studio 2005 SP1</a>. Other versions of Visual Studio will not work.</div>
 
 <ul>
- <li><a href="https://www.visualstudio.com/downloads/">Visual Studio 2017a&gt; is available free from Microsoft.</a></li><a href="https://www.visualstudio.com/downloads/">
- </a><li><a href="https://www.visualstudio.com/downloads/">Visual C++ 10 is available from Microsoft as part of the free </a><a class="external" href="http://go.microsoft.com/?linkid=9709949">Visual C++ 2010 Express Edition</a>.</li>
+ <li><a href="https://www.visualstudio.com/downloads/">Visual Studio 2017a&gt; is available free from Microsoft.</a></li>
+ <li><a href="https://www.visualstudio.com/downloads/">Visual C++ 10 is available from Microsoft as part of the free </a><a class="external" href="http://go.microsoft.com/?linkid=9709949">Visual C++ 2010 Express Edition</a>.</li>
  <li>Visual C++ 9 is available from Microsoft as part of the free <a class="external" href="http://www.microsoft.com/downloads/details.aspx?FamilyId=F3FBB04E-92C2-4701-B4BA-92E26E408569&amp;displaylang=en">Visual C++ 2008 Express Edition with SP1</a> (make sure you get this and not the one without SP1!). You do not need to install the Silverlight runtime or the SQL Server 2008 Express Edition when offered. Alternatively you can install the command-line compiler as part of the Windows 7 SDK, but you are then expected to use the included WinDbg debugger.</li>
  <li>The Visual C++ 8 command-line compiler is included with the Vista SDK, but you are then expected to use the included WinDbg debugger.</li>
 </ul>


### PR DESCRIPTION
- Link outside of list item
- Move fake dt to paragraph