### PR TITLE
Make MDN/About cite contributors.txt, not $history

### DIFF
--- a/files/en-us/mdn/about/index.html
+++ b/files/en-us/mdn/about/index.html
@@ -47,7 +47,7 @@ tags:
   <p>Please attribute "Mozilla Contributors" and include a hyperlink (online) or URL (in print) to the specific wiki page for the content being sourced. For example, to provide attribution for this article, you can write:</p>
 
   <blockquote>
-  <p><a href="/en-US/docs/MDN/About">About MDN</a> by <a href="/en-US/docs/MDN/About$history">Mozilla Contributors</a> is licensed under <a href="https://creativecommons.org/licenses/by-sa/2.5/">CC-BY-SA 2.5</a>.</p>
+  <p><a href="/en-US/docs/MDN/About">About MDN</a> by <a href="/en-US/docs/MDN/About/contributors.txt">Mozilla Contributors</a> is licensed under <a href="https://creativecommons.org/licenses/by-sa/2.5/">CC-BY-SA 2.5</a>.</p>
   </blockquote>
 
   <p>Note that in the example, "Mozilla Contributors" links to the history of the cited page. See <a href="https://wiki.creativecommons.org/Marking/Users">Best practices for attribution</a> for further explanation.</p>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/694

---

Testing http://localhost:5000/en-US/docs/MDN/About/contributors.txt locally caused my Yari to crash, so I raised https://github.com/mdn/yari/pull/2287 with a fix.

But https://developer.mozilla.org/en-US/docs/MDN/About/contributors.txt already works in production, so I don’t think we need to block this mdn/content PR on that Yari PR being merged first.