### PR TITLE
fix: hightlight -> highlight

### DIFF
--- a/files/en-us/mdn/editor/source_mode/index.html
+++ b/files/en-us/mdn/editor/source_mode/index.html
@@ -60,7 +60,7 @@ tags:
  <li><code>highlight[<em>lineNumStart</em>-<em>lineNumEnd</em>, ..., <em>lineNumN</em>]</code></li>
 </ul>
 
-<pre class="syntaxbox notranslate">"hightlight[" <a href="#highlight-line-number-list">&lt;line-number-list&gt;</a> "]"
+<pre class="syntaxbox notranslate">"highlight[" <a href="#highlight-line-number-list">&lt;line-number-list&gt;</a> "]"
 
 <strong>Where:</strong>
 <a id="highlight-line-number-list">&lt;line-number-list&gt;</a> = <a href="/en-US/docs/Web/CSS/Value_definition_syntax#Brackets">[</a> <a href="#highlight-line-number">&lt;line-number&gt;</a> <a href="/en-US/docs/Web/CSS/Value_definition_syntax#Single_bar">|</a> <a href="#highlight-line-range">&lt;line-range&gt;</a> <a href="/en-US/docs/Web/CSS/Value_definition_syntax#Brackets">]</a><a href="/en-US/docs/Web/CSS/Value_definition_syntax#Hash_mark">#</a>

--- a/files/en-us/web/css/_colon_indeterminate/index.html
+++ b/files/en-us/web/css/_colon_indeterminate/index.html
@@ -53,7 +53,7 @@ input:indeterminate {
 
 <h4 id="CSS">CSS</h4>
 
-<pre class="brush: css; hightlight[5] notranslate">input:indeterminate + label {
+<pre class="brush: css; highlight[5] notranslate">input:indeterminate + label {
   background: lime;
 }
 </pre>
@@ -78,7 +78,7 @@ for (var i = 0; i &lt; inputs.length; i++) {
 
 <h4 id="CSS_2">CSS</h4>
 
-<pre class="brush: css; hightlight[5] notranslate">progress {
+<pre class="brush: css; highlight[5] notranslate">progress {
   margin: 4px;
 }
 

--- a/files/en-us/web/css/shape-image-threshold/index.html
+++ b/files/en-us/web/css/shape-image-threshold/index.html
@@ -75,7 +75,7 @@ shape-image-threshold: unset;
 
 <h4 id="CSS">CSS</h4>
 
-<pre class="brush: css; hightlight[9] notranslate">#gradient-shape {
+<pre class="brush: css; highlight[9] notranslate">#gradient-shape {
   width: 150px;
   height: 150px;
   float: left;

--- a/files/en-us/web/svg/attribute/basefrequency/index.html
+++ b/files/en-us/web/svg/attribute/basefrequency/index.html
@@ -19,7 +19,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="noise1" x="0" y="0" width="100%" height="100%"&gt;
     &lt;feTurbulence baseFrequency="0.025" /&gt;
   &lt;/filter&gt;

--- a/files/en-us/web/svg/attribute/diffuseconstant/index.html
+++ b/files/en-us/web/svg/attribute/diffuseconstant/index.html
@@ -21,7 +21,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
     &lt;feDiffuseLighting in="SourceGraphic" diffuseConstant="1"&gt;
       &lt;fePointLight x="60" y="60" z="20" /&gt;

--- a/files/en-us/web/svg/attribute/flood-color/index.html
+++ b/files/en-us/web/svg/attribute/flood-color/index.html
@@ -21,7 +21,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="flood1"&gt;
     &lt;feFlood flood-color="skyblue" x="0" y="0" width="200" height="200"/&gt;
   &lt;/filter&gt;

--- a/files/en-us/web/svg/attribute/flood-opacity/index.html
+++ b/files/en-us/web/svg/attribute/flood-opacity/index.html
@@ -21,7 +21,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,6]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="flood1"&gt;
     &lt;feFlood flood-color="seagreen" flood-opacity="1" x="0" y="0" width="200" height="200"/&gt;
   &lt;/filter&gt;

--- a/files/en-us/web/svg/attribute/font-family/index.html
+++ b/files/en-us/web/svg/attribute/font-family/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-family="Arial, Helvetica, sans-serif"&gt;Sans serif&lt;/text&gt;
   &lt;text x="100" y="20" font-family="monospace"&gt;Monospace&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/font-size-adjust/index.html
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[9]">&lt;svg width="600" height="80" viewBox="0 0 500 80"
+<pre class="brush: html; highlight[9]">&lt;svg width="600" height="80" viewBox="0 0 500 80"
     xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-family="Times, serif" font-size="10px"&gt;
     This text uses the Times font (10px), which is hard to read in small sizes.

--- a/files/en-us/web/svg/attribute/font-size/index.html
+++ b/files/en-us/web/svg/attribute/font-size/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-size="smaller"&gt;smaller&lt;/text&gt;
   &lt;text x="100" y="20" font-size="2em"&gt;2em&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/font-style/index.html
+++ b/files/en-us/web/svg/attribute/font-style/index.html
@@ -27,7 +27,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3] notranslate">&lt;svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3] notranslate">&lt;svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-style="normal"&gt;Normal font style&lt;/text&gt;
   &lt;text x="150" y="20" font-style="italic"&gt;Italic font style&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/font-variant/index.html
+++ b/files/en-us/web/svg/attribute/font-variant/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-variant="normal"&gt;Normal text&lt;/text&gt;
   &lt;text x="100" y="20" font-variant="small-caps"&gt;Small-caps text&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/font-weight/index.html
+++ b/files/en-us/web/svg/attribute/font-weight/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" font-weight="normal"&gt;Normal text&lt;/text&gt;
   &lt;text x="100" y="20" font-weight="bold"&gt;Bold text&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/gradienttransform/index.html
+++ b/files/en-us/web/svg/attribute/gradienttransform/index.html
@@ -18,7 +18,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[10]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[10]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;radialGradient id="gradient1" gradientUnits="userSpaceOnUse"
       cx="100" cy="100" r="100" fx="100" fy="100"&gt;
     &lt;stop offset="0%" stop-color="darkblue" /&gt;

--- a/files/en-us/web/svg/attribute/href/index.html
+++ b/files/en-us/web/svg/attribute/href/index.html
@@ -22,7 +22,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2]">&lt;svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;a href="https://developer.mozilla.org/"&gt;&lt;text x="10" y="25"&gt;MDN Web Docs&lt;/text&gt;&lt;/a&gt;
 &lt;/svg&gt;</pre>
 

--- a/files/en-us/web/svg/attribute/kerning/index.html
+++ b/files/en-us/web/svg/attribute/kerning/index.html
@@ -22,7 +22,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,8]">&lt;svg viewBox="0 0 150 125" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 150 125" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text x="10" y="30" kerning="auto"&gt;auto&lt;/text&gt;
   &lt;text x="10" y="70" kerning="0"&gt;number&lt;/text&gt;
   &lt;text x="10" y="110" kerning="20px"&gt;length&lt;/text&gt;

