### PR TITLE
correct for...in "see also" item

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for...in/index.html
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.html
@@ -137,7 +137,7 @@ for (var i = 0 in obj) {
  <li>{{jsxref("Statements/for...of", "for...of")}} – a similar statement that iterates over the property <em>values</em></li>
  <li>{{jsxref("Statements/for_each...in", "for each...in")}} – a similar but deprecated statement that iterates over the values of an object's properties, rather than the property names themselves</li>
  <li>{{jsxref("Statements/for", "for")}}</li>
- <li><a href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Generator expressions</a> (uses the <code>for...in</code> syntax)</li>
+ <li><a href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterators and Generator functions</a> (usable with <code>for...of</code> syntax)</li>
  <li><a href="/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties">Enumerability and ownership of properties</a></li>
  <li>{{jsxref("Object.getOwnPropertyNames()")}}</li>
  <li>{{jsxref("Object.prototype.hasOwnProperty()")}}</li>


### PR DESCRIPTION
Original content didn't make much sense, generator expressions don't exist in JS as far as I know and iterators and generators can be used with `for...of` and do not necessarily use `for...in`.