### PR TITLE
Remove useless colspan and rowspan

### DIFF
--- a/files/en-us/learn/common_questions/what_software_do_i_need/index.html
+++ b/files/en-us/learn/common_questions/what_software_do_i_need/index.html
@@ -148,7 +148,7 @@ tags:
  <thead>
   <tr>
    <th scope="col">Operating system</th>
-   <th colspan="2" rowspan="1" scope="col" style="text-align: center;"> FTP software</th>
+   <th colspan="2" scope="col" style="text-align: center;"> FTP software</th>
   </tr>
  </thead>
  <tbody>
@@ -160,7 +160,7 @@ tags:
      <li><a href="http://mobaxterm.mobatek.net/">Moba Xterm</a></li>
     </ul>
    </td>
-   <td colspan="1" rowspan="3">
+   <td rowspan="3">
     <ul>
      <li><a href="https://filezilla-project.org/">FileZilla</a> (All OS)</li>
     </ul>
@@ -190,7 +190,7 @@ tags:
      <li><a href="https://shiftedit.net/">ShiftEdit</a> (All OS)</li>
     </ul>
    </td>
-   <td colspan="1"></td>
+   <td></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.html
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.html
@@ -510,7 +510,7 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("background")}}</th>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No</td>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No</td>
-   <td colspan="1" rowspan="3">
+   <td rowspan="3">
     <p>Supported but there is too much inconsistency between browsers to be reliable.</p>
    </td>
   </tr>
@@ -825,7 +825,7 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("background")}}</th>
    <td style="text-align: center; background-color: rgb(255, 255, 102); vertical-align: top;">Partial<sup>[1]</sup></td>
    <td style="text-align: center; background-color: rgb(255, 255, 102); vertical-align: top;">Partial<sup>[1]</sup></td>
-   <td colspan="1" rowspan="3">
+   <td rowspan="3">
     <ol>
      <li>Most of the browsers only support this property on the <code>{{htmlelement("select")}}</code> element.</li>
     </ol>
@@ -1545,7 +1545,7 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("background")}}</th>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No<sup>[1]</sup></td>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No<sup>[1]</sup></td>
-   <td colspan="1" rowspan="3">
+   <td rowspan="3">
     <ol>
      <li>Supported, but there is too much inconsistency between browsers to be reliable.</li>
     </ol>
@@ -1683,7 +1683,7 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("background")}}</th>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No<sup>[1]</sup></td>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No<sup>[1]</sup></td>
-   <td colspan="1" rowspan="3">
+   <td rowspan="3">
     <ol>
      <li>Supported, but there is too much inconsistency between browsers to be reliable.</li>
     </ol>
@@ -1825,7 +1825,7 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("background")}}</th>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No<sup>[1]</sup></td>
    <td style="text-align: center; background-color: rgb(255, 153, 153); vertical-align: top;">No<sup>[1]</sup></td>
-   <td colspan="1" rowspan="3">
+   <td rowspan="3">
     <ol>
      <li>Supported, but there is too much inconsistency between browsers to be reliable.</li>
     </ol>
@@ -1959,13 +1959,13 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("background")}}</th>
    <td style="text-align: center; background-color: rgb(204, 255, 102); vertical-align: top;">Yes</td>
    <td style="text-align: center; background-color: rgb(204, 255, 102); vertical-align: top;">Yes</td>
-   <td colspan="1"></td>
+   <td></td>
   </tr>
   <tr>
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("border-radius")}}</th>
    <td style="text-align: center; background-color: rgb(255, 255, 102); vertical-align: top;">Partial<sup>[1]</sup></td>
    <td style="text-align: center; background-color: rgb(255, 255, 102); vertical-align: top;">Partial<sup>[1]</sup></td>
-   <td colspan="1">
+   <td>
     <ol>
      <li>IE9 does not support this property.</li>
     </ol>
@@ -1975,7 +1975,7 @@ tags:
    <th scope="row" style="white-space: nowrap; vertical-align: top;">{{cssxref("box-shadow")}}</th>
    <td style="text-align: center; background-color: rgb(255, 255, 102); vertical-align: top;">Partial<sup>[1]</sup></td>
    <td style="text-align: center; background-color: rgb(255, 255, 102); vertical-align: top;">Partial<sup>[1]</sup></td>
-   <td colspan="1">
+   <td>
     <ol>
      <li>IE9 does not support this property.</li>
     </ol>

--- a/files/en-us/mozilla/projects/nss/jss/using_jss/index.html
+++ b/files/en-us/mozilla/projects/nss/jss/using_jss/index.html
@@ -146,7 +146,7 @@ tags:
      <td>3.3</td>
     </tr>
     <tr>
-     <td rowspan="1">JSS 3.0</td>
+     <td>JSS 3.0</td>
      <td>NSPR</td>
      <td>3.5.1</td>
     </tr>

--- a/files/en-us/web/accessibility/aria/how_to_file_aria-related_bugs/index.html
+++ b/files/en-us/web/accessibility/aria/how_to_file_aria-related_bugs/index.html
@@ -22,7 +22,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="3">Screen readers</td>
+   <td rowspan="3">Screen readers</td>
    <td>
     <p><a class="external" href="http://www.freedomscientific.com/products/fs/jaws-product-page.asp">Freedom Scientific JAWS</a></p>
    </td>
@@ -40,7 +40,7 @@ tags:
    <td><a href="/en/Accessibility/JAWS_Issues_with_Firefox" title="JAWS Issues with Firefox">Discuss NVDA issues</a></td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="6">Browsers</td>
+   <td rowspan="6">Browsers</td>
    <td>Apple Safari</td>
    <td><a class="external" href="http://www.webkit.org/quality/reporting.html">File WebKit.org bugs</a></td>
    <td> </td>
@@ -79,7 +79,7 @@ tags:
    <td><span class="external">Use [ARIA] in the summary field</span></td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="2">JS Libraries</td>
+   <td rowspan="2">JS Libraries</td>
    <td>Dojo Toolkit</td>
    <td><a class="external" href="http://dojotoolkit.org/blog/how-file-dojo-bug-report">File Dojo bug</a></td>
    <td><span class="external">Put Accessibility in the component field</span></td>

--- a/files/en-us/web/accessibility/understanding_wcag/perceivable/index.html
+++ b/files/en-us/web/accessibility/understanding_wcag/perceivable/index.html
@@ -31,7 +31,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="5">1.1.1 Provide text equivalents  (A)</td>
+   <td rowspan="5">1.1.1 Provide text equivalents  (A)</td>
    <td>All images that convey meaningful content should be given suitable alternative text.</td>
    <td><a href="/en-US/docs/Learn/Accessibility/HTML#Text_alternatives">Text alternatives.</a></td>
   </tr>
@@ -78,47 +78,47 @@ tags:
    <th scope="col">Practical resource</th>
   </tr>
   <tr>
-   <td colspan="1" rowspan="1">1.2.1 Provide alternatives for pre-recorded audio-only and video-only content (A)</td>
+   <td>1.2.1 Provide alternatives for pre-recorded audio-only and video-only content (A)</td>
    <td>A transcript should be provided for prerecorded audio-only media, and a transcript or audio description should be provided for prerecorded video-only media (i.e., silent video).</td>
    <td>See <a href="/en-US/docs/Learn/Accessibility/Multimedia#Audio_transcripts">Audio transcripts</a> for transcript information. No audio description tutorial is available yet.</td>
   </tr>
   <tr>
-   <td colspan="1">1.2.2 Provide captions for web-based video (A)</td>
+   <td>1.2.2 Provide captions for web-based video (A)</td>
    <td>You should provide captions for video presented on the web (e.g., HTML5 video). This is for the benefit of people who can't hear the audio part of the video.</td>
    <td>See <a href="/en-US/docs/Learn/Accessibility/Multimedia#Video_text_tracks">Video text tracks</a> for HTML5 video captions, and <a href="/en-US/docs/Learn/Accessibility/Multimedia#Other_multimedia_content">Other multimedia content</a> for other technologies. See also <a href="https://support.google.com/youtube/answer/2734796?hl=en">Add your own subtitles &amp; closed captions</a> (YouTube).</td>
   </tr>
   <tr>
