### PR TITLE
Drop all remaining IncludeSubnav macro invocations

### DIFF
--- a/files/en-us/glossary/asynchronous/index.html
+++ b/files/en-us/glossary/asynchronous/index.html
@@ -34,5 +34,3 @@ tags:
  <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data">Fetching data from the server</a> (Learning Area)</li>
  <li>{{glossary("Synchronous")}}</li>
 </ul>
-
-<p>{{IncludeSubnav("/en-US/docs/Glossary")}}</p>

--- a/files/en-us/glossary/snap_positions/index.html
+++ b/files/en-us/glossary/snap_positions/index.html
@@ -8,5 +8,3 @@ tags:
 <p>A <a href="/en-US/docs/Glossary/Scroll_container">scroll container</a> may set <strong>snap positions</strong> — points that the <a href="/en-US/docs/Glossary/Scrollport">scrollport</a> will stop moving at after a scrolling operation is completed. This allows a scrolling experience that gives the effect of paging through content rather than needing to drag content into view.</p>
 
 <p>Defining Snap positions on the scroll container was introduced in the <a href="/en-US/docs/Web/CSS/CSS_Scroll_Snap">CSS Scroll Snap specification</a>.</p>
-
-<p>{{IncludeSubnav("/en-US/docs/Glossary")}}</p>

--- a/files/en-us/learn/common_questions/available_text_editors/index.html
+++ b/files/en-us/learn/common_questions/available_text_editors/index.html
@@ -8,8 +8,6 @@ tags:
   - Tools
   - text editor
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <div class="summary">
 <p>In this article we highlight some things to think about when installing a text editor for web development.</p>
 </div>

--- a/files/en-us/learn/common_questions/common_web_layouts/index.html
+++ b/files/en-us/learn/common_questions/common_web_layouts/index.html
@@ -8,8 +8,6 @@ tags:
   - HTML
   - NeedsActiveLearning
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <div class="summary">
 <p>When designing pages for your website, it's good to have an idea of the most common layouts.</p>
 </div>

--- a/files/en-us/learn/common_questions/design_for_all_types_of_users/index.html
+++ b/files/en-us/learn/common_questions/design_for_all_types_of_users/index.html
@@ -10,8 +10,6 @@ tags:
   - Mobile
   - NeedsActiveLearning
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <div class="summary">
 <p>This article provides basic tips to help you design websites for any kind of user.</p>
 </div>

--- a/files/en-us/learn/common_questions/what_are_browser_developer_tools/index.html
+++ b/files/en-us/learn/common_questions/what_are_browser_developer_tools/index.html
@@ -11,8 +11,6 @@ tags:
   - JavaScript
   - Learn
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <div class="summary">
 <p>Every modern web browser includes a powerful suite of developer tools. These tools do a range of things, from inspecting currently-loaded HTML, CSS and JavaScript to showing which assets the page has requested and how long they took to load. This article explains how to use the basic functions of your browser's devtools.</p>
 </div>

--- a/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.html
@@ -11,8 +11,6 @@ tags:
   - WebGL
   - scissor
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Color_masking","Learn/WebGL/By_example/Canvas_size_and_WebGL")}}</p>
 
 <div id="basic-scissoring">

--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.html
@@ -8,8 +8,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Canvas_size_and_WebGL","Learn/WebGL/By_example/Scissor_animation")}}</p>
 
 <div id="boilerplate-1">

--- a/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
@@ -8,8 +8,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Basic_scissoring","Learn/WebGL/By_example/Boilerplate_1")}}</p>
 
 <div class="summary">

--- a/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.html
@@ -9,8 +9,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_with_colors","Learn/WebGL/By_example/Simple_color_animation")}}</p>
 
 <div id="clearing-by-clicking">

--- a/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.html
@@ -9,8 +9,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Detect_WebGL","Learn/WebGL/By_example/Clearing_by_clicking")}}</p>
 
 <div id="clearing-with-colors">

--- a/files/en-us/web/api/webgl_api/by_example/color_masking/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/color_masking/index.html
@@ -9,8 +9,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Simple_color_animation","Learn/WebGL/By_example/Basic_scissoring")}}</p>
 
 <div id="color-masking">

--- a/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.html
@@ -9,8 +9,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example","Learn/WebGL/By_example/Clearing_with_colors")}}</p>
 
 <div id="detect-webgl">

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.html
@@ -11,8 +11,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Raining_rectangles","Learn/WebGL/By_example/Hello_vertex_attributes")}}</p>
 
 <div id="hello-glsl">

--- a/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.html
@@ -9,8 +9,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Hello_GLSL","Learn/WebGL/By_example/Textures_from_code")}}</p>
 
 <div id="hello-vertex-attributes">

--- a/files/en-us/web/api/webgl_api/by_example/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/index.html
@@ -8,8 +8,6 @@ tags:
   - Learn
   - WebGL
 ---
-<div>{{learnsidebar}}{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{Next("Learn/WebGL/By_example/Detect_WebGL")}}</p>
 
 <div id="webgl-by-example">

--- a/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.html
@@ -11,8 +11,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Scissor_animation","Learn/WebGL/By_example/Hello_GLSL")}}</p>
 
 <div id="raining-rectangles">

--- a/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.html
@@ -11,8 +11,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Boilerplate_1","Learn/WebGL/By_example/Raining_rectangles")}}</p>
 
 <div id="scissor-animation">

--- a/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.html
@@ -9,8 +9,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_by_clicking","Learn/WebGL/By_example/Color_masking")}}</p>
 
 <div id="simple-color-animation">

--- a/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.html
@@ -13,8 +13,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-<div>{{draft}} {{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Hello_vertex_attributes","Learn/WebGL/By_example/Video_textures")}}</p>
 
 <div id="textures-from-code">

--- a/files/en-us/web/api/webgl_api/by_example/video_textures/index.html
+++ b/files/en-us/web/api/webgl_api/by_example/video_textures/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <p>{{ draft() }}</p>
 
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{Previous("Learn/WebGL/By_example/Textures_from_code")}}</p>
 
 <div id="video-textures">

--- a/files/en-us/web/guide/index/index.html
+++ b/files/en-us/web/guide/index/index.html
@@ -5,6 +5,6 @@ tags:
   - Guide
   - Index
 ---
-<div>{{MDNSidebar}}{{IncludeSubnav("/en-US/docs/MDN")}}</div>
+<div>{{MDNSidebar}}</div>
 
 <p>{{Index("/en-US/docs/Web/Guide")}}</p>


### PR DESCRIPTION
As far as I can tell, the IncludeSubnav macro has no effect in practice any longer — and anyway is redundant with existing sidebars. So this change removes all of the remaining ones in MDN content.

Related to https://github.com/mdn/kumascript/issues/804
Fixes https://github.com/mdn/content/issues/824