--- a/files/en-us/web/svg/attribute/lengthadjust/index.html
+++ b/files/en-us/web/svg/attribute/lengthadjust/index.html
@@ -18,7 +18,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3-6]">&lt;svg width="300" height="150" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3-6]">&lt;svg width="300" height="150" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;g font-face="sans-serif"&gt;
     &lt;text x="0" y="20" textLength="300" lengthAdjust="spacing"&gt;
       Stretched using spacing only.

--- a/files/en-us/web/svg/attribute/letter-spacing/index.html
+++ b/files/en-us/web/svg/attribute/letter-spacing/index.html
@@ -24,7 +24,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 400 30" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" letter-spacing="2"&gt;Bigger letter-spacing&lt;/text&gt;
   &lt;text x="200" y="20" letter-spacing="-0.5"&gt;Smaller letter-spacing&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/lighting-color/index.html
+++ b/files/en-us/web/svg/attribute/lighting-color/index.html
@@ -19,7 +19,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
     &lt;feDiffuseLighting in="SourceGraphic" lighting-color="white"&gt;
       &lt;fePointLight x="60" y="60" z="20" /&gt;

--- a/files/en-us/web/svg/attribute/marker-end/index.html
+++ b/files/en-us/web/svg/attribute/marker-end/index.html
@@ -22,7 +22,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[12] notranslate">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[12] notranslate">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
     &lt;marker id="triangle" viewBox="0 0 10 10"
           refX="1" refY="5"

