### PR TITLE
The correct Stack Overflow tag is “html5-canvas”, not “canvas”

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/finale/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/finale/index.html
@@ -41,8 +41,8 @@ tags:
 <h2 id="Questions">Questions</h2>
 
 <dl>
- <dt><a href="http://stackoverflow.com/questions/tagged/canvas">Stack Overflow</a></dt>
- <dd>Questions tagged with "canvas".</dd>
+ <dt><a href="https://stackoverflow.com/questions/tagged/html5-canvas">Stack Overflow</a></dt>
+ <dd>Questions tagged with "html5-canvas".</dd>
  <dt><a href="/en-US/docs/MDN">Comments about this tutorial – the MDN documentation community</a></dt>
  <dd>If you have any comments about this tutorial or want to thank us, feel free to reach out to us!</dd>
 </dl>


### PR DESCRIPTION
The `canvas` tag is for general Canvas APIs across different languages and platforms. Even though HTML5 Canvas falls into that category, it has a more specific tag: `html5-canvas`, so it’s better to direct users there. Also, use `https` instead of `http`.