### PR TITLE
Fix up window.toolbar docs

### DIFF
--- a/files/en-us/web/api/window/toolbar/index.html
+++ b/files/en-us/web/api/window/toolbar/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{APIRef}}</div>
 
-<p>The <code><strong>Window.toolbar</strong></code> property returns the toolbar object, whose visibility can be toggled in the window.</p>
+<p>The <code><strong>Window.toolbar</strong></code> property returns the toolbar object, which can be used to check the browser toolbar visibility.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -20,33 +20,26 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>{{deprecated_inline()}} The following complete HTML example shows way that the visible property of the various "bar" objects is used, and also the change to the privileges necessary to write to the visible property of any of the bars on an existing window. Due to <a href="/en-US/docs/Bypassing_Security_Restrictions_and_Signing_Code" title="Bypassing_Security_Restrictions_and_Signing_Code">deprecation of enablePrivilege</a> this functionality can not be used in web pages. EnablePrivilege is disabled in Firefox 15 and will be removed in Firefox 17.</p>
+<p>The following complete HTML example demonstrates how the <code>visible</code> property of the <code>toolbar</code> object is used.</p>
 
-<pre class="brush:html">&lt;!DOCTYPE html&gt;
-&lt;html&gt;
+<pre class="brush:html">&lt;html&gt;
 &lt;head&gt;
-&lt;title&gt;Various DOM Tests&lt;/title&gt;
-&lt;script&gt;
-
-// changing bar states on the existing window
-netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserWrite");
-window.toolbar.visible=!window.toolbar.visible;
-
-&lt;/script&gt;
+  &lt;title&gt;Various DOM Tests&lt;/title&gt;
+  &lt;script&gt;
+    var visible = window.toolbar.visible;
+  &lt;/script&gt;
 &lt;/head&gt;
-
 &lt;body&gt;
   &lt;p&gt;Various DOM Tests&lt;/p&gt;
 &lt;/body&gt;
-&lt;/html&gt;</pre>
+&lt;/html&gt;
+</pre>
 
-<h2 id="Notes">Notes</h2>
+<div class="note notebox">
+  <p>Very old versions of Firefox also allowed the toolbar visibility to be <em>set</em>, but the mechanisms that supported this <a href="/en-US/docs/Archive/Misc_top_level/Bypassing_Security_Restrictions_and_Signing_Code" title="Archived:Bypassing_Security_Restrictions_and_Signing_Code">have been removed</a>.</p>
 
-<p>When you load the example page above, the browser displays the following dialog: <img alt="Image:Modify_any_open_window_dialog.png"></p>
+</div>
 
-<p>To toggle the visibility of these bars, you must either sign your scripts or enable the appropriate privileges, as in the example above. Also be aware that dynamically updating the visibilty of the various toolbars can change the size of the window rather dramatically, and may affect the layout of your page.</p>
-
-<p>See also: <a href="/en-US/docs/Window.locationbar">window.locationbar</a>, <a href="/en-US/docs/Window.menubar">window.menubar</a>, <a href="/en-US/docs/Window.personalbar">window.personalbar</a>, <a href="/en-US/docs/Window.scrollbars">window.scrollbars</a>, <a href="/en-US/docs/Window.statusbar">window.statusbar</a></p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/446

The [Window.toolbar](https://developer.mozilla.org/en-US/docs/Web/API/Window/toolbar) refers to features that were removed in FF17, has an example based on that which no longer works with a missing image, and a broken link to a page that indicates that the non-standard feature has been removed: [Bypassing_Security_Restrictions_and_Signing_Code](https://developer.mozilla.org/en-US/docs/Archive/Misc_top_level/Bypassing_Security_Restrictions_and_Signing_Code).

This change removes the example and makes it more or less match docs for [Window.menubar](https://developer.mozilla.org/en-US/docs/Web/API/Window/menubar). The old version where this feature are not very relevant so what I have done is add a note that links to the page that has the relevant information:

![image](https://user-images.githubusercontent.com/5368500/103256541-c1a1ae80-49e1-11eb-8f4f-3c5b2fabecad.png)

i.e. if you want to go digging in ye olde days, you can, but this is now relevant to browsers that people might actually use.



