### PR TITLE
fix: Remove class with same name as ID

### DIFF
--- a/files/en-us/glossary/accessibility_tree/index.html
+++ b/files/en-us/glossary/accessibility_tree/index.html
@@ -29,7 +29,7 @@ tags:
 
 <p>While still in draft form within the Web Incubator Community Group, the <strong><a href="https://wicg.github.io/aom/explainer.html">Accessibility Object Model</a> (AOM)</strong> intends to incubate APIs that make it easier to express accessibility semantics and potentially allow read access to the computed accessibility tree.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/adobe_flash/index.html
+++ b/files/en-us/glossary/adobe_flash/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p id="Summary">Flash is a deprecated technology developed by Adobe for viewing expressive web applications, multimedia content, and streaming media. Adobe Flash can run from supporting {{Glossary("Browser","web browsers")}} via a browser plug-in.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="https://www.adobe.com/products/flashruntimes.html">Official web site</a></li>
  <li><a href="https://mozilla.github.io/shumway/">Shumway, a free implementation by Mozilla</a></li>

--- a/files/en-us/glossary/ajax/index.html
+++ b/files/en-us/glossary/ajax/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>With interactive websites and modern web standards, Ajax is gradually being replaced by functions within JavaScript frameworks and the official {{domxref("Fetch API")}} Standard.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>:
 

