### PR TITLE
fix: Redirected mozvr.com links

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.html
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.html
@@ -284,7 +284,7 @@ render();
 
 <ul>
  <li><a href="http://aframe.io/">A-Frame website</a></li>
- <li><a href="http://mozvr.com/">MozVR website</a></li>
+ <li><a href="https://mixedreality.mozilla.org/">Mozilla Mixed Reality website</a></li>
  <li><a href="https://aframe.io/blog/2015/12/16/introducing-aframe/">Introducing A-Frame 0.1.0 article</a></li>
  <li><a href="https://aframevr.tumblr.com/">Made with A-Frame Tumblr</a></li>
  <li><a href="https://github.com/ngokevin/aframe-physics-components">A-Frame physics plugin</a></li>

--- a/files/en-us/games/techniques/3d_on_the_web/webvr/index.html
+++ b/files/en-us/games/techniques/3d_on_the_web/webvr/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>Currently browser support for the WebVR API is still experimental — it works in <a href="https://nightly.mozilla.org/">nightly builds of Firefox</a> and <a href="https://drive.google.com/folderview?id=0BzudLt22BqGRbW9WTHMtOWMzNjQ&amp;usp=sharing#list">experimental builds of Chrome</a> (Mozilla and Google teamed up to work on the implementation together), but sooner rather than later we'll see it in regular builds.</p>
 
-<p>The <a href="https://mozvr.github.io/webvr-spec/webvr.html">WebVR spec</a> is in Editor's Draft status which means it is still subject to change. The development is led by <a href="https://twitter.com/vvuk">Vladimir Vukicevic</a> from Mozilla and <a href="https://twitter.com/tojiro">Brandon Jones</a> from Google. For more info be sure to visit the <a href="http://mozvr.com/">MozVR.com</a> and <a href="http://webvr.info/">WebVR.info</a> websites.</p>
+<p>The <a href="https://mozvr.github.io/webvr-spec/webvr.html">WebVR spec</a> is in Editor's Draft status which means it is still subject to change. The development is led by <a href="https://twitter.com/vvuk">Vladimir Vukicevic</a> from Mozilla and <a href="https://twitter.com/tojiro">Brandon Jones</a> from Google. For more info be sure to visit the <a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> and <a href="http://webvr.info/">WebVR.info</a> websites.</p>
 
 <h3 id="Using_the_WebVR_API">Using the WebVR API</h3>
 

