### PR TITLE
adds CSSImportRule

### DIFF
--- a/files/en-us/web/api/cssimportrule/href/index.html
+++ b/files/en-us/web/api/cssimportrule/href/index.html
@@ -13,7 +13,8 @@ tags:
 
 <p class="summary">The read-only <strong><code>href</code></strong> property of the {{domxref("CSSImportRule")}} interface returns the URL specified by the {{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>.</p>
 
-<p>The resolved URL will be the  {{HTMLAttrxRef("href","link")}} attribute of the associated stylesheet.</p>
+<p>The resolved URL will be the {{HTMLAttrxRef("href","link")}} attribute of the associated stylesheet.</p>
+
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssimportrule/href/index.html
+++ b/files/en-us/web/api/cssimportrule/href/index.html
@@ -1,0 +1,62 @@
+---
+title: CSSImportRule.href
+slug: Web/API/CSSImportRule/href
+tags:
+  - API
+  - CSSOM
+  - Property
+  - Reference
+  - CSSImportRule
+  - Read-only
+---
+<p>{{APIRef("CSSOM")}}</p>
+
+<p class="summary">The read-only <strong><code>href</code></strong> property of the {{domxref("CSSImportRule")}} interface returns the URL specified by the {{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>.</p>
+
+<p>The resolved URL will be the  {{HTMLAttrxRef("href","link")}} attribute of the associated stylesheet.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>href</var> = <var>CSSImportRule</var>.href;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("USVString")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following stylesheet includes a single {{cssxref("@import")}} rule. Therefore the first item in the list of CSS rules will be a <code>CSSImportRule</code>. The <code>href</code> property returns the URL of the imported stylesheet.</p>
+
+<pre class="brush:css">@import url("style.css") screen;</pre>
+
+<pre class="brush:javascript">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].href); //returns style.css</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('CSSOM', '#dom-cssimportrule-href', 'CSSImportRule.href')}}</td>
+			<td>{{Spec2('CSSOM')}}</td>
+			<td>No changes from {{SpecName('DOM2 Style')}}</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}</td>
+			<td>{{Spec2('DOM2 Style')}}</td>
+			<td>Initial definition</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSImportRule.href")}}</p>

--- a/files/en-us/web/api/cssimportrule/index.html
+++ b/files/en-us/web/api/cssimportrule/index.html
@@ -1,0 +1,68 @@
+---
+title: CSSImportRule
+slug: Web/API/CSSImportRule
+tags:
+  - API
+  - CSSOM
+  - Interface
+  - Reference
+---
+<p>{{APIRef("CSSOM")}}</p>
+
+<p>The <strong><code>CSSImportRule</code></strong> interface represents an {{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. It implements the {{domxref("CSSRule")}} interface.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>Inherits properties from its ancestor {{domxref("CSSRule")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("CSSImportRule.href")}}{{readonlyinline}}</dt>
+  <dd>Returns the url specified by the {{cssxref("@import")}} rule.</dd>
+  <dt>{{domxref("CSSImportRule.media")}}{{readonlyinline}}</dt>
+  <dd>Returns the value of the <code>media</code> attribute of the associated stylesheet.</dd>
+  <dt>{{domxref("CSSImportRule.stylesheet")}}{{readonlyinline}}</dt>
+  <dd>Returns the associated stylesheet.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>Inherits methods from its ancestor {{domxref("CSSRule")}}.</em></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following stylesheet includes a single {{cssxref("@import")}} rule. Therefore the first item in the list of CSS rules will be a <code>CSSImportRule</code>.</p>
+
+<pre class="brush:css">@import url("style.css") screen;</pre>
+
+<pre class="brush:javascript">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0]); //a CSSImportRule</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('CSSOM', '#cssimportrule', 'CSSImportRule')}}</td>
+			<td>{{Spec2('CSSOM')}}</td>
+			<td>No changes from {{SpecName('DOM2 Style')}}</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}</td>
+			<td>{{Spec2('DOM2 Style')}}</td>
+			<td>Initial definition</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSImportRule")}}</p>

