### PR TITLE
Don’t set Notification.permission in examples

### DIFF
--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.html
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.html
@@ -72,11 +72,6 @@ tags:
 <pre class="brush: js notranslate">function askNotificationPermission() {
   // function to actually ask the permissions
   function handlePermission(permission) {
-    // Whatever the user answers, we make sure Chrome stores the information
-    if(!('permission' in Notification)) {
-      Notification.permission = permission;
-    }
-
     // set the button to shown or hidden, depending on what the user answers
     if(Notification.permission === 'denied' || Notification.permission === 'default') {
       notificationBtn.style.display = 'block';
@@ -189,16 +184,6 @@ document.addEventListener('visibilitychange', function() {
 <p>It's possible to handle multiple notifications this way:</p>
 
 <pre class="brush: js notranslate">window.addEventListener('load', function () {
-  // At first, let's check if we have permission for notification
-  // If not, let's ask for it
-  if (window.Notification &amp;&amp; Notification.permission !== "granted") {
-    Notification.requestPermission(function (status) {
-      if (Notification.permission !== status) {
-        Notification.permission = status;
-      }
-    });
-  }
-
   var button = document.getElementsByTagName('button')[0];
 
   button.addEventListener('click', function () {


### PR DESCRIPTION
This change removes some example code in the Web/API/Notifications_API/Using_the_Notifications_API article which incorrectly showed the read-only `Notification.permission` property being set.

Fixes https://github.com/mdn/content/issues/576
Fixes https://github.com/mdn/sprints/issues/1493