### PR TITLE
fix: markup of "iterator" keyword in JavaScript references

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/entries/index.html
@@ -23,7 +23,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A new <code>Iterator</code> object that contains an array of <code>[value, value]</code> for each element in the given <code>Set</code>, in insertion order.</p>
+<p>A new iterator object that contains an array of <code>[value, value]</code> for each element in the given <code>Set</code>, in insertion order.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -62,14 +62,14 @@ tags:
 
 <dl>
  <dt>{{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]()")}}</dt>
- <dd>Returns a new <code>Iterator</code> object that yields the <strong>values</strong> for each element in the <code>Set</code> object in insertion order.</dd>
+ <dd>Returns a new iterator object that yields the <strong>values</strong> for each element in the <code>Set</code> object in insertion order.</dd>
  <dt>{{jsxref("Set.prototype.keys()")}}</dt>
- <dd>Returns a new <code>Iterator</code> object that yields the values for each element in the <code>Set</code> object in insertion order. (For Sets, this is the same as the <strong><code>values()</code></strong> method.)</dd>
+ <dd>Returns a new iterator object that yields the values for each element in the <code>Set</code> object in insertion order. (For Sets, this is the same as the <strong><code>values()</code></strong> method.)</dd>
  <dt>{{jsxref("Set.prototype.values()")}}</dt>
- <dd>Returns a new <code>Iterator</code> object that yields the <strong>values</strong> for each element in the <code>Set</code> object in insertion order. (For Sets, this is the same as the <strong><code>keys()</code></strong> method.)</dd>
+ <dd>Returns a new iterator object that yields the <strong>values</strong> for each element in the <code>Set</code> object in insertion order. (For Sets, this is the same as the <strong><code>keys()</code></strong> method.)</dd>
  <dt>{{jsxref("Set.prototype.entries()")}}</dt>
  <dd>
- <p>Returns a new <code>Iterator</code> object that contains <strong>an array of <code>[<var>value</var>, <var>value</var>]</code></strong> for each element in the <code>Set</code> object, in insertion order.</p>
+ <p>Returns a new iterator object that contains <strong>an array of <code>[<var>value</var>, <var>value</var>]</code></strong> for each element in the <code>Set</code> object, in insertion order.</p>
 
  <p>This is similar to the {{jsxref("Map")}} object, so that each entry's <em>key</em> is the same as its <em>value</em> for a <code>Set</code>.</p>
  </dd>

--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -297,7 +297,7 @@ otherwise my code is unreadable."
  <dt>{{jsxref("String.prototype.valueOf()")}}</dt>
  <dd>Returns the primitive value of the specified object. Overrides the {{jsxref("Object.prototype.valueOf()")}} method.</dd>
  <dt>{{jsxref("String.prototype.@@iterator()")}}</dt>
- <dd>Returns a new <code>Iterator</code> object that iterates over the code points of a String value, returning each code point as a String value.</dd>
+ <dd>Returns a new iterator object that iterates over the code points of a String value, returning each code point as a String value.</dd>
 </dl>
 
 <h2 id="HTML_wrapper_methods">HTML wrapper methods</h2>


### PR DESCRIPTION
"Iterator" should be written without the <code> element because it is not a keyword which appears such as an object name,