### PR TITLE
Drop obsolete polyfill link from TextEncoder doc

### DIFF
--- a/files/en-us/web/api/textencoder/index.html
+++ b/files/en-us/web/api/textencoder/index.html
@@ -13,10 +13,6 @@ tags:
 
 <p><code><strong>TextEncoder</strong></code> takes a stream of code points as input and emits a stream of UTF-8 bytes.</p>
 
-<div class="notecard note">
-<p><strong>Note</strong>: There is a polyfill implementation to support non-UTF-8 text encodings on <a href="https://github.com/inexorabletash/text-encoding">GitHub</a>.</p>
-</div>
-
 <p>{{AvailableInWorkers}}</p>
 
 <h2 id="Example">Example</h2>
@@ -149,8 +145,5 @@ console.log(view); // Uint8Array(3) [226, 130, 172]
 
 <ul>
  <li>The {{DOMxRef("TextDecoder")}} interface describing the inverse operation.</li>
- <li><a href="/en-US/Add-ons/Code_snippets/StringView"><code>StringView</code></a> – a C-like representation of strings based on typed arrays</li>
- <li>A <a href="https://github.com/inexorabletash/text-encoding">shim</a> allowing to use this interface in browsers that don't support it.</li>
- <li><code><a href="/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.importGlobalProperties">Components.utils.importGlobalProperties</a></code></li>
  <li><a href="https://nodejs.org/api/util.html#util_class_util_textencoder">Node.js supports global export from v11.0.0</a></li>
 </ul>


### PR DESCRIPTION
This change removes mention of an obsolete polyfill from the Web/API/TextEncoder article, as well as removing links for a couple of other obsolete resources from the See Also section.

Fixes https://github.com/mdn/content/issues/572