### PR TITLE
Update HTTP/Cookies Security section to properly reflect SameSite attribute behaviour

### DIFF
--- a/files/en-us/web/http/cookies/index.html
+++ b/files/en-us/web/http/cookies/index.html
@@ -193,7 +193,7 @@ console.log(document.cookie);
 
 <ul>
  <li>Use the <code>HttpOnly</code> attribute to prevent access to cookie values via JavaScript.</li>
- <li>Cookies that are used for sensitive information (such as indicating authentication) should have a short lifetime, with the <code>SameSite</code> attribute set to <code>Strict</code> or <code>Lax</code>. (See <a href="#">SameSite cookies</a>, above.) In <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#Browser_compatibility">browsers that support SameSite</a>, this has the effect of ensuring that the authentication cookie is not sent with cross-origin requests, so such a request is effectively unauthenticated to the application server.</li>
+ <li>Cookies that are used for sensitive information (such as indicating authentication) should have a short lifetime, with the <code>SameSite</code> attribute set to <code>Strict</code> or <code>Lax</code>. (See <a href="#">SameSite cookies</a>, above.) In <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#Browser_compatibility">browsers that support SameSite</a>, this has the effect of ensuring that the authentication cookie is not sent with cross-site requests, so such a request is effectively unauthenticated to the application server.</li>
 </ul>
 
 <h2 id="Tracking_and_privacy">Tracking and privacy</h2>


### PR DESCRIPTION
Why: SameSite attribute does not restrict usage with cross-origin requests, but rather with cross-site requests. F.e. a cookie with SameSite=Strict attribute set for a.something.com will still be sent with a request originated from b.something.com, as it is a same-site but cross-origin request.