### PR TITLE
Warn about XHR upload listener requirements

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/upload/index.html
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.html
@@ -21,9 +21,9 @@ tags:
 
 <p><span class="seoSummary">The {{domxref("XMLHttpRequest")}} <code>upload</code> property returns an {{domxref("XMLHttpRequestUpload")}} object that can be observed to monitor an upload's progress.</span> It is an opaque object, but because it's also an {{domxref("XMLHttpRequestEventTarget")}}, event listeners can be attached to track its process.</p>
 
-<div class="note"><strong>Note:</strong> Attaching event listeners to this object prevents the request from being a "simple request" and will cause a preflight request to be issued if cross-origin; see <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>. Because of this, event listeners need to be registered before calling {{domxref("XMLHttpRequest.send", "send()")}} or upload events won't be dispatched.</div>
+<div class="note notecard"><strong>Note:</strong> Attaching event listeners to this object prevents the request from being a "simple request" and will cause a preflight request to be issued if cross-origin; see <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>. Because of this, event listeners need to be registered before calling {{domxref("XMLHttpRequest.send", "send()")}} or upload events won't be dispatched.</div>
 
-<div class="note"><strong>Note:</strong> The spec also seems to indicate that event listeners should be attached after {{domxref("XMLHttpRequest.open", "open()")}}. However browsers are buggy on this matter, and often need the listeners to be registered <em>before</em> {{domxref("XMLHttpRequest.open", "open()")}} to work.</div>
+<div class="note notecard"><strong>Note:</strong> The spec also seems to indicate that event listeners should be attached after {{domxref("XMLHttpRequest.open", "open()")}}. However, browsers are buggy on this matter, and often need the listeners to be registered <em>before</em> {{domxref("XMLHttpRequest.open", "open()")}} to work.</div>
 
 <p>The following events can be triggered on an upload object and used to monitor the upload:</p>
 

--- a/files/en-us/web/api/xmlhttprequest/upload/index.html
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.html
@@ -21,6 +21,10 @@ tags:
 
 <p><span class="seoSummary">The {{domxref("XMLHttpRequest")}} <code>upload</code> property returns an {{domxref("XMLHttpRequestUpload")}} object that can be observed to monitor an upload's progress.</span> It is an opaque object, but because it's also an {{domxref("XMLHttpRequestEventTarget")}}, event listeners can be attached to track its process.</p>
 
+<div class="note"><strong>Note:</strong> Attaching event listeners to this object prevents the request from being a "simple request" and will cause a preflight request to be issued if cross-origin; see <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>. Because of this, event listeners need to be registered before calling {{domxref("XMLHttpRequest.send", "send()")}} or upload events won't be dispatched.</div>
+
+<div class="note"><strong>Note:</strong> The spec also seems to indicate that event listeners should be attached after {{domxref("XMLHttpRequest.open", "open()")}}. However browsers are buggy on this matter, and often need the listeners to be registered <em>before</em> {{domxref("XMLHttpRequest.open", "open()")}} to work.</div>
+
 <p>The following events can be triggered on an upload object and used to monitor the upload:</p>
 
 <table class="standard-table">


### PR DESCRIPTION
The XHR spec seems to indicate that upload events should be registered between the `open()` call and the `send()` call. It also mentions that registering upload events causes the request to have a preflight. I think these two things are important to mention.

But browsers are buggy and on Chromium, events won't fire unless I register them *before* `open()`. I tried to find an open issue but was unable to. [This one](https://bugs.chromium.org/p/chromium/issues/detail?id=700891) is close but not it.

Mention this too, to hopefully save hours of frustration to someone else.