### PR TITLE
Adds CSSFontFaceRule

### DIFF
--- a/files/en-us/web/api/cssfontfacerule/index.html
+++ b/files/en-us/web/api/cssfontfacerule/index.html
@@ -10,7 +10,9 @@ tags:
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
-<p>The <strong><code>CSSFontFaceRule</code></strong> interface represents an {{cssxref("@font-face")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. It implements the {{domxref("CSSRule")}} interface.</p>
+<p>The <strong><code>CSSFontFaceRule</code></strong> interface represents an {{cssxref("@font-face")}} {{cssxref("at-rule")}}.</p>
+
+<p>{{InheritanceDiagram}}</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/cssfontfacerule/index.html
+++ b/files/en-us/web/api/cssfontfacerule/index.html
@@ -1,0 +1,71 @@
+---
+title: CSSFontFaceRule
+slug: Web/API/CSSFontFaceRule
+tags:
+  - API
+  - CSSOM
+  - CSSFontFaceRule
+  - Interface
+  - Reference
+---
+<p>{{APIRef("CSSOM")}}</p>
+
+<p>The <strong><code>CSSFontFaceRule</code></strong> interface represents an {{cssxref("@font-face")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. It implements the {{domxref("CSSRule")}} interface.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>Inherits properties from its ancestor {{domxref("CSSRule")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("CSSFontFaceRule.style")}}{{readonlyinline}}</dt>
+  <dd>Returns a {{domxref("CSSStyleDeclaration")}}.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>Inherits methods from its ancestor {{domxref("CSSRule")}}.</em></p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>This example uses the CSS found as an example on the {{cssxref("@font-face")}} page. The first {{domxref("CSSRule")}} returned will be a <code>CSSFontFaceRule</code>.</p>
+
+<pre class="brush:css">@font-face {
+  font-family: MyHelvetica;
+  src: local("Helvetica Neue Bold"),
+  local("HelveticaNeue-Bold"),
+  url(MgOpenModernaBold.ttf);
+  font-weight: bold;
+}</pre>
+
+<pre class="brush:javascript">let myRules = document.styleSheets[0].cssRules;
+console.log(myRules[0]); //a CSSFontFaceRule</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('CSS4 Fonts', '#om-fontface', 'CSSFontFaceRule')}}</td>
+			<td>{{Spec2('CSS4 Fonts')}}</td>
+			<td>Supersedes definition in {{SpecName('DOM2 Style')}}</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSFontFaceRule', 'CSSFontFaceRule')}}</td>
+			<td>{{Spec2('DOM2 Style')}}</td>
+			<td>Initial definition</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSFontFaceRule")}}</p>

--- a/files/en-us/web/api/cssfontfacerule/style/index.html
+++ b/files/en-us/web/api/cssfontfacerule/style/index.html
@@ -1,0 +1,66 @@
+---
+title: CSSFontFaceRule.style
+slug: Web/API/CSSFontFaceRule/style
+tags:
+  - API
+  - CSSOM
+  - CSSFontFaceRule
+  - Property
+  - Reference
+  - Read-only
+---
+<p>{{APIRef("CSSOM")}}</p>
+
+<p class="summary">The read-only <strong><code>style</code></strong> property of the {{domxref("CSSFontFaceRule")}} interface returns the style information from the {{cssxref("@font-face")}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>. This will be in the form of a {{domxref("CSSStyleDeclaration")}} object.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>style</var> = <var>CSSFontFaceRule</var>.style;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("CSSStyleDeclaration")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>This example uses the CSS found as an example on the {{cssxref("@font-face")}} page. The first {{domxref("CSSRule")}} returned will be a <code>CSSFontFaceRule</code>. The <code>style</code> property returns a {{domxref("CSSStyleDeclaration")}} with the properties <code>fontFamily</code>, <code>fontWeight</code>, and <code>src</code> populated with the information from the rule.</p>
+
+<pre class="brush:css">@font-face {
+    font-family: MyHelvetica;
+    src: local("Helvetica Neue Bold"),
+    local("HelveticaNeue-Bold"),
+    url(MgOpenModernaBold.ttf);
+    font-weight: bold;
+  }</pre>
+  
+  <pre class="brush:javascript">let myRules = document.styleSheets[0].cssRules;
+  console.log(myRules[0].style); //a CSSStyleDeclaration</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('CSS4 Fonts', '#dom-cssfontfacerule-style', 'CSSFontFaceRule.style')}}</td>
+			<td>{{Spec2('CSS4 Fonts')}}</td>
+			<td>Supersedes definition in {{SpecName('DOM2 Style')}}</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('DOM2 Style', 'css.html#CSS-CSSFontFaceRule', 'CSSFontFaceRule')}}</td>
+			<td>{{Spec2('DOM2 Style')}}</td>
+			<td>Initial definition</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CSSFontFaceRule.style")}}</p>


### PR DESCRIPTION
Working on #344 
Fixes: #228 

This PR adds the missing documentation for CSSFontFaceRule and the CSSFontFaceRule.style property. BCD already exists.

https://drafts.csswg.org/css-fonts-4/#om-fontface

Reviewer: @jpmedley 