### PR TITLE
fix: Relative URLs and short urls

### DIFF
--- a/files/en-us/mozilla/developer_guide/build_instructions/adding_xpcom_components_to_mozilla_build_system/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/adding_xpcom_components_to_mozilla_build_system/index.html
@@ -27,7 +27,7 @@ tags:
 
 <p>Once you have your component written, you will need to write the makefiles. Your best bet is to copy the Makefile.in from another component similar to yours: most of the makefiles are very similar. These Makefile.in files are processed and the "real" Makefile is created. If you are using a separate directory tree for your object files, that final Makefiles will appear there.</p>
 
-<p>For more details on Makefiles see <a href="/en/How_Mozilla's_build_system_works">How Mozilla's build system works</a>.</p>
+<p>For more details on Makefiles see <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works">How Mozilla's build system works</a>.</p>
 
 <p>Generally, you will have a top-level directory <code>foo</code> for your component, which will then contain <code>foo/public</code>, <code>foo/src</code>, etc. subdirectories. The makefile in <code>foo</code> will just reference the subdirecories and otherwise just needs the boilerplate:</p>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/configure.in/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/configure.in/index.html
@@ -6,7 +6,7 @@ tags:
   - Developing Mozilla
 ---
 <p>The Mozilla {{ Source("configure") }} script is a standard method of determining compiler and system capabilities and options for Linux-based software. Mozilla uses <code>configure</code> on all platforms. <code>configure</code> is a shell script generated from an template file {{ Source("configure.in") }}, using <a class="external" href="http://www.gnu.org/software/autoconf/">Autoconf</a>.</p>
