### PR TITLE
"on the client-side" -> "by the user" for checkbox `value` attribute

### DIFF
--- a/files/en-us/web/html/element/input/checkbox/index.html
+++ b/files/en-us/web/html/element/input/checkbox/index.html
@@ -50,7 +50,7 @@ tags:
 
 <h2 id="Value">Value</h2>
 
-<p>A {{domxref("DOMString")}} representing the value of the checkbox. This is never seen on the client-side, but on the server this is the <code>value</code> given to the data submitted with the checkbox's <code>name</code>. Take the following example:</p>
+<p>A {{domxref("DOMString")}} representing the value of the checkbox. This is never seen by the user, but on the server this is the <code>value</code> given to the data submitted with the checkbox's <code>name</code>. Take the following example:</p>
 
 <pre class="brush: html notranslate">&lt;form&gt;
   &lt;div&gt;

--- a/files/en-us/web/html/element/input/checkbox/index.html
+++ b/files/en-us/web/html/element/input/checkbox/index.html
@@ -50,7 +50,7 @@ tags:
 
 <h2 id="Value">Value</h2>
 
-<p>A {{domxref("DOMString")}} representing the value of the checkbox. This is never seen by the user, but on the server this is the <code>value</code> given to the data submitted with the checkbox's <code>name</code>. Take the following example:</p>
+<p>A {{domxref("DOMString")}} representing the value of the checkbox. This is not displayed on the client-side, but on the server this is the <code>value</code> given to the data submitted with the checkbox's <code>name</code>. Take the following example:</p>
 
 <pre class="brush: html notranslate">&lt;form&gt;
   &lt;div&gt;


### PR DESCRIPTION
AFAIK, the value of the `value` attribute can be seen by the client (i.e. by JS and CSS), but it isn't (normally) shown to the user.