--- a/files/en-us/web/svg/attribute/marker-mid/index.html
+++ b/files/en-us/web/svg/attribute/marker-mid/index.html
@@ -22,7 +22,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[8] notranslate">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[8] notranslate">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
     &lt;marker id="circle" markerWidth="8" markerHeight="8" refX="4" refY="4"&gt;
         &lt;circle cx="4" cy="4" r="4" stroke="none" fill="#f00"/&gt;

--- a/files/en-us/web/svg/attribute/marker-start/index.html
+++ b/files/en-us/web/svg/attribute/marker-start/index.html
@@ -22,7 +22,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[12] notranslate">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[12] notranslate">&lt;svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
     &lt;marker id="triangle" viewBox="0 0 10 10"
           refX="1" refY="5"

--- a/files/en-us/web/svg/attribute/opacity/index.html
+++ b/files/en-us/web/svg/attribute/opacity/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
     &lt;linearGradient id="gradient" x1="0%" y1="0%" x2="0" y2="100%"&gt;
       &lt;stop offset="0%" style="stop-color:skyblue;" /&gt;

--- a/files/en-us/web/svg/attribute/surfacescale/index.html
+++ b/files/en-us/web/svg/attribute/surfacescale/index.html
@@ -20,7 +20,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
     &lt;feDiffuseLighting in="SourceGraphic" surfaceScale="1"&gt;
       &lt;fePointLight x="60" y="60" z="20" /&gt;

--- a/files/en-us/web/svg/attribute/text-decoration/index.html
+++ b/files/en-us/web/svg/attribute/text-decoration/index.html
@@ -24,7 +24,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" text-decoration="underline"&gt;Underlined text&lt;/text&gt;
   &lt;text x="0" y="40" text-decoration="line-through"&gt;Struck-through text&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/visibility/index.html
+++ b/files/en-us/web/svg/attribute/visibility/index.html
@@ -24,7 +24,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[5,6]">&lt;svg viewBox="0 0 220 120" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[5,6]">&lt;svg viewBox="0 0 220 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;rect x="10" y="10" width="200" height="100" stroke="black"
       stroke-width="5" fill="transparent" /&gt;
   &lt;g stroke="seagreen" stroke-width="5" fill="skyblue"&gt;

--- a/files/en-us/web/svg/attribute/word-spacing/index.html
+++ b/files/en-us/web/svg/attribute/word-spacing/index.html
@@ -24,7 +24,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2,3]">&lt;svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2,3]">&lt;svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;text y="20" word-spacing="2"&gt;Bigger spacing between words&lt;/text&gt;
   &lt;text x="0" y="40" word-spacing="-0.5"&gt;Smaller spacing between words&lt;/text&gt;
 &lt;/svg&gt;</pre>

--- a/files/en-us/web/svg/attribute/xlink_colon_href/index.html
+++ b/files/en-us/web/svg/attribute/xlink_colon_href/index.html
@@ -23,7 +23,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[2]">&lt;svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[2]">&lt;svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;a xlink:href="https://developer.mozilla.org/"&gt;&lt;text x="10" y="25"&gt;MDN Web Docs&lt;/text&gt;&lt;/a&gt;
 &lt;/svg&gt;</pre>
 

--- a/files/en-us/web/svg/attribute/z/index.html
+++ b/files/en-us/web/svg/attribute/z/index.html
@@ -19,7 +19,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
+<pre class="brush: html; highlight[3,8]">&lt;svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%"&gt;
     &lt;feDiffuseLighting in="SourceGraphic"&gt;
       &lt;fePointLight x="60" y="60" z="10" /&gt;

--- a/files/en-us/web/svg/attribute/zoomandpan/index.html
+++ b/files/en-us/web/svg/attribute/zoomandpan/index.html
@@ -23,7 +23,7 @@ tags:
 }</pre>
 </div>
 
-<pre class="brush: html; hightlight[1]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" zoomAndPan="disable"&gt;
+<pre class="brush: html; highlight[1]">&lt;svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" zoomAndPan="disable"&gt;
   &lt;filter id="diffuseLighting" x="0" y="0" width="100%" height="100%"&gt;
     &lt;feDiffuseLighting in="SourceGraphic" zoomAndPan="1"&gt;
       &lt;fePointLight x="60" y="60" z="20" /&gt;


### PR DESCRIPTION
Split this from other typos since it potentially affects rendering. Doing a search for `highlight[` return more results, so I'm pretty sure this was a bug