### PR TITLE
Fix `orient` anchor link

### DIFF
--- a/files/en-us/web/html/element/input/range/index.html
+++ b/files/en-us/web/html/element/input/range/index.html
@@ -132,7 +132,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td><code>{{anch("orient")}}</code></td>
+   <td><code>{{anch("attr-orient")}}</code></td>
    <td>Sets the orientation of the range slider. <strong>Firefox only.</strong></td>
   </tr>
  </tbody>


### PR DESCRIPTION
`htmlattrdef(attr)` creates an id following `attr-${attr}`. 

Alternatives:
1. `anchAttrDef` helper
2. Add explicit `orient` id
3. This is supposed to link somewhere else?