### PR TITLE
Django - fix up on_delete options and explanation

### DIFF
--- a/files/en-us/learn/server-side/django/models/index.html
+++ b/files/en-us/learn/server-side/django/models/index.html
@@ -313,7 +313,12 @@ class Book(models.Model):
 
 <p>The genre is a <code>ManyToManyField</code>, so that a book can have multiple genres and a genre can have many books. The author is declared as <code>ForeignKey</code>, so each book will only have one author, but an author may have many books (in practice a book might have multiple authors, but not in this implementation!)</p>
 
-<p>In both field types the related model class is declared as the first unnamed parameter using either the model class or a string containing the name of the related model. You must use the name of the model as a string if the associated class has not yet been defined in this file before it is referenced! The other parameters of interest in the <code>author</code> field are <code>null=True</code>, which allows the database to store a <code>Null</code> value if no author is selected, and <code>on_delete=models.SET_NULL</code>, which will set the value of the author to <code>Null</code> if the associated author record is deleted.</p>
+<p>In both field types the related model class is declared as the first unnamed parameter using either the model class or a string containing the name of the related model. You must use the name of the model as a string if the associated class has not yet been defined in this file before it is referenced! The other parameters of interest in the <code>author</code> field are <code>null=True</code>, which allows the database to store a <code>Null</code> value if no author is selected, and <code>on_delete=models.SET_NULL</code>, which will set the value of the book's author field to <code>Null</code> if the associated author record is deleted.</p>
+
+<div class="notecard warning">
+    <h4>Warning</h4>
+    <p>By default <code>on_delete=models.CASCADE</code>, which means that if the author was deleted, this book would be deleted too! We use <code>SET_NULL</code> here, but we could also use <code>PROTECT</code> or <code>RESTRICT</code> to prevent the author being deleted while any book uses it.</p>
+</div>
 
 <p>The model also defines <code>__str__()</code> , using the book's <code>title</code> field to represent a <code>Book</code> record. The final method, <code>get_absolute_url()</code> returns a URL that can be used to access a detail record for this model (for this to work we will have to define a URL mapping that has the name <code>book-detail</code>, and define an associated view and template).</p>
 
@@ -321,10 +326,10 @@ class Book(models.Model):
 
 <p>Next, copy the <code>BookInstance</code> model (shown below) under the other models. The <code>BookInstance</code> represents a specific copy of a book that someone might borrow, and includes information about whether the copy is available or on what date it is expected back, "imprint" or version details, and a unique id for the book in the library.</p>
 
-<p>Some of the fields and methods will now be familiar. The model uses</p>
+<p>Some of the fields and methods will now be familiar. The model uses:</p>
 
 <ul>
- <li><code>ForeignKey</code> to identify the associated <code>Book</code> (each book can have many copies, but a copy can only have one <code>Book</code>).</li>
+ <li><code>ForeignKey</code> to identify the associated <code>Book</code> (each book can have many copies, but a copy can only have one <code>Book</code>). The key specifies <code>on_delete=models.RESTRICT</code> to ensure that the <code>Book</code> cannot be deleted while referenced by a <code>BookInstance</code>.</li>
  <li><code>CharField</code> to represent the imprint (specific release) of the book.</li>
 </ul>
 
@@ -333,7 +338,7 @@ class Book(models.Model):
 class BookInstance(models.Model):
     """Model representing a specific copy of a book (i.e. that can be borrowed from the library)."""
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, help_text='Unique ID for this particular book across whole library')
-    book = models.ForeignKey('Book', on_delete=models.SET_NULL, null=True)
+    book = models.ForeignKey('Book', on_delete=models.RESTRICT)
     imprint = models.CharField(max_length=200)
     due_back = models.DateField(null=True, blank=True)
 
@@ -369,13 +374,13 @@ class BookInstance(models.Model):
 
 <p>The method <code>__str__()</code> represents the <code>BookInstance</code> object using a combination of its unique id and the associated <code>Book</code>'s title.</p>
 
-<div class="note">
-<p><strong>Note</strong>: A little Python:</p>
-
-<ul>
- <li>Starting with Python 3.6, you can use the string interpolation syntax (also known as f-strings): <code>f'{self.id} ({self.book.title})'</code>.</li>
- <li>In older versions of this tutorial, we were using a <a href="https://www.python.org/dev/peps/pep-3101/">formatted string</a> syntax, which is also a valid way of formatting strings in Python (e.g. <code>'{0} ({1})'.format(self.id,self.book.title)</code>).</li>
-</ul>
+<div class="notecard note">
+    <h4>Note</h4>
+    <p> A little Python:</p>
+    <ul>
+        <li>Starting with Python 3.6, you can use the string interpolation syntax (also known as f-strings): <code>f'{self.id} ({self.book.title})'</code>.</li>
+        <li>In older versions of this tutorial, we were using a <a href="https://www.python.org/dev/peps/pep-3101/">formatted string</a> syntax, which is also a valid way of formatting strings in Python (e.g. <code>'{0} ({1})'.format(self.id,self.book.title)</code>).</li>
+     </ul>
 </div>
 
 <h3 id="Author_model">Author model</h3>


### PR DESCRIPTION
Fixes #463

This changes code so that book cannot be deleted until no bookinstances reference it. As part of this I explained the default delete option (cascade). 