### PR TITLE
Fix CORS problem in the “XHR: progress event” article

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/progress_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/progress_event/index.html
@@ -140,5 +140,5 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <ul>
  <li>Related events: {{domxref("XMLHttpRequest/loadstart_event", "loadstart")}}, {{domxref("XMLHttpRequest/load_event", "load")}}, {{domxref("XMLHttpRequest/loadend_event", "loadend")}}, {{domxref("XMLHttpRequest/error_event", "error")}}, {{domxref("XMLHttpRequest/abort_event", "abort")}}</li>
- <li><a href="/en-US/docs/DOM/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress">Monitoring progress</a></li>
+ <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress">Monitoring progress</a></li>
 </ul>

--- a/files/en-us/web/api/xmlhttprequest/progress_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/progress_event/index.html
@@ -98,15 +98,15 @@ function runXHR(url) {
 }
 
 xhrButtonSuccess.addEventListener('click', () =&gt; {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg');
+    runXHR('https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json');
 });
 
 xhrButtonError.addEventListener('click', () =&gt; {
-    runXHR('https://somewhere.org/i-dont-exist');
+    runXHR('http://i-dont-exist');
 });
 
 xhrButtonAbort.addEventListener('click', () =&gt; {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg').abort();
+    runXHR('https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json').abort();
 });</pre>
 
 <h4 id="Result">Result</h4>


### PR DESCRIPTION
This change replaces https://mdn.mozillademos.org URLs in the “XHR: progress event” article with https://raw.githubusercontent.com/mdn/content URLs.

Otherwise, without this change, the examples the URLs are in do not work as expected, due to the fact the https://mdn.mozillademos.org URL responses are actually 302 redirects (to https://media.prod.mdn.mozit.cloud URLs), and those 302s have no Access-Control-Allow-Origin header.

https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json has the Access-Control-Allow-Origin header and is also a sufficiently large enough resource (3.2M) to be useful in a demonstration for progress events.

Fixes https://github.com/mdn/content/issues/709

---

If anybody has suggestions for a better replacement URL, please chime in.

We can’t use a relative URL here, because the live sample for this is served from a different frame — a same-origin frame locally, but a https://yari-demos.prod.mdn.mozit.cloud/ frame in production.

I still considered checking a new large file into the mdn/content repo, but that would requiring referencing it in the article using an absolute URL, not a relative one — and so that couldn’t be tested locally until after the resource was committed and merged.

And no existing media files (e.g., images) that are already part of the repo are sufficiently large enough to be useful in a demonstration of progress events. The largest image is a 104K PNG, but that’s less than a tenth of what we really need. It should be a multiple-megabyte resource.

https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4 is another alternative — but unfortunately that also has no Access-Control-Allow-Origin header.

And using a URL for a resource at a third-party site seems imprudent.

https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json therefore seems like a reasonable solution. It has the Access-Control-Allow-Origin header, it’s sufficiently large enough, and it’s a resource that’s in our own repo already — and it’s stable in that we don’t have any reason to move it or remove it from that location, since it’s a frozen history of the now-gone wiki.