### PR TITLE
Fix: Standard "Browser compatibility" header

### DIFF
--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -60,7 +60,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.html
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.html
@@ -74,7 +74,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
@@ -62,7 +62,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/audiocontext/baselatency/index.html
+++ b/files/en-us/web/api/audiocontext/baselatency/index.html
@@ -54,7 +54,7 @@ console.log(audioCtx2.baseLatency); // 0.15
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.html
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.html
@@ -88,7 +88,7 @@ function outputTimestamps() {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/audioparam/cancelandholdattime/index.html
+++ b/files/en-us/web/api/audioparam/cancelandholdattime/index.html
@@ -48,7 +48,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -44,7 +44,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
+++ b/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
@@ -73,7 +73,7 @@ var request = new PaymentRequest(supportedInstruments, details, options);
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/billingaddress/index.html
+++ b/files/en-us/web/api/basiccardresponse/billingaddress/index.html
@@ -70,7 +70,7 @@ request.show().then(function(instrumentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/cardholdername/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardholdername/index.html
@@ -70,7 +70,7 @@ request.show().then(function(instrumentResponse) {
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/cardnumber/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardnumber/index.html
@@ -70,7 +70,7 @@ request.show().then(function(instrumentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
@@ -70,7 +70,7 @@ request.show().then(function(instrumentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/expirymonth/index.html
+++ b/files/en-us/web/api/basiccardresponse/expirymonth/index.html
@@ -70,7 +70,7 @@ request.show().then(function(instrumentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/expiryyear/index.html
+++ b/files/en-us/web/api/basiccardresponse/expiryyear/index.html
@@ -70,7 +70,7 @@ request.show().then(function(instrumentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/basiccardresponse/index.html
+++ b/files/en-us/web/api/basiccardresponse/index.html
@@ -112,7 +112,7 @@ try {
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
@@ -132,6 +132,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.BiquadFilterNode.BiquadFilterNode")}}</p>

--- a/files/en-us/web/api/blobevent/timecode/index.html
+++ b/files/en-us/web/api/blobevent/timecode/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
@@ -73,7 +73,7 @@ if (characteristic.properties.notify) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
@@ -41,7 +41,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
@@ -65,6 +65,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.BluetoothRemoteGATTDescriptor")}}</p>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
@@ -41,7 +41,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.html
@@ -40,7 +40,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.html
@@ -41,7 +41,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
@@ -48,7 +48,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/budgetservice/index.html
+++ b/files/en-us/web/api/budgetservice/index.html
@@ -27,7 +27,7 @@ tags:
  <dd>Returns a {{domxref("Promise")}} that resolves to a boolean, indicating whether the requested budget operation can be reserved.</dd>
 </dl>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/budgetservice/reserve/index.html
+++ b/files/en-us/web/api/budgetservice/reserve/index.html
@@ -29,7 +29,7 @@ aPromise.then(function(boolean){ ... });</pre>
 
 <p>A {{domxref("Promise")}} that resolves to a boolean.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.html
@@ -66,7 +66,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -71,7 +71,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/index.html
@@ -68,7 +68,7 @@ var size = queueingStrategy.size()</span></code>;
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/cssstylerule/selectortext/index.html
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.html
@@ -47,6 +47,6 @@ alert(stylesheet.cssRules[0].selectorText); // body
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.CSSStyleRule.selectorText")}}</p>

--- a/files/en-us/web/api/delaynode/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/delaynode/index.html
@@ -64,7 +64,7 @@ const delayNode = new DelayNode(audioCtx, {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/directoryreadersync/index.html
+++ b/files/en-us/web/api/directoryreadersync/index.html
@@ -147,7 +147,7 @@ self.onmessage = function(e) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DirectoryReaderSync")}}</p>
 

--- a/files/en-us/web/api/document/doctype/index.html
+++ b/files/en-us/web/api/document/doctype/index.html
@@ -57,6 +57,6 @@ console.log(
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility"> Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Document.doctype")}}</p>

--- a/files/en-us/web/api/documentfragment/queryselector/index.html
+++ b/files/en-us/web/api/documentfragment/queryselector/index.html
@@ -72,7 +72,7 @@ document.querySelector('#foo\\:bar')   // Match the second div
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DocumentFragment.querySelector")}}</p>
 

--- a/files/en-us/web/api/documentorshadowroot/getselection/index.html
+++ b/files/en-us/web/api/documentorshadowroot/getselection/index.html
@@ -77,7 +77,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/domexception/code/index.html
+++ b/files/en-us/web/api/domexception/code/index.html
@@ -38,6 +38,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DOMException.code")}}</p>

--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -52,6 +52,6 @@ var domException = new DOMException(message, name);</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DOMException.DOMException")}}</p>

--- a/files/en-us/web/api/domexception/message/index.html
+++ b/files/en-us/web/api/domexception/message/index.html
@@ -38,6 +38,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DOMException.message")}}</p>

--- a/files/en-us/web/api/domrectreadonly/fromrect/index.html
+++ b/files/en-us/web/api/domrectreadonly/fromrect/index.html
@@ -56,7 +56,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/domtokenlist/foreach/index.html
+++ b/files/en-us/web/api/domtokenlist/foreach/index.html
@@ -99,7 +99,7 @@ classes.forEach(
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
@@ -50,7 +50,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/element/currentstyle/index.html
+++ b/files/en-us/web/api/element/currentstyle/index.html
@@ -35,7 +35,7 @@ if (!("currentStyle" in Element.prototype)) {
 
 <p>Microsoft <a href="https://web.archive.org/web/20150629144515/https://msdn.microsoft.com/en-us/library/ms535231(v=vs.85).aspx">had a description on MSDN</a>.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Element.currentStyle")}}</p>
 

--- a/files/en-us/web/api/element/runtimestyle/index.html
+++ b/files/en-us/web/api/element/runtimestyle/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>Microsoft <a href="https://web.archive.org/web/20160601091713/https://msdn.microsoft.com/en-us/library/ms535889(v=vs.85).aspx">had a description on MSDN</a>.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Element.runtimeStyle")}}</p>
 

--- a/files/en-us/web/api/element/scroll/index.html
+++ b/files/en-us/web/api/element/scroll/index.html
@@ -71,6 +71,6 @@ element.scroll(0, 1000);
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Element.scroll")}}</p>

--- a/files/en-us/web/api/element/scrollto/index.html
+++ b/files/en-us/web/api/element/scrollto/index.html
@@ -63,7 +63,7 @@ element.scrollTo(<em>options</em>)
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Element.scrollTo")}}</p>
 

--- a/files/en-us/web/api/element/slot/index.html
+++ b/files/en-us/web/api/element/slot/index.html
@@ -57,7 +57,7 @@ console.log(slottedSpan.slot); // logs <span class="message-body-wrapper"><span 
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.html
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.html
@@ -67,6 +67,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.EventTarget.dispatchEvent")}}</p>

--- a/files/en-us/web/api/fetchevent/navigationpreload/index.html
+++ b/files/en-us/web/api/fetchevent/navigationpreload/index.html
@@ -59,7 +59,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/fileentrysync/index.html
+++ b/files/en-us/web/api/fileentrysync/index.html
@@ -120,7 +120,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.FileEntrySync")}}</p>
 

--- a/files/en-us/web/api/filereadersync/index.html
+++ b/files/en-us/web/api/filereadersync/index.html
@@ -49,7 +49,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
@@ -62,7 +62,7 @@ slug: Web/API/FileReaderSync/readAsArrayBuffer
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.html
@@ -48,7 +48,7 @@ readAsBinaryString(<em>Blob</em>);
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.html
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.html
@@ -44,7 +44,7 @@ readAsDataURL(<em>Blob</em>);
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/filereadersync/readastext/index.html
+++ b/files/en-us/web/api/filereadersync/readastext/index.html
@@ -48,7 +48,7 @@ readAsText(<em>Blob</em>, <em>encoding</em>);
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/filesystemsync/index.html
+++ b/files/en-us/web/api/filesystemsync/index.html
@@ -49,7 +49,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.FileSystemSync")}}</p>
 

--- a/files/en-us/web/api/fontface/display/index.html
+++ b/files/en-us/web/api/fontface/display/index.html
@@ -65,7 +65,7 @@ FontFace.display = <em>display</em></pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
@@ -41,7 +41,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
@@ -49,7 +49,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/index.html
@@ -47,7 +47,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/gainnode/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/gainnode/index.html
@@ -58,7 +58,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/globaleventhandlers/onended/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onended/index.html
@@ -39,7 +39,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onended;
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility"> Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.GlobalEventHandlers.onended")}}</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onplaying/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplaying/index.html
@@ -41,7 +41,7 @@ var <var>handlerFunction</var> = <var>element</var>.onplaying;
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility"> Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.GlobalEventHandlers.onplaying")}}</p>
 

--- a/files/en-us/web/api/history/back/index.html
+++ b/files/en-us/web/api/history/back/index.html
@@ -56,7 +56,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.History.back")}}</p>
 

--- a/files/en-us/web/api/history/forward/index.html
+++ b/files/en-us/web/api/history/forward/index.html
@@ -55,7 +55,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.History.forward")}}</p>
 

--- a/files/en-us/web/api/history/scrollrestoration/index.html
+++ b/files/en-us/web/api/history/scrollrestoration/index.html
@@ -65,6 +65,6 @@ if (scrollRestoration === 'manual') {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.History.scrollRestoration")}}</p>

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>A {{jsxref("Boolean")}}.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmliframeelement/csp/index.html
+++ b/files/en-us/web/api/htmliframeelement/csp/index.html
@@ -40,7 +40,7 @@ HTMLIFrameElement.csp = <em>csp</em></pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmllinkelement/as/index.html
+++ b/files/en-us/web/api/htmllinkelement/as/index.html
@@ -41,7 +41,7 @@ HTMLLinkElement.<em>as</em> = <em>as</em></pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmlmediaelement/controlslist/index.html
+++ b/files/en-us/web/api/htmlmediaelement/controlslist/index.html
@@ -40,7 +40,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmlmediaelement/onencrypted/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onencrypted/index.html
@@ -32,7 +32,7 @@ slug: Web/API/HTMLMediaElement/onencrypted
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmlmediaelement/onwaitingforkey/index.html
+++ b/files/en-us/web/api/htmlmediaelement/onwaitingforkey/index.html
@@ -32,7 +32,7 @@ slug: Web/API/HTMLMediaElement/onwaitingforkey
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.html
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.html
@@ -48,7 +48,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmlorforeignelement/nonce/index.html
+++ b/files/en-us/web/api/htmlorforeignelement/nonce/index.html
@@ -48,7 +48,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.HTMLElement.nonce")}}</p>
 

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.html
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.html
@@ -58,7 +58,7 @@ let elements = slots.assignedElements({flatten: true});
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/htmlslotelement/name/index.html
+++ b/files/en-us/web/api/htmlslotelement/name/index.html
@@ -54,7 +54,7 @@ slots[1].addEventListener('slotchange', function(e) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/idbdatabaseexception/index.html
+++ b/files/en-us/web/api/idbdatabaseexception/index.html
@@ -118,6 +118,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.IDBDatabaseException")}}</p>

--- a/files/en-us/web/api/idbversionchangeevent/version/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/version/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>A <a href="/en-US/docs/NSPR_API_Reference/Long_Long_(64-bit)_Integers">64-bit integer</a>.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.IDBVersionChangeEvent.version")}}</p>
 

--- a/files/en-us/web/api/iirfilternode/iirfilternode/index.html
+++ b/files/en-us/web/api/iirfilternode/iirfilternode/index.html
@@ -67,7 +67,7 @@ const iirFilter = new IIRFilterNode(audioCtx, { feedforward: feedForward, feedba
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/imagecapture/takephoto/index.html
+++ b/files/en-us/web/api/imagecapture/takephoto/index.html
@@ -75,7 +75,7 @@ function takePhoto() {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/inputevent/datatransfer/index.html
+++ b/files/en-us/web/api/inputevent/datatransfer/index.html
@@ -67,7 +67,7 @@ editable.addEventListener('input', (e) =&gt; {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/inputevent/gettargetranges/index.html
+++ b/files/en-us/web/api/inputevent/gettargetranges/index.html
@@ -67,7 +67,7 @@ editableElem.addEventListener('beforeinput', (e) =&gt; {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -212,7 +212,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.LocalFileSystem")}}</p>
 

--- a/files/en-us/web/api/localfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/index.html
@@ -173,7 +173,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.LocalFileSystemSync")}}</p>
 

--- a/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
@@ -88,7 +88,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.LocalFileSystemSync.requestFileSystemSync")}}</p>
 

--- a/files/en-us/web/api/mediadeviceinfo/deviceid/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/deviceid/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediadeviceinfo/kind/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/kind/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.html
@@ -32,7 +32,7 @@ tags:
  </dd>
 </dl>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/entries/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/entries/index.html
@@ -42,7 +42,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/foreach/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/foreach/index.html
@@ -56,7 +56,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/get/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.html
@@ -45,7 +45,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/has/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/has/index.html
@@ -45,7 +45,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/keys/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/keys/index.html
@@ -42,7 +42,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/size/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/size/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediakeystatusmap/values/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/values/index.html
@@ -42,7 +42,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediametadata/album/index.html
+++ b/files/en-us/web/api/mediametadata/album/index.html
@@ -56,7 +56,7 @@ mediaMetaData.album = album</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediametadata/artist/index.html
+++ b/files/en-us/web/api/mediametadata/artist/index.html
@@ -60,7 +60,7 @@ mediaMetadata.artist = artist</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediametadata/artwork/index.html
+++ b/files/en-us/web/api/mediametadata/artwork/index.html
@@ -61,7 +61,7 @@ mediaMetadata.artwork = artwork[]</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/index.html
@@ -71,7 +71,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediametadata/title/index.html
+++ b/files/en-us/web/api/mediametadata/title/index.html
@@ -61,7 +61,7 @@ mediaMetaData.title = title</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
@@ -38,6 +38,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.MediaRecorder.audioBitsPerSecond")}}</p>

--- a/files/en-us/web/api/mediarecorder/ignoremutedmedia/index.html
+++ b/files/en-us/web/api/mediarecorder/ignoremutedmedia/index.html
@@ -23,6 +23,6 @@ MediaRecorder.ignoreMutedMedia = boolean</pre>
 
 <p>A {{jsxref("Boolean")}}.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.MediaRecorder.ignoreMutedMedia")}}</p>

--- a/files/en-us/web/api/mediasession/playbackstate/index.html
+++ b/files/en-us/web/api/mediasession/playbackstate/index.html
@@ -88,7 +88,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/mediastream/gettracks/index.html
+++ b/files/en-us/web/api/mediastream/gettracks/index.html
@@ -59,7 +59,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">
 <p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>

--- a/files/en-us/web/api/navigationpreloadmanager/index.html
+++ b/files/en-us/web/api/navigationpreloadmanager/index.html
@@ -77,6 +77,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.NavigationPreloadManager")}}</p>

--- a/files/en-us/web/api/navigator/presentation/index.html
+++ b/files/en-us/web/api/navigator/presentation/index.html
@@ -32,7 +32,7 @@ slug: Web/API/Navigator/presentation
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Navigator.presentation")}}</p>
 

--- a/files/en-us/web/api/nodelist/foreach/index.html
+++ b/files/en-us/web/api/nodelist/foreach/index.html
@@ -108,7 +108,7 @@ list.forEach(
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.NodeList.forEach")}}</p>
 

--- a/files/en-us/web/api/nondocumenttypechildnode/nextelementsibling/index.html
+++ b/files/en-us/web/api/nondocumenttypechildnode/nextelementsibling/index.html
@@ -100,7 +100,7 @@ if(!("nextElementSibling" in document.documentElement)){
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/index.html
@@ -91,7 +91,7 @@ tags:
 <p><strong>Note</strong>: This interface is specified in the <a href="/en-US/docs/Web/API/Notifications_API">Notifications API</a>, but accessed through {{domxref("ServiceWorkerGlobalScope")}}.</p>
 </div>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
@@ -55,7 +55,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/index.html
@@ -83,7 +83,7 @@ navigator.credentials.store(cred)
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentaddress/tojson/index.html
+++ b/files/en-us/web/api/paymentaddress/tojson/index.html
@@ -44,7 +44,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/abort/index.html
+++ b/files/en-us/web/api/paymentrequest/abort/index.html
@@ -60,7 +60,7 @@ var paymentTimeout = window.setTimeout(() =&gt; {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.html
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.html
@@ -98,7 +98,7 @@ async function initPaymentRquest() {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/id/index.html
+++ b/files/en-us/web/api/paymentrequest/id/index.html
@@ -67,7 +67,7 @@ console.log(json.requestId,response.requestId, request.id);
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.html
+++ b/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.html
@@ -59,7 +59,7 @@ payment.show().then(function(paymentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.html
+++ b/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.html
@@ -86,7 +86,7 @@ request.addEventListener('shippingaddresschange', e =&gt; {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/shippingaddress/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingaddress/index.html
@@ -86,7 +86,7 @@ function updateDetails(details, shippingAddress, resolve) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/shippingoption/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingoption/index.html
@@ -74,7 +74,7 @@ async function checkShipping(request) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentrequest/shippingtype/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingtype/index.html
@@ -40,7 +40,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentresponse/complete/index.html
+++ b/files/en-us/web/api/paymentresponse/complete/index.html
@@ -101,7 +101,7 @@ payment.show().then(function(paymentResponse) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentresponse/details/index.html
+++ b/files/en-us/web/api/paymentresponse/details/index.html
@@ -55,7 +55,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentresponse/payeremail/index.html
+++ b/files/en-us/web/api/paymentresponse/payeremail/index.html
@@ -37,7 +37,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentresponse/payername/index.html
+++ b/files/en-us/web/api/paymentresponse/payername/index.html
@@ -40,7 +40,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentresponse/requestid/index.html
+++ b/files/en-us/web/api/paymentresponse/requestid/index.html
@@ -40,7 +40,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.html
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.html
@@ -90,6 +90,6 @@ function updateDetails(details, shippingAddress, resolve) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PaymentResponse.shippingAddress")}}</p>

--- a/files/en-us/web/api/paymentresponse/shippingoption/index.html
+++ b/files/en-us/web/api/paymentresponse/shippingoption/index.html
@@ -78,7 +78,7 @@ function updateDetails(details, shippingOption, resolve, reject) {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/performance/timeorigin/index.html
+++ b/files/en-us/web/api/performance/timeorigin/index.html
@@ -39,7 +39,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/performancelongtasktiming/attribution/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/attribution/index.html
@@ -31,6 +31,6 @@ slug: Web/API/PerformanceLongTaskTiming/attribution
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PerformanceLongTaskTiming.attribution")}}</p>

--- a/files/en-us/web/api/performancelongtasktiming/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/index.html
@@ -38,6 +38,6 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PerformanceLongTaskTiming")}}</p>

--- a/files/en-us/web/api/photocapabilities/filllightmode/index.html
+++ b/files/en-us/web/api/photocapabilities/filllightmode/index.html
@@ -51,7 +51,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/photocapabilities/imageheight/index.html
+++ b/files/en-us/web/api/photocapabilities/imageheight/index.html
@@ -41,7 +41,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/photocapabilities/imagewidth/index.html
+++ b/files/en-us/web/api/photocapabilities/imagewidth/index.html
@@ -41,7 +41,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/photocapabilities/index.html
+++ b/files/en-us/web/api/photocapabilities/index.html
@@ -77,7 +77,7 @@ navigator.mediaDevices.getUserMedia({video: true})
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/photocapabilities/redeyereduction/index.html
+++ b/files/en-us/web/api/photocapabilities/redeyereduction/index.html
@@ -51,7 +51,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -483,7 +483,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility"><span>Browser compatibility</span></h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">
 <p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
@@ -42,7 +42,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">
 <p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>

--- a/files/en-us/web/api/presentation/defaultrequest/index.html
+++ b/files/en-us/web/api/presentation/defaultrequest/index.html
@@ -41,6 +41,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Presentation.defaultRequest")}}</p>

--- a/files/en-us/web/api/presentation/index.html
+++ b/files/en-us/web/api/presentation/index.html
@@ -45,6 +45,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Presentation")}}</p>

--- a/files/en-us/web/api/presentation/receiver/index.html
+++ b/files/en-us/web/api/presentation/receiver/index.html
@@ -75,7 +75,7 @@ navigator.presentation.receiver.connectionList
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Presentation.receiver")}}</p>
 

--- a/files/en-us/web/api/presentationavailability/index.html
+++ b/files/en-us/web/api/presentationavailability/index.html
@@ -52,6 +52,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationAvailability")}}</p>

--- a/files/en-us/web/api/presentationconnection/index.html
+++ b/files/en-us/web/api/presentationconnection/index.html
@@ -67,6 +67,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationConnection")}}</p>

--- a/files/en-us/web/api/presentationconnectionavailableevent/index.html
+++ b/files/en-us/web/api/presentationconnectionavailableevent/index.html
@@ -47,6 +47,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationConnectionAvailableEvent")}}</p>

--- a/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.html
+++ b/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.html
@@ -29,6 +29,6 @@ tags:
 
 <p>An instance of the {{domxref("PresentationConnectionAvailableEvent")}} interface.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationConnectionAvailableEvent.PresentationConnectionAvailableEvent")}}</p>

--- a/files/en-us/web/api/presentationconnectioncloseevent/index.html
+++ b/files/en-us/web/api/presentationconnectioncloseevent/index.html
@@ -47,6 +47,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationConnectionCloseEvent")}}</p>

--- a/files/en-us/web/api/presentationreceiver/index.html
+++ b/files/en-us/web/api/presentationreceiver/index.html
@@ -38,6 +38,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationReceiver")}}</p>

--- a/files/en-us/web/api/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/index.html
@@ -61,6 +61,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationRequest")}}</p>

--- a/files/en-us/web/api/presentationrequest/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/presentationrequest/index.html
@@ -41,6 +41,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationRequest.PresentationRequest")}}</p>

--- a/files/en-us/web/api/presentationrequest/start/index.html
+++ b/files/en-us/web/api/presentationrequest/start/index.html
@@ -44,6 +44,6 @@ promise.then(function(PresentationConnection) { ... })
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.PresentationRequest.start")}}</p>

--- a/files/en-us/web/api/pushevent/data/index.html
+++ b/files/en-us/web/api/pushevent/data/index.html
@@ -70,7 +70,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/index.html
@@ -84,7 +84,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushevent/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/pushevent/index.html
@@ -42,7 +42,7 @@ var myPushEvent = new PushEvent('push', dataInit);
 
 myPushEvent.data.text(); // should return 'Some sample text'</pre>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushmanager/haspermission/index.html
+++ b/files/en-us/web/api/pushmanager/haspermission/index.html
@@ -37,7 +37,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 <div>

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
@@ -39,7 +39,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 <div>

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
@@ -52,7 +52,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushmessagedata/blob/index.html
+++ b/files/en-us/web/api/pushmessagedata/blob/index.html
@@ -52,7 +52,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushmessagedata/json/index.html
+++ b/files/en-us/web/api/pushmessagedata/json/index.html
@@ -52,7 +52,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushmessagedata/text/index.html
+++ b/files/en-us/web/api/pushmessagedata/text/index.html
@@ -53,7 +53,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushregistrationmanager/index.html
+++ b/files/en-us/web/api/pushregistrationmanager/index.html
@@ -28,7 +28,7 @@ tags:
  <dd>Returns a promise that resolves to the {{domxref("PushPermissionStatus")}} of the requesting webapp.</dd>
 </dl>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushsubscription/expirationtime/index.html
+++ b/files/en-us/web/api/pushsubscription/expirationtime/index.html
@@ -40,7 +40,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushsubscription/getkey/index.html
+++ b/files/en-us/web/api/pushsubscription/getkey/index.html
@@ -82,7 +82,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushsubscription/options/index.html
+++ b/files/en-us/web/api/pushsubscription/options/index.html
@@ -44,7 +44,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.html
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
@@ -39,7 +39,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/rtcrtpreceiver/track/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/track/index.html
@@ -42,7 +42,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/screen_orientation_api/index.html
+++ b/files/en-us/web/api/screen_orientation_api/index.html
@@ -42,6 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="DOMxRef(ScreenOrientation)">{{DOMxRef("ScreenOrientation")}}</h3>
-
 <p>{{Compat("api.ScreenOrientation")}}</p>

--- a/files/en-us/web/api/screen_orientation_api/index.html
+++ b/files/en-us/web/api/screen_orientation_api/index.html
@@ -40,7 +40,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <h3 id="DOMxRef(ScreenOrientation)">{{DOMxRef("ScreenOrientation")}}</h3>
 

--- a/files/en-us/web/api/screenorientation/angle/index.html
+++ b/files/en-us/web/api/screenorientation/angle/index.html
@@ -39,7 +39,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/screenorientation/index.html
+++ b/files/en-us/web/api/screenorientation/index.html
@@ -57,6 +57,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.ScreenOrientation")}}</p>

--- a/files/en-us/web/api/screenorientation/lock/index.html
+++ b/files/en-us/web/api/screenorientation/lock/index.html
@@ -57,7 +57,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/screenorientation/onchange/index.html
+++ b/files/en-us/web/api/screenorientation/onchange/index.html
@@ -36,7 +36,7 @@ ScreenOrientation.onchange = function(e) { ... }</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/screenorientation/type/index.html
+++ b/files/en-us/web/api/screenorientation/type/index.html
@@ -39,7 +39,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/screenorientation/unlock/index.html
+++ b/files/en-us/web/api/screenorientation/unlock/index.html
@@ -43,7 +43,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/serviceworkerregistration/navigationpreload/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/navigationpreload/index.html
@@ -39,6 +39,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.ServiceWorkerRegistration.navigationPreload")}}</p>

--- a/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.html
@@ -34,7 +34,7 @@ tags:
 
 <p>from inside the shared worker.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.SharedWorkerGlobalScope.applicationCache")}}</p>
 

--- a/files/en-us/web/api/sharedworkerglobalscope/onconnect/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/onconnect/index.html
@@ -58,7 +58,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.SharedWorkerGlobalScope.onconnect")}}</p>
 

--- a/files/en-us/web/api/slottable/assignedslot/index.html
+++ b/files/en-us/web/api/slottable/assignedslot/index.html
@@ -54,6 +54,6 @@ console.log(slottedSpan.assignedSlot); // logs '<span class="message-body-wrappe
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Slottable.assignedSlot")}}</p>

--- a/files/en-us/web/api/slottable/index.html
+++ b/files/en-us/web/api/slottable/index.html
@@ -41,6 +41,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Slottable")}}</p>

--- a/files/en-us/web/api/stereopannernode/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/stereopannernode/index.html
@@ -54,7 +54,7 @@ tags:
 	</tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/storagemanager/persist/index.html
+++ b/files/en-us/web/api/storagemanager/persist/index.html
@@ -51,6 +51,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.StorageManager.persist")}}</p>

--- a/files/en-us/web/api/svgcircleelement/index.html
+++ b/files/en-us/web/api/svgcircleelement/index.html
@@ -88,7 +88,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.SVGCircleElement")}}</p>
 

--- a/files/en-us/web/api/svgtransformlist/index.html
+++ b/files/en-us/web/api/svgtransformlist/index.html
@@ -209,7 +209,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Example</h2>
+<h2 id="Examples">Examples</h2>
 
 <h3 id="Using_multiple_SVGTransform_objects">Using multiple SVGTransform objects</h3>
 

--- a/files/en-us/web/api/syncmanager/index.html
+++ b/files/en-us/web/api/syncmanager/index.html
@@ -43,7 +43,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility"><span style="font-size: 2.14285714285714rem;">Browser compatibility</span></h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/taskattributiontiming/containerid/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/text/assignedslot/index.html
+++ b/files/en-us/web/api/text/assignedslot/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/waveshapernode/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/waveshapernode/index.html
@@ -55,7 +55,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/window/event/index.html
+++ b/files/en-us/web/api/window/event/index.html
@@ -37,7 +37,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.event")}}</p>
 

--- a/files/en-us/web/api/window/minimize/index.html
+++ b/files/en-us/web/api/window/minimize/index.html
@@ -16,6 +16,6 @@ tags:
 
 <p>A way to undo this method programmatically is by calling {{ domxref("window.moveTo()") }}.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.minimize")}}</p>

--- a/files/en-us/web/api/window/opendialog/index.html
+++ b/files/en-us/web/api/window/opendialog/index.html
@@ -92,7 +92,7 @@ retVals.delivery = "immediate";
 
 <p>This is not part of any specification.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.openDialog")}}</p>
 

--- a/files/en-us/web/api/window/print/index.html
+++ b/files/en-us/web/api/window/print/index.html
@@ -36,7 +36,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.print")}}</p>
 

--- a/files/en-us/web/api/window/releaseevents/index.html
+++ b/files/en-us/web/api/window/releaseevents/index.html
@@ -44,6 +44,6 @@ tags:
 
 <p>This is not part of any specification.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.releaseEvents")}}</p>

--- a/files/en-us/web/api/window/routeevent/index.html
+++ b/files/en-us/web/api/window/routeevent/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p><span class="seoSummary">The {{domxref("Window")}} method <strong><code>routeEvent()</code></strong>, which is <em>obsolete</em> and no longer available, used to be called to forward an event to the next object that has asked to capture events.</span></p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.routeEvent")}}</p>
 

--- a/files/en-us/web/api/window/scroll/index.html
+++ b/files/en-us/web/api/window/scroll/index.html
@@ -71,7 +71,7 @@ window.scroll(<em>options</em>)
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.scroll")}}</p>
 

--- a/files/en-us/web/api/window/scrollby/index.html
+++ b/files/en-us/web/api/window/scrollby/index.html
@@ -72,6 +72,6 @@ window.scrollBy(<em>options</em>)
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.scrollBy")}}</p>

--- a/files/en-us/web/api/window/setcursor/index.html
+++ b/files/en-us/web/api/window/setcursor/index.html
@@ -29,6 +29,6 @@ tags:
 
 <p>This is not part of any specification.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.setCursor")}}</p>

--- a/files/en-us/web/api/window/stop/index.html
+++ b/files/en-us/web/api/window/stop/index.html
@@ -49,6 +49,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.stop")}}</p>

--- a/files/en-us/web/api/window/updatecommands/index.html
+++ b/files/en-us/web/api/window/updatecommands/index.html
@@ -36,6 +36,6 @@ tags:
 
 <p>DOM Level 0. Not part of specification.</p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.Window.updateCommands")}}</p>

--- a/files/en-us/web/api/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/index.html
@@ -137,7 +137,7 @@ sendMessage("Hello, world.", writableStream);</pre>
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/ready/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/ready/index.html
@@ -77,6 +77,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.WritableStreamDefaultWriter.ready")}}</p>

--- a/files/en-us/web/exslt/math/min/index.html
+++ b/files/en-us/web/exslt/math/min/index.html
@@ -35,7 +35,7 @@ tags:
 
 <p><a class="external" href="http://www.exslt.org/regexp/functions/min/index.html">EXSLT - MATH:MIN</a></p>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">
 <p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>

--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.html
@@ -272,7 +272,7 @@ var createMenuItem = function(id, lang, label) {
 <p><strong>Note</strong>: Some of the styling of cues with ::cue currently works on Chrome, Opera, and Safari, but not yet on Firefox.</p>
 </div>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p><a href="http://caniuse.com/webvtt">Browser support for WebVTT and the <code>&lt;track&gt;</code> element</a> is fairly good, although some browsers differ slightly in their implementation.</p>
 

--- a/files/en-us/web/guide/events/event_handlers/index.html
+++ b/files/en-us/web/guide/events/event_handlers/index.html
@@ -153,7 +153,7 @@ log(`Now even the HTML attribute has changed: &lt;code&gt; ${el.getAttribute("on
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <h4 id="Detecting_the_presence_of_event_handler_properties">Detecting the presence of event handler properties</h4>
 

--- a/files/en-us/web/guide/events/event_handlers/index.html
+++ b/files/en-us/web/guide/events/event_handlers/index.html
@@ -153,7 +153,7 @@ log(`Now even the HTML attribute has changed: &lt;code&gt; ${el.getAttribute("on
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
+<h2 id="Examples">Examples</h2>
 
 <h4 id="Detecting_the_presence_of_event_handler_properties">Detecting the presence of event handler properties</h4>
 

--- a/files/en-us/web/http/status/103/index.html
+++ b/files/en-us/web/http/status/103/index.html
@@ -36,7 +36,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser Compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("http.status.103")}}</p>
 

--- a/files/en-us/web/svg/attribute/baseline-shift/index.html
+++ b/files/en-us/web/svg/attribute/baseline-shift/index.html
@@ -74,6 +74,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.baseline-shift")}}</p>

--- a/files/en-us/web/svg/attribute/clip-path/index.html
+++ b/files/en-us/web/svg/attribute/clip-path/index.html
@@ -73,7 +73,7 @@ tags:
 
 <p class="note"><strong>Note:</strong> For more details on the clip-path syntax, see the CSS property {{cssxref('clip-path')}} reference page.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.clip-path")}}</p>
 

--- a/files/en-us/web/svg/attribute/clip-rule/index.html
+++ b/files/en-us/web/svg/attribute/clip-rule/index.html
@@ -93,7 +93,7 @@ tags:
  <li><a href="/en/SVG/Element#Graphical">Graphical elements</a> »</li>
 </ul>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.clip-rule")}}</p>
 

--- a/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
@@ -74,7 +74,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.color-interpolation-filters")}}</p>
 

--- a/files/en-us/web/svg/attribute/color-interpolation/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation/index.html
@@ -74,7 +74,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.color-interpolation")}}</p>
 

--- a/files/en-us/web/svg/attribute/color-profile/index.html
+++ b/files/en-us/web/svg/attribute/color-profile/index.html
@@ -64,6 +64,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.color-profile")}}</p>

--- a/files/en-us/web/svg/attribute/color/index.html
+++ b/files/en-us/web/svg/attribute/color/index.html
@@ -74,6 +74,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.color")}}</p>

--- a/files/en-us/web/svg/attribute/cursor/index.html
+++ b/files/en-us/web/svg/attribute/cursor/index.html
@@ -47,7 +47,7 @@ tags:
  <li><a href="/en/SVG/Element#Graphics_elements">Graphics elements</a> »</li>
 </ul>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.cursor")}}</p>
 

--- a/files/en-us/web/svg/attribute/dominant-baseline/index.html
+++ b/files/en-us/web/svg/attribute/dominant-baseline/index.html
@@ -177,7 +177,7 @@ text {
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.dominant-baseline")}}</p>
 

--- a/files/en-us/web/svg/attribute/fill-opacity/index.html
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.html
@@ -59,7 +59,7 @@ tags:
 
 <p class="note"><strong>Note:</strong> SVG2 introduces percentage values for <code>fill-opacity</code>, however, it is not widely supported yet (<em>See <a href="#Browser_Compatibility">Browser compatibility</a> below</em>) as a consequence, it is best practices to set opacity with a value in the range <code>[0-1]</code>.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.fill-opacity")}}</p>
 

--- a/files/en-us/web/svg/attribute/fill-rule/index.html
+++ b/files/en-us/web/svg/attribute/fill-rule/index.html
@@ -129,7 +129,7 @@ tags:
 
 <p>{{EmbedLiveSample('evenodd', '100%', 200)}}</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.fill-rule")}}</p>
 

--- a/files/en-us/web/svg/attribute/fill/index.html
+++ b/files/en-us/web/svg/attribute/fill/index.html
@@ -447,7 +447,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.fill")}}</p>
 

--- a/files/en-us/web/svg/attribute/filter/index.html
+++ b/files/en-us/web/svg/attribute/filter/index.html
@@ -77,7 +77,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.filter")}}</p>
 

--- a/files/en-us/web/svg/attribute/font-family/index.html
+++ b/files/en-us/web/svg/attribute/font-family/index.html
@@ -78,7 +78,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.font-family")}}</p>
 

--- a/files/en-us/web/svg/attribute/font-style/index.html
+++ b/files/en-us/web/svg/attribute/font-style/index.html
@@ -85,7 +85,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.font-style")}}</p>
 

--- a/files/en-us/web/svg/attribute/font-weight/index.html
+++ b/files/en-us/web/svg/attribute/font-weight/index.html
@@ -78,7 +78,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.font-weight")}}</p>
 

--- a/files/en-us/web/svg/attribute/pointer-events/index.html
+++ b/files/en-us/web/svg/attribute/pointer-events/index.html
@@ -74,7 +74,7 @@ tags:
 
 <p><em>For a detailed explanation of each possible value, have a look at the CSS  {{cssxref('pointer-events')}} documentation.</em></p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.pointer-events")}}</p>
 

--- a/files/en-us/web/svg/attribute/shape-rendering/index.html
+++ b/files/en-us/web/svg/attribute/shape-rendering/index.html
@@ -82,6 +82,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.shape-rendering")}}</p>

--- a/files/en-us/web/svg/attribute/spreadmethod/index.html
+++ b/files/en-us/web/svg/attribute/spreadmethod/index.html
@@ -156,6 +156,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.spreadMethod")}}</p>

--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.html
@@ -88,7 +88,7 @@ tags:
  </dd>
 </dl>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke-dasharray")}}</p>
 

--- a/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
@@ -83,7 +83,7 @@ tags:
 
 <p>The offset is usually expressed in user units resolved against the {{SVGAttr('pathLength')}} but if a <a href="/en/SVG/Content_type#Percentage">&lt;percentage&gt;</a> is used, the value is resolved as a percentage of the current viewport.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke-dashoffset")}}</p>
 

--- a/files/en-us/web/svg/attribute/stroke-linecap/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linecap/index.html
@@ -161,7 +161,7 @@ tags:
 
 <p>{{EmbedLiveSample('square', '100%', 200)}}</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke-linecap")}}</p>
 

--- a/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
+++ b/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
@@ -84,7 +84,7 @@ tags:
 
 <p>The value of <code>stroke-miterlimit</code> must be greater than or equal to 1.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke-miterlimit")}}</p>
 

--- a/files/en-us/web/svg/attribute/stroke-opacity/index.html
+++ b/files/en-us/web/svg/attribute/stroke-opacity/index.html
@@ -61,7 +61,7 @@ tags:
 
 <p>It's important to know that the stroke partially covers the fill of a shape, so a stroke with an opacity different than <code>1</code> will partially show the fill underneath. To avoid this effect, it is possible to apply a global opacity with the {{SVGAttr('opacity')}} attribute or to put the stroke behind the fill with the {{SVGAttr('paint-order')}} attribute.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke-opacity")}}</p>
 

--- a/files/en-us/web/svg/attribute/stroke-width/index.html
+++ b/files/en-us/web/svg/attribute/stroke-width/index.html
@@ -53,7 +53,7 @@ tags:
 
 <p class="note"><strong>Note:</strong> A percentage value is always computed as a percentage of the normalized {{SVGAttr('viewBox')}} diagonal length.</p>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke-width")}}</p>
 

--- a/files/en-us/web/svg/attribute/stroke/index.html
+++ b/files/en-us/web/svg/attribute/stroke/index.html
@@ -83,7 +83,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.stroke")}}</p>
 

--- a/files/en-us/web/svg/attribute/text-anchor/index.html
+++ b/files/en-us/web/svg/attribute/text-anchor/index.html
@@ -98,6 +98,6 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.text-anchor")}}</p>

--- a/files/en-us/web/svg/attribute/text-rendering/index.html
+++ b/files/en-us/web/svg/attribute/text-rendering/index.html
@@ -82,7 +82,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.presentation.text-rendering")}}</p>
 


### PR DESCRIPTION
Make headers of "Browser compatibility" sections consistent (match format `<h[23] id="Browser_compatibility">Browser compatibility</h[23]>`). Also, fix a couple mistakes along the way.

The first commit is straight-forward fix for capitalization, removal of extra spaces, etc. The only content fixes are separated into two other commits.

Related: #499.