### PR TITLE
Fix /en/XPath links

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.html
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.html
@@ -36,8 +36,8 @@ tags:
   or <code>document.createElementNS("<span class="nowiki">http://www.w3.org/1999/xhtml</span>", "foo")</code> continue
   to work in HTML documents.</li>
   </li>
-  <li>The <a href="/en/XPath/Functions/name"><code>name</code></a> and the <a
-      href="/en/XPath/Functions/local-name"><code>local-name</code></a> functions in XPath returns the name of HTML
+  <li>The <a href="/en-US/docs/Web/XPath/Functions/name"><code>name</code></a> and the <a
+      href="/en-US/docs/Web/XPath/Functions/local-name"><code>local-name</code></a> functions in XPath returns the name of HTML
     elements in lower case. Previously, in HTML documents, they returned it in upper case.</li>
 </ul>
 <p>The most probable upgrade problem is the pattern <code>if (elt.localName == "FOO")</code>.</p>

--- a/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.html
+++ b/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.html
@@ -143,7 +143,7 @@ doc.appendChild(peopleElem);
 <ul>
  <li><a class="internal" href="/en/XML">XML</a></li>
  <li><a class="internal" href="/en/JXON">JXON</a></li>
- <li><a class="internal" href="/en/XPath">XPath</a></li>
+ <li><a class="internal" href="/en-US/docs/Web/XPath">XPath</a></li>
  <li><a class="internal" href="/en/E4X">E4X (ECMAScript for XML)</a></li>
  <li><a class="internal" href="/en/Parsing_and_serializing_XML">Parsing and serializing XML</a></li>
  <li><a class="internal" href="/en/DOM/XMLHttpRequest">XMLHttpRequest</a></li>

--- a/files/en-us/web/guide/parsing_and_serializing_xml/index.html
+++ b/files/en-us/web/guide/parsing_and_serializing_xml/index.html
@@ -109,7 +109,7 @@ const xmlStr = serializer.serializeToString(doc);</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a class="internal" href="/en/XPath">XPath</a></li>
+	<li><a class="internal" href="/en-US/docs/Web/XPath">XPath</a></li>
 	<li>{{domxref("XMLHttpRequest")}}</li>
 	<li>{{domxref("Document")}}, {{domxref("XMLDocument")}}, and {{domxref("HTMLDocument")}}</li>
 </ul>

--- a/files/en-us/web/xpath/axes/index.html
+++ b/files/en-us/web/xpath/axes/index.html
@@ -8,37 +8,37 @@ tags:
   - XSLT
   - XSLT_Reference
 ---
-<p>{{ XsltRef() }} There are thirteen different axes in the <a href="/en/XPath">XPath</a> specification. An axis represents a relationship to the context node, and is used to locate nodes relative to that node on the tree. The following is an extremely brief description of the thirteen available axes and the degree of support available in <a href="/en/Gecko">Gecko</a>.</p>
+<p>{{ XsltRef() }} There are thirteen different axes in the <a href="/en-US/docs/Web/XPath">XPath</a> specification. An axis represents a relationship to the context node, and is used to locate nodes relative to that node on the tree. The following is an extremely brief description of the thirteen available axes and the degree of support available in <a href="/en/Gecko">Gecko</a>.</p>
 
 <p>For further information on using XPath expressions, please see the <a href="/en/Transforming_XML_with_XSLT/For_Further_Reading">For Further Reading</a> section at the end of <a href="/en/Transforming_XML_with_XSLT">Transforming XML with XSLT</a> document. Also see the <a href="https://www.w3.org/TR/xpath-30/#axes">'axes' section in the xpath spec</a>.</p>
 
 
 <dl>
- <dt><a href="/en/XPath/Axes/ancestor">ancestor</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/ancestor">ancestor</a></dt>
  <dd>Indicates all the ancestors of the context node beginning with the parent node and traveling through to the root node.</dd>
- <dt><a href="/en/XPath/Axes/ancestor-or-self">ancestor-or-self</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/ancestor-or-self">ancestor-or-self</a></dt>
  <dd>Indicates the context node and all of its ancestors, including the root node.</dd>
