### PR TITLE
Fix: remove nested <strong> tags

### DIFF
--- a/files/en-us/learn/server-side/django/forms/index.html
+++ b/files/en-us/learn/server-side/django/forms/index.html
@@ -516,7 +516,7 @@ class RenewBookModelForm(ModelForm):
        if data &lt; datetime.date.today():
            raise ValidationError(_('Invalid date - renewal in past'))
 
-       <strong># Check if a date is in the allowed range (+4 weeks from today).</strong>
+       # Check if a date is in the allowed range (+4 weeks from today).
        if data &gt; datetime.date.today() + datetime.timedelta(weeks=4):
            raise ValidationError(_('Invalid date - renewal more than 4 weeks ahead'))
 

--- a/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
-<p>The <code><strong>Geolocation<strong>Co</strong>ordinates.altitudeAccuracy</strong></code> read-only property is a strictly positive <code>double</code> representing the accuracy, with a 95% confidence level, of the <code>altitude</code> expressed in meters. This value is <code>null</code> if the implementation doesn't support measuring altitude.</p>
+<p>The <code><strong>GeolocationCoordinates.altitudeAccuracy</strong></code> read-only property is a strictly positive <code>double</code> representing the accuracy, with a 95% confidence level, of the <code>altitude</code> expressed in meters. This value is <code>null</code> if the implementation doesn't support measuring altitude.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Nested `<strong>` tags don't work in Markdown, so let's remove them.