### PR TITLE
Rename NDEFReading.onerror to onreadingerror

### DIFF
--- a/files/en-us/web/api/ndefreader/onreading/index.html
+++ b/files/en-us/web/api/ndefreader/onreading/index.html
@@ -34,5 +34,5 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{DOMxRef("NDEFReading.onerror")}}, property representing handler for <code>error</code> events.</li>
+ <li>{{DOMxRef("NDEFReading.onreadingerror")}}, property representing handler for <code>readingerror</code> events.</li>
 </ul>


### PR DESCRIPTION
This PR updates Web NFC API to reflect latest spec changes.
See https://github.com/w3c/web-nfc/blob/gh-pages/EXPLAINER.md#changes-done-after-origin-trial-ot and https://web.dev/nfc/

Disclaimer: I'm an editor of the spec.