- <dt><a href="/en/XPath/Axes/attribute">attribute</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/attribute">attribute</a></dt>
  <dd>Indicates the attributes of the context node. Only elements have attributes. This axis can be abbreviated with the at sign (<code>@</code>).</dd>
- <dt><a href="/en/XPath/Axes/child">child</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/child">child</a></dt>
  <dd>Indicates the children of the context node. If an XPath expression does not specify an axis, this is understood by default. Since only the root node or element nodes have children, any other use will select nothing.</dd>
- <dt><a href="/en/XPath/Axes/descendant">descendant</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/descendant">descendant</a></dt>
  <dd>Indicates all of the children of the context node, and all of their children, and so forth. Attribute and namespace nodes are <strong>not</strong> included - the <code>parent</code> of an <code>attribute</code> node is an element node, but <code>attribute</code> nodes are not the children of their parents.</dd>
- <dt><a href="/en/XPath/Axes/descendant-or-self">descendant-or-self</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/descendant-or-self">descendant-or-self</a></dt>
  <dd>Indicates the context node and all of its descendants. Attribute and namespace nodes are <strong>not</strong> included - the <code>parent</code> of an <code>attribute</code> node is an element node, but <code>attribute</code> nodes are not the children of their parents.</dd>
- <dt><a href="/en/XPath/Axes/following">following</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/following">following</a></dt>
  <dd>Indicates all the nodes that appear after the context node, except any <code>descendant</code>, <code>attribute</code>, and <code>namespace</code> nodes.</dd>
- <dt><a href="/en/XPath/Axes/following-sibling">following-sibling</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/following-sibling">following-sibling</a></dt>
  <dd>Indicates all the nodes that have the same parent as the context node and appear after the context node in the source document.</dd>
- <dt><a href="/en/XPath/Axes/namespace">namespace</a> <em>(not supported)</em></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/namespace">namespace</a> <em>(not supported)</em></dt>
  <dd>Indicates all the nodes that are in scope for the context node. In this case, the context node must be an element node.</dd>
- <dt><a href="/en/XPath/Axes/parent">parent</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/parent">parent</a></dt>
  <dd>Indicates the single node that is the parent of the context node. It can be abbreviated as two periods (<code>..</code>).</dd>
- <dt><a href="/en/XPath/Axes/preceding">preceding</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/preceding">preceding</a></dt>
  <dd>Indicates all the nodes that precede the context node in the document except any <code>ancestor</code>, <code>attribute</code> and <code>namespace</code> nodes.</dd>
- <dt><a href="/en/XPath/Axes/preceding-sibling">preceding-sibling</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/preceding-sibling">preceding-sibling</a></dt>
  <dd>Indicates all the nodes that have the same parent as the context node and appear before the context node in the source document.</dd>
- <dt><a href="/en/XPath/Axes/self">self</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Axes/self">self</a></dt>
  <dd>Indicates the context node itself. It can be abbreviated as a single period (<code>.</code>).</dd>
 </dl>
 

--- a/files/en-us/web/xpath/functions/index.html
+++ b/files/en-us/web/xpath/functions/index.html
@@ -8,46 +8,46 @@ tags:
   - XSLT
   - XSLT_Reference
 ---
-<p>{{ XsltRef() }} The following is an annotated list of core <a href="/en/XPath">XPath</a> functions and <a href="/en/XSLT">XSLT</a>-specific additions to XPath, including a description, syntax, a list of arguments, result-type, source in the appropriate W3C Recommendation, and degree of present <a href="/en/Gecko">Gecko</a> support. For further information on using XPath/XSLT functions, please see the <a href="/en/Transforming_XML_with_XSLT/For_Further_Reading">For Further Reading</a> page.</p>
+<p>{{ XsltRef() }} The following is an annotated list of core <a href="/en-US/docs/Web/XPath">XPath</a> functions and <a href="/en/XSLT">XSLT</a>-specific additions to XPath, including a description, syntax, a list of arguments, result-type, source in the appropriate W3C Recommendation, and degree of present <a href="/en/Gecko">Gecko</a> support. For further information on using XPath/XSLT functions, please see the <a href="/en/Transforming_XML_with_XSLT/For_Further_Reading">For Further Reading</a> page.</p>
 
 <ul>