--- a/files/en-us/web/api/cssimportrule/index.html
+++ b/files/en-us/web/api/cssimportrule/index.html
@@ -9,7 +9,9 @@ tags:
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p>The <strong><code>CSSImportRule</code></strong> interface represents an {{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. It implements the {{domxref("CSSRule")}} interface.</p>
+<p>The <strong><code>CSSImportRule</code></strong> interface represents an {{cssxref("@import")}} {{cssxref("at-rule")}}.</p>
+
+<p>{{InheritanceDiagram}}</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/cssimportrule/media/index.html
+++ b/files/en-us/web/api/cssimportrule/media/index.html
@@ -1,0 +1,60 @@
+---
+title: CSSImportRule.media
+slug: Web/API/CSSImportRule/media
+tags:
+  - API
+  - CSSOM
+  - Property
+  - Reference
+  - CSSImportRule
+  - Read-only
+---
+<p>{{APIRef("CSSOM")}}</p>
+
+<p class="summary">The read-only <strong><code>media</code></strong> property of the {{domxref("CSSImportRule")}} interface returns a {{domxref("MediaList")}} object, containing the value of the <code>media</code> attribute of the associated stylesheet.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>media</var> = <var>CSSImportRule</var>.media;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("MediaList")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following stylesheet includes a single {{cssxref("@import")}} rule. Therefore the first item in the list of CSS rules will be a <code>CSSImportRule</code>. The <code>media</code> property returns a {{domxref("MediaList")}} object. This includes the <code>mediaText</code> property with a value of <code>screen</code>.</p>
+
+<pre class="brush:css">@import url("style.css") screen;</pre>
+
+<pre class="brush:javascript">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].media); //returns a MediaList</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('CSSOM', '#dom-cssimportrule-media', 'CSSImportRule.media')}}</td>
+			<td>{{Spec2('CSSOM')}}</td>
+			<td>No changes from {{SpecName('DOM2 Style')}}</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}</td>
+			<td>{{Spec2('DOM2 Style')}}</td>
+			<td>Initial definition</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSImportRule.media")}}</p>

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.html
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.html
@@ -1,0 +1,62 @@
+---
+title: CSSImportRule.stylesheet
+slug: Web/API/CSSImportRule/stylesheet
+tags:
+  - API
+  - CSSOM
+  - Property
+  - Reference
+  - CSSImportRule
+  - Read-only
+---
+<p>{{APIRef("CSSOM")}}</p>
+
+<p class="summary">The read-only <strong><code>styleSheet</code></strong> property of the {{domxref("CSSImportRule")}} interface returns the CSS Stylesheet specified by the {{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. This will be in the form of a {{domxref("CSSStyleSheet")}} object.</p>
+
+<p>An {{cssxref("@import")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a> always has an associated stylesheet.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>href</var> = <var>CSSImportRule</var>.styleSheet;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSStyleSheet")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following stylesheet includes a single {{cssxref("@import")}} rule. Therefore the first item in the list of CSS rules will be a <code>CSSImportRule</code>. The <code>styleSheet</code> property returns the imported stylesheet.</p>
+
+<pre class="brush:css">@import url("style.css") screen;</pre>
+
+<pre class="brush:javascript">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0].styleSheet); //returns a CSSStyleSheet object</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('CSSOM', '#dom-cssimportrule-stylesheet', 'CSSImportRule.styleSheet')}}</td>
+			<td>{{Spec2('CSSOM')}}</td>
+			<td>No changes from {{SpecName('DOM2 Style')}}</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSImportRule', 'CSSImportRule')}}</td>
+			<td>{{Spec2('DOM2 Style')}}</td>
+			<td>Initial definition</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSImportRule.styleSheet")}}</p>


### PR DESCRIPTION
Working on #344 
Fixes: #229 

The CSSImportRule API of the CSSOM was not documented at all, so this PR adds that interface and property pages.

https://drafts.csswg.org/cssom/#the-cssimportrule-interface

Reviewer: @jpmedley 

