### PR TITLE
Add Contact Picker API spec

### DIFF
--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -104,8 +104,8 @@ async function getContacts() {
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td><a href="https://wicg.github.io/contact-api/spec/">Contact Picker API</a></td>
-   <td>Unofficial Proposal Draft, 2 January 2020</td>
+   {{SpecName('Contact Picker API')}}
+   <td>{{Spec2('Contact Picker API')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>

--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>The following code checks whether the Contact Picker API is supported.</p>
 
-<pre class="brush: js notranslate">const supported = ('contacts' in navigator &amp;&amp; 'ContactsManager' in window);
+<pre class="brush: js notranslate">const supported = 'contacts' in navigator;
 </pre>
 
 <h3 id="Checking_for_Supported_Properties">Checking for Supported Properties</h3>

--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -104,7 +104,7 @@ async function getContacts() {
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   {{SpecName('Contact Picker API')}}
+   <td>{{SpecName('Contact Picker API')}}</td>
    <td>{{Spec2('Contact Picker API')}}</td>
    <td>Initial definition.</td>
   </tr>

--- a/files/en-us/web/api/contact_picker_api/index.html
+++ b/files/en-us/web/api/contact_picker_api/index.html
@@ -104,8 +104,8 @@ async function getContacts() {
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('Contact Picker API')}}</td>
-   <td>{{Spec2('Contact Picker API')}}</td>
+   <td><a href="https://wicg.github.io/contact-api/spec/">Contact Picker API</a></td>
+   <td>Unofficial Proposal Draft, 2 January 2020</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>


### PR DESCRIPTION
`{{SpecName('Contact Picker API')}}` and` {{Spec2('Contact Picker API')}}` links were not working. Spec provided here https://github.com/mdn/browser-compat-data/issues/7851#issuecomment-748028567

Also updated the feature test