### PR TITLE
fix: Updating extensions for Firefox 3.6

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.html
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.html
@@ -2,28 +2,61 @@
 title: Updating extensions for Firefox 3.6
 slug: Mozilla/Firefox/Releases/3.6/Updating_extensions
 tags:
-  - Extensions
-  - Firefox
-  - Firefox 3.6
+- Extensions
+- Firefox
+- Firefox 3.6
 ---
-<div>{{FirefoxSidebar}}</div><p>{{ fx_minversion_header(3.6) }}</p>
-<p>This article provides helpful information to extension developers trying to update their extensions to work properly in Firefox 3.6.</p>
+<div>{{FirefoxSidebar}}</div>
+<p>{{ fx_minversion_header(3.6) }}</p>
+<p>This article provides helpful information to extension developers trying to update their extensions to work properly
+  in Firefox 3.6.</p>
 <h2 id="User_interface_changes">User interface changes</h2>
-<p><a class=" link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=513147">Right-clicking on elements (including links and images) no longer offers a "Properties" menu item.</a> The properties dialog box was not useful for most users and has been removed. If your extension interacts with that menu item in any way, you'll need to revise your code to add it yourself, or contribute your own context menu entry directly.</p><h2 id="Add-on_package_changes">Add-on package changes</h2>
-<p>In order to allow add-ons' icons to be displayed even when they're disabled, Gecko 1.9.2 added support for automatically detecting and using an icon named <code>icon.png</code>, located in the add-on's root directory. This is used if the add-on is disabled, or if the manifest is missing an <code>iconURL</code> entry.</p>
+<p><a class=" link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=513147">Right-clicking on elements
+    (including links and images) no longer offers a "Properties" menu item.</a> The properties dialog box was not useful
+  for most users and has been removed. If your extension interacts with that menu item in any way, you'll need to revise
+  your code to add it yourself, or contribute your own context menu entry directly.</p>
+<h2 id="Add-on_package_changes">Add-on package changes</h2>
+<p>In order to allow add-ons' icons to be displayed even when they're disabled, Gecko 1.9.2 added support for
+  automatically detecting and using an icon named <code>icon.png</code>, located in the add-on's root directory. This is
+  used if the add-on is disabled, or if the manifest is missing an <code>iconURL</code> entry.</p>
 <h2 id="HTML_5_compliance_improvements">HTML 5 compliance improvements</h2>
 <p>The DOM Level 2 views to HTML and XHTML documents are now unified per HTML 5.</p>
-<ul> <li>The <a class="internal" href="/En/DOM/Node.localName"><code>localName</code></a> DOM property now returns the name of HTML element nodes in lower case. Previously, in HTML documents, it returned it in upper case. (DOM Level 1 <a class="internal" href="/en/DOM/node.tagName"><code>tagName</code></a> continues to return in upper case in HTML documents.)</li> <li>The <a class="internal" href="/En/DOM/Node.namespaceURI"><code>namespaceURI</code></a> DOM property now returns <code>"<span class="nowiki">http://www.w3.org/1999/xhtml</span>"</code> on HTML element nodes. Previously, in HTML documents, it returned <code>null</code>.</li> <li><code>document.<a class="internal" href="/en/DOM/document.createElementNS">createElementNS</a>(null, "FOO")</code> no longer creates an HTML element node in HTML documents. <code>document.<a class="internal" href="/en/DOM/document.createElement")</code> or <code>document.createElementNS("<span class="nowiki">http://www.w3.org/1999/xhtml</span>", "foo")</code> continue to work in HTML documents.</li> <li>The <a href="/en/XPath/Functions/name"><code>name</code></a> and the <a href="/en/XPath/Functions/local-name"><code>local-name</code></a> functions in XPath returns the name of HTML elements in lower case. Previously, in HTML documents, they returned it in upper case.</li>
+<ul>
+  <li>The <a class="internal" href="/En/DOM/Node.localName"><code>localName</code></a> DOM property now returns the name
+    of HTML element nodes in lower case. Previously, in HTML documents, it returned it in upper case. (DOM Level 1 <a
+      class="internal" href="/en/DOM/node.tagName"><code>tagName</code></a> continues to return in upper case in HTML
+    documents.)</li>
+  <li>The <a class="internal" href="/En/DOM/Node.namespaceURI"><code>namespaceURI</code></a> DOM property now returns
+    <code>"<span class="nowiki">http://www.w3.org/1999/xhtml</span>"</code> on HTML element nodes. Previously, in
+    HTML documents, it returned <code>null</code>.
+  </li>
+  <code>document.<a class="internal" href="/en/DOM/document.createElementNS">createElementNS</a>(null, "FOO")</code>
+  no longer creates an HTML element node in HTML documents.
+  <code>document.<a class="internal" href="/en/DOM/document.createElement">createElement</a>("FOO")</code>
+  or <code>document.createElementNS("<span class="nowiki">http://www.w3.org/1999/xhtml</span>", "foo")</code> continue
+  to work in HTML documents.</li>
+  </li>
+  <li>The <a href="/en/XPath/Functions/name"><code>name</code></a> and the <a
+      href="/en/XPath/Functions/local-name"><code>local-name</code></a> functions in XPath returns the name of HTML
+    elements in lower case. Previously, in HTML documents, they returned it in upper case.</li>
 </ul>
 <p>The most probable upgrade problem is the pattern <code>if (elt.localName == "FOO")</code>.</p>
 <h3 id="Example_Testing_if_an_element_is_an_HTML_img_element">Example: Testing if an element is an HTML img element</h3>
 <h4 id="Firefox_3.6_both_texthtml_and_applicationxhtmlxml">Firefox 3.6, both text/html and application/xhtml+xml</h4>