-<p>Here's an example of how to add a configure option to the <a href="en/How_Mozilla's_build_system_works">build</a>. Please consult the build system owner (<a>Benjamin Smedberg</a>) before adding configure options. New options will only be accepted if they are going to be maintained and tested appropriately.</p>
+<p>Here's an example of how to add a configure option to the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works">build</a>. Please consult the build system owner (<a>Benjamin Smedberg</a>) before adding configure options. New options will only be accepted if they are going to be maintained and tested appropriately.</p>
 <pre class="eval">MOZ_ARG_ENABLE_BOOL(foo,
 [  --enable-foo     Insert some documentation here. Try to keep the spacing lined up right.],
     MOZ_FOO=1,

--- a/files/en-us/mozilla/developer_guide/build_instructions/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/index.html
@@ -6,7 +6,7 @@ tags:
   - Developing Mozilla
 ---
 <div class="note">
-<p>The mechanism used to build Firefox for Android also <a href="/en-US/docs/Simple_Firefox_for_Android_build">has its own page</a>.</p>
+<p>The mechanism used to build Firefox for Android also <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_for_Android_build">has its own page</a>.</p>
 
 <p>The mechanism used to build Firefox for iOS also <a href="https://github.com/mozilla/firefox-ios">has its own github</a>.</p>
 </div>
@@ -19,7 +19,7 @@ tags:
 
 <p>These build pages are for the projects which use the autoconf-based build system: Firefox, Thunderbird, Mozilla Suite / SeaMonkey, XULRunner, Sunbird, and standalone Composer.</p>
 
-<p>For build information on other Mozilla projects, visit their project or build page: <a class="external" href="http://wiki.caminobrowser.org/Development:Building">Camino</a>, <a href="/en/NSPR_build_instructions">NSPR</a>, <a href="/en-US/SpiderMonkey/Build_Documentation">Spidermonkey</a>, <a class="external" href="http://www.mozilla.org/projects/security/pki/nss/">NSS</a>, and <a class="external" href="http://wiki.mozilla.org/LDAP_C_SDK">Directory SDK for C</a>.</p>
+<p>For build information on other Mozilla projects, visit their project or build page: <a class="external" href="http://wiki.caminobrowser.org/Development:Building">Camino</a>, <a href="/en-US/NSPR_build_instructions">NSPR</a>, <a href="/en-US/SpiderMonkey/Build_Documentation">Spidermonkey</a>, <a class="external" href="http://www.mozilla.org/projects/security/pki/nss/">NSS</a>, and <a class="external" href="http://wiki.mozilla.org/LDAP_C_SDK">Directory SDK for C</a>.</p>
 
 <p>If you are having build problems, please post questions to the newsgroup <a class="link-news" href="news://news.mozilla.org/mozilla.dev.builds">mozilla.dev.builds</a> (<a class="external" href="http://groups.google.com/group/mozilla.dev.builds">access via Google Groups</a>). Make your post as precise as possible, including details about your operating system, your mozconfig/configure flags, and the precise error you are experiencing.</p>
 
@@ -30,9 +30,9 @@ tags:
 <p>The quickest way to build Mozilla is to use the instructions at the simple build pages:</p>
 
 <ul>
-	<li><a class="internal" href="/en-US/Simple_Firefox_build">Simple Firefox build</a></li>
-	<li><a class="internal" href="/en-US/Simple_Thunderbird_build" title="en/Simple Thunderbird build">Simple Thunderbird build</a></li>
-	<li><a class="internal" href="/en-US/Simple_SeaMonkey_build" title="en/Simple SeaMonkey build">Simple SeaMonkey build</a></li>
+	<li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build">Simple Firefox build</a></li>
+	<li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build">Simple Thunderbird build</a></li>
+	<li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_SeaMonkey_build">Simple SeaMonkey build</a></li>
 </ul>
 
 <p>For more detail, see below.</p>
@@ -47,66 +47,66 @@ tags:
 	<li><a href="https://firefox-source-docs.mozilla.org/setup/linux_build.html">Unix/Linux</a></li>
 	<li><a href="https://firefox-source-docs.mozilla.org/setup/windows_build.html">Windows</a></li>
 	<li><a href="https://firefox-source-docs.mozilla.org/setup/macos_build.html">macOS</a></li>
-	<li><a href="/en-US/Developer_Guide/Build_Instructions/Solaris_Prerequisites">Solaris</a></li>
-	<li><a href="/en-US/Developer_Guide/Build_Instructions/OS2_Build_Prerequisites">OS/2 and eComStation</a></li>
-	<li><a href="/en-US/Developer_Guide/Build_Instructions/Building_JavaXPCOM">JavaXPCOM Build Requirements</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Solaris_Prerequisites">Solaris</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/OS2_Build_Prerequisites">OS/2 and eComStation</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Building_JavaXPCOM">JavaXPCOM Build Requirements</a></li>
 </ul>
 
 <h3 id="Get_the_source">Get the source</h3>
 
 <dl>
-	<dt><a href="/en-US/docs/Developer_Guide/Source_Code/Downloading_Source_Archives">Download Mozilla Source Code</a></dt>
+	<dt><a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Downloading_Source_Archives">Download Mozilla Source Code</a></dt>
 	<dd>Source code for releases is available for download. Use this if you're a Linux distribution.</dd>
 	<dt><a href="https://firefox-source-docs.mozilla.org/contributing/vcs/mercurial.html#using-hg-clone">Mozilla Source Code via Mercurial</a></dt>
 	<dd>Get the latest source code using Mercurial. Use this if you're casually interested in Firefox development or you want to work on Firefox.</dd>
 	<dt><a href="https://firefox-source-docs.mozilla.org/mobile/android/geckoview/contributor/mc-quick-start.html">Mozilla Source Code via Git</a></dt>
 	<dd>Get the latest source code using Git. (The steps may seem a little weird. You'll have to install a Git extension, git-cinnabar, so that <code>git</code> knows how to clone and pull commits from our Mercurial repository.)</dd>
-	<dt><a href="/en-US/docs/Developer_Guide/Source_Code/Getting_comm-central">Comm-central Source Code via Mercurial</a></dt>
+	<dt><a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Comm-central Source Code via Mercurial</a></dt>
 	<dd>Those doing active development on Thunderbird/SeaMonkey/Firefox can check out the latest source using Mercurial. This method includes all the code for the applications mentioned, so you can work on Firefox development, and still build Thunderbird or SeaMonkey as well.</dd>
 </dl>
 
 <h3 id="Configuring_build_options">Configuring build options</h3>
 
-<p>Running configure and make with the default options will not give you a good working build. You should use a <code>.mozconfig</code> file to obtain a reasonable release build. Please read <a href="/en/Configuring_Build_Options">Configuring Build Options</a> carefully before building.</p>
+<p>Running configure and make with the default options will not give you a good working build. You should use a <code>.mozconfig</code> file to obtain a reasonable release build. Please read <a href="/en-US/Configuring_Build_Options">Configuring Build Options</a> carefully before building.</p>
 
 <h3 id="Build_and_install">Build and install</h3>
 
 <p>After setting up your environment, downloading the source, and configuring the build, refer to the following per-app instructions on how to build:</p>
 
 <ul>
-	<li><a class="internal" href="/en-US/Simple_Firefox_build#Building">Building Firefox</a></li>
-	<li><a class="internal" href="/en-US/Simple_Thunderbird_build#Building_Thunderbird" title="en/Simple Thunderbird build">Building Thunderbird</a></li>
-	<li><a class="internal" href="/en-US/Simple_SeaMonkey_build#Building_SeaMonkey" title="en/Simple SeaMonkey build">Building SeaMonkey</a></li>
+	<li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build#Building">Building Firefox</a></li>
+	<li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build#Building_Thunderbird">Building Thunderbird</a></li>
+	<li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_SeaMonkey_build#Building_SeaMonkey">Building SeaMonkey</a></li>
 </ul>
 
 <h2 id="Random_FAQs_and_Developer_Documentation">Random FAQs and Developer Documentation</h2>
 
 <ul>
-	<li><a href="/en/Developer_Guide/Mozilla_build_FAQ">Mozilla Build FAQ</a></li>
-	<li><a href="/en/Adding_Files_to_the_Build">Adding Files to the Build</a></li>
-	<li><a href="/en/Adding_XPCOM_components_to_Mozilla_build_system">Adding Components</a></li>
-	<li><a href="/en/Creating_a_Release_Tag">Creating a Release Tag</a></li>
-	<li><a href="/en/Cross-Compiling_Mozilla">Cross-Compiling Mozilla</a></li>
-	<li><a href="/en/Compiling_32-bit_Firefox_on_a_Linux_64-bit_OS">Compiling 32-bit Firefox on a Linux 64-bit OS</a></li>
-	<li><a href="/en/Mozilla_Release_Checklist">Mozilla Release Checklist</a></li>
-	<li><a href="/en/Clang_Static_Analysis" title="Clang Static Analysis">Clang Static Analysis</a></li>
-	<li><a href="/en/Package_Filename_Convention">Package Filename Convention</a></li>
-	<li><a href="/en/Building_with_Profile-Guided_Optimization">Building with Profile-Guided Optimization</a></li>
-	<li><a href="/en-US/docs/Building_Firefox_with_Debug_Symbols">Building Firefox with Debug Symbols</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Mozilla_build_FAQ">Mozilla Build FAQ</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Adding_Files_to_the_Build">Adding Files to the Build</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Adding_XPCOM_components_to_Mozilla_build_system">Adding Components</a></li>
+	<li><a href="/en-US/docs/Creating_a_Release_Tag">Creating a Release Tag</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Cross-compiling_Mozilla">Cross-Compiling Mozilla</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Compiling_32-bit_Firefox_on_a_Linux_64-bit_OS">Compiling 32-bit Firefox on a Linux 64-bit OS</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mozilla_Release_Checklist">Mozilla Release Checklist</a></li>
+	<li><a href="/en-US/docs/Clang_Static_Analysis">Clang Static Analysis</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Package_Filename_Convention">Package Filename Convention</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Building_with_Profile-Guided_Optimization">Building with Profile-Guided Optimization</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Building_Firefox_with_Debug_Symbols">Building Firefox with Debug Symbols</a></li>
 	<li><a href="/en-US/docs/Mozilla/Projects/SpiderMonkey/Build_Documentation">Building only SpiderMonkey</a></li>
-	<li><a href="/en-US/Firefox/Building_Firefox_with_Rust_code">Building Firefox with Rust Code</a></li>
-	<li><a href="/en/Mozilla_Release_Build_Notes">Notes on how mozilla.org does release builds</a> (circa 2007)</li>
-	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Building_Firefox_on_Windows_with_clang-cl" title="Building Firefox on Windows with clang-cl">Building Firefox on Windows with clang-cl</a></li>
+	<li><a href="/en-US/docs/Mozilla/Firefox/Building_Firefox_with_Rust_code">Building Firefox with Rust Code</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mozilla_Release_Build_Notes">Notes on how mozilla.org does release builds</a> (circa 2007)</li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Building Firefox on Windows with clang-cl</a></li>
 </ul>
 
 <ul>
-	<li><a class="internal" href="/en-US/docs/tag/Build_documentation" title="All articles tagged as build documentation.">All build documentation</a></li>
+	<li><a class="internal" href="/en-US/docs/tag/Build_documentation">All build documentation</a></li>
 </ul>
 
 <h2 id="Hacking_the_Build_System">Hacking the Build System</h2>
 
 <ul>
-	<li><a href="/en/How_Mozilla's_build_system_works">How Mozilla's build system works</a></li>
-	<li><a class="internal" href="/Special:Tags?tag=Build_Glossary" title="Special:Tags?tag=Build Glossary">Build Glossary</a> <a class="external" href="http://www.mozilla.org/build/glossary.html">(old glossary)</a></li>
-	<li><a href="/en/JAR_Manifests">Build and Register Chrome JARs with JAR Manifests</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works">How Mozilla's build system works</a></li>
+	<li><a class="internal" href="/Special:Tags?tag=Build_Glossary">Build Glossary</a> <a class="external" href="http://www.mozilla.org/build/glossary.html">(old glossary)</a></li>
+	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build and Register Chrome JARs with JAR Manifests</a></li>
 </ul>

--- a/files/en-us/mozilla/developer_guide/build_instructions/old_thunderbird_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/old_thunderbird_build/index.html
@@ -2,7 +2,7 @@
 title: Old Thunderbird build
 slug: Mozilla/Developer_guide/Build_Instructions/Old_Thunderbird_build
 ---
-<p>This page covers the basic steps needed to build a Thunderbird up to version 59. For Thunderbird 60 and later, see the <a class="internal" href="Simple_Thunderbird_build" rel="internal">new build instructions</a>. For additional information, see the <a class="internal" href="../../../../Developer_Guide/Build_Instructions" rel="internal">build documentation</a>.</p>
+<p>This page covers the basic steps needed to build a Thunderbird up to version 59. For Thunderbird 60 and later, see the <a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build" rel="internal">new build instructions</a>. For additional information, see the <a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions" rel="internal">build documentation</a>.</p>
 
 <h2 id="Hardware_requirements">Hardware requirements</h2>
 
@@ -20,14 +20,14 @@ slug: Mozilla/Developer_guide/Build_Instructions/Old_Thunderbird_build
 </div>
 
 <ul>
- <li><a href="/en-US/docs/Developer_Guide/Build_Instructions/Windows_Prerequisites">Windows Build Prerequisites</a></li>
- <li><a href="/en-US/docs/Simple_Firefox_build/Linux_and_MacOS_build_preparation">GNU/Linux Build Prerequisites</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows Build Prerequisites</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build/Linux_and_MacOS_build_preparation">GNU/Linux Build Prerequisites</a></li>
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mac_OS_X_Prerequisites">Mac OS X Build Prerequisites</a></li>
 </ul>
 
 <h2 id="Get_the_source">Get the source</h2>
 
-<div class="note"><strong>Note:</strong> On Windows, you won't be able to build the Thunderbird source code if it's under a directory with spaces in the path (e.g., don't use "Documents and Settings"). You can pick any other location, such as a new directory C:/thunderbird-src (where "C:/", with a forward slash, is intentional to clarify you are in the MozillaBuild command prompt per <a href="/en-US/docs/Developer_Guide/Build_Instructions/Windows_Prerequisites">Windows build prerequisite</a>).</div>
+<div class="note"><strong>Note:</strong> On Windows, you won't be able to build the Thunderbird source code if it's under a directory with spaces in the path (e.g., don't use "Documents and Settings"). You can pick any other location, such as a new directory C:/thunderbird-src (where "C:/", with a forward slash, is intentional to clarify you are in the MozillaBuild command prompt per <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows build prerequisite</a>).</div>
 
 <div class="note"><strong>Note:</strong> Parts of the build process also have problems when the source code is in a directory where the path is long (nested many levels deep). On Linux, this can manifest as problems setting up the virtualenv for running tests (failure to install pip or virtualenv because of OS access denied errors, where access is denied not because of permission problems, but because the paths being accessed have been truncated, and so do not exist). Having the source deep in a filesystem hierarchy can also cause problems with pymake builds on Windows. If you run into seemingly arbitrary problems in building and the source is deeply nested, try moving it close to the root of your machine and re-building.</div>
 
@@ -47,7 +47,7 @@ slug: Mozilla/Developer_guide/Build_Instructions/Old_Thunderbird_build
 
 <div class="warning">On some types of network connections, "hg clone" might fail because it gets interrupted. It is faster and more efficient to use <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial/Bundles">Mercurial bundles</a> instead the first time you fetch the complete repo. In this case, you need a bundle for comm-central, and a bundle for mozilla-central. Unbundle mozilla-central into a "mozilla" subdirectory of your comm-central repo after unbundling comm-central. (Make sure the unbundled folder's name is now "mozilla" and not "mozilla-central"). Then run "python client.py checkout"  to ensure you are up-to-date.</div>
 
-<p class="editable">The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. For more on getting the source code, see the page <a href="/en-US/docs/Developer_Guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
+<p class="editable">The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. For more on getting the source code, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
 
 <h2 class="editable" id="Build_configuration">Build configuration</h2>
 
@@ -66,7 +66,7 @@ echo 'ac_add_options --enable-application=mail' &gt; mozconfig
 <pre>ac_add_options --enable-debug
 </pre>
 
-<p>For more on configuration options, see the page <a href="/en/Configuring_Build_Options" rel="internal" title="en/Configuring Build Options">Configuring build options</a>. Note that if you use an MOZ_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!</p>
+<p>For more on configuration options, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Configuring_Build_Options" rel="internal">Configuring build options</a>. Note that if you use an MOZ_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!</p>
 
 <h2 id="Building_Thunderbird">Building Thunderbird</h2>
 
@@ -77,9 +77,9 @@ echo 'ac_add_options --enable-application=mail' &gt; mozconfig
 <pre>./mozilla/mach build
 </pre>
 
-<p>mach is our command-line tool to streamline common developer tasks. See the <a href="/en-US/docs/Developer_Guide/mach">mach</a> article for more.</p>
+<p>mach is our command-line tool to streamline common developer tasks. See the <a href="/en-US/docs/Mozilla/Developer_guide/mach">mach</a> article for more.</p>
 
-<p>Building can take a significant amount of time, depending on your system, OS, and chosen build options. Linux builds on a fast box may take under 15 minutes, but Windows builds on a slow box may take several hours. <strong><a href="/en/Developer_Guide/Mozilla_build_FAQ#Making_builds_faster" rel="internal">Tips for making builds faster</a></strong>.</p>
+<p>Building can take a significant amount of time, depending on your system, OS, and chosen build options. Linux builds on a fast box may take under 15 minutes, but Windows builds on a slow box may take several hours. <strong><a href="/en-US/docs/Mozilla/Developer_guide/Mozilla_build_FAQ#Making_builds_faster" rel="internal">Tips for making builds faster</a></strong>.</p>
 
 <p><span style="line-height: 1.572;">The executable will be at the location listed under <strong>Running</strong> below.</span></p>
 
@@ -155,7 +155,7 @@ echo 'ac_add_options --enable-application=mail' &gt; mozconfig
  <li>Check <a class="external" href="https://treeherder.mozilla.org/#/jobs?repo=comm-central">comm-central on Treeherder</a> for known failures at the time you pulled the code. The current status of the trunk can also be checked at <a href="https://treestatus.mozilla.org/">https://treestatus.mozilla.org/</a>
 
   <ul>
-   <li>If the trunk is broken (i.e. closed), you may wish to consider building <a href="/En/Developer_Guide/Source_Code/Getting_comm-central">one of the branches</a> (to pull the source code from a branch, just replace the url to the repository in the hg clone instruction).</li>
+   <li>If the trunk is broken (i.e. closed), you may wish to consider building <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">one of the branches</a> (to pull the source code from a branch, just replace the url to the repository in the hg clone instruction).</li>
   </ul>
  </li>
  <li>On Windows: check that the MAPI header files from <a href="https://www.microsoft.com/en-us/download/details.aspx?id=12905">https://www.microsoft.com/en-us/download/details.aspx?id=12905</a> are installed because the MAPI header files are not bundled with Visual Studio 2013/2015 (Windows SDK 8.1/10). You should copy the header files to a Windows SDK include directory so that the build process will find the files, for example to <code>C:\Program Files (x86)\Windows Kits\8.1\Include\shared</code> and/or <code>C:\Program Files (x86)\Windows Kits\10\Include\10.0.nnnnn.0\shared</code> respectively, where <code>nnnnn</code> is the highest number present on the system.</li>
@@ -173,7 +173,7 @@ echo 'ac_add_options --enable-application=mail' &gt; mozconfig
 <h3 id="References">References</h3>
 
 <ul>
- <li><a class="internal" href="/En/Developer_Guide/Build_Instructions" title="En/Developer Guide/Build Instructions">General Build Documentation</a></li>
- <li><a class="internal" href="/en/comm-central">comm-central</a></li>
- <li><a href="/en/Using_the_Mozilla_symbol_server" title="en/Using the Mozilla symbol server">Using the Mozilla symbol server</a></li>
+ <li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">General Build Documentation</a></li>
+ <li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">comm-central</a></li>
+ <li><a href="/en-US/docs/mozilla/Using_the_Mozilla_symbol_server">Using the Mozilla symbol server</a></li>
 </ul>

--- a/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/index.html
@@ -212,7 +212,7 @@ ac_add_options --disable-debug</pre>
 
 <p>Once the build is complete, the binaries can be found in <code>obj/dist/bin</code>. If you want to make a package, please follow the instructions on <a href="/en/Building_a_SeaMonkey_package">Building a SeaMonkey package</a>.</p>
 
-<p>If these information is not enough, there is some background info in <a href="/en/How_Mozilla's_build_system_works">How Mozilla's build system works</a>.</p>
+<p>If these information is not enough, there is some background info in <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works">How Mozilla's build system works</a>.</p>
 
 <h2 id="Tricks">Tricks</h2>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/simple_instantbird_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/simple_instantbird_build/index.html
@@ -6,7 +6,7 @@ tags:
   - Guide
   - instantbird
 ---
-<p>This page covers the basic steps needed to build a bleeding-edge, development version of Instantbird. For additional, more detailed information, see the <a class="internal" href="../../../../En/Developer_Guide/Build_Instructions" rel="internal">build documentation</a>. This should be kept in sync with <a href="/docs/Simple_Thunderbird_build">Simple Thunderbird build</a>, you might want to take a look at that page too.</p>
+<p>This page covers the basic steps needed to build a bleeding-edge, development version of Instantbird. For additional, more detailed information, see the <a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions" rel="internal">build documentation</a>. This should be kept in sync with <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build">Simple Thunderbird build</a>, you might want to take a look at that page too.</p>
 
 <h2 id="Build_prerequisites">Build prerequisites</h2>
 
@@ -22,8 +22,8 @@ tags:
 <p>Depending on your Operating System you will need to carry out a different process to prepare your machine. So firstly complete the instructions for your OS and then continue following these build instructions.</p>
 
 <ul>
- <li><a href="/en-US/docs/Developer_Guide/Build_Instructions/Windows_Prerequisites">Windows Build Prerequisites</a></li>
- <li><a href="/en-US/docs/Simple_Firefox_build/Linux_and_MacOS_build_preparation">GNU/Linux Build Prerequisites</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows Build Prerequisites</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build/Linux_and_MacOS_build_preparation">GNU/Linux Build Prerequisites</a></li>
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mac_OS_X_Prerequisites">Mac OS X Build Prerequisites</a></li>
 </ul>
 
@@ -53,7 +53,7 @@ tags:
 
 <p class="editable">The source code requires 1.5GB of free space or more.</p>
 
-<p class="editable">For more on getting the source code, see the page <a href="/en-US/docs/Developer_Guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
+<p class="editable">For more on getting the source code, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
 
 <h2 class="editable" id="Build_configuration">Build configuration</h2>
 
@@ -62,7 +62,7 @@ tags:
 <pre>ac_add_options --enable-debug
 </pre>
 
-<p>For more on configuration options, see the page <a href="/en/Configuring_Build_Options" rel="internal" title="en/Configuring Build Options">Configuring build options</a>. Note that if you use an MOZ_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!</p>
+<p>For more on configuration options, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Configuring_Build_Options" rel="internal">Configuring build options</a>. Note that if you use an MOZ_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!</p>
 
 <h2 id="Building_Instantbird">Building Instantbird</h2>
 
@@ -76,7 +76,7 @@ tags:
 <pre>./mozilla/mach build
 </pre>
 
-<p>mach is our command-line tool to streamline common developer tasks. See the <a href="/en-US/docs/Developer_Guide/mach">mach</a> article for more.</p>
+<p>mach is our command-line tool to streamline common developer tasks. See the <a href="/en-US/docs/Mozilla/Developer_guide/mach">mach</a> article for more.</p>
 
 <p>Building can take a significant amount of time, depending on your system, OS, and chosen build options. Linux builds on a fast box may take under 15 minutes, but Windows builds on a slow box may take several hours.</p>
 
@@ -142,7 +142,7 @@ tags:
  </li>
  <li>Checked the <a class="external" href="http://buildbot.instantbird.org/grid">Instantbird buildbot</a> for known failures at the time you pulled the code?
   <ul>
-   <li>If the trunk is broken, you may wish to consider building <a href="/En/Developer_Guide/Source_Code/Getting_comm-central">one of the branches</a> (to pull the source code from a branch, just replace the url to the repository in the hg clone instruction).</li>
+   <li>If the trunk is broken, you may wish to consider building <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">one of the branches</a> (to pull the source code from a branch, just replace the url to the repository in the hg clone instruction).</li>
   </ul>
  </li>
  <li>Checked to make sure that the path in which you placed the source code has no spaces, and is not too long?</li>
@@ -153,8 +153,8 @@ tags:
 <h3 id="References">References</h3>
 
 <ul>
- <li><a class="internal" href="/En/Developer_Guide/Build_Instructions" title="En/Developer Guide/Build Instructions">General Build Documentation</a></li>
- <li><a class="internal" href="/en/comm-central">comm-central</a></li>
+ <li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">General Build Documentation</a></li>
+ <li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">comm-central</a></li>
 </ul>
 
-<p><a href="/docs/Simple_Thunderbird_build">Simple Thunderbird build</a></p>
+<p><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build">Simple Thunderbird build</a></p>

--- a/files/en-us/mozilla/developer_guide/build_instructions/simple_thunderbird_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/simple_thunderbird_build/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><strong>NOTE! Current instructions for building Thunderbird are now at <a href="https://developer.thunderbird.net/thunderbird-development/building-thunderbird">https://developer.thunderbird.net/thunderbird-development/building-thunderbird</a></strong></p>
 
-<p>This page covers the basic steps needed to build a bleeding-edge, development version of Thunderbird 60 or later. For Thunderbird up to 59, see the <a class="internal" href="Old_Thunderbird_build" rel="internal">old build documentation</a>. For additional, more detailed information, see the <a class="internal" href="../../../../Developer_Guide/Build_Instructions" rel="internal">build documentation</a>.</p>
+<p>This page covers the basic steps needed to build a bleeding-edge, development version of Thunderbird 60 or later. For Thunderbird up to 59, see the <a class="internal" href="Old_Thunderbird_build" rel="internal">old build documentation</a>. For additional, more detailed information, see the <a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions" rel="internal">build documentation</a>.</p>
 
 <h2 id="Hardware_requirements">Hardware requirements</h2>
 
@@ -22,8 +22,8 @@ tags:
 <p>Depending on your Operating System you will need to carry out a different process to prepare your machine. So firstly complete the instructions for your OS and then continue following these build instructions.</p>
 
 <ul>
- <li><a href="/en-US/docs/Developer_Guide/Build_Instructions/Windows_Prerequisites">Windows Build Prerequisites</a></li>
- <li><a href="/en-US/docs/Simple_Firefox_build/Linux_and_MacOS_build_preparation">GNU/Linux Build Prerequisites</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows Build Prerequisites</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build/Linux_and_MacOS_build_preparation">GNU/Linux Build Prerequisites</a></li>
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mac_OS_X_Prerequisites">macOS Build Prerequisites</a></li>
 </ul>
 
@@ -53,7 +53,7 @@ tags:
 
 <h2 id="Get_the_source">Get the source</h2>
 
-<div class="note"><strong>Note:</strong> On Windows, you won't be able to build the Thunderbird source code if it's under a directory with spaces in the path (e.g., don't use "Documents and Settings"). You can pick any other location, such as a new directory C:/thunderbird-src (where "C:/", with a forward slash, is intentional to clarify you are in the MozillaBuild command prompt per <a href="/en-US/docs/Developer_Guide/Build_Instructions/Windows_Prerequisites">Windows build prerequisite</a>).</div>
+<div class="note"><strong>Note:</strong> On Windows, you won't be able to build the Thunderbird source code if it's under a directory with spaces in the path (e.g., don't use "Documents and Settings"). You can pick any other location, such as a new directory C:/thunderbird-src (where "C:/", with a forward slash, is intentional to clarify you are in the MozillaBuild command prompt per <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Windows build prerequisite</a>).</div>
 
 <div class="note"><strong>Note:</strong> Parts of the build process also have problems when the source code is in a directory where the path is long (nested many levels deep). On Linux, this can manifest as problems setting up the virtualenv for running tests (failure to install pip or virtualenv because of OS access denied errors, where access is denied not because of permission problems, but because the paths being accessed have been truncated, and so do not exist). Having the source deep in a filesystem hierarchy can also cause problems with pymake builds on Windows. If you run into seemingly arbitrary problems in building and the source is deeply nested, try moving it closer to the root of your machine and re-building.</div>
 
@@ -66,7 +66,7 @@ hg clone https://hg.mozilla.org/comm-central comm/
 
 <p class="editable">The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. Instead of using <code>hg clone</code>, you can follow <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial/Bundles">these instructions</a> on downloading and "unpacking" a Mercurial bundle.</p>
 
-<p class="editable"><strong>Warning: The page </strong><a href="/en-US/docs/Developer_Guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a><strong> is 99% out of date!</strong> Only useful content is working with Github.</p>
+<p class="editable"><strong>Warning: The page </strong><a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a><strong> is 99% out of date!</strong> Only useful content is working with Github.</p>
 
 <h2 class="editable" id="Build_configuration">Build configuration</h2>
 
@@ -85,7 +85,7 @@ hg clone https://hg.mozilla.org/comm-central comm/
 
 <p>Each of these <code>ac_add_options</code> entries needs to be on its own line.</p>
 
-<p>For more on configuration options, see the page <a href="/en/Configuring_Build_Options" rel="internal" title="en/Configuring Build Options">Configuring build options</a>. Note that if you use an MOZ_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!</p>
+<p>For more on configuration options, see the page <a href="/en-US/Configuring_Build_Options" rel="internal">Configuring build options</a>. Note that if you use an MOZ_OBJDIR it cannot be a sibling folder to your source directory. Use an absolute path to be sure!</p>
 
 <h4 id="To_also_build_Lightning_when_building_Thunderbird_DEPRECATED">To also build Lightning when building Thunderbird (DEPRECATED)</h4>
 
@@ -110,9 +110,9 @@ hg clone https://hg.mozilla.org/comm-central comm/
 <pre class="notranslate">./mach build
 </pre>
 
-<p>mach is our command-line tool to streamline common developer tasks. See the <a href="/en-US/docs/Developer_Guide/mach">mach</a> article for more.</p>
+<p>mach is our command-line tool to streamline common developer tasks. See the <a href="/en-US/docs/Mozilla/Developer_guide/mach">mach</a> article for more.</p>
 
-<p>Building can take a significant amount of time, depending on your system, OS, and chosen build options. Linux builds on a fast box may take under 15 minutes, but Windows builds on a slow box may take several hours. <strong><a href="/en/Developer_Guide/Mozilla_build_FAQ#Making_builds_faster" rel="internal">Tips for making builds faster</a></strong>.</p>
+<p>Building can take a significant amount of time, depending on your system, OS, and chosen build options. Linux builds on a fast box may take under 15 minutes, but Windows builds on a slow box may take several hours. <strong><a href="/en-US/Developer_Guide/Mozilla_build_FAQ#Making_builds_faster" rel="internal">Tips for making builds faster</a></strong>.</p>
 
 <p><span style="line-height: 1.572;">The executable will be at the location listed under <strong>Running</strong> below.</span></p>
 
@@ -188,7 +188,7 @@ cd ..
  <li>Check <a class="external" href="https://treeherder.mozilla.org/#/jobs?repo=comm-central">comm-central on Treeherder</a> for known failures at the time you pulled the code. The current status of the trunk can also be checked at <a href="https://treestatus.mozilla.org/">https://treestatus.mozilla.org/</a>
 
   <ul>
-   <li>If the trunk is broken (i.e. closed), you may wish to consider building <a href="/En/Developer_Guide/Source_Code/Getting_comm-central">one of the branches</a> (to pull the source code from a branch, just replace the url to the repository in the hg clone instruction).</li>
+   <li>If the trunk is broken (i.e. closed), you may wish to consider building <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">one of the branches</a> (to pull the source code from a branch, just replace the url to the repository in the hg clone instruction).</li>
   </ul>
  </li>
  <li>Check to make sure that the path in which you placed the source code has no spaces, and is not too long.</li>
@@ -205,7 +205,7 @@ cd ..
 <h3 id="References">References</h3>
 
 <ul>
- <li><a class="internal" href="/En/Developer_Guide/Build_Instructions" title="En/Developer Guide/Build Instructions">General Build Documentation</a></li>
- <li><a class="internal" href="/en/comm-central">comm-central</a></li>
- <li><a href="/en/Using_the_Mozilla_symbol_server" title="en/Using the Mozilla symbol server">Using the Mozilla symbol server</a></li>
+ <li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">General Build Documentation</a></li>
+ <li><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">comm-central</a></li>
+ <li><a href="/en-US/docs/mozilla/Using_the_Mozilla_symbol_server">Using the Mozilla symbol server</a></li>
 </ul>

--- a/files/en-us/mozilla/developer_guide/the_comm-central_build_system/index.html
+++ b/files/en-us/mozilla/developer_guide/the_comm-central_build_system/index.html
@@ -15,7 +15,7 @@ tags:
 
 <h3 id="Introduction">Introduction</h3>
 
-<p>The <a href="en/Comm-central">comm-central</a> build system is an extension of the system used for <a href="en/Mozilla-central">mozilla-central</a>. Readers of this document should first read <a href="en/How_Mozilla's_build_system_works">How_Mozilla's_build_system_works</a> and ensure they are familiar with it.</p>
+<p>The <a href="en/Comm-central">comm-central</a> build system is an extension of the system used for <a href="en/Mozilla-central">mozilla-central</a>. Readers of this document should first read <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works">How_Mozilla's_build_system_works</a> and ensure they are familiar with it.</p>
 
 <p>It is also worth being familiar with the <a href="/docs/Mozilla/Thunderbird/comm-central#comm-central_code_layout">code layout of comm-central</a>.</p>
 

--- a/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.html
+++ b/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.html
@@ -124,6 +124,6 @@ NS_QueryNotificationCallbacks(channel, loadContext);
 <p>Firefox 3.5 introduces support for adding and removing progress listeners that listen on all tabs.  See <a class="internal" href="/En/Listening_to_events_on_all_tabs" title="en/Listening to events on all tabs">Listening to events on all tabs</a> for details.</p>
 <h2 id="For_Theme_developers">For Theme developers:</h2>
 <ul>
-  <li>Check <a class="internal" href="../../../../En/Theme_changes_in_Firefox_3.1" rel="internal">Theme changes in Firefox 3.1</a>.</li>
+  <li>Check <a class="internal" href="/En/Theme_changes_in_Firefox_3.1" rel="internal">Theme changes in Firefox 3.1</a>.</li>
   <li>Go to the Mozillazine forum <a class="topictitle external" href="http://forums.mozillazine.org/viewtopic.php?f=18&amp;t=665138">Theme changes for FF3.1</a> to get an overview / listing of all changes between 3.0 and 3.1 that impact theme developers. This concerns new CSS features (like nth-child, -moz-box-shadow, etc), changes to existing widgets, overall UI improvements, and new FF3.1 features (audio/video support, private browsing, extended session restore, box/window/text shadows).</li>
 </ul>

--- a/files/en-us/tools/remote_debugging/firefox_for_android/index.html
+++ b/files/en-us/tools/remote_debugging/firefox_for_android/index.html
@@ -10,7 +10,7 @@ tags:
 <div class="note">
 <p>This guide is for Firefox version 36 and earlier. To debug in Firefox 68 and later, follow the instructions on <a href="/en-US/docs/Tools/about:debugging">about:debugging</a>.</p>
 
-<p>For Firefox between 37 and 67, please use the <a href="./Debugging_Firefox_for_Android_with_WebIDE">WebIDE</a> guide.</p>
+<p>For Firefox between 37 and 67, please use the <a href="/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE">WebIDE</a> guide.</p>
 </div>
 
 <p>This guide explains how to use <a href="/en-US/docs/Tools/Remote_Debugging">remote debugging </a>to inspect or debug code running in <a href="/en-US/docs/Mozilla/Firefox_for_Android">Firefox for Android </a>over USB.</p>

--- a/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.html
+++ b/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.html
@@ -133,7 +133,7 @@ tags:
 
 <h4 id="Technique_2_aria-activedescendant">Technique 2: aria-activedescendant</h4>
 
-<p>This technique involves binding a single event handler to the container widget and using the <code>aria-activedescendant</code> to track a "virtual" focus. (For more information about ARIA, see this <a class="external text" href="../../../../An_Overview_of_Accessible_Web_Applications_and_Widgets" rel="nofollow">overview of accessible web applications and widgets</a>.)</p>
+<p>This technique involves binding a single event handler to the container widget and using the <code>aria-activedescendant</code> to track a "virtual" focus. (For more information about ARIA, see this <a class="external text" href="/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets" rel="nofollow">overview of accessible web applications and widgets</a>.)</p>
 
 <p>The <code>aria-activedescendant</code> property identifies the ID of the descendent element that currently has the virtual focus. The event handler on the container must respond to key and mouse events by updating the value of <code>aria-activedescendant</code> and ensuring that the current item is styled appropriately (for example, with a border or background color). See the source code of this <a class="external text" href="http://www.oaa-accessibility.org/example/28/" rel="nofollow">ARIA radiogroup example</a> for a direct illustration of how this works.</p>
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -460,7 +460,7 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
  <li><a href="http://lawrencemandel.com/2012/07/27/decision-made-firefox-os-user-agent-string/">Firefox OS User Agent String</a> (blog post w/<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=777710">bug 777710</a> reference)</li>
  <li><a class="external" href="https://hacks.mozilla.org/2010/09/final-user-agent-string-for-firefox-4/">Final User Agent string for Firefox 4</a> (blog post)</li>
  <li>Recommendations on <a href="/en/Browser_Detection_and_Cross_Browser_Support">sniffing the UA string for cross-browser support</a></li>
- <li><a href="../../../../en/DOM/window.navigator.userAgent" rel="internal">window.navigator.userAgent</a></li>
+ <li><a href="/en-US/docs/Web/API/Window/navigator" rel="internal">window.navigator.userAgent</a></li>
  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1169772">Add Android version to Fennec UA String (bug 1169772)</a></li>
 </ul>
 

--- a/files/en-us/web/javascript/reference/operators/this/index.html
+++ b/files/en-us/web/javascript/reference/operators/this/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>A <strong>function's <code>this</code> keyword</strong> behaves a little differently in JavaScript compared to other languages. It also has some differences between <a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode">strict mode</a> and non-strict mode.</p>
 
-<p>In most cases, the value of <code>this</code> is determined by how a function is called (runtime binding). It can't be set by assignment during execution, and it may be different each time the function is called. ES5 introduced the {{jsxref("Function.prototype.bind()", "bind()")}} method to {{jsxref('Operators/this', "set the value of a function's <code>this</code> regardless of how it's called", 'The_bind_method', 1)}}, and ES2015 introduced <a href="../Functions/Arrow_functions">arrow functions</a> which don't provide their own <code>this</code> binding (it retains the <code>this</code> value of the enclosing lexical context).</p>
+<p>In most cases, the value of <code>this</code> is determined by how a function is called (runtime binding). It can't be set by assignment during execution, and it may be different each time the function is called. ES5 introduced the {{jsxref("Function.prototype.bind()", "bind()")}} method to {{jsxref('Operators/this', "set the value of a function's <code>this</code> regardless of how it's called", 'The_bind_method', 1)}}, and ES2015 introduced <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a> which don't provide their own <code>this</code> binding (it retains the <code>this</code> value of the enclosing lexical context).</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-this.html")}}</div>
 

--- a/files/en-us/web/manifest/description/index.html
+++ b/files/en-us/web/manifest/description/index.html
@@ -21,7 +21,7 @@ tags:
  </tbody>
 </table>
 
-<p>The <dfn><code>description</code></dfn> member is a string in which developers can explain what the application does. <code>description</code> is directionality-capable, which means it can be displayed left to right or right to left based on the values of the <code><a href="./dir">dir</a></code> and <code><a href="./lang">lang</a></code> manifest members.</p>
+<p>The <dfn><code>description</code></dfn> member is a string in which developers can explain what the application does. <code>description</code> is directionality-capable, which means it can be displayed left to right or right to left based on the values of the <code><a href="/en-US/docs/Web/Manifest/dir">dir</a></code> and <code><a href="/en-US/docs/Web/Manifest/lang">lang</a></code> manifest members.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/manifest/dir/index.html
+++ b/files/en-us/web/manifest/dir/index.html
@@ -21,7 +21,7 @@ tags:
  </tbody>
 </table>
 
-<p>The base direction in which to display direction-capable members of the manifest. Together with the <code><a href="./lang">lang</a></code> member, it helps to correctly display right-to-left languages.</p>
+<p>The base direction in which to display direction-capable members of the manifest. Together with the <code><a href="/en-US/docs/Web/Manifest/lang">lang</a></code> member, it helps to correctly display right-to-left languages.</p>
 
 <p>The <code>dir</code> member can be set to one of the following values:</p>
 
@@ -34,9 +34,9 @@ tags:
 <p>The <dfn>directionality-capable members</dfn> are:</p>
 
 <ul>
- <li><code><a href="./name">name</a></code></li>
- <li><code><a href="./short_name">short_name</a></code></li>
- <li><code><a href="./description">description</a></code></li>
+ <li><code><a href="/en-US/docs/Web/Manifest/name">name</a></code></li>
+ <li><code><a href="/en-US/docs/Web/Manifest/short_name">short_name</a></code></li>
+ <li><code><a href="/en-US/docs/Web/Manifest/description">description</a></code></li>
 </ul>
 
 <div class="notecard note">

--- a/files/en-us/web/manifest/lang/index.html
+++ b/files/en-us/web/manifest/lang/index.html
@@ -21,7 +21,7 @@ tags:
  </tbody>
 </table>
 
-<p>The <dfn><code>lang</code></dfn> member is a string containing a single <a href="../HTML/Global_attributes/lang">language tag</a>. It specifies the primary language for the values of the manifest's directionality-capable members, and together with <code><a href="./dir">dir</a></code> determines their directionality.</p>
+<p>The <dfn><code>lang</code></dfn> member is a string containing a single <a href="/en-US/docs/web/HTML/Global_attributes/lang">language tag</a>. It specifies the primary language for the values of the manifest's directionality-capable members, and together with <code><a href="/en-US/docs/Web/HTML/Global_attributes/dir">dir</a></code> determines their directionality.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/manifest/name/index.html
+++ b/files/en-us/web/manifest/name/index.html
@@ -21,7 +21,7 @@ tags:
  </tbody>
 </table>
 
-<p>The <dfn><code>name</code></dfn> member is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon). <code>name</code> is directionality-capable, which means it can be displayed left-to-right or right-to-left based on the values of the <code><a href="./dir">dir</a></code> and <code><a href="./lang">lang</a></code> manifest members.</p>
+<p>The <dfn><code>name</code></dfn> member is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon). <code>name</code> is directionality-capable, which means it can be displayed left-to-right or right-to-left based on the values of the <code><a href="/en-US/docs/Web/Manifest/dir">dir</a></code> and <code><a href="/en-US/docs/Web/Manifest/lang">lang</a></code> manifest members.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/manifest/prefer_related_applications/index.html
+++ b/files/en-us/web/manifest/prefer_related_applications/index.html
@@ -21,7 +21,7 @@ tags:
  </tbody>
 </table>
 
-<p>The <dfn><code>prefer_related_applications</code></dfn> member is a boolean value that specifies that applications listed in <code><a href="./related_applications">related_applications</a></code> should be preferred over the web application. If the <code>prefer_related_applications</code> member is set to <code>true</code>, the user agent might suggest installing one of the related applications instead of this web app.</p>
+<p>The <dfn><code>prefer_related_applications</code></dfn> member is a boolean value that specifies that applications listed in <code><a href="/en-US/docs/Web/Manifest/related_applications">related_applications</a></code> should be preferred over the web application. If the <code>prefer_related_applications</code> member is set to <code>true</code>, the user agent might suggest installing one of the related applications instead of this web app.</p>
 
 <p>If omitted, <dfn><code>prefer_related_applications</code></dfn> defaults to <code>false</code>.</p>
 

--- a/files/en-us/web/manifest/short_name/index.html
+++ b/files/en-us/web/manifest/short_name/index.html
@@ -21,7 +21,7 @@ tags:
  </tbody>
 </table>
 
-<p>The <code><dfn>short_name</dfn></code> member is a string that represents the name of the web application displayed to the user if there is not enough space to display <code><a href="./name">name</a></code> (e.g., as a label for an icon on the phone home screen). <code>short_name</code> is directionality-capable, which means it can be displayed left-to-right or right-to-left based on the value of the <code><a href="./dir">dir</a></code> and <code><a href="./lang">lang</a></code> manifest members.</p>
+<p>The <code><dfn>short_name</dfn></code> member is a string that represents the name of the web application displayed to the user if there is not enough space to display <code><a href="/en-US/docs/Web/Manifest/name">name</a></code> (e.g., as a label for an icon on the phone home screen). <code>short_name</code> is directionality-capable, which means it can be displayed left-to-right or right-to-left based on the value of the <code><a href="/en-US/docs/Web/Manifest/dir">dir</a></code> and <code><a href="/en-US/docs/Web/Manifest/lang">lang</a></code> manifest members.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Tried to fix a bunch in the "Build instructions" pages and redirect to correct links. Some of those seem like they should be retired since the links end up pointing at the source control site