--- a/files/en-us/glossary/blink/index.html
+++ b/files/en-us/glossary/blink/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>Blink is an open-source browser layout engine developed by Google as part of Chromium (and therefore part of {{glossary("Google Chrome", "Chrome")}} as well). Specifically, Blink began as a fork of the WebCore library in {{glossary("WebKit")}}, which handles layout, rendering, and {{glossary("DOM")}}, but now stands on its own as a separate {{glossary("rendering engine")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/bootstrap/index.html
+++ b/files/en-us/glossary/bootstrap/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>Initially, Bootstrap was called Twitter Blueprint and was developed by a team working at <a href="https://twitter.com/">Twitter</a>. It supports responsive design and features predefined design templates that you can use out of the box, or customize for your needs with your code. You don't need to worry about compatibility with other browsers either, as Bootstrap is compatible with all modern browsers and newer versions of {{glossary("Microsoft Internet Explorer", "Internet Explorer")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>{{interwiki("wikipedia", "Bootstrap (front-end framework)", "Bootstrap")}} on Wikipedia</li>
  <li><a href="https://getbootstrap.com/">Download Bootstrap</a></li>

--- a/files/en-us/glossary/brotli_compression/index.html
+++ b/files/en-us/glossary/brotli_compression/index.html
@@ -21,7 +21,7 @@ tags:
  <li><a href="https://caniuse.com/#feat=brotli">Brotli on Caniuse</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>
   <details open><summary></summary> {{ListSubpages("/en-US/docs/Glossary")}}</details>

--- a/files/en-us/glossary/browser/index.html
+++ b/files/en-us/glossary/browser/index.html
@@ -18,7 +18,7 @@ tags:
  <li><a href="https://www.opera.com/" rel="external">Opera Browser</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/cacheable/index.html
+++ b/files/en-us/glossary/cacheable/index.html
@@ -42,7 +42,7 @@ tags:
 Cache-Control: no-cache
 (…)</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/call_stack/index.html
+++ b/files/en-us/glossary/call_stack/index.html
@@ -79,7 +79,7 @@ greeting();
  <li>{{Interwiki("wikipedia", "Call stack")}} on Wikipedia</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/character_set/index.html
+++ b/files/en-us/glossary/character_set/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>If a character set is used incorrectly (For example, Unicode for an article encoded in Big5), you may see nothing but broken characters, which are called {{Interwiki("wikipedia", "Mojibake")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Wikipedia articles
   <ol>

--- a/files/en-us/glossary/cipher/index.html
+++ b/files/en-us/glossary/cipher/index.html
@@ -22,7 +22,7 @@ tags:
  <li><a href="https://en.wikipedia.org/wiki/Asymmetric_key_algorithm">asymmetric key</a> algorithms use a different key for encryption and decryption.</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/cors-safelisted_response_header/index.html
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.html
@@ -29,7 +29,7 @@ tags:
 
 <pre class="notranslate">Access-Control-Expose-Headers: X-Custom-Header, Content-Length</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>See also
   <ol>

--- a/files/en-us/glossary/crawler/index.html
+++ b/files/en-us/glossary/crawler/index.html
@@ -15,7 +15,7 @@ tags:
  <li>{{Interwiki("wikipedia", "Web crawler")}} on Wikipedia</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
   <ol>

--- a/files/en-us/glossary/cross_axis/index.html
+++ b/files/en-us/glossary/cross_axis/index.html
@@ -40,7 +40,7 @@ tags:
  <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/cryptographic_hash_function/index.html
+++ b/files/en-us/glossary/cryptographic_hash_function/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>Cryptographic hash functions such as MD5 and SHA-1 are considered broken, as attacks have been found that significantly reduce their collision resistance.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>{{interwiki("wikipedia", "Cryptographic hash function", "Cryptographic hash function")}} on Wikipedia</li>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>

--- a/files/en-us/glossary/cryptography/index.html
+++ b/files/en-us/glossary/cryptography/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p><span class="seoSummary"><strong>Cryptography</strong>, or cryptology, is the science that studies how to encode and transmit messages securely. Cryptography designs and studies algorithms used to encode and decode messages in an insecure environment, and their applications.</span> More than just <strong>data confidentiality</strong>, cryptography also tackles <strong>identification</strong>, <strong>authentication</strong>, <strong>non-repudiation</strong>, and <strong>data integrity</strong>. Therefore it also studies usage of cryptographic methods in context, <strong>cryptosystems</strong>.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/css_preprocessor/index.html
+++ b/files/en-us/glossary/css_preprocessor/index.html
@@ -9,7 +9,7 @@ tags:
 
 <p>To use a CSS preprocessor, you must install a CSS compiler on your web {{Glossary("server")}}; Or use the CSS preprocessor to compile on the development environment, and then upload compiled CSS file to the web server.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Few of most popular CSS preprocessors
   <ol>

--- a/files/en-us/glossary/css_selector/index.html
+++ b/files/en-us/glossary/css_selector/index.html
@@ -54,7 +54,7 @@ div.warning {
 
 <p>{{EmbedLiveSample("glossary-selector-details", 640, 210)}}</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Learn/CSS/Introduction_to_CSS/Selectors">Learn more about CSS selectors</a> in our introduction to CSS.</li>
  <li>Basic selectors

--- a/files/en-us/glossary/database/index.html
+++ b/files/en-us/glossary/database/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>Browsers also have their own database system called {{glossary("IndexedDB")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>{{Interwiki("wikipedia", "Database")}} on Wikipedia
   <ol>

--- a/files/en-us/glossary/document_directive/index.html
+++ b/files/en-us/glossary/document_directive/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Document_directives">Document directives</a> for a complete list.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/dom/index.html
+++ b/files/en-us/glossary/dom/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>DOM was not originally specified—it came about when browsers began implementing {{Glossary("JavaScript")}}. This legacy DOM is sometimes called DOM 0. Today, the WHATWG maintains the DOM Living Standard.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>{{interwiki("wikipedia", "Document_Object_Model", "The Document Object Model")}} on Wikipedia</li>
  <li><a href="/en-US/docs/DOM">The DOM documentation on MDN</a></li>

--- a/files/en-us/glossary/endianness/index.html
+++ b/files/en-us/glossary/endianness/index.html
@@ -20,7 +20,7 @@ tags:
  <li><em>mixed-endian</em> (historic and very rare): <code>0x34 0x12 0x78 0x56</code></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>See also
   <ol>

--- a/files/en-us/glossary/favicon/index.html
+++ b/files/en-us/glossary/favicon/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>They are used to improve user experience and enforce brand consistency. When a familiar icon is seen in the browser's address bar, for example, it helps users know they are in the right place.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>{{interwiki("wikipedia", "Favicon", "Favicon")}} on Wikipedia</li>
  <li>Tools

--- a/files/en-us/glossary/fetch_directive/index.html
+++ b/files/en-us/glossary/fetch_directive/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Fetch_directives">Fetch directives</a> for a complete list.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/fetch_metadata_request_header/index.html
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.html
@@ -18,7 +18,7 @@ tags:
  <li>{{HTTPHeader("Sec-Fetch-Dest")}}</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Fetch Me
   <ol>

--- a/files/en-us/glossary/first-class_function/index.html
+++ b/files/en-us/glossary/first-class_function/index.html
@@ -93,7 +93,7 @@ sayHello()();
 
 <p>We are using double parentheses <code>()()</code> to invoke the returned function as well.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>{{Interwiki("wikipedia", "First-class_function", "First-class functions")}} on Wikipedia</li>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>

--- a/files/en-us/glossary/flexbox/index.html
+++ b/files/en-us/glossary/flexbox/index.html
@@ -47,7 +47,7 @@ tags:
  <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox">Typical use cases of flexbox</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/forbidden_header_name/index.html
+++ b/files/en-us/glossary/forbidden_header_name/index.html
@@ -44,7 +44,7 @@ tags:
 <p><strong>Note</strong>: The <code>User-Agent</code> header is no longer forbidden, <a href="https://fetch.spec.whatwg.org/#terminology-headers">as per spec</a> — see forbidden header name list (this was implemented in Firefox 43) — it can now be set in a Fetch <a href="/en-US/docs/Web/API/Headers">Headers</a> object, or via XHR <a href="/en-US/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29">setRequestHeader()</a>.  However, Chrome will silently drop the header from Fetch requests (see <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=571722">Chromium bug 571722</a>).</p>
 </div>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/fork/index.html
+++ b/files/en-us/glossary/fork/index.html
@@ -21,7 +21,7 @@ tags:
  <li><a href="https://www.libreoffice.org/about-us/who-are-we/">LibreOffice, a fork of OpenOffice</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General Knowledge
   <ol>

--- a/files/en-us/glossary/fps/index.html
+++ b/files/en-us/glossary/fps/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>Movies generally have a frame rate of 24 fps. They are able to have fewer frames per second because the illusion of life is created with motion blurs. When moving on a computer screen there are no motion blurs (unless you are animating an image <a href="/en-US/docs/Web/CSS/CSS_Images/Implementing_image_sprites_in_CSS">sprite</a> with motion blurs).</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>

--- a/files/en-us/glossary/global_object/index.html
+++ b/files/en-us/glossary/global_object/index.html
@@ -53,7 +53,7 @@ window.greeting(); // It is the same as the normal invoking: greeting();
    console.log("Hi!");
 }</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/graceful_degradation/index.html
+++ b/files/en-us/glossary/graceful_degradation/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>It is a useful technique that allows Web developers to focus on developing the best possible websites, given that those websites are accessed by multiple unknown user-agents. {{Glossary("Progressive enhancement")}} is related but different — often seen as going in the opposite direction to graceful degradation. In reality both approaches are valid and can often complement one another.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>{{Interwiki("wikipedia", "Graceful degradation")}} on Wikipedia</li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS">Handling common HTML and CSS problems</a></li>

--- a/files/en-us/glossary/grid/index.html
+++ b/files/en-us/glossary/grid/index.html
@@ -56,7 +56,7 @@ tags:
 
 <p>{{ EmbedLiveSample('example', '500', '330') }}</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>CSS Grid Layout Guide:<br>
   <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>

--- a/files/en-us/glossary/grid_tracks/index.html
+++ b/files/en-us/glossary/grid_tracks/index.html
@@ -56,7 +56,7 @@ tags:
 
 <p>Tracks created in the implicit grid are auto-sized by default, however you can define a size for these tracks using the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>CSS Grid Layout Guide: <br>
  <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>

--- a/files/en-us/glossary/gzip_compression/index.html
+++ b/files/en-us/glossary/gzip_compression/index.html
@@ -15,7 +15,7 @@ tags:
  <li><a href="https://en.wikipedia.org/wiki/Gzip">Gzip on Wikipedia</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>
   <details><summary><a href="/en-US/docs/Glossary">MDN Glossary</a></summary> {{ListSubpages("/en-US/docs/Glossary")}}</details>

--- a/files/en-us/glossary/hotlink/index.html
+++ b/files/en-us/glossary/hotlink/index.html
@@ -9,7 +9,7 @@ tags:
 
 <p>The practice is often frowned upon as it can cause unwanted bandwidth usage on the website hosting the linked-to object, and copyright concerns — it is considered stealing when it is done without permission.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/http_2/index.html
+++ b/files/en-us/glossary/http_2/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>HTTP/2 does not modify the application semantics of HTTP in any way. All the core concepts found in HTTP 1.1, such as HTTP methods, status codes, URIs, and header fields, remain in place. Instead, HTTP/2 modifies how the data is formatted (framed) and transported between the client and server, both of which manage the entire process, and hides application complexity within the new framing layer. As a result, all existing applications can be delivered without modification.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/http_3/index.html
+++ b/files/en-us/glossary/http_3/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><span class="seoSummary"><strong>HTTP/3</strong> is the upcoming major revision of the <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP">HTTP network protocol</a></span>, succeeding {{glossary("HTTP 2", "HTTP/2")}}. The major point of HTTP/3 is that it uses a new {{glossary("UDP")}} protocol named QUIC, instead of {{glossary("TCP")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/http_header/index.html
+++ b/files/en-us/glossary/http_header/index.html
@@ -54,7 +54,7 @@ X-Cache: Hit from cloudfront
 X-Cache-Info: cached
 </pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Specifications
   <ol>

--- a/files/en-us/glossary/https/index.html
+++ b/files/en-us/glossary/https/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p><strong>HTTPS</strong> (<strong><em>HyperText Transfer Protocol Secure</em></strong>) is an encrypted version of the {{Glossary("HTTP")}} protocol. It uses {{Glossary("SSL")}} or {{Glossary("TLS")}} to encrypt all communication between a client and a server. This secure connection allows clients to safely exchange sensitive data with a server, such as when performing banking activities or online shopping.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/identifier/index.html
+++ b/files/en-us/glossary/identifier/index.html
@@ -21,7 +21,7 @@ tags:
  <li>{{interwiki("wikipedia", "Identifier#In_computer_science", "Identifier")}} on Wikipedia</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>

--- a/files/en-us/glossary/iife/index.html
+++ b/files/en-us/glossary/iife/index.html
@@ -41,7 +41,7 @@ aName // throws "Uncaught ReferenceError: aName is not defined"
 // Immediately creates the output:
 result; // "Barry"</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Learn about it
   <ol>

--- a/files/en-us/glossary/input_method_editor/index.html
+++ b/files/en-us/glossary/input_method_editor/index.html
@@ -12,7 +12,7 @@ tags:
  <li>to enter text on a touch screen using handwriting recognition</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Wikipedia articles
   <ol>

--- a/files/en-us/glossary/internationalization_and_localization/index.html
+++ b/files/en-us/glossary/internationalization_and_localization/index.html
@@ -18,7 +18,7 @@ tags:
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a> and <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Grid layout</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>
   <details open><summary></summary> {{ListSubpages("/en-US/docs/Glossary")}}</details>

--- a/files/en-us/glossary/key/index.html
+++ b/files/en-us/glossary/key/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>In {{Glossary("symmetric-key cryptography")}}, the same key is used for both encryption and decryption. In {{Glossary("public-key cryptography")}}, there exists a pair of related keys known as the <em>public key</em> and <em>private key</em>. The public key is freely available, whereas the private key is kept secret. The public key is able to encrypt messages that only the corresponding private key is able to decrypt, and vice versa.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/latency/index.html
+++ b/files/en-us/glossary/latency/index.html
@@ -21,4 +21,4 @@ tags:
  <li><a href="/en-US/docs/Learn/Performance/Understanding_latency">Understanding Latency</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links"> </section>
+<section id="Quick_links"> </section>

--- a/files/en-us/glossary/ligature/index.html
+++ b/files/en-us/glossary/ligature/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>You can implement ligatures in your webpage with {{cssxref("font-variant-ligatures")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li>{{interwiki("wikipedia", "Typographic ligature", "Ligature")}} on Wikipedia</li>
  </ol>

--- a/files/en-us/glossary/local_variable/index.html
+++ b/files/en-us/glossary/local_variable/index.html
@@ -17,7 +17,7 @@ function fun(){
 }
 </pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/loop/index.html
+++ b/files/en-us/glossary/loop/index.html
@@ -70,7 +70,7 @@ while(i &lt; 5){
  <li>The code block will continue to run as long as the variable (i) is less than 5.</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General Knowledge
   <ol>

--- a/files/en-us/glossary/lossless_compression/index.html
+++ b/files/en-us/glossary/lossless_compression/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>{{glossary("Lossy compression")}}, on the other hand, uses inexact approximations by discarding some data from the original file, making it an irreversible compression method.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/ltr/index.html
+++ b/files/en-us/glossary/ltr/index.html
@@ -16,7 +16,7 @@ tags:
  <li><a href="/en-US/docs/Web/Localization">Localization and internationalization</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/main_thread/index.html
+++ b/files/en-us/glossary/main_thread/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>Unless intentionally using a <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">web worker</a>, such as a <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">service worker</a>, JavaScript runs on the main thread, so it's easy for a script to cause delays in event processing or painting. The less work required of the main thread, the more that thread can respond to user events, paint, and generally be responsive to the user.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>See also
   <ol>

--- a/files/en-us/glossary/markup/index.html
+++ b/files/en-us/glossary/markup/index.html
@@ -22,7 +22,7 @@ tags:
  <dd>Labels sections of documents as to how the program should handle them. For example, the HTML {{HTMLElement("td")}} defines a cell in a HTML table.</dd>
 </dl>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/mathml/index.html
+++ b/files/en-us/glossary/mathml/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p id="Summary"><strong>MathML </strong>(an {{glossary("XML")}} application) is an open standard for representing mathematical expressions in webpages.  In 1998 the W3C first recommended MathML for representing mathematical expressions in the {{glossary("browser")}}. MathML has other applications also including scientific content and voice synthesis.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General Knowledge
   <ol>

--- a/files/en-us/glossary/method/index.html
+++ b/files/en-us/glossary/method/index.html
@@ -27,7 +27,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Methods_Index">List of JavaScript built-in methods</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/microsoft_edge/index.html
+++ b/files/en-us/glossary/microsoft_edge/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><strong>Microsoft Edge</strong> is a free-of-cost graphical {{glossary("World Wide Web", "Web")}} {{Glossary("browser")}} bundled with Windows 10 and developed by Microsoft since 2014. Initially known as Spartan, Edge replaced the longstanding browser {{glossary("Microsoft Internet Explorer","Internet Explorer")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>See also
   <ol>

--- a/files/en-us/glossary/navigation_directive/index.html
+++ b/files/en-us/glossary/navigation_directive/index.html
@@ -32,7 +32,7 @@ tags:
 </ul>
 </div>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/network_throttling/index.html
+++ b/files/en-us/glossary/network_throttling/index.html
@@ -20,7 +20,7 @@ tags:
  <li><a href="/en-US/docs/Glossary/Synthetic_monitoring">Synthetic monitoring</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>
   <details open><summary></summary> {{ListSubpages("/en-US/docs/Glossary")}}</details>

--- a/files/en-us/glossary/null/index.html
+++ b/files/en-us/glossary/null/index.html
@@ -13,7 +13,7 @@ tags:
 
 <pre class="brush: js notranslate">typeof null === 'object' // true</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><strong><a href="/en-US/docs/Glossary">Glossary</a></strong>
 

--- a/files/en-us/glossary/perceived_performance/index.html
+++ b/files/en-us/glossary/perceived_performance/index.html
@@ -24,7 +24,7 @@ tags:
  <li><a href="/en-US/docs/Learn/Performance/perceived_performance">perceived performance</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>
   <details open><summary></summary> {{ListSubpages("/en-US/docs/Glossary")}}</details>

--- a/files/en-us/glossary/php/index.html
+++ b/files/en-us/glossary/php/index.html
@@ -43,7 +43,7 @@ tags:
  echo $email;
 ?&gt;</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="http://php.net/">Official website</a></li>
  <li>{{Interwiki("wikipedia", "PHP")}} on Wikipedia</li>

--- a/files/en-us/glossary/pop/index.html
+++ b/files/en-us/glossary/pop/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>Clients usually retrieve all messages and then delete them from the server, but POP3 does allow retaining a copy on the server. Nearly all email servers and clients currently support POP3.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>{{Interwiki("wikipedia", "Post Office Protocol", "POP")}} on Wikipedia</li>
  <li><a href="https://tools.ietf.org/html/rfc1734">RFC 1734</a> (Specification of POP3 authentication mechanism)</li>

--- a/files/en-us/glossary/primitive/index.html
+++ b/files/en-us/glossary/primitive/index.html
@@ -59,7 +59,7 @@ bar = bar.toUpperCase();       // BAZ
  <li>{{Interwiki("wikipedia", "Primitive data type")}} on Wikipedia</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/public-key_cryptography/index.html
+++ b/files/en-us/glossary/public-key_cryptography/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>Commonly used public-key cryptosystems are RSA (for both signing and encryption), DSA (for signing) and Diffie-Hellman (for key agreement).</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/python/index.html
+++ b/files/en-us/glossary/python/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>Python is developed under an OSI-approved open source license, making it freely usable and distributable, even for commercial use. Python's license is administered by the <a href="https://www.python.org/psf">Python Software Foundation</a>.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Learn more
   <ol>

--- a/files/en-us/glossary/reporting_directive/index.html
+++ b/files/en-us/glossary/reporting_directive/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Reporting_directives">Reporting directives</a> for a complete list.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/response_header/index.html
+++ b/files/en-us/glossary/response_header/index.html
@@ -29,7 +29,7 @@ X-Cache-Info: not cacheable; meta data too large
 X-kuma-revision: 1085259
 x-frame-options: DENY</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Learn more
   <ol>

--- a/files/en-us/glossary/rng/index.html
+++ b/files/en-us/glossary/rng/index.html
@@ -28,7 +28,7 @@ tags:
  <li>{{domxref("Crypto.getRandomValues()")}}: this is intended to provide cryptographically secure numbers.</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>{{domxref("RandomSource")}}</li>
  <li>{{jsxref("Math.random()")}}</li>

--- a/files/en-us/glossary/rtl/index.html
+++ b/files/en-us/glossary/rtl/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>The opposite of RTL, LTR (Left To Right) is used in other languages, including English (<code>en</code>, <code>en-US</code>, <code>en-GB</code>, etc.), Spanish (<code>es</code>), and French (<code>fr</code>).</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/rtsp/index.html
+++ b/files/en-us/glossary/rtsp/index.html
@@ -18,7 +18,7 @@ tags:
  <li><a href="https://tools.ietf.org/html/rfc7826">RFC 7826</a> (one of the documents that specifies precisely how the protocol works)</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/same-origin_policy/index.html
+++ b/files/en-us/glossary/same-origin_policy/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><span class="seoSummary">The <strong>same-origin policy</strong> is a critical security mechanism that restricts how a document or script loaded from one {{Glossary("origin")}} can interact with a resource from another origin.</span> It helps isolate potentially malicious documents, reducing possible attack vectors.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>:
   <ul>

--- a/files/en-us/glossary/scroll_container/index.html
+++ b/files/en-us/glossary/scroll_container/index.html
@@ -9,7 +9,7 @@ tags:
 
 <p>The scroll container allows the user to scroll through parts of the overflow region that would otherwise be clipped and hidden from view. The visible part of the scroll container is referred to as the {{glossary("Scrollport", "scrollport")}}.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>:
 

--- a/files/en-us/glossary/scrollport/index.html
+++ b/files/en-us/glossary/scrollport/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>The <strong>scrollport</strong> is the visual viewport of a {{glossary("Scroll container", "scroll container")}} in a document. A scroll container is created by applying <code>overflow: scroll</code> to a container, or <code>overflow: auto</code> when there is enough content to cause overflow. The scrollport coincides with the padding box of that container and represents the content that can be seen as the box is scrolled.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>:
   <ul>

--- a/files/en-us/glossary/semantics/index.html
+++ b/files/en-us/glossary/semantics/index.html
@@ -73,7 +73,7 @@ tags:
  <li>{{interwiki("wikipedia", "Semantics#Computer_science", "The meaning of semantics in computer science")}} on Wikipedia</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/simd/index.html
+++ b/files/en-us/glossary/simd/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>See also {{Glossary("SISD")}} for a sequential architecture with no parallelism in either the instructions or the data sets.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/sld/index.html
+++ b/files/en-us/glossary/sld/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>As another example, in <code>developer.mozilla.org</code>, the <code>developer</code> subdomain is used to specify that the subdomain contains the developer section of the Mozilla website.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Wikipedia articles
   <ol>

--- a/files/en-us/glossary/smtp/index.html
+++ b/files/en-us/glossary/smtp/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>The protocol is relatively straightforward. Primary complications include supporting various authentication mechanisms (<a class="external" href="https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface"><abbr title="Generic Security Services Application Program Interface">GSSAPI</abbr></a>, <a class="external" href="https://en.wikipedia.org/wiki/CRAM-MD5"><abbr title="challenge-response authentication mechanism">CRAM-MD5</abbr></a>, <a class="external" href="https://en.wikipedia.org/wiki/NTLM"><abbr title="NT LAN Manager">NTLM</abbr></a>, MSN, AUTH LOGIN, AUTH PLAIN, etc.), handling error responses, and falling back when authentication mechanisms fail (e.g., the server claims to support a mechanism, but doesn't).</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/spa/index.html
+++ b/files/en-us/glossary/spa/index.html
@@ -22,7 +22,7 @@ tags:
  <li><a href="https://vuejs.org/">Vue.JS</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Wikipedia articles
   <ol>

--- a/files/en-us/glossary/ssl/index.html
+++ b/files/en-us/glossary/ssl/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p class="seoSummary">Secure Sockets Layer, or SSL, was the old standard security technology for creating an encrypted network link between a server and client, ensuring all data passed is private and secure. The current version of SSL is version 3.0, released by Netscape in 1996, and has been superseded by the {{Glossary("TLS", "Transport Layer Security (TLS)")}} protocol.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>See also
   <ol>

--- a/files/en-us/glossary/static_method/index.html
+++ b/files/en-us/glossary/static_method/index.html
@@ -27,7 +27,7 @@ tags:
 
 myNotification.close();</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>General knowledge
   <ol>

--- a/files/en-us/glossary/strict_mode/index.html
+++ b/files/en-us/glossary/strict_mode/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>Strict mode for an entire script is invoked by including the statement <code>"use strict";</code> before any other statements.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode">strict mode</a></li>
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode">transitioning to strict mode</a></li>

--- a/files/en-us/glossary/symmetric-key_cryptography/index.html
+++ b/files/en-us/glossary/symmetric-key_cryptography/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>Most symmetric-key algorithms currently in use are block ciphers: this means that they encrypt data one block at a time. The size of each block is fixed and determined by the algorithm: for example {{Glossary("AES")}} uses 16-byte blocks. Block ciphers are always used with a <em>{{Glossary("Block cipher mode of operation", "mode")}}</em>, which specifies how to securely encrypt messages that are longer than the block size. For example, AES is a cipher, while CTR, CBC, and GCM are all modes. Using an inappropriate mode, or using a mode incorrectly, can completely undermine the security provided by the underlying cipher.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
   <ul>

--- a/files/en-us/glossary/tcp/index.html
+++ b/files/en-us/glossary/tcp/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>TCP role is to ensure the packets are reliably delivered, error free.  TCP has concurrence control, which means the initial requests start small, increasing in size to the levels of bandwidth the computers, servers, and network can support.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>

--- a/files/en-us/glossary/thread/index.html
+++ b/files/en-us/glossary/thread/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>Overall it can be observed these threads within our operating system are extremely helpful. They help minimize the context switching time, enables more efficient communication and allows further use of the multiprocessor architecture.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>See also
   <ol>

--- a/files/en-us/glossary/tls/index.html
+++ b/files/en-us/glossary/tls/index.html
@@ -16,7 +16,7 @@ tags:
 <p><strong>Note</strong>: TLS 1.0 and 1.1 support will be removed from all major browsers in early 2020; you'll need to make sure your web server supports TLS 1.2 or 1.3 going forward. From version 74 onwards, Firefox will return a <a href="https://support.mozilla.org/en-US/kb/secure-connection-failed-firefox-did-not-connect">Secure Connection Failed</a> error when connecting to servers using the older TLS versions ({{bug(1606734)}}).</p>
 </div>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Specifications
   <ol>

--- a/files/en-us/glossary/type/index.html
+++ b/files/en-us/glossary/type/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>If you are unsure of the type of a value, you can use the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/typeof">typeof</a> operator.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
 

--- a/files/en-us/glossary/type_coercion/index.html
+++ b/files/en-us/glossary/type_coercion/index.html
@@ -22,7 +22,7 @@ console.log(sum);</pre>
 
 <pre class="brush: js">sum = Number(value1) + value2;</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>

--- a/files/en-us/glossary/type_conversion/index.html
+++ b/files/en-us/glossary/type_conversion/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>Type conversion (or typecasting) means transfer of data from one data type to another. <em>Implicit conversion</em> happens when the compiler automatically assigns data types, but the source code can also <em>explicitly</em> require a conversion to take place. For example, given the instruction <code>5+2.0</code>, the floating point <code>2.0</code> is implicitly typecasted into an integer, but given the instruction <code>Number("0x11")</code>, the string "0x11" is explicitly typecasted as the number 17.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>

--- a/files/en-us/glossary/user_agent/index.html
+++ b/files/en-us/glossary/user_agent/index.html
@@ -38,7 +38,7 @@ tags:
  <li>{{RFC(2616, "14.43")}}: The <code>User-Agent</code> header</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/web_performance/index.html
+++ b/files/en-us/glossary/web_performance/index.html
@@ -16,7 +16,7 @@ tags:
  <li><a href="/en-US/docs/Glossary/Perceived_performance">Perceived performance</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li>
   <details open><summary></summary> {{ListSubpages("/en-US/docs/Glossary")}}</details>

--- a/files/en-us/glossary/web_server/index.html
+++ b/files/en-us/glossary/web_server/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>A web server is a piece of software that often runs on a hardware server offering service to a user, usually referred to as the client. A server, on the other hand, is a piece of hardware that lives in a room full of computers, commonly known as a data center.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Learn/Common_questions/What_is_a_web_server">Introduction to servers</a></li>
  <li>{{Interwiki("wikipedia", "Server (computing)")}} on Wikipedia</li>

--- a/files/en-us/glossary/webassembly/index.html
+++ b/files/en-us/glossary/webassembly/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p><strong>WebAssembly</strong> (abbr. <em>Wasm</em>) is an open {{Glossary("binary")}} programming format that can be run in modern web {{Glossary("Browser", "browsers")}} in order to gain performance and/or provide new features for web pages.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Learn more
   <ol>

--- a/files/en-us/glossary/whitespace/index.html
+++ b/files/en-us/glossary/whitespace/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>The <a href="https://tc39.es/ecma262/#sec-white-space">ECMAScript Language Specification</a> defines several Unicode codepoints as “white space”: U+0009 CHARACTER TABULATION &lt;TAB&gt;, U+000B LINE TABULATION &lt;VT&gt;, U+000C FORM FEED &lt;FF&gt;, U+0020 SPACE &lt;SP&gt;, U+00A0 NO-BREAK SPACE &lt;NBSP&gt;, U+FEFF ZERO WIDTH NO-BREAK SPACE &lt;ZWNBSP&gt;, and any other Unicode “Space_Separator” code points &lt;USP&gt;.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li>Specifications
   <ol>

--- a/files/en-us/glossary/wrapper/index.html
+++ b/files/en-us/glossary/wrapper/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>{{Interwiki("wikipedia", "Wrapper function")}} on Wikipedia</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
   <ol>

--- a/files/en-us/learn/forms/form_validation/index.html
+++ b/files/en-us/learn/forms/form_validation/index.html
@@ -656,7 +656,7 @@ function showError() {
   &lt;p&gt;
     &lt;label for="mail"&gt;
         &lt;span&gt;Please enter an email address:&lt;/span&gt;
-        &lt;input type="text" class="mail" id="mail" name="mail"&gt;
+        &lt;input type="text" id="mail" name="mail"&gt;
         &lt;span class="error" aria-live="polite"&gt;&lt;/span&gt;
     &lt;/label&gt;
   &lt;/p&gt;

--- a/files/en-us/mdn/contribute/howto/write_interface_reference_documentation/sample_interface_document/index.html
+++ b/files/en-us/mdn/contribute/howto/write_interface_reference_documentation/sample_interface_document/index.html
@@ -8,7 +8,7 @@ tags:
   - MDN Meta
   - Reference
 ---
-<div><section class="Quick_links" id="Quick_Links">
+<div><section id="Quick_links">
   <ol>
     <li class="toggle">
         <details>

--- a/files/en-us/mozilla/developer_guide/index.html
+++ b/files/en-us/mozilla/developer_guide/index.html
@@ -65,7 +65,7 @@ tags:
 </div>
 
 <div class="section">
-<h2 class="Tools" id="Tools">Tools</h2>
+<h2 id="Tools">Tools</h2>
 
 <dl>
  <dt><a class="link-https" href="https://bugzilla.mozilla.org/">Bugzilla</a></dt>

--- a/files/en-us/mozilla/projects/nss/index.html
+++ b/files/en-us/mozilla/projects/nss/index.html
@@ -18,7 +18,7 @@ tags:
  <tbody>
   <tr>
    <td>
-    <h2 class="Documentation" id="Documentation" name="Documentation">Documentation</h2>
+    <h2 id="Documentation">Documentation</h2>
 
     <h3 id="Background_Information">Background Information</h3>
 
@@ -151,7 +151,7 @@ tags:
     </ul>
    </td>
    <td>
-    <h2 class="Community" id="Community" name="Community">Community</h2>
+    <h2 id="Community">Community</h2>
 
     <ul>
      <li>View Mozilla Security forums...</li>
@@ -165,7 +165,7 @@ tags:
 
     <p>{{ DiscussionList("dev-tech-crypto", "mozilla.dev.tech.crypto") }}</p>
 
-    <h2 class="Related_Topics" id="Related_Topics" name="Related_Topics">Related Topics</h2>
+    <h2 id="Related_Topics">Related Topics</h2>
 
     <ul>
      <li><a href="/en-US/docs/Security" title="Security">Security</a></li>

--- a/files/en-us/mozilla/projects/nss/jss/index.html
+++ b/files/en-us/mozilla/projects/nss/jss/index.html
@@ -61,7 +61,7 @@ tags:
  <tbody>
   <tr>
    <td>
-    <h2 class="Documentation" id="Documentation" name="Documentation">Documentation</h2>
+    <h2 id="Documentation" name="Documentation">Documentation</h2>
 
     <p>Before you use JSS, you should have a good understanding of the crypto technologies it uses. You might want to read these documents:</p>
 
@@ -117,13 +117,13 @@ tags:
     </ul>
    </td>
    <td>
-    <h2 class="Community" id="Community" name="Community">Community</h2>
+    <h2 id="Community" name="Community">Community</h2>
 
     <ul>
      <li>View Mozilla Cryptography forums...{{DiscussionList("dev-tech-crypto", "mozilla.dev.tech.crypto")}}</li>
     </ul>
 
-    <h2 class="Related_Topics" id="Related_Topics" name="Related_Topics">Related Topics</h2>
+    <h2 id="Related_Topics" name="Related_Topics">Related Topics</h2>
 
     <ul>
      <li><a href="/en-US/docs/Security" title="Security">Security</a></li>

--- a/files/en-us/related/imsc/basics/index.html
+++ b/files/en-us/related/imsc/basics/index.html
@@ -257,7 +257,7 @@ tags:
 
 <p>That's it for your crash course in IMSC code basics! We've only really scratched the surface here, and you'll go much deeper into the above topics in subsequent articles.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/imsc_and_other_standards/index.html
+++ b/files/en-us/related/imsc/imsc_and_other_standards/index.html
@@ -48,7 +48,7 @@ tags:
 
 <p>This document gives you all you need to know about IMSC and its relationship with other specifications.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/index.html
+++ b/files/en-us/related/imsc/index.html
@@ -183,7 +183,7 @@ tags:
 
 <p>If you want to get involved with documenting IMSC, please contact <a href="mailto:tai@irt.de">Andreas Tai</a>.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.html
+++ b/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.html
@@ -59,7 +59,7 @@ tags:
 
 <p>By describing this actual frame rate, you are now able to describe time expressions in frames, or f. This is the actual frame number that the event begins and ends. Here is the same example as above, where the event begins at 01:00:00:00, and ends one second later.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/namespaces/index.html
+++ b/files/en-us/related/imsc/namespaces/index.html
@@ -131,7 +131,7 @@ tags:
 <p><strong>Note:</strong> The namespace/prefix match is only a document-wide agreement. Theoretically you can use another prefix than <code>tts</code> to bind the styling namespace. It is completely legal to define <code>xmlns:foo="http://www.w3.org/ns/ttml#styling"</code> and then write <code>&lt;p foo:color="yellow"&gt;</code>. But it makes your IMSC document much more readable if you use the official prefixes listed in <a href="https://www.w3.org/TR/ttml-imsc1.0.1/#namespaces">namespace section</a> of the IMSC standard.</p>
 </div>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/styling/index.html
+++ b/files/en-us/related/imsc/styling/index.html
@@ -145,7 +145,7 @@ tags:
 
 <pre class="brush: xml">&lt;p style=”s1 s2”&gt;Hello, I am Mork from Ork&lt;/p&gt;</pre>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/subtitle_placement/index.html
+++ b/files/en-us/related/imsc/subtitle_placement/index.html
@@ -35,7 +35,7 @@ tags:
  <li><code>tts:displayAlign</code> — the vertical alignment of the text. This can be set to <code>before</code>, <code>center</code>, or <code>after</code>. <code>before</code> means that the text will start from the very top of the region box, and flow downwards. <code>center</code> means the text will be vertically centered within the region box. After means that the text will start from the very bottom of the region box, and flow upwards.</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/timing_in_imsc/index.html
+++ b/files/en-us/related/imsc/timing_in_imsc/index.html
@@ -78,7 +78,7 @@ tags:
 </div>
 
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.html
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.html
@@ -247,7 +247,7 @@ client.send()</pre>
 
 <p>the best solution is to building your own custom controls. Find out how in our <a href="/en-US/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/cross_browser_video_player">Creating a cross-browser video player</a> tutorial.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
  <li class="toggle">

--- a/files/en-us/web/accessibility/index.html
+++ b/files/en-us/web/accessibility/index.html
@@ -13,7 +13,7 @@ tags:
 
 <div class="cleared topicpage-table">
 <div class="section">
-<h2 class="Key_accessibility_tutorials" id="Key_accessibility_tutorials">Key tutorials</h2>
+<h2 id="Key_accessibility_tutorials">Key tutorials</h2>
 
 <p>The MDN <a href="/en-US/docs/Learn/Accessibility">Accessibility Learning Area</a> contains modern, up-to-date tutorials covering accessibility essentials:</p>
 

--- a/files/en-us/web/api/cssstylerule/selectortext/index.html
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.html
@@ -24,7 +24,7 @@ var stylesheet = document.styleSheets[0];
 alert(stylesheet.cssRules[0].selectorText); // body
 </pre>
 
-<h2 class="Notes" id="Notes">Notes</h2>
+<h2 id="Notes">Notes</h2>
 
 <p>The implementation may have stripped out insignificant whitespace while parsing the selector. If set to a selector string which cannot be parsed, a SyntaxError is thrown.</p>
 

--- a/files/en-us/web/css/align-tracks/index.html
+++ b/files/en-us/web/css/align-tracks/index.html
@@ -110,7 +110,7 @@ align-tracks: unset;
 
 <h2 id="Subnav">Subnav</h2>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_flow_layout/index.html
+++ b/files/en-us/web/css/css_flow_layout/index.html
@@ -42,7 +42,7 @@ tags:
  <li>{{Glossary("Block/CSS", "Block (CSS)")}}</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.html
@@ -553,7 +553,7 @@ dd {
 
 <p>It may be that you come up with your own use cases for auto-placement or any other part of grid layout. If you do, raise them as issues or add to an existing issue that could solve your use case. This will help to make future versions of the specification better.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -663,7 +663,7 @@ tags:
 
 <h2 id="Subnav">Subnav</h2>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.html
@@ -656,7 +656,7 @@ tags:
 
 <p>Setting auto margins, using <code>margin-right</code> or <code>margin-left</code> however, or absolutely positioning items using the <code>top</code>, <code>right</code>, <code>bottom</code> and <code>left</code> offsets would not honor writing modes. In the next guide, we will look further into this interaction between CSS grid layout, box alignment and writing modes. This will be important to understand, if you develop sites that are then displayed in multiple languages, or if you want to mix languages or writing modes in a design.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/css_grid,_logical_values_and_writing_modes/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid,_logical_values_and_writing_modes/index.html
@@ -441,7 +441,7 @@ gap: 10px;
 
 <p>The <a href="https://drafts.csswg.org/css-logical-props/">CSS Logical Properties specification</a> means that you can use the <a href="/en-US/docs/Web/CSS/CSS_Logical_Properties">logical equivalents</a> for properties, such as {{cssxref("margin-left")}} and {{cssxref("margin-right")}}, in your CSS. These properties and values have good support in modern browsers. Your understanding of block and inline through grid will help you to understand how to use these too.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
@@ -393,7 +393,7 @@ img {
  <li><a href="https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer">CSS Grid and the New Autoprefixer</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.html
@@ -114,7 +114,7 @@ tags:
 
 <p>As a way to start thinking about these issues, as you use CSS Grid Layout I would suggest reading <em><a href="http://tink.uk/flexbox-the-keyboard-navigation-disconnect/">Flexbox &amp; the Keyboard Navigation Disconnect</a></em> from Léonie Watson. Also <a href="https://www.youtube.com/watch?v=spxT2CmHoPk">the video of Léonie’s presentation from ffconf</a> is helpful to understand more about how screen readers work with the visual representation of things in CSS. Adrian Roselli has also posted regarding <a href="http://adrianroselli.com/2015/10/html-source-order-vs-css-display-order.html">tab order in various browsers</a> – although this was prior to grid support being fully implemented in Firefox.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.html
@@ -469,7 +469,7 @@ tags:
 
 <p>If you have worked through these initial guides you now should be in a position to create grid layouts using line-based placement or named areas. Take some time to build some common layout patterns using grid, while there are lots of new terms to learn, the syntax is relatively straightforward. As you develop examples, you are likely to come up with some questions and use cases for things we haven't covered yet. In the rest of these guides we will be looking at some more of the detail included in the specification – in order that you can begin to create advanced layouts with it.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/index.html
@@ -208,7 +208,7 @@ tags:
  </tbody>
 </table>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
+++ b/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.html
@@ -435,7 +435,7 @@ tags:
 
 <p>That’s all I need. I don’t need to do any calculations, grid automatically removed my 10 pixel gutter track before assigning the space to the <code>1fr</code> column tracks. As you start to build out your own layouts, you will find that the syntax becomes more familiar and you choose the ways that work best for you and the type of projects you like to build. Try building some common patterns with these various methods, and you will soon find your most productive way to work. Then, in the next guide we will look at how grid can position items for us - without us needing to use placement properties at all!</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.html
@@ -601,7 +601,7 @@ tags:
 
 <p>Also, remember that items on the grid can overlap each other when you place them explicitly like this. That can create some nice effects, however you can also end up with things overlapping incorrectly if you specify the wrong start or end line. The <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts">Firefox Grid Highlighter</a> can be very useful as you learn, especially if your grid is quite complicated.</p>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.html
@@ -85,7 +85,7 @@ tags:
  <li><a href="https://www.smashingmagazine.com/native-css-masonry-layout-css-grid/">Native CSS Masonry Layout In CSS Grid</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.html
@@ -537,7 +537,7 @@ tags:
  <li>For additional common layout patterns see <em><a href="http://gridbyexample.com">Grid by Example</a></em>, where there are many smaller examples of grid layout and also some larger UI patterns and full page layouts.</li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.html
@@ -573,7 +573,7 @@ tags:
  <li><a href="/en-US/docs/Web/CSS/CSS_Columns">Multiple-column Layout Guides</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.html
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.html
@@ -120,7 +120,7 @@ tags:
 
 <h2 id="Subnav">Subnav</h2>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-area/index.html
+++ b/files/en-us/web/css/grid-area/index.html
@@ -161,7 +161,7 @@ grid-area: unset;</pre>
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/grid-template-areas/">Grid Template Areas</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-auto-columns/index.html
+++ b/files/en-us/web/css/grid-auto-columns/index.html
@@ -153,7 +153,7 @@ grid-auto-columns: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-auto-placement-order/">Introducing Grid auto-placement and order</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-auto-flow/index.html
+++ b/files/en-us/web/css/grid-auto-flow/index.html
@@ -164,7 +164,7 @@ inputElem.addEventListener('change', changeGridAutoFlow);
 	<li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-auto-placement-order/">Introducing Grid auto-placement and order</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
 	<li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
 	<li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-auto-rows/index.html
+++ b/files/en-us/web/css/grid-auto-rows/index.html
@@ -148,7 +148,7 @@ grid-auto-rows: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-auto-placement-order/">Introducing Grid auto-placement and order</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-column-end/index.html
+++ b/files/en-us/web/css/grid-column-end/index.html
@@ -168,7 +168,7 @@ grid-column-end: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-line-based-placement/">Line-based placement</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-column-start/index.html
+++ b/files/en-us/web/css/grid-column-start/index.html
@@ -178,7 +178,7 @@ grid-column-start: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-line-based-placement/">Line-based placement</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-column/index.html
+++ b/files/en-us/web/css/grid-column/index.html
@@ -141,7 +141,7 @@ tags:
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-line-based-placement/">Line-based placement</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-row-end/index.html
+++ b/files/en-us/web/css/grid-row-end/index.html
@@ -168,7 +168,7 @@ grid-row-end: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-line-based-placement/">Line-based placement</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-row-start/index.html
+++ b/files/en-us/web/css/grid-row-start/index.html
@@ -179,7 +179,7 @@ grid-row-start: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-line-based-placement/">Line-based placement</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-row/index.html
+++ b/files/en-us/web/css/grid-row/index.html
@@ -157,7 +157,7 @@ grid-row: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/series-line-based-placement/">Line-based placement</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-template-areas/index.html
+++ b/files/en-us/web/css/grid-template-areas/index.html
@@ -131,7 +131,7 @@ grid-template-areas: unset;
  <li>Video tutorial: <em><a href="http://gridbyexample.com/video/grid-template-areas/">Grid Template Areas</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-template-columns/index.html
+++ b/files/en-us/web/css/grid-template-columns/index.html
@@ -169,7 +169,7 @@ grid-template-columns: unset;
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid">Subgrid</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-template-rows/index.html
+++ b/files/en-us/web/css/grid-template-rows/index.html
@@ -174,7 +174,7 @@ grid-template-rows: unset;
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid">Subgrid</a></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid-template/index.html
+++ b/files/en-us/web/css/grid-template/index.html
@@ -153,7 +153,7 @@ footer {
  <li>Video tutorial:<em> <a href="http://gridbyexample.com/video/grid-template-shorthand/">Grid Template shorthand</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/grid/index.html
+++ b/files/en-us/web/css/grid/index.html
@@ -148,7 +148,7 @@ grid: unset;
  <li>Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas#Grid_definition_shorthands">Grid template areas - Grid definition shorthands</a></em></li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/justify-tracks/index.html
+++ b/files/en-us/web/css/justify-tracks/index.html
@@ -113,7 +113,7 @@ justify-tracks: unset;
 
 <h2 id="Subnav">Subnav</h2>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/masonry-auto-flow/index.html
+++ b/files/en-us/web/css/masonry-auto-flow/index.html
@@ -162,7 +162,7 @@ selectElem.addEventListener('change', changeMasonryFlow);
 
 <h2 id="Subnav">Subnav</h2>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/minmax()/index.html
+++ b/files/en-us/web/css/minmax()/index.html
@@ -155,7 +155,7 @@ minmax(auto, 300px)
  </li>
 </ul>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/CSS"><strong>CSS</strong></a></li>
  <li><a href="/en-US/docs/Web/CSS/Reference"><strong>CSS Reference</strong></a></li>

--- a/files/en-us/web/css/pseudo-classes/index.html
+++ b/files/en-us/web/css/pseudo-classes/index.html
@@ -180,7 +180,7 @@ button:hover {
 
 <p>Pseudo-classes defined by a set of CSS specifications include the following:</p>
 
-<div class="index" id="index"><span>A</span>
+<div id="index"><span>A</span>
 
 <ul>
  <li>{{CSSxRef(":active")}}</li>

--- a/files/en-us/web/css/pseudo-elements/index.html
+++ b/files/en-us/web/css/pseudo-elements/index.html
@@ -39,7 +39,7 @@ p::first-line {
 
 <p>Pseudo-elements defined by a set of CSS specifications include the following:</p>
 
-<div class="index" id="index"><span>A</span>
+<div id="index"><span>A</span>
 
 <ul>
  <li>{{CSSxRef("::after", "::after (:after)")}}</li>

--- a/files/en-us/web/guide/ajax/index.html
+++ b/files/en-us/web/guide/ajax/index.html
@@ -21,7 +21,7 @@ An introduction to Ajax.</div>
 
 <div class="row topicpage-table">
 <div class="section">
-<h2 class="Documentation" id="Documentation">Documentation</h2>
+<h2 id="Documentation">Documentation</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Guide/AJAX/Getting_Started">Getting Started</a></dt>

--- a/files/en-us/web/svg/index.html
+++ b/files/en-us/web/svg/index.html
@@ -30,7 +30,7 @@ This tutorial will help get you started using SVG.</div>
 
 <div class="cleared row topicpage-table">
 <div class="section">
-<h2 class="Documentation" id="Documentation">Documentation</h2>
+<h2 id="Documentation">Documentation</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/SVG/Element">SVG element reference</a></dt>
@@ -45,13 +45,13 @@ This tutorial will help get you started using SVG.</div>
 
 <p><span class="alllinks"><a href="/en-US/docs/tag/SVG">View All...</a></span></p>
 
-<h2 class="Community" id="Community">Community</h2>
+<h2 id="Community">Community</h2>
 
 <ul>
  <li>View Mozilla forums... {{DiscussionList("dev-tech-svg", "mozilla.dev.tech.svg")}}</li>
 </ul>
 
-<h2 class="Tools" id="Tools">Tools</h2>
+<h2 id="Tools">Tools</h2>
 
 <ul>
  <li><a href="https://github.com/w3c/svgwg/wiki/Testing">SVG Test Suite</a></li>

--- a/files/en-us/web/xslt/index.html
+++ b/files/en-us/web/xslt/index.html
@@ -38,7 +38,7 @@ tags:
 
 <div class="topicpage-table">
 <div class="section">
-<h2 class="Documentation" id="Documentation">Documentation</h2>
+<h2 id="Documentation">Documentation</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/XSLT/Element">XSLT Element Reference</a></dt>
@@ -65,13 +65,13 @@ tags:
 </div>
 
 <div class="section">
-<h2 class="Community" id="Community">Community</h2>
+<h2 id="Community">Community</h2>
 
 <ul>
  <li>View Mozilla forums... {{DiscussionList("dev-tech-xslt", "mozilla.dev.tech.xslt")}}</li>
 </ul>
 
-<h4 class="Related_Topics" id="Related_Topics">Related Topics</h4>
+<h4 id="Related_Topics">Related Topics</h4>
 
 <ul>
  <li><a href="/en-US/docs/XML_introduction">XML</a>, <a href="/en-US/docs/Web/XPath">XPath</a>, <a href="/en-US/docs/Archive/XQuery">XQuery</a></li>


### PR DESCRIPTION
Find: `class="(\S*)" id="\1"`
Replace: `id="$1"`

Possible that some of these might be intentional, but seems likely another old Wiki oddity