### PR TITLE
Fix: replace <nav> tags with <p>

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -12,7 +12,7 @@ tags:
   - onmessage
   - runtime
 ---
-<nav>{{AddonSidebar()}}</nav>
+<p>{{AddonSidebar()}}</p>
 
 <p>Use this event to listen for messages from another part of your extension.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
@@ -12,7 +12,7 @@ tags:
   - sendMessage
   - tabs
 ---
-<nav>{{AddonSidebar()}}</nav>
+<p>{{AddonSidebar()}}</p>
 
 <p>Sends a single message from the extension's background scripts (or other privileged scripts, such as popup scripts or options page scripts) to any <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts">content scripts</a> or extension pages/iframes that belong to the extension and are running in the specified tab.</p>
 

--- a/files/en-us/web/api/eventtarget/index.html
+++ b/files/en-us/web/api/eventtarget/index.html
@@ -8,7 +8,7 @@ tags:
   - EventTarget
   - Interface
 ---
-<nav>{{ApiRef("DOM Events")}}</nav>
+<p>{{ApiRef("DOM Events")}}</p>
 
 <p><span class="seoSummary"><strong><code>EventTarget</code></strong> is a DOM interface implemented by objects that can receive events and may have listeners for them.</span></p>
 


### PR DESCRIPTION
To simplify transition to Markdown, let's remove `<nav>` tag from content.

Tag `<nav>` is not well-represented in Markdown, so let's use `<p>` like on majority of other pages. (In all these cases the macros will be rendered into `<nav>`, so choice of tag does not make any difference.).