### PR TITLE
selector namespacing

### DIFF
--- a/files/en-us/web/css/type_selectors/index.html
+++ b/files/en-us/web/css/type_selectors/index.html
@@ -18,7 +18,7 @@ a {
   color: red;
 }</pre>
 
-<p>Type selectors can be namespaced when using {{CSSXref("@namespace")}}, this is useful when dealing with documents containing multiple namespaces—such as HTML5 with inline SVG or MathML, or XML that mixes multiple vocabularies.</p>
+<p>Type selectors can be namespaced when using {{CSSXref("@namespace")}}. This is useful when dealing with documents containing multiple namespaces such as HTML5 with inline SVG or MathML, or XML that mixes multiple vocabularies.</p>
 
 <ul>
   <li><code>ns|h1</code> - matches <code>&lt;h1&gt;</code> elements in namespace <em>ns</em></li>

--- a/files/en-us/web/css/type_selectors/index.html
+++ b/files/en-us/web/css/type_selectors/index.html
@@ -18,6 +18,14 @@ a {
   color: red;
 }</pre>
 
+<p>Type selectors can be namespaced when using {{CSSXref("@namespace")}}, this is useful when dealing with documents containing multiple namespaces—such as HTML5 with inline SVG or MathML, or XML that mixes multiple vocabularies.</p>
+
+<ul>
+  <li><code>ns|h1</code> - matches <code>&lt;h1&gt;</code> elements in namespace <em>ns</em></li>
+  <li><code>*|h1</code> - matches all <code>&lt;h1&gt;</code> elements</li>
+  <li><code>|h1</code> - matches all <code>&lt;h1&gt;</code> elements without any declared namespace</li>
+ </ul>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox notranslate">element { <em>style properties</em> }
@@ -42,6 +50,14 @@ a {
 <h3 id="Result">Result</h3>
 
 <p>{{EmbedLiveSample('Examples', '100%', 150)}}</p>
+
+<h3 id="namespacing">Namespaces</h3>
+
+<p>In this example the selector will only match <code>&lt;h1&gt;</code> elements in the example namespace.</p>
+
+<pre class="brush: css notranslate">@namespace example url(http://www.example.com);
+example|h1 { color: blue } 
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/universal_selectors/index.html
+++ b/files/en-us/web/css/universal_selectors/index.html
@@ -16,13 +16,13 @@ tags:
   color: green;
 }</pre>
 
-<p>Beginning with CSS3, the asterisk may be used in combination with {{cssxref("CSS_Namespaces", "namespaces")}}:</p>
+<p>Universal selectors can be namespaced when using {{CSSXref("@namespace")}}, this is useful when dealing with documents containing multiple namespaces—such as HTML5 with inline SVG or MathML, or XML that mixes multiple vocabularies.</p>
 
 <ul>
- <li><code>ns|*</code> - matches all elements in namespace <em>ns</em></li>
- <li><code>*|*</code> - matches all elements</li>
- <li><code>|*</code> - matches all elements without any declared namespace</li>
-</ul>
+  <li><code>ns|*</code> - matches all elements in namespace <em>ns</em></li>
+  <li><code>*|*</code> - matches all elements</li>
+  <li><code>|*</code> - matches all elements without any declared namespace</li>
+ </ul>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -68,6 +68,14 @@ tags:
 <h3 id="Result">Result</h3>
 
 <p>{{EmbedLiveSample('Examples')}}</p>
+
+<h3 id="namespacing">Namespaces</h3>
+
+<p>In this example the selector will only match elements in the example namespace.</p>
+
+<pre class="brush: css notranslate">@namespace example url(http://www.example.com);
+example|* { color: blue } 
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/universal_selectors/index.html
+++ b/files/en-us/web/css/universal_selectors/index.html
@@ -16,7 +16,7 @@ tags:
   color: green;
 }</pre>
 
-<p>Universal selectors can be namespaced when using {{CSSXref("@namespace")}}, this is useful when dealing with documents containing multiple namespaces—such as HTML5 with inline SVG or MathML, or XML that mixes multiple vocabularies.</p>
+<p>Universal selectors can be namespaced when using {{CSSXref("@namespace")}}. This is useful when dealing with documents containing multiple namespaces such as HTML5 with inline SVG or MathML, or XML that mixes multiple vocabularies.</p>
 
 <ul>
   <li><code>ns|*</code> - matches all elements in namespace <em>ns</em></li>


### PR DESCRIPTION
Fixes: https://github.com/mdn/sprints/issues/835

Adds namespacing information to selectors pages.