### PR TITLE
CSSGroupingRule

### DIFF
--- a/files/en-us/web/api/cssgroupingrule/cssrules/index.html
+++ b/files/en-us/web/api/cssgroupingrule/cssrules/index.html
@@ -1,0 +1,52 @@
+---
+title: CSSGroupingRule.cssRules
+slug: Web/API/CSSGroupingRule/cssRules
+tags:
+  - API
+  - CSSOM
+  - CSSGroupingRule
+  - Property
+  - Reference
+---
+<p>{{ APIRef("CSSOM") }}</p>
+
+<p class="summary">The <strong><code>cssRules</code></strong> property of the {{domxref("CSSGroupingRule")}} interface returns a {{domxref("CSSRuleList")}} containing a collection of {{domxref("CSSRule")}} objects.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>cssRules</var> = <var>cssGroupingRule</var>.cssRules;</pre>
+
+
+<h3>Value</h3>
+<p>a {{domxref("CSSRuleList")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules);
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+    <thead>
+     <tr>
+      <th scope="col">Specification</th>
+      <th scope="col">Status</th>
+      <th scope="col">Comment</th>
+     </tr>
+    </thead>
+    <tbody>
+     <tr>
+      <td>{{ SpecName('CSSOM', '#dom-cssgroupingrule-cssrules', 'CSSRules') }}</td>
+      <td>{{ Spec2('CSSOM') }}</td>
+      <td>Initial definition.</td>
+     </tr>
+    </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSGroupingRule")}}</p>

--- a/files/en-us/web/api/cssgroupingrule/deleterule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/deleterule/index.html
@@ -1,0 +1,72 @@
+---
+title: CSSGroupingRule.deleteRule()
+slug: Web/API/CSSGroupingRule/deleteRule
+tags:
+  - API
+  - CSSOM
+  - CSSGroupingRule
+  - Method
+  - Reference
+---
+<p>{{ APIRef("CSSOM") }}</p>
+
+<p class="summary">The <strong><code>deleteRule()</code></strong> method of the {{domxref("CSSGroupingRule")}} interface removes a CSS rule from a list of child CSS rules.</p>
+
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate"><var>cssGroupingRule</var>.deleteRule(<var>index</var>);</pre>
+
+
+<h3 id="Parameters">Parameters</h3>
+<dl>
+  <dt>index</dt>
+  <dd>The index of the rule to delete.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>undefined</p>
+
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>A {{domxref("DOMException")}} IndexSizeError</dt>
+  <dd>Thrown if <var>index</var> is greater than or equal to the number of child CSS rules.</dd>
+
+  <dt>A {{domxref("DOMException")}} InvalidStateError</dt>
+  <dd>Thrown if the rule being removed is an <code>@namespace</code> at-rule, and the list of child CSS rules contains anything other than <code>@import</code> at-rules and <code>@namespace</code> at-rules.</dd>
+
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+myRules[0].deleteRule(2); /* deletes the rule at index 2 */
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+    <thead>
+     <tr>
+      <th scope="col">Specification</th>
+      <th scope="col">Status</th>
+      <th scope="col">Comment</th>
+     </tr>
+    </thead>
+    <tbody>
+     <tr>
+      <td>{{ SpecName('CSSOM', '#dom-cssgroupingrule-deleterule', 'deleteRule') }}</td>
+      <td>{{ Spec2('CSSOM') }}</td>
+      <td>Initial definition.</td>
+     </tr>
+    </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSGroupingRule")}}</p>

--- a/files/en-us/web/api/cssgroupingrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/index.html
@@ -9,12 +9,12 @@ tags:
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p>An object implementing the <strong><code>CSSGroupingRule</code></strong> interface represents any CSS at-rule that contains other rules nested within it.</p>
+<p>The <strong><code>CSSGroupingRule</code></strong> interface of the {{domxref("CSS Object Model")}} represents any CSS {{CSSXref("at-rule")}} that contains other rules nested within it.</p>
 
-<p>Objects deriving from it :</p>
+<p>Objects deriving from it:</p>
 
 <ul>
- <li>{{domxref("CSSConditionRule")}} and its children: {{domxref("CSSMediaRule")}}, {{domxref("CSSSupportsRule")}}, and {{domxref("CSSDocumentRule")}}.</li>
+ <li>{{domxref("CSSConditionRule")}} and its children: {{domxref("CSSMediaRule")}} and {{domxref("CSSSupportsRule")}}.</li>
  <li>{{domxref("CSSPageRule")}}</li>
 </ul>
 
@@ -38,9 +38,9 @@ tags:
  <dd>Returns a {{domxref("CSSRuleList")}} of the CSS rules in the media rule.</dd>
 </dl>
 
-<h2 id="Methods_common_to_all_CSSGroupingRule_instances">Methods common to all CSSGroupingRule instances</h2>
+<h2 id="Methods">Methods</h2>
 
-<p>The <code>CSSGroupingRule</code> derives from {{domxref("CSSRule")}} and inherits all methods of this class. It has two specific methods:</p>
+<p><em>Inherits methods from its ancestor {{domxref("CSSRule")}}.</em></p>
 
 <dl>
  <dt id="deleteRule">{{domxref("CSSGroupingRule.deleteRule")}}</dt>

--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.html
@@ -1,0 +1,77 @@
+---
+title: CSSGroupingRule.insertRule()
+slug: Web/API/CSSGroupingRule/insertRule
+tags:
+  - API
+  - CSSOM
+  - CSSGroupingRule
+  - Method
+  - Reference
+---
+<p>{{ APIRef("CSSOM") }}</p>
+
+<p class="summary">The <strong><code>insertRule()</code></strong> method of the {{domxref("CSSGroupingRule")}} interface adds a new CSS rule to a list of CSS rules.</p>
+
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>index</var> = <var>cssGroupingRule</var>.insertRule(<var>rule</var>, <var>index</var>);</pre>
+
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt>rule</dt>
+  <dd>A {{domxref("CSSOMString")}}</dd>
+  <dt>index{{optional_inline}}</dt>
+  <dd>An optional index at which to insert the rule; defaults to 0.</dd>
+
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The index of the new rule.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+ <dt>A {{domxref("DOMException")}} IndexSizeError</dt>
+ <dd>Thrown if <var>index</var> is greater than the number of child CSS rules.</dd>
+  <dt>A {{domxref("DOMException")}} HierarchyRequestError</dt>
+  <dd>Thrown if, due to constraints specified by CSS, the new rule cannot be inserted into the list at the (zero-index) index position given.</dd>
+
+  <dt>A {{domxref("DOMException")}} InvalidStateError</dt>
+  <dd>Thrown if the new rule is an <code>@namespace</code> at-rule, and the list of child CSS rules contains anything other than <code>@import</code> at-rules and <code>@namespace</code> at-rules.</dd>
+
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+myRules[0].insertRule('html {background-color: blue;}',0); /* inserts a rule for the html element at position 0 */
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+    <thead>
+     <tr>
+      <th scope="col">Specification</th>
+      <th scope="col">Status</th>
+      <th scope="col">Comment</th>
+     </tr>
+    </thead>
+    <tbody>
+     <tr>
+      <td>{{ SpecName('CSSOM', '#dom-cssgroupingrule-insertrule', 'insertRule') }}</td>
+      <td>{{ Spec2('CSSOM') }}</td>
+      <td>Initial definition.</td>
+     </tr>
+    </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSGroupingRule")}}</p>


### PR DESCRIPTION
I am working on #344 in which I discovered that many of the CSSRule interfaces only had their main interface page. So there will be a few linked PRs as I work through them.

This one adds the missing pages to https://developer.mozilla.org/en-US/docs/Web/API/CSSGroupingRule and fixes up some stuff on the interface page.