### PR TITLE
Update global attributes spec URLs to match BCD

### DIFF
--- a/files/en-us/web/html/attributes/autocomplete/index.html
+++ b/files/en-us/web/html/attributes/autocomplete/index.html
@@ -240,15 +240,11 @@ TN99 8ZZ</p>
 	<thead>
 		<tr>
 			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
 		</tr>
 	</thead>
 	<tbody>
 		<tr>
-			<td>{{SpecName('HTML WHATWG', "#autofill")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td></td>
+			<td>{{SpecName('HTML WHATWG', "#attr-fe-autocomplete")}}</td>
 		</tr>
 	</tbody>
 </table>

--- a/files/en-us/web/html/attributes/autocomplete/index.html
+++ b/files/en-us/web/html/attributes/autocomplete/index.html
@@ -244,7 +244,7 @@ TN99 8ZZ</p>
 	</thead>
 	<tbody>
 		<tr>
-			<td>{{SpecName('HTML WHATWG', "#attr-fe-autocomplete")}}</td>
+			<td>{{SpecName('HTML WHATWG', "#attr-fe-autocomplete", "autocomplete")}}</td>
 		</tr>
 	</tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/autocapitalize/index.html
+++ b/files/en-us/web/html/global_attributes/autocapitalize/index.html
@@ -28,15 +28,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', "interaction.html#autocapitalization", "autocapitalize")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
+   <td>{{SpecName('HTML WHATWG', "interaction.html#attr-autocapitalize", "autocapitalize")}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/data-_star_/index.html
+++ b/files/en-us/web/html/global_attributes/data-_star_/index.html
@@ -43,25 +43,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', "dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes", "data-*")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#element-attrdef-global-data", "data-*")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#element-attrdef-global-data", "data-*")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition.</td>
+   <td>{{SpecName('HTML WHATWG', "dom.html#attr-data-*", "data-*")}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/hidden/index.html
+++ b/files/en-us/web/html/global_attributes/hidden/index.html
@@ -34,23 +34,9 @@ tags:
  <tbody>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
   <tr>
    <td>{{SpecName('HTML WHATWG', "interaction.html#the-hidden-attribute", "hidden")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "rendering.html#hiddenCSS", "Hidden elements")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Defines the suggested default rendering of the <code>hidden</code> attribute using CSS</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "editing.html#the-hidden-attribute", "hidden")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/inputmode/index.html
+++ b/files/en-us/web/html/global_attributes/inputmode/index.html
@@ -45,15 +45,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName("HTML WHATWG", "interaction.html#input-modalities:-the-inputmode-attribute", "inputmode")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
+   <td>{{SpecName("HTML WHATWG", "interaction.html#attr-inputmode", "inputmode")}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/lang/index.html
+++ b/files/en-us/web/html/global_attributes/lang/index.html
@@ -120,30 +120,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', "dom.html#the-lang-and-xml:lang-attributes", "lang")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-lang-and-xml:lang-attributes", "lang")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-lang-and-xml:lang-attributes", "lang")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, behavior with <code>xml:lang</code> and language determination algorithm defined. It also is a true global attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', 'struct/dirlang.html#h-8.1', 'lang')}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Supported on all elements but {{HTMLElement("applet")}}, {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("br")}}, {{HTMLElement("frame")}}, {{HTMLElement("frameset")}}, {{HTMLElement("iframe")}}, {{HTMLElement("param")}}, and {{HTMLElement("script")}}.</td>
+   <td>{{SpecName('HTML WHATWG', "dom.html#attr-lang", "lang")}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/spellcheck/index.html
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.html
@@ -35,20 +35,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', "interaction.html#spelling-and-grammar-checking", "spellcheck")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "editing.html#spelling-and-grammar-checking", "spellcheck")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition</td>
+   <td>{{SpecName('HTML WHATWG', "interaction.html#attr-spellcheck", "spellcheck")}}</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
This change aligns the MDN spec URL values for HTML global attributes to sync with the spec URL data we have in BCD.

See https://github.com/mdn/browser-compat-data/pull/8064 for discussion on the changes we made to some values when we added them to BCD.