### PR TITLE
fix Intl.PluralRules constructor

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.html
@@ -15,7 +15,7 @@ tags:
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("PluralRules.PluralRules()", "Intl.PluralRules.PluralRules()")}}</dt>
+ <dt>{{jsxref("PluralRules.PluralRules()", "Intl.PluralRules()")}}</dt>
  <dd>Creates a new <code>Intl.PluralRules</code> object.</dd>
 </dl>
 


### PR DESCRIPTION
It should be `Intl.PluralRules()`, not `Intl.PluralRules.PluralRules()`