### PR TITLE
Fix default for statusText (HTTP/2 does not support status message)

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -368,7 +368,7 @@ try {
 
 <ul>
  <li>{{domxref("Response.status")}} — An integer (default value 200) containing the response status code.</li>
- <li>{{domxref("Response.statusText")}} — A string (default value "OK"), which corresponds to the HTTP status code message.</li>
+ <li>{{domxref("Response.statusText")}} — A string (default value ""), which corresponds to the HTTP status code message. Note that HTTP/2 <a href="https://fetch.spec.whatwg.org/#concept-response-status-message">does not support</a> status messages.</li>
  <li>{{domxref("Response.ok")}} — seen in use above, this is a shorthand for checking that status is in the range 200-299 inclusive. This returns a {{domxref("Boolean")}}.</li>
 </ul>
 

--- a/files/en-us/web/api/response/statustext/index.html
+++ b/files/en-us/web/api/response/statustext/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>A {{domxref("ByteString")}}.</p>
 
-<p>The default value is "".</p>
+<p>The default value is "". Note that HTTP/2 <a href="https://fetch.spec.whatwg.org/#concept-response-status-message">does not support</a> status messages.</p>
 
 <h2 id="Example">Example</h2>
 


### PR DESCRIPTION
See also, e.g.:

- https://bugzilla.mozilla.org/show_bug.cgi?id=1508996
- https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/67#APIs
- https://github.com/node-fetch/node-fetch/issues/578