- <li><a href="/en/XPath/Functions/boolean">boolean()</a></li>
- <li><a href="/en/XPath/Functions/ceiling">ceiling()</a></li>
- <li><a href="/en/XPath/Functions/choose">choose()</a></li>
- <li><a href="/en/XPath/Functions/concat">concat()</a></li>
- <li><a href="/en/XPath/Functions/contains">contains()</a></li>
- <li><a href="/en/XPath/Functions/count">count()</a></li>
- <li><a href="/en/XPath/Functions/current">current()</a> <em>XSLT-specific</em></li>
- <li><a href="/en/XPath/Functions/document">document()</a> <em>XSLT-specific</em></li>
- <li><a href="/en/XPath/Functions/element-available">element-available()</a></li>
- <li><a href="/en/XPath/Functions/false">false()</a></li>
- <li><a href="/en/XPath/Functions/floor">floor()</a></li>
- <li><a href="/en/XPath/Functions/format-number">format-number()</a> <em>XSLT-specific</em></li>
- <li><a href="/en/XPath/Functions/function-available">function-available()</a></li>
- <li><a href="/en/XPath/Functions/generate-id">generate-id()</a> <em>XSLT-specific</em></li>
- <li><a href="/en/XPath/Functions/id">id()</a> <em>(partially supported)</em></li>
- <li><a href="/en/XPath/Functions/key">key()</a> <em>XSLT-specific</em></li>
- <li><a href="/en/XPath/Functions/lang">lang()</a></li>
- <li><a href="/en/XPath/Functions/last">last()</a></li>
- <li><a href="/en/XPath/Functions/local-name">local-name()</a></li>
- <li><a href="/en/XPath/Functions/name">name()</a></li>
- <li><a href="/en/XPath/Functions/namespace-uri">namespace-uri()</a></li>
- <li><a href="/en/XPath/Functions/normalize-space">normalize-space()</a></li>
- <li><a href="/en/XPath/Functions/not">not()</a></li>
- <li><a href="/en/XPath/Functions/number">number()</a></li>
- <li><a href="/en/XPath/Functions/position">position()</a></li>
- <li><a href="/en/XPath/Functions/round">round()</a></li>
- <li><a href="/en/XPath/Functions/starts-with">starts-with()</a></li>
- <li><a href="/en/XPath/Functions/string">string()</a></li>
- <li><a href="/en/XPath/Functions/string-length">string-length()</a></li>
- <li><a href="/en/XPath/Functions/substring">substring()</a></li>
- <li><a href="/en/XPath/Functions/substring-after">substring-after()</a></li>
- <li><a href="/en/XPath/Functions/substring-before">substring-before()</a></li>
- <li><a href="/en/XPath/Functions/sum">sum()</a></li>
- <li><a href="/en/XPath/Functions/system-property">system-property()</a> <em>XSLT-specific</em></li>
- <li><a href="/en/XPath/Functions/translate">translate()</a></li>
- <li><a href="/en/XPath/Functions/true">true()</a></li>
- <li><a href="/en/XPath/Functions/unparsed-entity-url">unparsed-entity-url()</a> <em>XSLT-specific</em> <em>(not supported)</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/boolean">boolean()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/ceiling">ceiling()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/choose">choose()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/concat">concat()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/contains">contains()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/count">count()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/current">current()</a> <em>XSLT-specific</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/document">document()</a> <em>XSLT-specific</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/element-available">element-available()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/false">false()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/floor">floor()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/format-number">format-number()</a> <em>XSLT-specific</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/function-available">function-available()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/generate-id">generate-id()</a> <em>XSLT-specific</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/id">id()</a> <em>(partially supported)</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/key">key()</a> <em>XSLT-specific</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/lang">lang()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/last">last()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/local-name">local-name()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/name">name()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/namespace-uri">namespace-uri()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/normalize-space">normalize-space()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/not">not()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/number">number()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/position">position()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/round">round()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/starts-with">starts-with()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/string">string()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/string-length">string-length()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/substring">substring()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/substring-after">substring-after()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/substring-before">substring-before()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/sum">sum()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/system-property">system-property()</a> <em>XSLT-specific</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/translate">translate()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/true">true()</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/unparsed-entity-url">unparsed-entity-url()</a> <em>XSLT-specific</em> <em>(not supported)</em></li>
 </ul>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/XPath")}}</p>

