### PR TITLE
Update statements about PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable() implementation status

### DIFF
--- a/files/en-us/web/api/publickeycredential/index.html
+++ b/files/en-us/web/api/publickeycredential/index.html
@@ -37,7 +37,7 @@ tags:
  <dt>{{domxref("PublicKeyCredential.getClientExtensionResults()")}}{{securecontext_inline}}</dt>
  <dd>If any extensions were requested, this method will return the results of processing those extensions.</dd>
  <dt>{{domxref("PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()")}}{{securecontext_inline}}</dt>
- <dd>A static method returning a {{jsxref("Promise")}} which resolves to <code>true</code> if an authenticator bound to the platform is capable of <em>verifying</em> the user. With the current state of implementation, this method only resolves to <code>true</code> when <a href="https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/windows-integration/web-authentication">Windows Hello</a> is available on the system.</dd>
+ <dd>A static method returning a {{jsxref("Promise")}} which resolves to <code>true</code> if an authenticator bound to the platform is capable of <em>verifying</em> the user.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.html
+++ b/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.html
@@ -15,8 +15,6 @@ tags:
 
 <p>A user-verifying platform authenticator is a kind of multi-factor authenticator that is part of the client device (it is generally not removable) and that involves an action from the user in order to identify them.</p>
 
-<p>At the time of this writing, this method's result only resolves to <code>true</code> on Windows when <a href="https://support.microsoft.com/help/17215/windows-10-what-is-hello">Windows Hello</a> capabilities are available (on recent versions of this OS).</p>
-
 <div class="note">
 <p><strong>Note:</strong> This method may only be used in top-level contexts and will not be available in an {{HTMLElement("iframe")}} for example.</p>
 </div>
@@ -31,7 +29,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Promise")}} which resolves to a {{jsxref("Boolean")}} indicating whether or a not a user-verifying platform authenticator is available. As of today (March 2019), this is basically indicating if <a href="https://support.microsoft.com/help/17215/windows-10-what-is-hello">Windows Hello</a> may be used with the <a href="/en-US/docs/Web/API/Web_Authentication_API">Web Authentication API</a> and that the user has accepted its use.</p>
+<p>A {{jsxref("Promise")}} which resolves to a {{jsxref("Boolean")}} indicating whether or a not a user-verifying platform authenticator is available.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> This is a static method which is directly called on the {{domxref("PublicKeyCredential")}} interface and not on an instance.</p>


### PR DESCRIPTION
From https://developer.mozilla.org/docs/Web/API/PublicKeyCredential and https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable this change removes the following statements:

> With the current state of implementation, this method only resolves to true when Windows Hello is available on the system.
>
> As of today (March 2019), this is basically indicating if Windows Hello may be used with the Web Authentication API and that the user has accepted its use.
>
> At the time of this writing, this method's result only resolves to true on Windows when Windows Hello capabilities are available (on recent versions of this OS).

The state of implementations has changed since the time when those statements were first added, because testing indicates it resolves to true on Android and iOS (and reportedly also on macOS).

Fixes https://github.com/mdn/content/issues/614