--- a/files/en-us/games/techniques/control_mechanisms/other/index.html
+++ b/files/en-us/games/techniques/control_mechanisms/other/index.html
@@ -65,7 +65,7 @@ if(this.cursors.right.isDown) {
 
 <p>Have you ever thought about controlling a game only with your hands? It's possible with <a href="https://www.leapmotion.com/">Leap Motion</a>, an immersive controller for games and apps.</p>
 
-<p>Leapmotion is becoming more and more popular due to very good integration with VR headsets — demoing <a href="https://mozvr.com/webvr-demos/demos/rainbowmembrane/">Rainbow Membrane</a> on an Oculus Rift with Leap Motion attached to it was voted one of the best WebVR experiences by JavaScript developers visiting demo booths at conferences around the world.</p>
+<p>Leapmotion is becoming more and more popular due to very good integration with VR headsets — demoing <a href="http://mozilla.github.io/rainbow/">Rainbow Membrane</a> on an Oculus Rift with Leap Motion attached to it was voted one of the best WebVR experiences by JavaScript developers visiting demo booths at conferences around the world.</p>
 
 <p>As well as being great for virtual interfaces, it can also be used for a casual 2D gaming experiences. It would be very difficult to do everything with only your hands, but it's totally doable for the simple Captain Roger's gameplay — steering the ship and shooting the bullets.</p>
 

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -61,5 +61,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.html
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.html
@@ -59,5 +59,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/hmdvrdevice/index.html
+++ b/files/en-us/web/api/hmdvrdevice/index.html
@@ -70,5 +70,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.html
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.html
@@ -66,5 +66,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/navigator/activevrdisplays/index.html
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.html
@@ -62,5 +62,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/navigator/getvrdisplays/index.html
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.html
@@ -63,5 +63,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
@@ -74,5 +74,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
@@ -72,5 +72,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/positionsensorvrdevice/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/index.html
@@ -84,5 +84,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
@@ -49,5 +49,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
@@ -121,5 +121,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/capabilities/index.html
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/depthfar/index.html
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.html
@@ -64,5 +64,5 @@ navigator.getVRDisplays().then(function(displays) {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/depthnear/index.html
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.html
@@ -64,5 +64,5 @@ navigator<span class="punctuation token">.</span><span class="function token">ge
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/displayid/index.html
+++ b/files/en-us/web/api/vrdisplay/displayid/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/displayname/index.html
+++ b/files/en-us/web/api/vrdisplay/displayname/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.html
@@ -105,5 +105,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
@@ -61,5 +61,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/getframedata/index.html
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.html
@@ -125,5 +125,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
+++ b/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
@@ -42,5 +42,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/getlayers/index.html
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.html
@@ -58,5 +58,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/getpose/index.html
+++ b/files/en-us/web/api/vrdisplay/getpose/index.html
@@ -81,5 +81,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
+++ b/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
@@ -59,5 +59,5 @@ function reportDevices(devices) {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -122,5 +122,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -72,5 +72,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -73,5 +73,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
@@ -127,5 +127,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.html
@@ -117,5 +117,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/resetpose/index.html
+++ b/files/en-us/web/api/vrdisplay/resetpose/index.html
@@ -69,5 +69,5 @@ btn.addEventListener('click', function() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.html
@@ -54,5 +54,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplay/submitframe/index.html
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.html
@@ -121,5 +121,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
@@ -57,5 +57,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
@@ -54,5 +54,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -78,5 +78,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplayevent/display/index.html
+++ b/files/en-us/web/api/vrdisplayevent/display/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/index.html
@@ -65,5 +65,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplayevent/reason/index.html
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.html
@@ -60,5 +60,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -71,5 +71,5 @@ tags:
 
 <ul>
 	<li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
-	<li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+	<li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.html
@@ -54,5 +54,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/index.html
+++ b/files/en-us/web/api/vreyeparameters/index.html
@@ -84,5 +84,5 @@ tags:
 
 <ul>
 	<li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
-	<li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+	<li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
@@ -40,5 +40,5 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
  <li>{{domxref("VRFieldOfView")}}</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
@@ -40,5 +40,5 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
  <li>{{domxref("VRFieldOfView")}}</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -59,5 +59,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
@@ -56,5 +56,5 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
  <li>{{domxref("VRFieldOfView")}}</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/renderrect/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderrect/index.html
@@ -40,5 +40,5 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
  <li>{{domxref("VRFieldOfView")}}</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/index.html
@@ -102,5 +102,5 @@ function reportFieldOfView() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
@@ -82,5 +82,5 @@ var myFOV = new VRFieldOfView(init);</pre>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -68,5 +68,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -59,5 +59,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -59,5 +59,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/pose/index.html
+++ b/files/en-us/web/api/vrframedata/pose/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -59,5 +59,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -59,5 +59,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/timestamp/index.html
+++ b/files/en-us/web/api/vrframedata/timestamp/index.html
@@ -87,5 +87,5 @@ navigator<span class="punctuation token">.</span><span class="function token">ge
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -52,5 +52,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -94,5 +94,5 @@ if(navigator.getVRDisplays) {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.html
@@ -63,5 +63,5 @@ myVRLayerInit.leftBounds = [0.0, 0.0, 0.5, 1.0];</pre>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.html
@@ -63,5 +63,5 @@ myVRLayerInit.rightBounds = <code>[0.5, 0.0, 0.5, 1.0]</code>;</pre>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrlayerinit/source/index.html
+++ b/files/en-us/web/api/vrlayerinit/source/index.html
@@ -54,5 +54,5 @@ myVRLayerInit.source = myCanvas;</pre>
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -78,5 +78,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -78,5 +78,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/hasorientation/index.html
+++ b/files/en-us/web/api/vrpose/hasorientation/index.html
@@ -39,5 +39,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/hasposition/index.html
+++ b/files/en-us/web/api/vrpose/hasposition/index.html
@@ -39,5 +39,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/index.html
+++ b/files/en-us/web/api/vrpose/index.html
@@ -70,5 +70,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -78,5 +78,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -78,5 +78,5 @@ function drawVRScene() {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -70,5 +70,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -73,5 +73,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrpose/timestamp/index.html
+++ b/files/en-us/web/api/vrpose/timestamp/index.html
@@ -45,5 +45,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a>.</li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrstageparameters/index.html
+++ b/files/en-us/web/api/vrstageparameters/index.html
@@ -73,5 +73,5 @@ navigator.getVRDisplays().then(function(displays) {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrstageparameters/sizex/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/vrstageparameters/sizey/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/webvr_api/concepts/index.html
+++ b/files/en-us/web/api/webvr_api/concepts/index.html
@@ -200,7 +200,7 @@ tags:
 
 <p>Although our field of view is much larger (approximately 180º), we need to be aware that only in a small portion of that field can you perceive symbols (the center 60º) or read text (the center 10º). If you do not have an eye tracking sensor we assume that the center of the screen is where the user is focusing their eyes.</p>
 
-<p>This limitation is important to consider when deciding where place visuals on the app canvas — too far towards the edge of the cone of focus can lead to eye strain much more quickly. There is a very interesting post about this (amongst other things) at MozVR.com — see <a href="http://mozvr.com/posts/quick-vr-prototypes/">Quick VR Mockups with Illustrator</a>.</p>
+<p>This limitation is important to consider when deciding where place visuals on the app canvas — too far towards the edge of the cone of focus can lead to eye strain much more quickly. There is a very interesting post about this (amongst other things) at https://mixedreality.mozilla.org/ — see <a href="https://blog.mozvr.com/quick-vr-prototypes/">Quick VR Mockups with Illustrator</a>.</p>
 
 <h3 id="3D_Positional_Audio">3D Positional Audio</h3>
 

--- a/files/en-us/web/api/window/onvrdisplayactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplayactivate/index.html
@@ -57,5 +57,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplayblur/index.html
+++ b/files/en-us/web/api/window/onvrdisplayblur/index.html
@@ -57,5 +57,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplayconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplayconnect/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
@@ -54,5 +54,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
@@ -53,5 +53,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplayfocus/index.html
+++ b/files/en-us/web/api/window/onvrdisplayfocus/index.html
@@ -55,5 +55,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
@@ -51,5 +51,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
@@ -51,5 +51,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
@@ -61,5 +61,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplayactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayactivate_event/index.html
@@ -76,5 +76,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplayblur_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayblur_event/index.html
@@ -77,5 +77,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplayconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayconnect_event/index.html
@@ -76,5 +76,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
@@ -78,5 +78,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
@@ -76,5 +76,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplayfocus_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayfocus_event/index.html
@@ -76,5 +76,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
@@ -74,5 +74,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
@@ -74,5 +74,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
@@ -84,5 +84,5 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Web/API/WebVR_API">WebVR API homepage</a></li>
- <li><a href="http://mozvr.com/">MozVr.com</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
+ <li><a href="https://mixedreality.mozilla.org/">https://mixedreality.mozilla.org/</a> — demos, downloads, and other resources from the Mozilla VR team.</li>
 </ul>

--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -73,7 +73,7 @@ tags:
 
 <ul>
  <li>The Polar Sea (<a href="https://github.com/MozVR/polarsea">source code</a>)</li>
- <li><a href="https://mozvr.com/sechelt/">Sechelt fly-through</a> (<a href="https://github.com/mozvr/sechelt">source code</a>)</li>
+ <li><a href="https://mixedreality.mozilla.org/sechelt/">Sechelt fly-through</a> (<a href="https://github.com/mozvr/sechelt">source code</a>)</li>
 </ul>
 
 <h2 id="CSS">CSS</h2>


### PR DESCRIPTION
- Domain is redirected
- Blog subdomain remains but has different pattern
- Demo links have changed