### PR TITLE
Mismatch argument for BarcodeDetector.getSupportedFormats()

### DIFF
--- a/files/en-us/web/api/barcode_detection_api/index.html
+++ b/files/en-us/web/api/barcode_detection_api/index.html
@@ -137,7 +137,7 @@ if (!('BarcodeDetector' in window)) {
 
 <pre class="brush: js notranslate">// check supported types
 BarcodeDetector.getSupportedFormats()
-  .then(formats =&gt; {
+  .then(supportedFormats =&gt; {
     supportedFormats.forEach(format =&gt; console.log(format));
   });</pre>
 


### PR DESCRIPTION
Mismatched argument naming. supportedFormats cannot be found as the argument is named formats, suggesting the change from formats to supportedFormats.
Thanks 👍