-   <td colspan="1">1.2.3 Provide text transcript or audio description for web-based video (A)</td>
+   <td>1.2.3 Provide text transcript or audio description for web-based video (A)</td>
    <td>You should provide text transcripts or audio descriptions for video presented on the web (e.g., HTML5 video. This is for the benefit of people who can't see the visual part of the video, and don't get the full content from the audio alone.</td>
    <td>See <a href="/en-US/docs/Learn/Accessibility/Multimedia#Audio_transcripts">Audio transcripts</a> for transcript information. No audio description tutorial is available yet.</td>
   </tr>
   <tr>
-   <td colspan="1">1.2.4 Provide captions for live audio (AA)</td>
+   <td>1.2.4 Provide captions for live audio (AA)</td>
    <td>You should provide synchronized captions for all live multimedia that contains audio (e.g., video conferences, live audio broadcasts).</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.2.5 Provide audio descriptions for prerecorded video (AA)</td>
+   <td>1.2.5 Provide audio descriptions for prerecorded video (AA)</td>
    <td>Audio descriptions should be provided for prerecorded video, but only where the existing audio does not convey the full meaning expressed by the video.</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.2.6 Provide sign language equivalent to prerecorded audio (AAA)</td>
+   <td>1.2.6 Provide sign language equivalent to prerecorded audio (AAA)</td>
    <td>An equivalent sign language video should be provided for any prerecorded content containing audio.</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.2.7 Provide extended video with audio descriptions (AAA)</td>
+   <td>1.2.7 Provide extended video with audio descriptions (AAA)</td>
    <td>Where audio descriptions cannot be provided (see 1.2.5) due to video timing issues (e.g., there are no suitable pauses in the content in which to insert the audio descriptions), an alternative version of the video should be provided that includes inserted pauses (and audio descriptions).</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.2.8 Provide an alternative for prerecorded media (AAA)</td>
+   <td>1.2.8 Provide an alternative for prerecorded media (AAA)</td>
    <td>For all content that features video, a descriptive text transcript should be provided, for example a script of the movie you are watching. This is for the benefit of hearing-impaired viewers who cannot hear the content.</td>
    <td>See <a href="/en-US/docs/Learn/Accessibility/Multimedia#Audio_transcripts">Audio transcripts</a> for transcript information.</td>
   </tr>
   <tr>
-   <td colspan="1">1.2.9 Provide a transcript for live audio (AAA)</td>
+   <td>1.2.9 Provide a transcript for live audio (AAA)</td>
    <td>For any live audio content being broadcast, a descriptive text should be provided, for example a script of the play or musical you are listening to. This is for the benefit of hearing-impaired viewers who cannot hear the content.</td>
    <td>See <a href="/en-US/docs/Learn/Accessibility/Multimedia#Audio_transcripts">Audio transcripts</a> for transcript information.</td>
   </tr>
@@ -141,7 +141,7 @@ tags:
    <th scope="col">Practical resource</th>
   </tr>
   <tr>
-   <td colspan="1" rowspan="1">1.3.1 Info and relationships (A)</td>
+   <td>1.3.1 Info and relationships (A)</td>
    <td>
     <p>Any content structure—or visual relationship made between content—can also be determined programmatically, or be inferred from text description. The main situations in which this is relevant are:</p>
 
@@ -156,12 +156,12 @@ tags:
    </td>
   </tr>
   <tr>
-   <td colspan="1">1.3.2 Meaningful content sequence (A)</td>
+   <td>1.3.2 Meaningful content sequence (A)</td>
    <td>A sensible, logical reading order should be easy to determine for any content, even if it is visually presented in an unusual way. The order should be made obvious by use of correct semantic elements (e.g., headings, paragraphs), with CSS being used to create any unusual layout styles, irrespective of the markup.</td>
    <td>Again, refer to <a href="/en-US/docs/Learn/Accessibility/HTML">HTML: A good basis for accessibility</a>.</td>
   </tr>
   <tr>
-   <td colspan="1">1.3.3 Sensory characteristics (A)</td>
+   <td>1.3.3 Sensory characteristics (A)</td>
    <td>
     <p>Instructions for operating controls or understanding content do not rely on a single sense. This may prove inaccessible to people with a disability related to that sense, or a device that does not support that sense. So, for example:</p>
 
@@ -181,21 +181,21 @@ tags:
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.3.4 Orientation (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.3.4 Orientation (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>Content does not restrict its view and operation to a single display orientation, such as portrait or landscape, unless a specific display orientation is essential.</td>
    <td>
     <p><a href="https://www.w3.org/WAI/WCAG21/Understanding/orientation.html">Understanding Orientation</a> </p>
    </td>
   </tr>
   <tr>
-   <td colspan="1">1.3.5 Identify Input Purpose (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.3.5 Identify Input Purpose (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>
     <p>Follow the list of <a href="https://www.w3.org/TR/WCAG21/#input-purposes">53 input fields</a> to programmatically identify the purpose of a field.   </p>
    </td>
    <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html">Understanding Identify Input Purpose</a></td>
   </tr>
   <tr>
-   <td colspan="1">1.3.6 Identify Purpose (AAA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.3.6 Identify Purpose (AAA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>In content implemented using markup languages, the purpose of user interface components, icons, and regions can be programmatically determined.</td>
    <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-purpose.html">Understanding Identify Purpose</a></td>
   </tr>
@@ -218,19 +218,19 @@ tags:
    <th scope="col">Practical resource</th>
   </tr>
   <tr>
-   <td colspan="1" rowspan="1">1.4.1 Use of color (A)</td>
+   <td>1.4.1 Use of color (A)</td>
    <td>
     <p>Color should not be solely relied upon to convey information. For example, in forms, you should never mark required fields purely with a color (like red). Instead (or as well as), something like an asterisk with a label of "required" would be more appropriate.</p>
    </td>
    <td>See <a href="/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color contrast</a> and <a href="/en-US/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form#Multiple_labels">Multiple labels</a>.</td>
   </tr>
   <tr>
-   <td colspan="1">1.4.2 Audio controls (A)</td>
+   <td>1.4.2 Audio controls (A)</td>
    <td>For any audio that plays for longer than three seconds, provide accessible controls to play and pause the audio/video, and mute/adjust volume.</td>
    <td>Use native <code>&lt;button&gt;</code>s to provide accessible keyboard controls, as shown in <a href="/en-US/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/Video_player_styling_basics">Video player styling basics</a>.</td>
   </tr>
   <tr>
-   <td colspan="1">1.4.3 Minimum contrast (AA)</td>
+   <td>1.4.3 Minimum contrast (AA)</td>
    <td>
     <p>The color contrast between background and foreground content should be at a minimum level to ensure legibility:</p>
 
@@ -242,17 +242,17 @@ tags:
    <td>See <a href="/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color contrast</a>.</td>
   </tr>
   <tr>
-   <td colspan="1">1.4.4 Resize text (AA)</td>
+   <td>1.4.4 Resize text (AA)</td>
    <td>The page should be readable and usable when the text size is doubled. This means that designs should be responsive, so that when the text size is increased, the content is still accessible.</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.5 Images of text (AA)</td>
+   <td>1.4.5 Images of text (AA)</td>
    <td>Images should NOT be used to present content where text would do the job. For example, if an image is mostly textual, it could be represented using text as well as images.</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.6 Enhanced contrast (AAA)</td>
+   <td>1.4.6 Enhanced contrast (AAA)</td>
    <td>
     <p>This follows, and builds on, criterion 1.4.3.</p>
 
@@ -264,12 +264,12 @@ tags:
    <td>See <a href="/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color contrast</a>.</td>
   </tr>
   <tr>
-   <td colspan="1">1.4.7 Low or no background audio (AAA)</td>
+   <td>1.4.7 Low or no background audio (AAA)</td>
    <td>Prerecorded audio recordings that primarily feature speech should have minimal background noise, so the content can be easily understood.</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.8 Visual presentation (AAA)</td>
+   <td>1.4.8 Visual presentation (AAA)</td>
    <td>
     <p>For text content presentation, the following should be true:</p>
 
@@ -284,12 +284,12 @@ tags:
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.9 Images of text (No Exception) (AAA)</td>
+   <td>1.4.9 Images of text (No Exception) (AAA)</td>
    <td>Text should not be presented as part of an image unless it is purely decoration (i.e., it does not convey any content) or cannot be presented in any other way.</td>
    <td></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.10 Reflow (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.4.10 Reflow (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>
     <ul>
      <li>No horizontal scrolling for left-to-right languages (like English) or right-to-left languages (like Arabic)   </li>
@@ -300,12 +300,12 @@ tags:
    <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html">Understanding Reflow</a></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.11 Non-Text Contrast(AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.4.11 Non-Text Contrast(AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>Minimum color contrast ratio of 3:1 for user interface components and graphical objects. </td>
    <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">Understanding Non-Text Contrast</a></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.12 Text Spacing (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.4.12 Text Spacing (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>
     <p>No loss of content or functionality occurs when the following styles are applied: </p>
 
@@ -319,7 +319,7 @@ tags:
    <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html">Understanding Text Spacing</a></td>
   </tr>
   <tr>
-   <td colspan="1">1.4.13 Content on Hover or Focus (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
+   <td>1.4.13 Content on Hover or Focus (AA) <em><a href="https://www.w3.org/TR/WCAG21/#new-features-in-wcag-2-1">added in 2.1</a></em></td>
    <td>
     <p>While additional content may appear and disappear in coordination with hover and keyboard focus, this success criterion specifies three conditions that must be met:</p>
 

--- a/files/en-us/web/api/filesystemflags/index.html
+++ b/files/en-us/web/api/filesystemflags/index.html
@@ -42,7 +42,7 @@ tags:
 <table class="standard-table">
  <thead>
   <tr>
-   <th colspan="3" rowspan="1" scope="col" style="text-align: center;">Option values</th>
+   <th colspan="3" scope="col" style="text-align: center;">Option values</th>
    <th rowspan="2" scope="col">File/directory condition</th>
    <th rowspan="2" scope="col">Result</th>
   </tr>

--- a/files/en-us/web/api/keyboardevent/code/code_values/index.html
+++ b/files/en-us/web/api/keyboardevent/code/code_values/index.html
@@ -14,7 +14,7 @@ slug: Web/API/KeyboardEvent/code/code_values
  <thead>
   <tr>
    <th scope="row"></th>
-   <th colspan="2" rowspan="1" scope="col" style="text-align: center;"><strong><code>KeyboardEvent.code</code></strong> value</th>
+   <th colspan="2" scope="col" style="text-align: center;"><strong><code>KeyboardEvent.code</code></strong> value</th>
   </tr>
   <tr>
    <th scope="row">Code</th>
@@ -1103,8 +1103,8 @@ slug: Web/API/KeyboardEvent/code/code_values
  <thead>
   <tr>
    <th scope="row">Virtual keycode</th>
-   <th colspan="1" rowspan="1" scope="col">Gecko {{gecko_minversion_inline("32.0")}}</th>
-   <th rowspan="1" scope="col">Chromium (48)</th>
+   <th scope="col">Gecko {{gecko_minversion_inline("32.0")}}</th>
+   <th scope="col">Chromium (48)</th>
   </tr>
  </thead>
  <tbody>

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.html
@@ -52,7 +52,7 @@ tags:
    <td>Either <kbd>Alt</kbd> key or <kbd>AltGr</kbd> key pressed</td>
    <td><kbd>Alt</kbd> key pressed</td>
    <td><kbd>⌥ Option</kbd> key pressed</td>
-   <td colspan="2" rowspan="1"><kbd>Alt</kbd> key or <kbd>option</kbd> key pressed</td>
+   <td colspan="2"><kbd>Alt</kbd> key or <kbd>option</kbd> key pressed</td>
   </tr>
   <tr>
    <th scope="row"><code>"AltGraph"</code></th>
@@ -61,7 +61,7 @@ tags:
    </td>
    <td><kbd>Level 3 Shift</kbd> key (or <kbd>Level 5 Shift</kbd> key {{gecko_minversion_inline("20.0")}}) pressed</td>
    <td><kbd>⌥ Option</kbd> key pressed</td>
-   <td colspan="2" rowspan="1" style="background-color: rgb(204, 204, 204); text-align: center;"><em>Not supported</em></td>
+   <td colspan="2" style="background-color: rgb(204, 204, 204); text-align: center;"><em>Not supported</em></td>
   </tr>
   <tr>
    <th scope="row"><code>"CapsLock"</code></th>
@@ -84,7 +84,7 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"FnLock"</code></th>
-   <td colspan="5" rowspan="1" style="background-color: rgb(204, 204, 204); text-align: center;"><em>Not supported</em></td>
+   <td colspan="5" style="background-color: rgb(204, 204, 204); text-align: center;"><em>Not supported</em></td>
   </tr>
   <tr>
    <th scope="row"><code>"Hyper"</code></th>
@@ -109,7 +109,7 @@ tags:
    <th scope="row"><code>"OS"</code></th>
    <td><kbd>⊞ Windows Logo</kbd> key pressed</td>
    <td><kbd>Super</kbd> key or <kbd>Hyper</kbd> key pressed (typically, mapped to <kbd>⊞ Windows Logo</kbd> key)</td>
-   <td colspan="3" rowspan="1" style="background-color: rgb(204, 204, 204); text-align: center;"><em>Not supported</em></td>
+   <td colspan="3" style="background-color: rgb(204, 204, 204); text-align: center;"><em>Not supported</em></td>
   </tr>
   <tr>
    <th scope="row"><code>"ScrollLock"</code></th>
@@ -120,7 +120,7 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"Shift"</code></th>
-   <td colspan="5" rowspan="1" style="text-align: center;"><kbd>⇧ Shift</kbd> key pressed</td>
+   <td colspan="5" style="text-align: center;"><kbd>⇧ Shift</kbd> key pressed</td>
   </tr>
   <tr>
    <th scope="row"><code>"Super"</code></th>

--- a/files/en-us/web/api/keyboardevent/keycode/index.html
+++ b/files/en-us/web/api/keyboardevent/keycode/index.html
@@ -366,7 +366,7 @@ tags:
    <th scope="row"><code>"KeyD"</code></th>
    <td colspan="3"><code>0x44 (68)</code></td>
    <td colspan="3"><code>0x44 (68)</code></td>
-   <td colspan="3"><code>0x44 (68)<span style="display: none;"> </span></code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
    <td colspan="3"><code>0x44 (68)</code></td>
    <td colspan="3"><code>0x44 (68)</code></td>
    <td colspan="3"><code>0x44 (68)</code></td>

--- a/files/en-us/web/api/keyboardevent/keycode/index.html
+++ b/files/en-us/web/api/keyboardevent/keycode/index.html
@@ -128,22 +128,22 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by printable keys in standard position</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
-   <th colspan="3" rowspan="1" scope="col">Internet Explorer 11</th>
-   <th colspan="6" rowspan="1" scope="col">Google Chrome 34</th>
-   <th colspan="3" rowspan="1" scope="col">Chromium 34</th>
-   <th colspan="3" rowspan="1" scope="col">Safari 7</th>
-   <th colspan="9" rowspan="1" scope="col">Gecko 29</th>
+   <th rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th colspan="3" scope="col">Internet Explorer 11</th>
+   <th colspan="6" scope="col">Google Chrome 34</th>
+   <th colspan="3" scope="col">Chromium 34</th>
+   <th colspan="3" scope="col">Safari 7</th>
+   <th colspan="9" scope="col">Gecko 29</th>
   </tr>
   <tr>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
   </tr>
   <tr>
    <th scope="col">US</th>
@@ -167,14 +167,14 @@ tags:
    <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
-   <th colspan="1" scope="col">US</th>
+   <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
   </tr>
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
@@ -196,432 +196,432 @@ tags:
    <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
-   <th colspan="1" scope="col">US</th>
+   <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
   </tr>
   <tr>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
   </tr>
   <tr>
-   <th colspan="3" rowspan="1" scope="col">Internet Explorer 11</th>
-   <th colspan="6" rowspan="1" scope="col">Google Chrome 34</th>
-   <th colspan="3" rowspan="1" scope="col">Chromium 34</th>
-   <th colspan="3" rowspan="1" scope="col">Safari 7</th>
-   <th colspan="9" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Internet Explorer 11</th>
+   <th colspan="6" scope="col">Google Chrome 34</th>
+   <th colspan="3" scope="col">Chromium 34</th>
+   <th colspan="3" scope="col">Safari 7</th>
+   <th colspan="9" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>
   <tr>
    <th scope="row"><code>"Digit1"</code></th>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
-   <td colspan="3" rowspan="1"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
+   <td colspan="3"><code>0x31 (49)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit2"</code></th>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
-   <td colspan="3" rowspan="1"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
+   <td colspan="3"><code>0x32 (50)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit3"</code></th>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
-   <td colspan="3" rowspan="1"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
+   <td colspan="3"><code>0x33 (51)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit4"</code></th>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
-   <td colspan="3" rowspan="1"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
+   <td colspan="3"><code>0x34 (52)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit5"</code></th>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
-   <td colspan="3" rowspan="1"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
+   <td colspan="3"><code>0x35 (53)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit6"</code></th>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
-   <td colspan="3" rowspan="1"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
+   <td colspan="3"><code>0x36 (54)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit7"</code></th>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
-   <td colspan="3" rowspan="1"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
+   <td colspan="3"><code>0x37 (55)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit8"</code></th>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
-   <td colspan="3" rowspan="1"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
+   <td colspan="3"><code>0x38 (56)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit9"</code></th>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
-   <td colspan="3" rowspan="1"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
+   <td colspan="3"><code>0x39 (57)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Digit0"</code></th>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
-   <td colspan="3" rowspan="1"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
+   <td colspan="3"><code>0x30 (48)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyA"</code></th>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
-   <td colspan="3" rowspan="1"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
+   <td colspan="3"><code>0x41 (65)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyB"</code></th>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
-   <td colspan="3" rowspan="1"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
+   <td colspan="3"><code>0x42 (66)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyC"</code></th>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
-   <td colspan="3" rowspan="1"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
+   <td colspan="3"><code>0x43 (67)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyD"</code></th>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)<span style="display: none;"> </span></code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
-   <td colspan="3" rowspan="1"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)<span style="display: none;"> </span></code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
+   <td colspan="3"><code>0x44 (68)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyE"</code></th>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
-   <td colspan="3" rowspan="1"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
+   <td colspan="3"><code>0x45 (69)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyF"</code></th>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
-   <td colspan="3" rowspan="1"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
+   <td colspan="3"><code>0x46 (70)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyG"</code></th>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
-   <td colspan="3" rowspan="1"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
+   <td colspan="3"><code>0x47 (71)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyH"</code></th>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
-   <td colspan="3" rowspan="1"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
+   <td colspan="3"><code>0x48 (72)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyI"</code></th>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
-   <td colspan="3" rowspan="1"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
+   <td colspan="3"><code>0x49 (73)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyJ"</code></th>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
+   <td colspan="3"><code>0x4A (74)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyK"</code></th>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
+   <td colspan="3"><code>0x4B (75)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyL"</code></th>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
+   <td colspan="3"><code>0x4C (76)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyM"</code></th>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
+   <td colspan="3"><code>0x4D (77)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyN"</code></th>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
+   <td colspan="3"><code>0x4E (78)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyO"</code></th>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
-   <td colspan="3" rowspan="1"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
+   <td colspan="3"><code>0x4F (79)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyP"</code></th>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
-   <td colspan="3" rowspan="1"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
+   <td colspan="3"><code>0x50 (80)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyQ"</code></th>
-   <td colspan="3" rowspan="1"><code>0x51 (81)</code></td>
-   <td colspan="3" rowspan="1"><code>0x51 (81)</code></td>
-   <td rowspan="1"><code>0x51 (81)</code></td>
-   <td rowspan="1"><code>0x51 (81)</code></td>
+   <td colspan="3"><code>0x51 (81)</code></td>
+   <td colspan="3"><code>0x51 (81)</code></td>
+   <td><code>0x51 (81)</code></td>
+   <td><code>0x51 (81)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
    <td><code>0x51 (81)</code></td>
    <td><code>0x51 (81)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
-   <td rowspan="1"><code>0x51 (81)</code></td>
-   <td rowspan="1"><code>0x51 (81)</code></td>
-   <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
-   <td colspan="3" rowspan="1"><code>0x51 (81)</code></td>
    <td><code>0x51 (81)</code></td>
    <td><code>0x51 (81)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
-   <td colspan="3" rowspan="1"><code>0x51 (81)</code></td>
+   <td colspan="3"><code>0x51 (81)</code></td>
+   <td><code>0x51 (81)</code></td>
+   <td><code>0x51 (81)</code></td>
+   <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
+   <td colspan="3"><code>0x51 (81)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyR"</code></th>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
-   <td colspan="3" rowspan="1"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
+   <td colspan="3"><code>0x52 (82)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyS"</code></th>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
-   <td colspan="3" rowspan="1"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
+   <td colspan="3"><code>0x53 (83)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyT"</code></th>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
-   <td colspan="3" rowspan="1"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
+   <td colspan="3"><code>0x54 (84)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyU"</code></th>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
-   <td colspan="3" rowspan="1"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
+   <td colspan="3"><code>0x55 (85)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyV"</code></th>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
-   <td colspan="3" rowspan="1"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
+   <td colspan="3"><code>0x56 (86)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyW"</code></th>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
-   <td colspan="3" rowspan="1"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
+   <td colspan="3"><code>0x57 (87)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyX"</code></th>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
-   <td colspan="3" rowspan="1"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
+   <td colspan="3"><code>0x58 (88)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyY"</code></th>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
-   <td colspan="3" rowspan="1"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
+   <td colspan="3"><code>0x59 (89)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"KeyZ"</code></th>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
-   <td colspan="3" rowspan="1"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
+   <td colspan="3"><code>0x5A (90)</code></td>
   </tr>
  </tbody>
 </table>
@@ -630,22 +630,22 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by printable keys in standard position (punctuations in US layout):</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
-   <th colspan="3" rowspan="1" scope="col">Internet Explorer 11</th>
-   <th colspan="6" rowspan="1" scope="col">Google Chrome 34</th>
-   <th colspan="3" rowspan="1" scope="col">Chromium 34</th>
-   <th colspan="3" rowspan="1" scope="col">Safari 7</th>
-   <th colspan="9" rowspan="1" scope="col">Gecko 29</th>
+   <th rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th colspan="3" scope="col">Internet Explorer 11</th>
+   <th colspan="6" scope="col">Google Chrome 34</th>
+   <th colspan="3" scope="col">Chromium 34</th>
+   <th colspan="3" scope="col">Safari 7</th>
+   <th colspan="9" scope="col">Gecko 29</th>
   </tr>
   <tr>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Windows (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Windows (10.9)</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
   </tr>
   <tr>
    <th scope="col">US</th>
@@ -669,14 +669,14 @@ tags:
    <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
-   <th colspan="1" scope="col">US</th>
+   <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
   </tr>
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="3" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
@@ -698,26 +698,26 @@ tags:
    <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
-   <th colspan="1" scope="col">US</th>
+   <th scope="col">US</th>
    <th scope="col">Japanese</th>
    <th scope="col">Greek</th>
   </tr>
   <tr>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Windows</th>
-   <th colspan="3" rowspan="1" scope="col">Mac (10.9)</th>
-   <th colspan="3" rowspan="1" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Windows</th>
+   <th colspan="3" scope="col">Mac (10.9)</th>
+   <th colspan="3" scope="col">Linux (Ubuntu 14.04)</th>
   </tr>
   <tr>
-   <th colspan="3" rowspan="1" scope="col">Internet Explorer 11</th>
-   <th colspan="6" rowspan="1" scope="col">Google Chrome 34</th>
-   <th colspan="3" rowspan="1" scope="col">Chromium 34</th>
-   <th colspan="3" rowspan="1" scope="col">Safari 7</th>
-   <th colspan="9" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Internet Explorer 11</th>
+   <th colspan="6" scope="col">Google Chrome 34</th>
+   <th colspan="3" scope="col">Chromium 34</th>
+   <th colspan="3" scope="col">Safari 7</th>
+   <th colspan="9" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>
@@ -751,29 +751,29 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"Semicolon"</code></th>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
    <td><code>0xBA (186)</code> *1</td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE5 (229) *2</code></td>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
    <td><code>0xBA (186)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE5 (229) *3</code></td>
-   <td colspan="1" rowspan="2"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xBA (186)</code></td>
    <td><code>0xBA (186)</code> *1</td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE5 (229) *2</code></td>
-   <td colspan="1" rowspan="2"><code>0x3B (59)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3B (59)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3B (59)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3B (59)</code> *1</td>
+   <td rowspan="2"><code>0x3B (59)</code></td>
+   <td rowspan="2"><code>0x3B (59)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3B (59)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3B (59)</code></td>
+   <td rowspan="2"><code>0x3B (59)</code></td>
+   <td rowspan="2"><code>0x3B (59)</code> *1</td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0x3B (59)</code></td>
+   <td rowspan="2"><code>0x3B (59)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x00 (0)</code></td>
   </tr>
   <tr>
@@ -784,30 +784,30 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"Quote"</code></th>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186) *1</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xBA (186)</code>  *1</td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x3A (58)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x3A (58)</code> *1</td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x3A (58)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x3A (58)</code> *1</td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x3A (58)</code></td>
+   <td rowspan="2"><code>0xDE (222)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Quote"</code> with Shift</th>
@@ -817,30 +817,30 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"BracketLeft"</code></th>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xC0(192)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xC0(192)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xC0(192)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xC0(192)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
    <td><code>0xDB (219)</code> *1</td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0x32 (50)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
    <td><code>0xDB (219) *1 </code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x40 (64)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x40 (64)</code> *1</td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x40 (64)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x40 (64)</code> *1</td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x40 (64)</code></td>
+   <td rowspan="2"><code>0xDB (219)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"BracketLeft"</code> with <kbd>Shift</kbd></th>
@@ -850,78 +850,78 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"BracketRight"</code></th>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219) *1</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219) *1</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219) *1</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code> *1</td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDB (219)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDD (221)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"BracketRight"</code> with <kbd>Shift</kbd></th>
   </tr>
   <tr>
    <th scope="row"><code>"Backquote"</code></th>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(153, 153, 153);"><code>N/A</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(153, 153, 153);"><code>N/A</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2" style="background-color: rgb(153, 153, 153);"><code>N/A</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2" style="background-color: rgb(153, 153, 153);"><code>N/A</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
    <td colspan="3" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xF4 (244)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
    <td colspan="3" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(153, 153, 153);"><code>N/A</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2" style="background-color: rgb(153, 153, 153);"><code>N/A</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
    <td colspan="3" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0xC0 (192)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Backquote"</code> with <kbd>Shift</kbd></th>
   </tr>
   <tr>
    <th scope="row"><code>"Backslash"</code></th>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="3" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="3" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="3" rowspan="2"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td colspan="3" rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td colspan="3" rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td colspan="3" rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDD (221)</code></td>
+   <td rowspan="2"><code>0xDC (220)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Backslash"</code> with <kbd>Shift</kbd></th>
@@ -930,15 +930,15 @@ tags:
    <th scope="row"><code>"Minus"</code></th>
    <td colspan="3" rowspan="2"><code>0xBD (189)</code></td>
    <td colspan="3" rowspan="2"><code>0xBD (189)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBD (189)</code></td>
+   <td rowspan="2"><code>0xBD (189)</code></td>
    <td><code>0xBD (189)</code> *1</td>
-   <td colspan="1" rowspan="2"><code>0xBD (189)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBD (189)</code></td>
+   <td rowspan="2"><code>0xBD (189)</code></td>
+   <td rowspan="2"><code>0xBD (189)</code></td>
    <td><code>0xBD (189)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBD (189)</code></td>
-   <td rowspan="1"><code>0xBD (189)</code></td>
-   <td rowspan="1"><code>0xBD (189) *1</code></td>
-   <td rowspan="1"><code>0xBD (189)</code></td>
+   <td rowspan="2"><code>0xBD (189)</code></td>
+   <td><code>0xBD (189)</code></td>
+   <td><code>0xBD (189) *1</code></td>
+   <td><code>0xBD (189)</code></td>
    <td colspan="3" rowspan="2"><code>0xAD (173)</code></td>
    <td rowspan="2"><code>0xAD (173)</code></td>
    <td rowspan="2"><code>0xAD (173) *1</code></td>
@@ -955,30 +955,30 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"Equal"</code></th>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDE (222)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDE (222)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
    <td><code>0xBB (187) *1</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>0x36 (54)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBB (187)</code></td>
-   <td rowspan="1"><code>0xBB (187)</code></td>
-   <td rowspan="1"><code>0xBB (187) *1</code></td>
-   <td rowspan="1"><code>0xBB (187)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3D (61)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xA0 (160)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3D (61)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3D (61)</code></td>
-   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xA0 (160)</code> *1</td>
-   <td colspan="1" rowspan="2"><code>0x3D (61)</code></td>
+   <td rowspan="2"><code>0xBB (187)</code></td>
+   <td><code>0xBB (187)</code></td>
+   <td><code>0xBB (187) *1</code></td>
+   <td><code>0xBB (187)</code></td>
    <td rowspan="2"><code>0x3D (61)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xA0 (160)</code></td>
-   <td colspan="1" rowspan="2"><code>0x3D (61)</code></td>
+   <td rowspan="2"><code>0x3D (61)</code></td>
+   <td rowspan="2"><code>0x3D (61)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xA0 (160)</code> *1</td>
+   <td rowspan="2"><code>0x3D (61)</code></td>
+   <td rowspan="2"><code>0x3D (61)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xA0 (160)</code></td>
+   <td rowspan="2"><code>0x3D (61)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"Equal"</code> with <kbd>Shift</kbd></th>
@@ -990,61 +990,61 @@ tags:
   </tr>
   <tr>
    <th scope="row"><code>"IntlRo"</code></th>
-   <td colspan="1" rowspan="2"><code>0xC1 (193)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE2 (226)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC1 (193)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC1 (193)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE2 (226)</code></td>
-   <td colspan="1" rowspan="2"><code>0xC1 (193)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBD (189)</code></td>
-   <td colspan="1" rowspan="2"><code>0xBD (189)</code></td>
+   <td rowspan="2"><code>0xC1 (193)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE2 (226)</code></td>
+   <td rowspan="2"><code>0xC1 (193)</code></td>
+   <td rowspan="2"><code>0xC1 (193)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE2 (226)</code></td>
+   <td rowspan="2"><code>0xC1 (193)</code></td>
+   <td rowspan="2"><code>0xBD (189)</code></td>
+   <td rowspan="2"><code>0xBD (189)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2">*4</td>
+   <td rowspan="2">*4</td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code><br>
      </td>
-   <td colspan="1" rowspan="2">*4</td>
+   <td rowspan="2">*4</td>
    <td rowspan="2"><code>0xBD (189)</code></td>
    <td rowspan="2"><code>0xBD (189)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE5 </code>(229) *5</td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0xA7 (167)</code></td>
-   <td colspan="1" rowspan="2"><code>0xA7 (167)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE5 </code>(229) *5</td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0xA7 (167)</code></td>
+   <td rowspan="2"><code>0xA7 (167)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"IntlRo"</code> with <kbd>Shift</kbd></th>
   </tr>
   <tr>
    <th scope="row"><code>"IntlYen"</code></th>
-   <td colspan="1" rowspan="2"><code>0xFF (255)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0xFF (255)</code></td>
-   <td colspan="1" rowspan="2"><code>0xFF (255)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0xFF (255)</code></td>
+   <td rowspan="2"><code>0xFF (255)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xFF (255)</code></td>
+   <td rowspan="2"><code>0xFF (255)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
+   <td rowspan="2"><code>0xFF (255)</code></td>
    <td><code>0x00 (0)</code></td>
    <td><code>0x00 (0)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2">*4</td>
+   <td rowspan="2">*4</td>
    <td style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2">*4</td>
-   <td rowspan="1"><code>0x00 (0)</code></td>
-   <td rowspan="1"><code>0x00 (0)</code></td>
+   <td rowspan="2">*4</td>
+   <td><code>0x00 (0)</code></td>
+   <td><code>0x00 (0)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xE5 </code>(229) *5</td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC </code>(220)</td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0xDC </code>(220)</td>
-   <td colspan="1" rowspan="2"><code>0xDC </code>(220)</td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC </code>(220)</td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0xDC </code>(220)</td>
+   <td rowspan="2"><code>0xDC </code>(220)</td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
    <td rowspan="2" style="background-color: rgb(255, 255, 204);"><code>0xDC (220)</code></td>
-   <td colspan="1" rowspan="2"><code>0x00 (0)</code></td>
+   <td rowspan="2"><code>0x00 (0)</code></td>
   </tr>
   <tr>
    <th scope="row"><code>"IntlYen"</code> with <kbd>Shift</kbd></th>
@@ -1073,12 +1073,12 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by modifier keys:</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
   <tr>
    <th scope="col">Windows</th>
@@ -1093,7 +1093,7 @@ tags:
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Windows</th>
    <th scope="col">Windows</th>
    <th scope="col">Mac (10.9)</th>
@@ -1105,10 +1105,10 @@ tags:
   </tr>
   <tr>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>
@@ -1235,12 +1235,12 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by non-printable keys:</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
   <tr>
    <th scope="col">Windows</th>
@@ -1255,7 +1255,7 @@ tags:
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Windows</th>
    <th scope="col">Windows</th>
    <th scope="col">Mac (10.9)</th>
@@ -1267,10 +1267,10 @@ tags:
   </tr>
   <tr>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>
@@ -1502,12 +1502,12 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by function keys:</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
   <tr>
    <th scope="col">Windows</th>
@@ -1522,7 +1522,7 @@ tags:
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Windows</th>
    <th scope="col">Windows</th>
    <th scope="col">Mac (10.9)</th>
@@ -1534,10 +1534,10 @@ tags:
   </tr>
   <tr>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>
@@ -1830,12 +1830,12 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by keys in numpad in NumLock state</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
   <tr>
    <th scope="col">Windows</th>
@@ -1850,7 +1850,7 @@ tags:
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Windows</th>
    <th scope="col">Windows</th>
    <th scope="col">Mac (10.9)</th>
@@ -1862,10 +1862,10 @@ tags:
   </tr>
   <tr>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="2" rowspan="1" scope="col">Google Chrome 34</th>
+   <th colspan="2" scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
    <th scope="col">Safari 7</th>
-   <th colspan="3" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="3" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>
@@ -2109,11 +2109,11 @@ tags:
  <caption>keyCode values of each browser's keydown event caused by keys in numpad without NumLock state</caption>
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="1" rowspan="1" scope="col">Google Chrome 34</th>
+   <th scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
-   <th colspan="2" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="2" scope="col">Gecko 29</th>
   </tr>
   <tr>
    <th scope="col">Windows</th>
@@ -2125,7 +2125,7 @@ tags:
  </thead>
  <tfoot>
   <tr>
-   <th colspan="1" rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
+   <th rowspan="2" scope="row">{{domxref("KeyboardEvent.code")}}</th>
    <th scope="col">Windows</th>
    <th scope="col">Windows</th>
    <th scope="col">Linux (Ubuntu 14.04)</th>
@@ -2134,9 +2134,9 @@ tags:
   </tr>
   <tr>
    <th scope="col">Internet Explorer 11</th>
-   <th colspan="1" rowspan="1" scope="col">Google Chrome 34</th>
+   <th scope="col">Google Chrome 34</th>
    <th scope="col">Chromium 34</th>
-   <th colspan="2" rowspan="1" scope="col">Gecko 29</th>
+   <th colspan="2" scope="col">Gecko 29</th>
   </tr>
  </tfoot>
  <tbody>

--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
@@ -168,7 +168,7 @@ var buffer = context.createBuffer(1, 22050, 22050);</pre>
  </thead>
  <tbody>
   <tr>
-   <th colspan="1" rowspan="13" scope="row"><code>speakers</code></th>
+   <th rowspan="13" scope="row"><code>speakers</code></th>
    <td><code>1</code> <em>(Mono)</em></td>
    <td><code>2</code> <em>(Stereo)</em></td>
    <td><em>Up-mix from mono to stereo</em>.<br>
@@ -280,20 +280,20 @@ var buffer = context.createBuffer(1, 22050, 22050);</pre>
     output.SR = input.SR</code></code></td>
   </tr>
   <tr>
-   <td colspan="2" rowspan="1">Other, non-standard layouts</td>
+   <td colspan="2">Other, non-standard layouts</td>
    <td>Non-standard channel layouts are handled as if <code>channelInterpretation</code> is set to <code>discrete</code>.<br>
     The specification explicitly allows the future definition of new speaker layouts. This fallback is therefore not future proof as the behavior of the browsers for a specific number of channels may change in the future.</td>
   </tr>
   <tr>
-   <th colspan="1" rowspan="2" scope="row"><code>discrete</code></th>
-   <td rowspan="1">any (<code>x</code>)</td>
-   <td rowspan="1">any (<code>y</code>) where <code>x&lt;y</code></td>
+   <th rowspan="2" scope="row"><code>discrete</code></th>
+   <td>any (<code>x</code>)</td>
+   <td>any (<code>y</code>) where <code>x&lt;y</code></td>
    <td><em>Up-mix discrete channels.</em><br>
     Fill each output channel with its input counterpart, that is the input channel with the same index. Channels with no corresponding input channels are left silent.</td>
   </tr>
   <tr>
-   <td rowspan="1">any (<code>x</code>)</td>
-   <td rowspan="1">any (<code>y</code>) where <code>x&gt;y</code></td>
+   <td>any (<code>x</code>)</td>
+   <td>any (<code>y</code>) where <code>x&gt;y</code></td>
    <td><em>Down-mix discrete channels.</em><br>
     Fill each output channel with its input counterpart, that is the input channel with the same index. Input channels with no corresponding output channels are dropped.</td>
   </tr>

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.html
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.html
@@ -338,11 +338,11 @@ let cosineTerms = null;
  <tbody>
   <tr>
    <th scope="row">Octave</th>
-   <td colspan="8" rowspan="1">Notes</td>
-   <td rowspan="1"></td>
-   <td rowspan="1"></td>
-   <td rowspan="1"></td>
-   <td rowspan="1"></td>
+   <td colspan="8">Notes</td>
+   <td></td>
+   <td></td>
+   <td></td>
+   <td></td>
   </tr>
   <tr>
    <th scope="row">0</th>
@@ -376,7 +376,7 @@ let cosineTerms = null;
   </tr>
   <tr>
    <th scope="row">2</th>
-   <td colspan="12" rowspan="1" style="text-align: center;">. . .</td>
+   <td colspan="12" style="text-align: center;">. . .</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -109,9 +109,9 @@ white-space: nowrap;</pre>
 <table class="standard-table">
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="col" style="width: 15em;">CSS value</th>
-   <th colspan="2" rowspan="1" scope="col" style="text-align: center;"><code>direction: ltr</code></th>
-   <th colspan="2" rowspan="1" scope="col" style="text-align: center;"><code>direction: rtl</code></th>
+   <th rowspan="2" scope="col" style="width: 15em;">CSS value</th>
+   <th colspan="2" scope="col" style="text-align: center;"><code>direction: ltr</code></th>
+   <th colspan="2" scope="col" style="text-align: center;"><code>direction: rtl</code></th>
   </tr>
   <tr>
    <th scope="col">Expected Result</th>

--- a/files/en-us/web/css/transform-function/matrix()/index.html
+++ b/files/en-us/web/css/transform-function/matrix()/index.html
@@ -45,10 +45,10 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd></mtr> <mtr><mtd>b</mtd><mtd>d</mtd></mtr> </mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd></mtr> <mtr><mtd>b</mtd><mtd>d</mtd></mtr> </mtable> </mfenced> </math></td>
    <td><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd><mtd>tx</mtd></mtr><mtr><mtd>b</mtd><mtd>d</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd><mtd>tx</mtd></mtr><mtr><mtd>b</mtd><mtd>d</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd><mtd>0</mtd><mtd>tx</mtd></mtr><mtr><mtd>b</mtd><mtd>d</mtd><mtd>0</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd><mtd>tx</mtd></mtr><mtr><mtd>b</mtd><mtd>d</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>a</mtd><mtd>c</mtd><mtd>0</mtd><mtd>tx</mtd></mtr><mtr><mtd>b</mtd><mtd>d</mtd><mtd>0</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[a b c d tx ty]</code></td>

--- a/files/en-us/web/css/transform-function/matrix3d()/index.html
+++ b/files/en-us/web/css/transform-function/matrix3d()/index.html
@@ -41,8 +41,8 @@ tags:
 	<tbody>
 		<tr>
 			<td colspan="2" rowspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-			<td colspan="1" rowspan="2">A generic 3D <a href="https://en.wikipedia.org/wiki/Affine_transformation">affine transformation</a> can't be represented using a Cartesian-coordinate matrix, as translations are not linear transformations.</td>
-			<td colspan="1" rowspan="2"><math><mfenced><mtable><mtr><mtd>a1</mtd><mtd>a2</mtd><mtd>a3</mtd><mtd>a4</mtd></mtr><mtr><mtd>b1</mtd><mtd>b2</mtd><mtd>b3</mtd><mtd>b4</mtd></mtr><mtr><mtd>c1</mtd><mtd>c2</mtd><mtd>c3</mtd><mtd>c4</mtd></mtr><mtr><mtd>d1</mtd><mtd>d2</mtd><mtd>d3</mtd><mtd>d4</mtd></mtr></mtable> </mfenced> </math></td>
+			<td rowspan="2">A generic 3D <a href="https://en.wikipedia.org/wiki/Affine_transformation">affine transformation</a> can't be represented using a Cartesian-coordinate matrix, as translations are not linear transformations.</td>
+			<td rowspan="2"><math><mfenced><mtable><mtr><mtd>a1</mtd><mtd>a2</mtd><mtd>a3</mtd><mtd>a4</mtd></mtr><mtr><mtd>b1</mtd><mtd>b2</mtd><mtd>b3</mtd><mtd>b4</mtd></mtr><mtr><mtd>c1</mtd><mtd>c2</mtd><mtd>c3</mtd><mtd>c4</mtd></mtr><mtr><mtd>d1</mtd><mtd>d2</mtd><mtd>d3</mtd><mtd>d4</mtd></mtr></mtable> </mfenced> </math></td>
 		</tr>
 	</tbody>
 </table>

--- a/files/en-us/web/css/transform-function/perspective()/index.html
+++ b/files/en-us/web/css/transform-function/perspective()/index.html
@@ -44,8 +44,8 @@ tags:
    <td colspan="2" rowspan="2">
     <p>This transformation applies to the 3D space and can't be represented on the plane.</p>
    </td>
-   <td colspan="1" rowspan="2">This transformation is not a linear transformation in ℝ<sup>3</sup>, and can't be represented using a Cartesian-coordinate matrix.</td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd><mo>−</mo>1<mo>/</mo>d</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2">This transformation is not a linear transformation in ℝ<sup>3</sup>, and can't be represented using a Cartesian-coordinate matrix.</td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd><mo>−</mo>1<mo>/</mo>d</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/rotate()/index.html
+++ b/files/en-us/web/css/transform-function/rotate()/index.html
@@ -39,10 +39,10 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd></mtr> <mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd></mtr></mtable></mfenced></math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd></mtr> <mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd></mtr></mtable></mfenced></math></td>
    <td><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[cos(a) sin(a) -sin(a) cos(a) 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/rotate3d()/index.html
+++ b/files/en-us/web/css/transform-function/rotate3d()/index.html
@@ -49,11 +49,11 @@ tags:
   </tr>
   <tr>
    <th scope="col">Cartesian coordinates on ℝ<sup>3</sup></th>
-   <td colspan="1"><a href="/@api/deki/files/5987/=transform-functions-rotate3d_cart.png"><img src="/@api/deki/files/5987/=transform-functions-rotate3d_cart.png?size=webview" style="height: 47px; width: 510px;"></a><math> <mfenced><mtable><mtr><mtd>1<mo>+</mo>(1<mo>-</mo>cos(<mi>a</mi>))(<msup><mi>x</mi><mn>2</mn></msup><mo>-</mo>1)</mtd><mtd><mi>z</mi><mo>·</mo>sin(<mi>a</mi>)+<mi>x</mi><mi>y</mi>(1<mo>-</mo>cos(<mi>a</mi>))</mtd><mtd><mo>-</mo><mi>y</mi><mo>·</mo>sin(<mi>a</mi>)<mo>+</mo><mi>x</mi><mi>z</mi><mo>·</mo>(1<mo>-</mo>cos(<mi>a</mi>))</mtd></mtr><mtr><mtd><mo>-</mo><mi>z</mi><mo>·</mo>sin(<mi>a</mi>)<mo>+</mo><mi>x</mi><mi>y</mi><mo>·</mo>(1<mo>-</mo>cos(<mi>a</mi>))</mtd><mtd>1+(1-cos(a))(y2-1)</mtd><mtd><mi>x</mi><mo>·</mo>sin(<mi>a</mi>)<mo>+</mo><mi>y</mi><mi>z</mi><mo>·</mo>(1<mo>-</mo>cos(<mi>a</mi>))</mtd><mtr><mtd>ysin(a) + xz(1-cos(a))</mtd><mtd>-xsin(a)+yz(1-cos(a))</mtd><mtd>1+(1-cos(a))(z2-1)</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr> </mtr></mtable></mfenced></math></td>
+   <td><a href="/@api/deki/files/5987/=transform-functions-rotate3d_cart.png"><img src="/@api/deki/files/5987/=transform-functions-rotate3d_cart.png?size=webview" style="height: 47px; width: 510px;"></a><math> <mfenced><mtable><mtr><mtd>1<mo>+</mo>(1<mo>-</mo>cos(<mi>a</mi>))(<msup><mi>x</mi><mn>2</mn></msup><mo>-</mo>1)</mtd><mtd><mi>z</mi><mo>·</mo>sin(<mi>a</mi>)+<mi>x</mi><mi>y</mi>(1<mo>-</mo>cos(<mi>a</mi>))</mtd><mtd><mo>-</mo><mi>y</mi><mo>·</mo>sin(<mi>a</mi>)<mo>+</mo><mi>x</mi><mi>z</mi><mo>·</mo>(1<mo>-</mo>cos(<mi>a</mi>))</mtd></mtr><mtr><mtd><mo>-</mo><mi>z</mi><mo>·</mo>sin(<mi>a</mi>)<mo>+</mo><mi>x</mi><mi>y</mi><mo>·</mo>(1<mo>-</mo>cos(<mi>a</mi>))</mtd><mtd>1+(1-cos(a))(y2-1)</mtd><mtd><mi>x</mi><mo>·</mo>sin(<mi>a</mi>)<mo>+</mo><mi>y</mi><mi>z</mi><mo>·</mo>(1<mo>-</mo>cos(<mi>a</mi>))</mtd><mtr><mtd>ysin(a) + xz(1-cos(a))</mtd><mtd>-xsin(a)+yz(1-cos(a))</mtd><mtd>1+(1-cos(a))(z2-1)</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr> </mtr></mtable></mfenced></math></td>
   </tr>
   <tr>
    <th scope="col">Homogeneous coordinates on ℝℙ<sup>3</sup></th>
-   <td colspan="1"><a href="/@api/deki/files/5986/=transform-functions-rotate3d_hom4.png"><img src="/@api/deki/files/5986/=transform-functions-rotate3d_hom4.png?size=webview" style="height: 61px; width: 522px;"></a></td>
+   <td><a href="/@api/deki/files/5986/=transform-functions-rotate3d_hom4.png"><img src="/@api/deki/files/5986/=transform-functions-rotate3d_hom4.png?size=webview" style="height: 61px; width: 522px;"></a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/rotatex()/index.html
+++ b/files/en-us/web/css/transform-function/rotatex()/index.html
@@ -48,8 +48,8 @@ tags:
  <tbody>
   <tr>
    <td colspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-   <td colspan="1"><math> <mfenced><mtable><mtr><mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>cos(a)</mtd><mtd>-sin(a)</mtd></mtr><mtr><mtd>0</mtd><mtd>sin(a)</mtd><mtd>cos(a)</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1"><math><mfenced><mtable><mtr><mtd>1</mtd><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td><math> <mfenced><mtable><mtr><mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>cos(a)</mtd><mtd>-sin(a)</mtd></mtr><mtr><mtd>0</mtd><mtd>sin(a)</mtd><mtd>cos(a)</mtd></mtr></mtable> </mfenced> </math></td>
+   <td><math><mfenced><mtable><mtr><mtd>1</mtd><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/rotatey()/index.html
+++ b/files/en-us/web/css/transform-function/rotatey()/index.html
@@ -48,8 +48,8 @@ tags:
  <tbody>
   <tr>
    <td colspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-   <td colspan="1"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>0</mtd><mtd>sin(a)</mtd></mtr><mtr><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>cos(a)</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1"><math><mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>0</mtd><mtd>sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>0</mtd><mtd>sin(a)</mtd></mtr><mtr><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>cos(a)</mtd></mtr></mtable> </mfenced> </math></td>
+   <td><math><mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>0</mtd><mtd>sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/rotatez()/index.html
+++ b/files/en-us/web/css/transform-function/rotatez()/index.html
@@ -48,8 +48,8 @@ tags:
  <tbody>
   <tr>
    <td colspan="2" rowspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr> <mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr> </mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>cos(a)</mtd><mtd>-sin(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr> <mtr><mtd>sin(a)</mtd><mtd>cos(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr> </mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/scale()/index.html
+++ b/files/en-us/web/css/transform-function/scale()/index.html
@@ -49,10 +49,10 @@ scale(<var>sx</var>, <var>sy</var>)
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>sx</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>sy</mtd></mtr> </mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>sx</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>sy</mtd></mtr> </mtable> </mfenced> </math></td>
    <td><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>sy</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>sy</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[sx 0 0 sy 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/scale3d()/index.html
+++ b/files/en-us/web/css/transform-function/scale3d()/index.html
@@ -48,8 +48,8 @@ tags:
  <tbody>
   <tr>
    <td colspan="2" rowspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>sz</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>sz</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>sz</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>sx<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>sy</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>sz</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/scalex()/index.html
+++ b/files/en-us/web/css/transform-function/scalex()/index.html
@@ -43,10 +43,10 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>s</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>1</mtd></mtr> </mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced> <mtable> <mtr><mtd>s</mtd><mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>1</mtd></mtr> </mtable> </mfenced> </math></td>
    <td><math> <mfenced><mtable><mtr>s<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>s<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>s<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>s<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>s<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[s 0 0 1 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/scaley()/index.html
+++ b/files/en-us/web/css/transform-function/scaley()/index.html
@@ -45,10 +45,10 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>s</mtd></mtr> </mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd></mtr> <mtr><mtd>0</mtd><mtd>s</mtd></mtr> </mtable> </mfenced> </math></td>
    <td><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>s</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>s</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>s</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>s</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>s</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 0 0 s 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/scalez()/index.html
+++ b/files/en-us/web/css/transform-function/scalez()/index.html
@@ -46,8 +46,8 @@ tags:
  <tbody>
   <tr>
    <td colspan="2" rowspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>s</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>s</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>s</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>s</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/skew()/index.html
+++ b/files/en-us/web/css/transform-function/skew()/index.html
@@ -47,10 +47,10 @@ skew(<var>ax</var>, <var>ay</var>)
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd></mtr><mtr>tan(ay)<mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd></mtr><mtr>tan(ay)<mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
    <td><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd><mtd>0</mtd></mtr><mtr>tan(ay)<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr><mtr></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd><mtd>0</mtd></mtr><mtr>tan(ay)<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(ay)<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd><mtd>0</mtd></mtr><mtr>tan(ay)<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(ax)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(ay)<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 tan(ay) tan(ax) 1 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/skewx()/index.html
+++ b/files/en-us/web/css/transform-function/skewx()/index.html
@@ -43,10 +43,10 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd></mtr><mtr>0<mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd></mtr><mtr>0<mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
    <td><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>tan(a)</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 0 tan(a) 1 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/skewy()/index.html
+++ b/files/en-us/web/css/transform-function/skewy()/index.html
@@ -39,10 +39,10 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
    <td><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>tan(a)<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 tan(a) 0 1 0 0]</code></td>

--- a/files/en-us/web/css/transform-function/translate()/index.html
+++ b/files/en-us/web/css/transform-function/translate()/index.html
@@ -49,12 +49,12 @@ transform: translate(30%, 50%);
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2">
+   <td rowspan="2">
     <p>A translation is not a linear transformation in ℝ<sup>2</sup> and can't be represented using a Cartesian-coordinate matrix.</p>
    </td>
    <td><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 0 0 1 tx ty]</code></td>

--- a/files/en-us/web/css/transform-function/translate3d()/index.html
+++ b/files/en-us/web/css/transform-function/translate3d()/index.html
@@ -46,8 +46,8 @@ tags:
    <td colspan="2" rowspan="2">
     <p>This transformation applies to the 3D space and can't be represented on the plane.</p>
    </td>
-   <td colspan="1" rowspan="2">A translation is not a linear transformation in ℝ<sup>3</sup> and can't be represented using a Cartesian-coordinate matrix.</td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>tz</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2">A translation is not a linear transformation in ℝ<sup>3</sup> and can't be represented using a Cartesian-coordinate matrix.</td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>tx</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>ty</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>tz</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/transform-function/translatex/index.html
+++ b/files/en-us/web/css/transform-function/translatex/index.html
@@ -43,12 +43,12 @@ transform: translateX(50%);
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2">
+   <td rowspan="2">
     <p>A translation is not a linear transformation in ℝ<sup>2</sup> and can't be represented using a Cartesian-coordinate matrix.</p>
    </td>
    <td><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>t</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>t</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>t</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>t</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>t</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 0 0 1 t 0]</code></td>

--- a/files/en-us/web/css/transform-function/translatey()/index.html
+++ b/files/en-us/web/css/transform-function/translatey()/index.html
@@ -43,12 +43,12 @@ transform: translateY(50%);
  </thead>
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2">
+   <td rowspan="2">
     <p>A translation is not a linear transformation in ℝ<sup>2</sup> and can't be represented using a Cartesian-coordinate matrix.</p>
    </td>
    <td><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
-   <td colspan="1" rowspan="2"><math> <math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></math></td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2"><math> <math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></math></td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
   <tr>
    <td><code>[1 0 0 1 0 t]</code></td>

--- a/files/en-us/web/css/transform-function/translatez()/index.html
+++ b/files/en-us/web/css/transform-function/translatez()/index.html
@@ -49,8 +49,8 @@ tags:
  <tbody>
   <tr>
    <td colspan="2" rowspan="2">This transformation applies to the 3D space and can't be represented on the plane.</td>
-   <td colspan="1" rowspan="2">A translation is not a linear transformation in ℝ<sup>3</sup> and can't be represented using a Cartesian-coordinate matrix.</td>
-   <td colspan="1" rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
+   <td rowspan="2">A translation is not a linear transformation in ℝ<sup>3</sup> and can't be represented using a Cartesian-coordinate matrix.</td>
+   <td rowspan="2"><math> <mfenced><mtable><mtr>1<mtd>0</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr>0<mtd>1</mtd><mtd>0</mtd><mtd>0</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd><mtd>t</mtd></mtr><mtr><mtd>0</mtd><mtd>0</mtd><mtd>0</mtd><mtd>1</mtd></mtr></mtable> </mfenced> </math></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/accesskey/index.html
+++ b/files/en-us/web/html/global_attributes/accesskey/index.html
@@ -31,7 +31,7 @@ tags:
   </tr>
   <tr>
    <th>Firefox</th>
-   <td colspan="2" rowspan="1" style="text-align: center;"><kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd><em>key</em></kbd></td>
+   <td colspan="2" style="text-align: center;"><kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd><em>key</em></kbd></td>
    <td>On Firefox 57 or newer: <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd><em>key</em></kbd> or <kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd><em>key</em></kbd><br>
     On Firefox 14 or newer: <kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd><em>key</em></kbd><br>
     On Firefox 13 or older: <kbd>Control</kbd> + <kbd><em>key</em></kbd></td>
@@ -40,7 +40,7 @@ tags:
    <th>Internet Explorer</th>
    <td rowspan="3" style="text-align: center;"><kbd>Alt</kbd> + <kbd><em>key</em></kbd><br>
     <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd><em>key</em></kbd></td>
-   <td colspan="2" rowspan="1" style="text-align: center;">N/A</td>
+   <td colspan="2" style="text-align: center;">N/A</td>
   </tr>
   <tr>
    <th>Edge</th>
@@ -60,12 +60,12 @@ tags:
   </tr>
   <tr>
    <th>Opera 15+</th>
-   <td colspan="2" rowspan="1" style="text-align: center;"><kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
+   <td colspan="2" style="text-align: center;"><kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
    <td style="text-align: center;"><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
   </tr>
   <tr>
    <th>Opera 12</th>
-   <td colspan="3" rowspan="1">
+   <td colspan="3">
     <kbd>Shift</kbd> + <kbd>Esc</kbd> opens a contents list which are accessible by accesskey, then, can choose an item by pressing <kbd><em>key</em></kbd>
    </td>
   </tr>

--- a/files/en-us/web/html/global_attributes/itemid/index.html
+++ b/files/en-us/web/html/global_attributes/itemid/index.html
@@ -35,9 +35,9 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td colspan="1" rowspan="14">itemscope</td>
+   <td rowspan="14">itemscope</td>
    <td>itemtype: itemid</td>
-   <td colspan="2" rowspan="1">
+   <td colspan="2">
     <div class="jyrRxf-eEDwDf jcd3Mb IZ65Hb-hUbt4d">http://vocab.example.net/book: urn:isbn:0-330-34032-8</div>
    </td>
   </tr>

--- a/files/en-us/web/html/global_attributes/itemprop/index.html
+++ b/files/en-us/web/html/global_attributes/itemprop/index.html
@@ -34,8 +34,8 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td colspan="1" rowspan="2"> </td>
-   <th colspan="2" rowspan="1"><strong>Item</strong></th>
+   <td rowspan="2"> </td>
+   <th colspan="2"><strong>Item</strong></th>
   </tr>
   <tr>
    <th><strong>itemprop name</strong></th>
@@ -221,8 +221,8 @@ tags:
 <table class="standard-table">
  <thead>
   <tr>
-   <th colspan="1" rowspan="2" scope="col"> </th>
-   <th colspan="2" rowspan="1" scope="col">Item</th>
+   <th rowspan="2" scope="col"> </th>
+   <th colspan="2" scope="col">Item</th>
   </tr>
   <tr>
    <th scope="col">itemprop <strong>name</strong></th>
@@ -402,9 +402,9 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td colspan="1" rowspan="14">itemscope</td>
+   <td rowspan="14">itemscope</td>
    <td>itemtype: itemid</td>
-   <td colspan="2" rowspan="1">http://vocab.example.net/book: urn:isbn:0-330-34032-8</td>
+   <td colspan="2">http://vocab.example.net/book: urn:isbn:0-330-34032-8</td>
   </tr>
   <tr>
    <td>itemprop</td>

--- a/files/en-us/web/html/global_attributes/itemscope/index.html
+++ b/files/en-us/web/html/global_attributes/itemscope/index.html
@@ -133,9 +133,9 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td colspan="1" rowspan="14">itemscope</td>
+   <td rowspan="14">itemscope</td>
    <td>itemtype</td>
-   <td colspan="2" rowspan="1">Recipe</td>
+   <td colspan="2">Recipe</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -194,7 +194,7 @@ tags:
   </tr>
   <tr>
    <td>itemprop</td>
-   <td colspan="2" rowspan="1">author [Person]</td>
+   <td colspan="2">author [Person]</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -202,9 +202,9 @@ tags:
    <td>Carol Smith</td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="3">itemscope</td>
+   <td rowspan="3">itemscope</td>
    <td>itemprop[itemtype]</td>
-   <td colspan="2" rowspan="1">aggregateRating [AggregateRating]</td>
+   <td colspan="2">aggregateRating [AggregateRating]</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -217,9 +217,9 @@ tags:
    <td>35</td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="4">itemscope</td>
+   <td rowspan="4">itemscope</td>
    <td>itemprop[itemtype]</td>
-   <td colspan="2" rowspan="1">nutrition [NutritionInformation]</td>
+   <td colspan="2">nutrition [NutritionInformation]</td>
   </tr>
   <tr>
    <td>itemprop</td>

--- a/files/en-us/web/html/global_attributes/itemtype/index.html
+++ b/files/en-us/web/html/global_attributes/itemtype/index.html
@@ -43,7 +43,7 @@ tags:
   <tr>
    <td rowspan="4">itemscope</td>
    <td>itemtype</td>
-   <td colspan="2" rowspan="1">schema.org Product</td>
+   <td colspan="2">schema.org Product</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -52,7 +52,7 @@ tags:
   </tr>
   <tr>
    <td>itemprop</td>
-   <td colspan="2" rowspan="1">brand [Thing]</td>
+   <td colspan="2">brand [Thing]</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -110,9 +110,9 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td colspan="1" rowspan="7">itemscope</td>
+   <td rowspan="7">itemscope</td>
    <td>itemtype</td>
-   <td colspan="2" rowspan="1">Product (http://schema.org/Product)</td>
+   <td colspan="2">Product (http://schema.org/Product)</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -145,7 +145,7 @@ tags:
    <td>ACME</td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="9">itemscope</td>
+   <td rowspan="9">itemscope</td>
    <td>itemprop[itemtype]</td>
    <td>aggregateRating[AggregateRating]</td>
    <td> </td>
@@ -191,7 +191,7 @@ tags:
    <td>http://schema.org/InStock</td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="2">itemscope</td>
+   <td rowspan="2">itemscope</td>
    <td>itemprop[itemtype]</td>
    <td>seller [Organization]</td>
    <td>http://schema.org/Organization</td>

--- a/files/en-us/web/html/microdata/index.html
+++ b/files/en-us/web/html/microdata/index.html
@@ -96,9 +96,9 @@ tags:
 <table class="standard-table">
  <tbody>
   <tr>
-   <td colspan="1" rowspan="4">itemscope</td>
+   <td rowspan="4">itemscope</td>
    <td>itemtype</td>
-   <td colspan="2" rowspan="1"><span>SoftwareApplication (</span>http://schema.org/SoftwareApplication)</td>
+   <td colspan="2"><span>SoftwareApplication (</span>http://schema.org/SoftwareApplication)</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -116,9 +116,9 @@ tags:
    <td><span>GameApplication (http://schema.org/GameApplication)</span></td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="3">itemscope</td>
+   <td rowspan="3">itemscope</td>
    <td>itemprop[itemtype]</td>
-   <td colspan="2" rowspan="1"><span>aggregateRating</span> [<span>AggregateRating</span>]</td>
+   <td colspan="2"><span>aggregateRating</span> [<span>AggregateRating</span>]</td>
   </tr>
   <tr>
    <td>itemprop</td>
@@ -131,9 +131,9 @@ tags:
    <td><span>8864</span></td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="3">itemscope</td>
+   <td rowspan="3">itemscope</td>
    <td>itemprop[itemtype]</td>
-   <td colspan="2" rowspan="1"><span>offers</span> [<span>Offer</span>]</td>
+   <td colspan="2"><span>offers</span> [<span>Offer</span>]</td>
   </tr>
   <tr>
    <td>itemprop</td>

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -89,7 +89,7 @@ console.log(obj === undefined); // false
    <td style="text-align: center;">Object</td>
   </tr>
   <tr>
-   <th colspan="1" rowspan="6" scope="row">Operand A</th>
+   <th rowspan="6" scope="row">Operand A</th>
    <td>Undefined</td>
    <td style="text-align: center;"><code>true</code></td>
    <td style="text-align: center;"><code>true</code></td>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -63,7 +63,7 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
  </thead>
  <tbody>
   <tr>
-   <th colspan="1" rowspan="4" scope="row" style="vertical-align: top;"><code>result</code></th>
+   <th rowspan="4" scope="row" style="vertical-align: top;"><code>result</code></th>
    <td><code>[0]</code></td>
    <td>The full string of characters matched</td>
    <td><code>"Quick Brown Fox Jumps"</code></td>
@@ -92,7 +92,7 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
    <td><code>The Quick Brown Fox Jumps Over The Lazy Dog</code></td>
   </tr>
   <tr>
-   <th colspan="1" rowspan="5" scope="row" style="vertical-align: top;"><code>re</code></th>
+   <th rowspan="5" scope="row" style="vertical-align: top;"><code>re</code></th>
    <td><code>lastIndex</code></td>
    <td>
     <p>The index at which to start the next match.</p>

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.html
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.html
@@ -196,7 +196,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
    <td><code>( … )</code></td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="5">20</td>
+   <td rowspan="5">20</td>
    <td>{{jsxref("Operators/Property_Accessors", "Member Access", "#Dot_notation", 1)}}</td>
    <td>left-to-right</td>
    <td><code>… . …</code></td>
@@ -222,7 +222,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
    <td><code>?.</code></td>
   </tr>
   <tr>
-   <td rowspan="1">19</td>
+   <td>19</td>
    <td>{{jsxref("Operators/new","new")}} (without argument list)</td>
    <td>right-to-left</td>
    <td><code>new …</code></td>
@@ -230,7 +230,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="2">18</td>
    <td>{{jsxref("Operators/Arithmetic_Operators","Postfix Increment","#Increment", 1)}}</td>
-   <td colspan="1" rowspan="2">n/a</td>
+   <td rowspan="2">n/a</td>
    <td><code>… ++</code></td>
   </tr>
   <tr>
@@ -238,9 +238,9 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
    <td><code>… --</code></td>
   </tr>
   <tr>
-   <td colspan="1" rowspan="10">17</td>
+   <td rowspan="10">17</td>
    <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT">Logical NOT (!)</a></td>
-   <td colspan="1" rowspan="10">right-to-left</td>
+   <td rowspan="10">right-to-left</td>
    <td><code>! …</code></td>
   </tr>
   <tr>
@@ -288,7 +288,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="3">15</td>
    <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication">Multiplication (*)</a></td>
-   <td colspan="1" rowspan="3">left-to-right</td>
+   <td rowspan="3">left-to-right</td>
    <td><code>… * …</code></td>
   </tr>
   <tr>
@@ -302,7 +302,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="2">14</td>
    <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Addition">Addition (+)</a></td>
-   <td colspan="1" rowspan="2">left-to-right</td>
+   <td rowspan="2">left-to-right</td>
    <td><code>… + …</code></td>
   </tr>
   <tr>
@@ -312,7 +312,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="3">13</td>
    <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Left_shift">Bitwise Left Shift (&lt;&lt;)</a></td>
-   <td colspan="1" rowspan="3">left-to-right</td>
+   <td rowspan="3">left-to-right</td>
    <td><code>… &lt;&lt; …</code></td>
   </tr>
   <tr>
@@ -326,7 +326,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="6">12</td>
    <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">Less Than (&lt;)</a></td>
-   <td colspan="1" rowspan="6">left-to-right</td>
+   <td rowspan="6">left-to-right</td>
    <td><code>… &lt; …</code></td>
   </tr>
   <tr>
@@ -352,7 +352,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="4">11</td>
    <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Equality">Equality (==)</a></td>
-   <td colspan="1" rowspan="4">left-to-right</td>
+   <td rowspan="4">left-to-right</td>
    <td><code>… == …</code></td>
   </tr>
   <tr>
@@ -463,7 +463,7 @@ a?.b.c;        // evaluate `a` first, then produce `undefined` if `a` is `null` 
   <tr>
    <td rowspan="2">2</td>
    <td>{{jsxref("Operators/yield", "yield")}}</td>
-   <td colspan="1" rowspan="2">right-to-left</td>
+   <td rowspan="2">right-to-left</td>
    <td><code>yield …</code></td>
   </tr>
   <tr>

--- a/files/en-us/web/media/formats/containers/index.html
+++ b/files/en-us/web/media/formats/containers/index.html
@@ -1219,8 +1219,8 @@ tags:
  <thead>
   <tr>
    <th rowspan="2" scope="row" style="vertical-align: bottom;">Container format name</th>
-   <th colspan="3" rowspan="1" scope="col" style="text-align: center; border-right: 2px solid #d4dde4;">Audio</th>
-   <th colspan="3" rowspan="1" scope="col" style="text-align: center;">Video</th>
+   <th colspan="3" scope="col" style="text-align: center; border-right: 2px solid #d4dde4;">Audio</th>
+   <th colspan="3" scope="col" style="text-align: center;">Video</th>
   </tr>
   <tr>
    <th scope="col" style="vertical-align: bottom;">MIME type</th>


### PR DESCRIPTION
`rowspan` and `colspan` default to `"1"`, so writing `colspan="1"` and `rowspan="1"` is unnecessary. Let's remove them to reduce amount of markup.