-<p><code>if (elt.localName == "img" &amp;&amp; elt.namespaceURI == "<a class=" external" href="https://www.w3.org/1999/xhtml" rel="freelink">http://www.w3.org/1999/xhtml</a>")</code></p>
-<h4 id="Firefox_3.5_and_3.6_only_extension-supplied_texthtml_without_foreign_(e.g._SVG)_script-inserted_elements">Firefox 3.5 and 3.6, only extension-supplied text/html without foreign (e.g. SVG) script-inserted elements</h4>
+<p>
+  <code>if (elt.localName == "img" &amp;&amp; elt.namespaceURI == "<a class=" external" href="https://www.w3.org/1999/xhtml" rel="freelink">http://www.w3.org/1999/xhtml</a>")</code>
+</p>
+<h4 id="Firefox_3.5_and_3.6_only_extension-supplied_texthtml_without_foreign_(e.g._SVG)_script-inserted_elements">
+  Firefox 3.5 and 3.6, only extension-supplied text/html without foreign (e.g. SVG) script-inserted elements</h4>
 <p><code>if (elt.tagName == "IMG")</code></p>
-<h4 id="Firefox_3.5_and_3.6_both_texthtml_and_applicationxhtmlxml">Firefox 3.5 and 3.6, both text/html and application/xhtml+xml</h4>
+<h4 id="Firefox_3.5_and_3.6_both_texthtml_and_applicationxhtmlxml">Firefox 3.5 and 3.6, both text/html and
+  application/xhtml+xml</h4>
 <p><code>if (elt instanceof HTMLImageElement)</code></p>
 <h2 id="contents.rdf_no_longer_supported">contents.rdf no longer supported</h2>
-<p>Support for the obsolete <code>contents.rdf</code> method for registering chrome has been removed in Gecko 1.9.2, and is no longer supported by Firefox 3.6. This means that add-ons that use contents.rdf can no longer be installed.</p>
-<p>Make sure you include a <a href="/en/Chrome_Registration" title="en/Chrome Registration">chrome.manifest</a> in your XPI.</p>
-<div class="note"><strong>Note:</strong> Add-ons that are already installed using the old contents.rdf method for registering chrome will continue to function if already installed. Make sure that you test your add-on by actually removing and reinstalling it to ensure that the install works after updating it to use an install manifest.</div>
+<p>Support for the obsolete <code>contents.rdf</code> method for registering chrome has been removed in Gecko 1.9.2, and
+  is no longer supported by Firefox 3.6. This means that add-ons that use contents.rdf can no longer be installed.</p>
+<p>Make sure you include a <a href="/en/Chrome_Registration" title="en/Chrome Registration">chrome.manifest</a> in your
+  XPI.</p>
+<div class="note"><strong>Note:</strong> Add-ons that are already installed using the old contents.rdf method for
+  registering chrome will continue to function if already installed. Make sure that you test your add-on by actually
+  removing and reinstalling it to ensure that the install works after updating it to use an install manifest.</div>


### PR DESCRIPTION
- Run formatter to better see elements
- Broken link from previous regex fix