### PR TITLE
Update broken link in aria-describedby docs

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-describedby_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-describedby_attribute/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <h3 id="Description">Description</h3>
 
-<p><span class="seoSummary">The <a class="external" href="https://www.w3.org/TR/wai-aria/#aria-describedby" rel="external"><code>aria-describedby</code></a> attribute is used to indicate the IDs of the elements that describe the object. It is used to establish a relationship between widgets or groups and text that described them. This is very similar to <a href="/en/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute" title="Using the aria-labelledby attribute">aria-labelledby</a>: a label describes the essence of an object, while a description provides more information that the user might need.</span></p>
+<p><span class="seoSummary">The <a class="external" href="https://www.w3.org/TR/wai-aria/#aria-describedby" rel="external"><code>aria-describedby</code></a> attribute is used to indicate the IDs of the elements that describe the object. It is used to establish a relationship between widgets or groups and text that described them. This is very similar to <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute" title="Using the aria-labelledby attribute">aria-labelledby</a>: a label describes the essence of an object, while a description provides more information that the user might need.</span></p>
 
 <p>The <code>aria-describedby</code> attribute is not used only for form elements; it is also used to associate static text with widgets, groups of elements, panes, regions that have a heading, definitions, and more. The {{ anch("Examples") }} section below provides more information about how to use the attribute in these cases.</p>
 


### PR DESCRIPTION
Changed `/en/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute` to `/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute` as the href value for think link to the aria-labelledby docs.

Tested new link works and goes to correct page.

Original issue described in https://github.com/mdn/content/issues/740