### PR TITLE
Fix description of Date object

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.html
@@ -39,8 +39,8 @@ tags:
 
 <dl>
  <dt>{{jsxref("Date/Date", "Date()")}}</dt>
-  <dd>When called as a function, returns a string representation of the current date and time as for <code>new Date().toString()</code>
-<dt>{{jsxref("Date/Date", "new Date()")}}</dt>
+ <dd>When called as a function, returns a string representation of the current date and time, exactly as <code>new Date().toString()</code> does.</dd>
+ <dt>{{jsxref("Date/Date", "new Date()")}}</dt>
  <dd>When called as a constructor, returns a new <code>Date</code> object.</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.html
@@ -39,7 +39,9 @@ tags:
 
 <dl>
  <dt>{{jsxref("Date/Date", "Date()")}}</dt>
- <dd>Creates a new <code>Date</code> object.</dd>
+  <dd>When called as a function, returns a string representation of the current date and time as for <code>new Date().toString()</code>
+<dt>{{jsxref("Date/Date", "new Date()")}}</dt>
+ <dd>When called as a constructor, returns a new <code>Date</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>


### PR DESCRIPTION
Clarify difference between calling Date as a function and as a constructor.

In the original, the code `Date()` was explained as creating a new Date instance when that literal code does not do that, it returns a string. I think it is very important to distinguish at the very beginning the difference between calling the function as a function and as a constructor. 

The note regarding calling Date as a function is buried further down the page as a note, when it should be clearly explained as a feature.