--- a/files/en-us/web/xpath/functions/not/index.html
+++ b/files/en-us/web/xpath/functions/not/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt><code><em>expression</em> </code></dt>
- <dd>The expression is evaluated exactly as if it were passed as an argument to the <a href="/en/XPath/Functions/boolean"> boolean()</a> function.</dd>
+ <dd>The expression is evaluated exactly as if it were passed as an argument to the <a href="/en-US/docs/Web/XPath/Functions/boolean"> boolean()</a> function.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>
@@ -29,7 +29,7 @@ tags:
 <h3 id="Notes">Notes</h3>
 
 <ul>
- <li>This function should behave similarly to the <a href="/en/XPath/Functions/boolean"> boolean()</a> function except that it returns the opposite value.</li>
+ <li>This function should behave similarly to the <a href="/en-US/docs/Web/XPath/Functions/boolean"> boolean()</a> function except that it returns the opposite value.</li>
  <li>You can test if an element doesn't have some attribute.</li>
 </ul>
 

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
@@ -328,7 +328,7 @@ doc.evaluate('//myns:entry', doc, resolver, XPathResult.ANY_TYPE, null)
 
 <p>For example, one might try (incorrectly) to grab an element with a namespaced attribute as follows: <code>var xpathlink = someElements[local-name(@*)="href" and namespace-uri(@*)='<span class="nowiki">http://www.w3.org/1999/xlink</span>'];</code></p>
 
-<p>This could inadvertently grab some elements if one of its attributes existed that had a local name of "<code>href</code>", but it was a different attribute which had the targeted (XLink) namespace (instead of <code><a href="/en/XPath/Axes/attribute">@href</a></code>).</p>
+<p>This could inadvertently grab some elements if one of its attributes existed that had a local name of "<code>href</code>", but it was a different attribute which had the targeted (XLink) namespace (instead of <code><a href="/en-US/docs/Web/XPath/Axes/attribute">@href</a></code>).</p>
 
 <p>In order to accurately grab elements with the XLink <code>@href</code> attribute (without also being confined to predefined prefixes in a namespace resolver), one could obtain them as follows:</p>
 

--- a/files/en-us/web/xpath/snippets/index.html
+++ b/files/en-us/web/xpath/snippets/index.html
@@ -91,7 +91,7 @@ alert(results.length);
 
 <h3 id="docEvaluateArray">docEvaluateArray</h3>
 
-<p>The following is a simple utility function to get (ordered) XPath results into an array, regardless of whether there is a special need for namespace resolvers, etc. It avoids the more complex syntax of <code><a href="/en/DOM/document.evaluate">document.evaluate()</a></code> for cases when it is not required as well as the need to use the special iterators on <code><a href="/en/XPathResult">XPathResult</a></code> (by returning an array instead).</p>
+<p>The following is a simple utility function to get (ordered) XPath results into an array, regardless of whether there is a special need for namespace resolvers, etc. It avoids the more complex syntax of <code><a href="/en/DOM/document.evaluate">document.evaluate()</a></code> for cases when it is not required as well as the need to use the special iterators on <code><a href="/en-US/docs/Web/XPathResult">XPathResult</a></code> (by returning an array instead).</p>
 
 <h5 id="Example_Defining_a_simple_docEvaluateArray()_utility_function">Example: Defining a simple <code>docEvaluateArray()</code> utility function</h5>
 
@@ -145,7 +145,7 @@ function docEvaluateArray (expr, doc, context, resolver) {
 <h3 id="Resources">Resources</h3>
 
 <ul>
- <li><a href="/en/XPath">XPath</a></li>
+ <li><a href="/en-US/docs/Web/XPath">XPath</a></li>
  <li><a class="external" href="http://forums.mozillazine.org/viewtopic.php?t=229106">Forum discussion on this topic</a></li>
 </ul>
 


### PR DESCRIPTION
In particular, the function links on https://developer.mozilla.org/en-US/docs/Web/XPath/Functions are broken at the moment.