### PR TITLE
Fix a typo in the video element docs

### DIFF
--- a/files/en-us/web/html/element/video/index.html
+++ b/files/en-us/web/html/element/video/index.html
@@ -58,7 +58,7 @@ tags:
  <p>Use the <a href="#disable_pip"><code>disablePictureInPicture</code></a> attribute if you want to disable the Picture-In-Picture mode (and the control).</p>
  </dd>
  <dt>{{htmlattrdef("crossorigin")}}</dt>
- <dd>This enumerated attribute indicates whether to use CORS to fetch the related image. <a href="/en-US/docs/Web/HTML/CORS_enabled_image">CORS-enabled resources</a> can be reused in the {{HTMLElement("canvas")}} element without being <em>tainted</em>. The allowed values are:
+ <dd>This enumerated attribute indicates whether to use CORS to fetch the related video. <a href="/en-US/docs/Web/HTML/CORS_enabled_image">CORS-enabled resources</a> can be reused in the {{HTMLElement("canvas")}} element without being <em>tainted</em>. The allowed values are:
  <dl>
   <dt><code>anonymous</code></dt>
   <dd>Sends a cross-origin request without a credential. In other words, it sends the <code>Origin:</code> HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the <code>Access-Control-Allow-Origin:</code> HTTP header), the image will be <em>tainted</em>, and its usage restricted.</dd>


### PR DESCRIPTION
This seemed like a copy/paste typo to me, assuming it's not supposed to refer to a poster image or something like that.