### PR TITLE
Update Intl.Locale polyfill URL to formatjs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/index.html
@@ -103,6 +103,6 @@ console.log(us12hour.hourCycle); // Prints "h12"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="https://github.com/zbraniecki/Intl.js/tree/intllocale">The Intl.Locale Polyfill</a></li>
+ <li><a href="https://formatjs.io/docs/polyfills/intl-locale">The Intl.Locale Polyfill</a></li>
  <li><a href="https://www.unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">Unicode locale identifiers spec</a></li>
 </ul>


### PR DESCRIPTION
Zibi's polyfill is super old and no longer implements the latest spec.