### PR TITLE
chore: Add initial EditorConfig for whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Went with the main style I could see which was more single/double with spaces.
Didn't do any formatting afterwards, but will be respected in IDEs or GitHub editor going forward