### PR TITLE
fix: JS references under Intl

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/@@tostringtag/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/@@tostringtag/index.html
@@ -3,15 +3,18 @@ title: 'Intl[@@toStringTag]'
 slug: Web/JavaScript/Reference/Global_Objects/Intl/@@toStringTag
 tags:
   - Internationalization
+  - Intl
   - JavaScript
+  - Property
+  - Localization
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>Intl[@@toStringTag]</code></strong> property has an initial value of "Intl".</p>
 
-<p>{{EmbedInteractiveExample("pages/js/intl-prototype-tostringtag.html","shorter")}}</p>
-
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
+<div>{{EmbedInteractiveExample("pages/js/intl-prototype-tostringtag.html","shorter")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <div>{{js_property_attributes(0,0,1)}}</div>
 
@@ -30,24 +33,24 @@ Intl.toString() // "[object Intl]"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl-toStringTag', 'Intl[@@toStringTag]')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl-toStringTag', 'Intl[@@toStringTag]')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.@@toStringTag")}}</p>
+<div>{{Compat("javascript.builtins.Intl.@@toStringTag")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Symbol.toStringTag")}}</li>
+	<li>{{jsxref("Symbol.toStringTag")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
 ---
 <div>{{JSRef}}</div>
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.Collator()</code></strong> constructor creates {{jsxref("Collator", "Intl.Collator")}} objects that enable language-sensitive string comparison.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-collator.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,72 +24,71 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code> {{optional_inline}}</dt>
- <dd>
-
- <p>Optional. A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code>locales</code> argument, see the {{jsxref("Global_Objects/Intl", "Intl page", "#Locale_identification_and_negotiation", 1)}}.</p>
- <p>The following Unicode extension keys are allowed:</p>
-
- <div class="note notecard">
-  <p>These keys can usually also be set with <code>options</code> (as listed below). When both are set, the <code>options</code> property takes precedence.</p>
- </div>
-
- <dl>
-  <dt><code>co</code></dt>
-  <dd>Variant collations for certain locales. Possible values include: "<code>big5han</code>", "<code>dict</code>", "<code>direct</code>", "<code>ducet</code>", "<code>gb2312</code>", "<code>phonebk</code>", "<code>phonetic</code>", "<code>pinyin</code>", "<code>reformed</code>", "<code>searchjl</code>", "<code>stroke</code>", "<code>trad</code>", "<code>unihan</code>".  This option can be also be set through the <code><var>options</var></code> property "<code><var>collation</var></code>".</dd>
-  <dt><code>kn</code></dt>
-  <dd>Whether numeric collation should be used, such that "1" &lt; "2" &lt; "10". Possible values are "<code>true</code>" and "<code>false</code>". This option can be also be set through the <code><var>options</var></code> property "<code><var>numeric</var></code>".</dd>
-  <dt><code>kf</code></dt>
-  <dd>Whether upper case or lower case should sort first. Possible values are "<code>upper</code>", "<code>lower</code>", or "<code>false</code>" (use the locale's default). This option can be also be set through the <code><var>options</var></code> property "<code><var>caseFirst</var></code>".</dd>
- </dl>
- </dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object with some or all of the following properties:</p>
-
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
-  <dt><code>usage</code></dt>
-  <dd>Whether the comparison is for sorting or for searching for matching strings. Possible values are "<code>sort</code>" and "<code>search</code>"; the default is "<code>sort</code>".</dd>
-  <dt><code>sensitivity</code></dt>
-  <dd>
-  <p>Which differences in the strings should lead to non-zero result values. Possible values are:</p>
-
-  <ul>
-   <li>"<code>base</code>": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
-   <li>"<code>accent</code>": Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
-   <li>"<code>case</code>": Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
-   <li>"<code>variant</code>": Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
-  </ul>
-
-  <p>The default is "<code>variant</code>" for usage "<code>sort</code>"; it's locale dependent for usage "<code>search</code>".</p>
-  </dd>
-  <dt><code>ignorePunctuation</code></dt>
-  <dd>Whether punctuation should be ignored. Possible values are <code>true</code> and <code>false</code>; the default is <code>false</code>.</dd>
-  <dt><code>numeric</code></dt>
-  <dd>Whether numeric collation should be used, such that "1" &lt; "2" &lt; "10". Possible values are <code>true</code> and <code>false</code>; the default is <code>false</code>.
-    <div class="note notecard">
-      <p>This option can also be set through the <code>kn</code> Unicode extension key; if both are provided, this <code>options</code> property takes precedence.</p>
-    </div> 
-  </dd>
-
-  <dt><code>caseFirst</code></dt>
-  <dd>Whether upper case or lower case should sort first. Possible values are "<code>upper</code>", "<code>lower</code>", or "<code>false</code>" (use the locale's default). This option can be set through an <code><var>options</var></code> property or through a Unicode extension key; if both are provided, the <code><var>options</var></code> property takes precedence.
-    <div class="note notecard">
-      <p>This option can also be set through the <code>kf</code> Unicode extension key; if both are provided, this <code>options</code> property takes precedence.</p>
-    </div>
-  </dd>
-  <dt><code>collation</code></dt>
-  <dd>Variant collations for certain locales. Possible values include: "<code>big5han</code>", "<code>dict</code>", "<code>direct</code>", "<code>ducet</code>", "<code>gb2312</code>", "<code>phonebk</code>" (only supported in German), "<code>phonetic</code>", "<code>pinyin</code>", "<code>reformed</code>", "<code>searchjl</code>", "<code>stroke</code>", "<code>trad</code>", "<code>unihan</code>".
-  <div class="note notecard">
-    <p>This option can also be set through the <code>co</code> Unicode extension key; if both are provided, this <code>options</code> property takes precedence.</p>
-  </div>
-</dd>
+	<dt><code><var>locales</var></code> {{optional_inline}}</dt>
+	<dd>
+		
+		<p>Optional. A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code>locales</code> argument, see the {{jsxref("Global_Objects/Intl", "Intl page", "#Locale_identification_and_negotiation", 1)}}.</p>
+		<p>The following Unicode extension keys are allowed:</p>
+		
+		<div class="note notecard">
+			<p>These keys can usually also be set with <code>options</code> (as listed below). When both are set, the <code>options</code> property takes precedence.</p>
+		</div>
+		
+		<dl>
+			<dt><code>co</code></dt>
+			<dd>Variant collations for certain locales. Possible values include: "<code>big5han</code>", "<code>dict</code>", "<code>direct</code>", "<code>ducet</code>", "<code>gb2312</code>", "<code>phonebk</code>", "<code>phonetic</code>", "<code>pinyin</code>", "<code>reformed</code>", "<code>searchjl</code>", "<code>stroke</code>", "<code>trad</code>", "<code>unihan</code>".  This option can be also be set through the <code><var>options</var></code> property "<code><var>collation</var></code>".</dd>
+			<dt><code>kn</code></dt>
+			<dd>Whether numeric collation should be used, such that "1" &lt; "2" &lt; "10". Possible values are "<code>true</code>" and "<code>false</code>". This option can be also be set through the <code><var>options</var></code> property "<code><var>numeric</var></code>".</dd>
+			<dt><code>kf</code></dt>
+			<dd>Whether upper case or lower case should sort first. Possible values are "<code>upper</code>", "<code>lower</code>", or "<code>false</code>" (use the locale's default). This option can be also be set through the <code><var>options</var></code> property "<code><var>caseFirst</var></code>".</dd>
+		</dl>
+	</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object with some or all of the following properties:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+			<dt><code>usage</code></dt>
+			<dd>Whether the comparison is for sorting or for searching for matching strings. Possible values are "<code>sort</code>" and "<code>search</code>"; the default is "<code>sort</code>".</dd>
+			<dt><code>sensitivity</code></dt>
+			<dd>
+				<p>Which differences in the strings should lead to non-zero result values. Possible values are:</p>
+				
+				<ul>
+					<li>"<code>base</code>": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A.</li>
+					<li>"<code>accent</code>": Only strings that differ in base letters or accents and other diacritic marks compare as unequal. Examples: a ≠ b, a ≠ á, a = A.</li>
+					<li>"<code>case</code>": Only strings that differ in base letters or case compare as unequal. Examples: a ≠ b, a = á, a ≠ A.</li>
+					<li>"<code>variant</code>": Strings that differ in base letters, accents and other diacritic marks, or case compare as unequal. Other differences may also be taken into consideration. Examples: a ≠ b, a ≠ á, a ≠ A.</li>
+				</ul>
+				
+				<p>The default is "<code>variant</code>" for usage "<code>sort</code>"; it's locale dependent for usage "<code>search</code>".</p>
+			</dd>
+			<dt><code>ignorePunctuation</code></dt>
+			<dd>Whether punctuation should be ignored. Possible values are <code>true</code> and <code>false</code>; the default is <code>false</code>.</dd>
+			<dt><code>numeric</code></dt>
+			<dd>Whether numeric collation should be used, such that "1" &lt; "2" &lt; "10". Possible values are <code>true</code> and <code>false</code>; the default is <code>false</code>.
+				<div class="note notecard">
+					<p>This option can also be set through the <code>kn</code> Unicode extension key; if both are provided, this <code>options</code> property takes precedence.</p>
+				</div> 
+			</dd>
+			
+			<dt><code>caseFirst</code></dt>
+			<dd>Whether upper case or lower case should sort first. Possible values are "<code>upper</code>", "<code>lower</code>", or "<code>false</code>" (use the locale's default). This option can be set through an <code><var>options</var></code> property or through a Unicode extension key; if both are provided, the <code><var>options</var></code> property takes precedence.
+				<div class="note notecard">
+					<p>This option can also be set through the <code>kf</code> Unicode extension key; if both are provided, this <code>options</code> property takes precedence.</p>
+				</div>
+			</dd>
+			<dt><code>collation</code></dt>
+			<dd>Variant collations for certain locales. Possible values include: "<code>big5han</code>", "<code>dict</code>", "<code>direct</code>", "<code>ducet</code>", "<code>gb2312</code>", "<code>phonebk</code>" (only supported in German), "<code>phonetic</code>", "<code>pinyin</code>", "<code>reformed</code>", "<code>searchjl</code>", "<code>stroke</code>", "<code>trad</code>", "<code>unihan</code>".
+				<div class="note notecard">
+					<p>This option can also be set through the <code>co</code> Unicode extension key; if both are provided, this <code>options</code> property takes precedence.</p>
+				</div>
+			</dd>
+		</dl>
+	</dd>
 </dl>
- </dd>
-</dl>
-
 
 <h2 id="Examples">Examples</h2>
 
@@ -107,16 +106,16 @@ console.log(new Intl.Collator().compare('a', 'a')); // → 0
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-the-intl-collator-constructor', 'Intl.Collator constructor')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-the-intl-collator-constructor', 'Intl.Collator constructor')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -126,6 +125,6 @@ console.log(new Intl.Collator().compare('a', 'a')); // → 0
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.Collator")}}</li>
- <li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
+	<li>{{jsxref("Intl.Collator")}}</li>
+	<li>{{jsxref("Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.html
@@ -6,16 +6,17 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>Intl.Collator.prototype.compare()</code></strong> method compares two strings according to the sort order of this {{jsxref("Collator")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-collator-prototype-compare.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,14 +25,14 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>string1</var></code></dt>
- <dt><code><var>string2</var></code></dt>
- <dd>The strings to compare against each other.</dd>
+	<dt><code><var>string1</var></code></dt>
+	<dt><code><var>string2</var></code></dt>
+	<dd>The strings to compare against each other.</dd>
 </dl>
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>compare</code> getter function returns a number indicating how <code>string1</code> and <code>string2</code> compare to each other according to the sort order of this {{jsxref("Collator")}} object: a negative value if <code>string1</code> comes before <code>string2</code>; a positive value if <code>string1</code> comes after <code>string2</code>; 0 if they are considered equal.</p>
+<p>The <code>compare</code> getter function returns a number indicating how <code><var>string1</var></code> and <code><var>string2</var></code> compare to each other according to the sort order of this {{jsxref("Collator")}} object: a negative value if <code><var>string1</var></code> comes before <code><var>string2</var></code>; a positive value if <code><var>string1</var></code> comes after <code><var>string2</var></code>; 0 if they are considered equal.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -61,26 +62,25 @@ console.log(matches.join(', '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.collator.prototype.compare', 'Intl.Collator.prototype.compare')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.collator.prototype.compare', 'Intl.Collator.prototype.compare')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.Collator.compare")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.Collator.compare")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Collator", "Intl.Collator")}}</li>
- <li>{{jsxref("String.prototype.localeCompare()")}}</li>
+	<li>{{jsxref("Intl.Collator")}}</li>
+	<li>{{jsxref("String.prototype.localeCompare()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
 ---
 <div>{{JSRef}}</div>
@@ -14,30 +15,29 @@ tags:
 <p>The <strong><code>Intl.Collator</code></strong> object enables language-sensitive string comparison.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-collator.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("Intl/Collator/Collator", "Intl.Collator()")}}</dt>
- <dd>Creates a new <code>Collator</code> object.</dd>
+	<dt>{{jsxref("Intl/Collator/Collator", "Intl.Collator()")}}</dt>
+	<dd>Creates a new <code>Collator</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("Collator.supportedLocalesOf", "Intl.Collator.supportedLocalesOf()")}}</dt>
- <dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
+	<dt>{{jsxref("Collator.supportedLocalesOf", "Intl.Collator.supportedLocalesOf()")}}</dt>
+	<dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{jsxref("Collator.compare", "Intl.Collator.prototype.compare")}}</dt>
- <dd>Getter function that compares two strings according to the sort order of this {{jsxref("Global_Objects/Collator", "Intl.Collator")}} object.</dd>
- <dt>{{jsxref("Collator.resolvedOptions", "Intl.Collator.prototype.resolvedOptions()")}}</dt>
- <dd>Returns a new object with properties reflecting the locale and collation options computed during initialization of the object.</dd>
+	<dt>{{jsxref("Collator.compare", "Intl.Collator.prototype.compare")}}</dt>
+	<dd>Getter function that compares two strings according to the sort order of this {{jsxref("Global_Objects/Collator", "Intl.Collator")}} object.</dd>
+	<dt>{{jsxref("Collator.resolvedOptions", "Intl.Collator.prototype.resolvedOptions()")}}</dt>
+	<dd>Returns a new object with properties reflecting the locale and collation options computed during initialization of the object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -82,16 +82,16 @@ console.log(new Intl.Collator('sv', { sensitivity: 'base' }).compare('ä', 'a'))
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#collator-objects', 'Intl.Collator')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#collator-objects', 'Intl.Collator')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -101,5 +101,5 @@ console.log(new Intl.Collator('sv', { sensitivity: 'base' }).compare('ä', 'a'))
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl")}}</li>
+	<li>{{jsxref("Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.html
@@ -6,16 +6,17 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>Intl.Collator.prototype.resolvedOptions()</code></strong> method returns a new object with properties reflecting the locale and collation options computed during initialization of this {{jsxref("Collator")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-collator-prototype-resolvedoptions.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -30,17 +31,17 @@ tags:
 <p>The resulting object has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>usage</code></dt>
- <dt><code>sensitivity</code></dt>
- <dt><code>ignorePunctuation</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults.</dd>
- <dt><code>collation</code></dt>
- <dd>The value requested using the Unicode extension key <code>"co"</code>, if it is supported for <code>locale</code>, or <code>"default"</code>.</dd>
- <dt><code>numeric</code></dt>
- <dt><code>caseFirst</code></dt>
- <dd>The values requested for these properties in the <code>options</code> argument or using the Unicode extension keys <code>"kn"</code> and <code>"kf"</code> or filled in as defaults. If the implementation does not support these properties, they are omitted.</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>usage</code></dt>
+	<dt><code>sensitivity</code></dt>
+	<dt><code>ignorePunctuation</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults.</dd>
+	<dt><code>collation</code></dt>
+	<dd>The value requested using the Unicode extension key "<code>co</code>", if it is supported for <code>locale</code>, or "<code>default</code>".</dd>
+	<dt><code>numeric</code></dt>
+	<dt><code>caseFirst</code></dt>
+	<dd>The values requested for these properties in the <code>options</code> argument or using the Unicode extension keys "<code>kn</code>" and "<code>kf</code>" or filled in as defaults. If the implementation does not support these properties, they are omitted.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -61,25 +62,24 @@ usedOptions.numeric;           // false
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.collator.prototype.resolvedoptions', 'Intl.Collator.prototype.resolvedOptions')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.collator.prototype.resolvedoptions', 'Intl.Collator.prototype.resolvedOptions')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.Collator.resolvedOptions")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.Collator.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Collator", "Intl.Collator")}}</li>
+	<li>{{jsxref("Intl.Collator")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/supportedlocalesof/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Reference
 ---
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.Collator.supportedLocalesOf()</code></strong> method returns an array containing those of the provided locales that are supported in collation without having to fall back to the runtime's default locale.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-collator-prototype-supportedlocalesof.html","shorter")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,17 +24,17 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
 
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -60,16 +60,16 @@ console.log(Intl.Collator.supportedLocalesOf(locales, options).join(', '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.collator.supportedlocalesof', 'Intl.Collator.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.collator.supportedlocalesof', 'Intl.Collator.supportedLocalesOf()')}}</td>
+			</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -79,5 +79,5 @@ console.log(Intl.Collator.supportedLocalesOf(locales, options).join(', '));
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.Collator")}}</li>
+	<li>{{jsxref("Intl.Collator")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
 ---
 <div>{{JSRef}}</div>
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.DateTimeFormat()</code></strong> constructor creates {{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}} objects that enable language-sensitive date and time formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat.html", "taller")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,155 +24,155 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code> {{optional_inline}}</dt>
- <dd>
- <p>A string with a BCP 47 language tag, or an array of such strings. To use the browser's default locale, pass an empty array. Unicode extension are supported (for example "<code>en-US-u-ca-buddhist</code>"). For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page. The following Unicode extension keys are allowed:</p>
-
- <dl>
-  <dt><code>nu</code></dt>
-  <dd>Numbering system. Possible values include: "<code>arab</code>", "<code>arabext</code>", "<code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", "<code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", "<code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", "<code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", "<code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
-  <dt><code>ca</code></dt>
-  <dd>Calendar. Possible values include: "<code>buddhist</code>", "<code>chinese</code>", "<code>coptic</code>", "<code>ethiopia</code>", "<code>ethiopic</code>", "<code>gregory</code>", "<code>hebrew</code>", "<code>indian</code>", "<code>islamic</code>", "<code>iso8601</code>", "<code>japanese</code>", "<code>persian</code>", "<code>roc</code>".</dd>
-  <dt><code>hc</code></dt>
-  <dd>Hour cycle. Possible values include: "<code>h11</code>", "<code>h12</code>", "<code>h23</code>", "<code>h24</code>".</dd>
- </dl>
- </dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object with some or all of the following properties:</p>
-
- <dl>
-  <dt><code>dateStyle</code></dt>
-  <dd>The date formatting style to use when calling <code>format()</code>. Possible values include:
-  <ul>
-   <li>"<code>full</code>"</li>
-   <li>"<code>long</code>"</li>
-   <li>"<code>medium</code>"</li>
-   <li>"<code>short</code>"</li>
-  </ul>
-
-  <div class="notecard note">
-  <p><code>dateStyle</code> can be used with <code>timeStyle</code>, but not with other options (e.g. <code>weekday</code>, <code>hour</code>, <code>month</code>, etc.).</p>
-  </div>
-  </dd>
-  <dt><code>timeStyle</code></dt>
-  <dd>The time formatting style to use when calling <code>format()</code>. Possible values include:
-  <ul>
-   <li>"<code>full</code>"</li>
-   <li>"<code>long</code>"</li>
-   <li>"<code>medium</code>"</li>
-   <li>"<code>short</code>"</li>
-  </ul>
-  </dd>
-  <dd>
-  <div class="notecard note">
-  <p><code>timeStyle</code> can be used with <code>dateStyle</code>, but not with other options (e.g. <code>weekday</code>, <code>hour</code>, <code>month</code>, etc.).</p>
-  </div>
-  </dd>
-  <dt><code>calendar</code></dt>
-  <dd>Calendar. Possible values include: "<code>buddhist</code>", "<code>chinese</code>", " <code>coptic</code>", "<code>ethiopia</code>", "<code>ethiopic</code>", "<code>gregory</code>", " <code>hebrew</code>", "<code>indian</code>", "<code>islamic</code>", "<code>iso8601</code>", " <code>japanese</code>", "<code>persian</code>", "<code>roc</code>".</dd>
-  <dt><code>dayPeriod</code></dt>
-  <dd>The way day periods should be expressed. Possible values include: "<code>narrow</code>", "<code>short</code>", " <code>long</code>".</dd>
-  <dt><code>numberingSystem</code></dt>
-  <dd>Numbering System. Possible values include: "<code>arab</code>", "<code>arabext</code>", " <code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", " <code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", " <code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", " <code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", " <code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
-  <dt><code>timeZone</code></dt>
-  <dd>The time zone to use. The only value implementations must recognize is "<code>UTC</code>"; the default is the runtime's default time zone. Implementations may also recognize the time zone names of the <a href="https://www.iana.org/time-zones">IANA time zone database</a>, such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>", "<code>America/New_York</code>".</dd>
-  <dt><code>hour12</code></dt>
-  <dd>Whether to use 12-hour time (as opposed to 24-hour time). Possible values are <code>true</code> and <code>false</code>; the default is locale dependent. This option overrides the <code>hc</code> language tag and/or the <code>hourCycle</code> option in case both are present.</dd>
-  <dt><code>hourCycle</code></dt>
-  <dd>The hour cycle to use. Possible values are "<code>h11</code>", "<code>h12</code>", "<code>h23</code>", or "<code>h24</code>". This option overrides the <code>hc</code> language tag, if both are present, and the <code>hour12</code> option takes precedence in case both options have been specified.</dd>
-  <dt><code>formatMatcher</code></dt>
-  <dd>The format matching algorithm to use. Possible values are "<code>basic</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". See the following paragraphs for information about the use of this property.</dd>
- </dl>
-
- <p>The following properties describe the date-time components to use in formatted output, and their desired representations. Implementations are required to support at least the following subsets:</p>
-
- <ul>
-  <li><code>weekday</code>, <code>year</code>, <code>month</code>, <code>day</code>, <code>hour</code>, <code>minute</code>, <code>second</code></li>
-  <li><code>weekday</code>, <code>year</code>, <code>month</code>, <code>day</code></li>
-  <li><code>year</code>, <code>month</code>, <code>day</code></li>
-  <li><code>year</code>, <code>month</code></li>
-  <li><code>month</code>, <code>day</code></li>
-  <li><code>hour</code>, <code>minute</code>, <code>second</code></li>
-  <li><code>hour</code>, <code>minute</code></li>
- </ul>
-
- <p>Implementations may support other subsets, and requests will be negotiated against all available subset-representation combinations to find the best match. Two algorithms are available for this negotiation and selected by the <code>formatMatcher</code> property: A <a href="http://www.ecma-international.org/ecma-402/1.0/#BasicFormatMatcher">fully specified "<code>basic</code>" algorithm</a> and an implementation-dependent "<code>best fit</code>" algorithm.</p>
-
- <dl>
-  <dt><code>weekday</code></dt>
-  <dd>The representation of the weekday. Possible values are:
-  <ul>
-   <li>"<code>long</code>" (e.g., <code>Thursday</code>)</li>
-   <li>"<code>short</code>" (e.g., <code>Thu</code>)</li>
-   <li>"<code>narrow</code>" (e.g., <code>T</code>). Two weekdays may have the same narrow style for some locales (e.g. <code>Tuesday</code>'s narrow style is also <code>T</code>).</li>
-  </ul>
-  </dd>
-  <dt><code>era</code></dt>
-  <dd>The representation of the era. Possible values are:
-  <ul>
-   <li>"<code>long</code>" (e.g., <code>Anno Domini</code>)</li>
-   <li>"<code>short</code>" (e.g., <code>AD</code>)</li>
-   <li>"<code>narrow</code>" (e.g., <code>A</code>)</li>
-  </ul>
-  </dd>
-  <dt><code>year</code></dt>
-  <dd>The representation of the year. Possible values are:
-  <ul>
-   <li>"<code>numeric</code>" (e.g., <code>2012</code>)</li>
-   <li>"<code>2-digit</code>" (e.g., <code>12</code>)</li>
-  </ul>
-  </dd>
-  <dt><code>month</code></dt>
-  <dd>The representation of the month. Possible values are:
-  <ul>
-   <li>"<code>numeric</code>" (e.g., <code>2</code>)</li>
-   <li>"<code>2-digit</code>" (e.g., <code>02</code>)</li>
-   <li>"<code>long</code>" (e.g., <code>March</code>)</li>
-   <li>"<code>short</code>" (e.g., <code>Mar</code>)</li>
-   <li>"<code>narrow</code>" (e.g., <code>M</code>). Two months may have the same narrow style for some locales (e.g. <code>May</code>'s narrow style is also <code>M</code>).</li>
-  </ul>
-  </dd>
-  <dt><code>day</code></dt>
-  <dd>The representation of the day. Possible values are:
-  <ul>
-   <li>"<code>numeric</code>" (e.g., <code>1</code>)</li>
-   <li>"<code>2-digit</code>" (e.g., <code>01</code>)</li>
-  </ul>
-  </dd>
-  <dt><code>hour</code></dt>
-  <dd>The representation of the hour. Possible values are "<code>numeric</code>", "<code>2-digit</code>".</dd>
-  <dt><code>minute</code></dt>
-  <dd>The representation of the minute. Possible values are "<code>numeric</code>", "<code>2-digit</code>".</dd>
-  <dt><code>second</code></dt>
-  <dd>The representation of the second. Possible values are "<code>numeric</code>", "<code>2-digit</code>".</dd>
-  <dt><code>fractionalSecondDigits</code></dt>
-  <dd>
-  <div class="notecard note">
-  <p class="noinclude">Added in Firefox 84, Chrome 84, etc. See compatibility table for more information.</p>
-  </div>
-  The number of digits used to represent fractions of a second (any additional digits are truncated). Possible values are:
-
-  <ul>
-   <li><code>0</code> (Fractional part dropped.)</li>
-   <li><code>1</code> (Fractional part represented as 1 digit. For example, 736 is formatted as <code>7</code>.)</li>
-   <li><code>2</code> (Fractional part represented as 2 digits. For example, 736 is formatted as <code>73</code>.)</li>
-   <li><code>3</code> (Fractional part represented as 3 digits. For example, 736 is formatted as <code>736</code>.)</li>
-  </ul>
-  </dd>
-  <dt><code>timeZoneName</code></dt>
-  <dd>The representation of the time zone name. Possible values are:
-  <ul>
-   <li>"<code>long</code>" (e.g., <code>British Summer Time</code>)</li>
-   <li>"<code>short</code>" (e.g., <code>GMT+1</code>)</li>
-  </ul>
-  </dd>
- </dl>
-
- <p class="noinclude">The default value for each date-time component property is {{jsxref("undefined")}}, but if all component properties are {{jsxref("undefined")}}, then <code>year</code>, <code>month</code>, and <code>day</code> are assumed to be "<code>numeric</code>".</p>
- </dd>
+	<dt><code><var>locales</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>A string with a BCP 47 language tag, or an array of such strings. To use the browser's default locale, pass an empty array. Unicode extension are supported (for example "<code>en-US-u-ca-buddhist</code>"). For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page. The following Unicode extension keys are allowed:</p>
+		
+		<dl>
+			<dt><code>nu</code></dt>
+			<dd>Numbering system. Possible values include: "<code>arab</code>", "<code>arabext</code>", "<code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", "<code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", "<code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", "<code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", "<code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
+			<dt><code>ca</code></dt>
+			<dd>Calendar. Possible values include: "<code>buddhist</code>", "<code>chinese</code>", "<code>coptic</code>", "<code>ethiopia</code>", "<code>ethiopic</code>", "<code>gregory</code>", "<code>hebrew</code>", "<code>indian</code>", "<code>islamic</code>", "<code>iso8601</code>", "<code>japanese</code>", "<code>persian</code>", "<code>roc</code>".</dd>
+			<dt><code>hc</code></dt>
+			<dd>Hour cycle. Possible values include: "<code>h11</code>", "<code>h12</code>", "<code>h23</code>", "<code>h24</code>".</dd>
+		</dl>
+	</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object with some or all of the following properties:</p>
+		
+		<dl>
+			<dt><code>dateStyle</code></dt>
+			<dd>The date formatting style to use when calling <code>format()</code>. Possible values include:
+				<ul>
+					<li>"<code>full</code>"</li>
+					<li>"<code>long</code>"</li>
+					<li>"<code>medium</code>"</li>
+					<li>"<code>short</code>"</li>
+				</ul>
+				
+				<div class="notecard note">
+					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but not with other options (e.g. <code>weekday</code>, <code>hour</code>, <code>month</code>, etc.).</p>
+				</div>
+			</dd>
+			<dt><code>timeStyle</code></dt>
+			<dd>The time formatting style to use when calling <code>format()</code>. Possible values include:
+				<ul>
+					<li>"<code>full</code>"</li>
+					<li>"<code>long</code>"</li>
+					<li>"<code>medium</code>"</li>
+					<li>"<code>short</code>"</li>
+				</ul>
+			</dd>
+			<dd>
+				<div class="notecard note">
+					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but not with other options (e.g. <code>weekday</code>, <code>hour</code>, <code>month</code>, etc.).</p>
+				</div>
+			</dd>
+			<dt><code>calendar</code></dt>
+			<dd>Calendar. Possible values include: "<code>buddhist</code>", "<code>chinese</code>", " <code>coptic</code>", "<code>ethiopia</code>", "<code>ethiopic</code>", "<code>gregory</code>", " <code>hebrew</code>", "<code>indian</code>", "<code>islamic</code>", "<code>iso8601</code>", " <code>japanese</code>", "<code>persian</code>", "<code>roc</code>".</dd>
+			<dt><code>dayPeriod</code></dt>
+			<dd>The way day periods should be expressed. Possible values include: "<code>narrow</code>", "<code>short</code>", " <code>long</code>".</dd>
+			<dt><code>numberingSystem</code></dt>
+			<dd>Numbering System. Possible values include: "<code>arab</code>", "<code>arabext</code>", " <code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", " <code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", " <code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", " <code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", " <code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+			<dt><code>timeZone</code></dt>
+			<dd>The time zone to use. The only value implementations must recognize is "<code>UTC</code>"; the default is the runtime's default time zone. Implementations may also recognize the time zone names of the <a href="https://www.iana.org/time-zones">IANA time zone database</a>, such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>", "<code>America/New_York</code>".</dd>
+			<dt><code>hour12</code></dt>
+			<dd>Whether to use 12-hour time (as opposed to 24-hour time). Possible values are <code>true</code> and <code>false</code>; the default is locale dependent. This option overrides the <code>hc</code> language tag and/or the <code>hourCycle</code> option in case both are present.</dd>
+			<dt><code>hourCycle</code></dt>
+			<dd>The hour cycle to use. Possible values are "<code>h11</code>", "<code>h12</code>", "<code>h23</code>", or "<code>h24</code>". This option overrides the <code>hc</code> language tag, if both are present, and the <code>hour12</code> option takes precedence in case both options have been specified.</dd>
+			<dt><code>formatMatcher</code></dt>
+			<dd>The format matching algorithm to use. Possible values are "<code>basic</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". See the following paragraphs for information about the use of this property.</dd>
+		</dl>
+		
+		<p>The following properties describe the date-time components to use in formatted output, and their desired representations. Implementations are required to support at least the following subsets:</p>
+		
+		<ul>
+			<li><code>weekday</code>, <code>year</code>, <code>month</code>, <code>day</code>, <code>hour</code>, <code>minute</code>, <code>second</code></li>
+			<li><code>weekday</code>, <code>year</code>, <code>month</code>, <code>day</code></li>
+			<li><code>year</code>, <code>month</code>, <code>day</code></li>
+			<li><code>year</code>, <code>month</code></li>
+			<li><code>month</code>, <code>day</code></li>
+			<li><code>hour</code>, <code>minute</code>, <code>second</code></li>
+			<li><code>hour</code>, <code>minute</code></li>
+		</ul>
+		
+		<p>Implementations may support other subsets, and requests will be negotiated against all available subset-representation combinations to find the best match. Two algorithms are available for this negotiation and selected by the <code>formatMatcher</code> property: A <a href="http://www.ecma-international.org/ecma-402/1.0/#BasicFormatMatcher">fully specified "<code>basic</code>" algorithm</a> and an implementation-dependent "<code>best fit</code>" algorithm.</p>
+		
+		<dl>
+			<dt><code>weekday</code></dt>
+			<dd>The representation of the weekday. Possible values are:
+				<ul>
+					<li>"<code>long</code>" (e.g., <code>Thursday</code>)</li>
+					<li>"<code>short</code>" (e.g., <code>Thu</code>)</li>
+					<li>"<code>narrow</code>" (e.g., <code>T</code>). Two weekdays may have the same narrow style for some locales (e.g. <code>Tuesday</code>'s narrow style is also <code>T</code>).</li>
+				</ul>
+			</dd>
+			<dt><code>era</code></dt>
+			<dd>The representation of the era. Possible values are:
+				<ul>
+					<li>"<code>long</code>" (e.g., <code>Anno Domini</code>)</li>
+					<li>"<code>short</code>" (e.g., <code>AD</code>)</li>
+					<li>"<code>narrow</code>" (e.g., <code>A</code>)</li>
+				</ul>
+			</dd>
+			<dt><code>year</code></dt>
+			<dd>The representation of the year. Possible values are:
+				<ul>
+					<li>"<code>numeric</code>" (e.g., <code>2012</code>)</li>
+					<li>"<code>2-digit</code>" (e.g., <code>12</code>)</li>
+				</ul>
+			</dd>
+			<dt><code>month</code></dt>
+			<dd>The representation of the month. Possible values are:
+				<ul>
+					<li>"<code>numeric</code>" (e.g., <code>2</code>)</li>
+					<li>"<code>2-digit</code>" (e.g., <code>02</code>)</li>
+					<li>"<code>long</code>" (e.g., <code>March</code>)</li>
+					<li>"<code>short</code>" (e.g., <code>Mar</code>)</li>
+					<li>"<code>narrow</code>" (e.g., <code>M</code>). Two months may have the same narrow style for some locales (e.g. <code>May</code>'s narrow style is also <code>M</code>).</li>
+				</ul>
+			</dd>
+			<dt><code>day</code></dt>
+			<dd>The representation of the day. Possible values are:
+				<ul>
+					<li>"<code>numeric</code>" (e.g., <code>1</code>)</li>
+					<li>"<code>2-digit</code>" (e.g., <code>01</code>)</li>
+				</ul>
+			</dd>
+			<dt><code>hour</code></dt>
+			<dd>The representation of the hour. Possible values are "<code>numeric</code>", "<code>2-digit</code>".</dd>
+			<dt><code>minute</code></dt>
+			<dd>The representation of the minute. Possible values are "<code>numeric</code>", "<code>2-digit</code>".</dd>
+			<dt><code>second</code></dt>
+			<dd>The representation of the second. Possible values are "<code>numeric</code>", "<code>2-digit</code>".</dd>
+			<dt><code>fractionalSecondDigits</code></dt>
+			<dd>
+				<div class="notecard note">
+					<p class="noinclude">Added in Firefox 84, Chrome 84, etc. See compatibility table for more information.</p>
+				</div>
+				The number of digits used to represent fractions of a second (any additional digits are truncated). Possible values are:
+				
+				<ul>
+					<li><code>0</code> (Fractional part dropped.)</li>
+					<li><code>1</code> (Fractional part represented as 1 digit. For example, 736 is formatted as <code>7</code>.)</li>
+					<li><code>2</code> (Fractional part represented as 2 digits. For example, 736 is formatted as <code>73</code>.)</li>
+					<li><code>3</code> (Fractional part represented as 3 digits. For example, 736 is formatted as <code>736</code>.)</li>
+				</ul>
+			</dd>
+			<dt><code>timeZoneName</code></dt>
+			<dd>The representation of the time zone name. Possible values are:
+				<ul>
+					<li>"<code>long</code>" (e.g., <code>British Summer Time</code>)</li>
+					<li>"<code>short</code>" (e.g., <code>GMT+1</code>)</li>
+				</ul>
+			</dd>
+		</dl>
+		
+		<p class="noinclude">The default value for each date-time component property is {{jsxref("undefined")}}, but if all component properties are {{jsxref("undefined")}}, then <code>year</code>, <code>month</code>, and <code>day</code> are assumed to be "<code>numeric</code>".</p>
+	</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -209,16 +209,16 @@ console.log(o.format(Date.now())); // "07/07/20, 13:31:55 AM"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl-datetimeformat-constructor', 'Intl.DateTimeFormat')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl-datetimeformat-constructor', 'Intl.DateTimeFormat')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -234,6 +234,6 @@ console.log(o.format(Date.now())); // "07/07/20, 13:31:55 AM"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DateTimeFormat")}}</li>
- <li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
+	<li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.html
@@ -6,16 +6,17 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>Intl.DateTimeFormat.prototype.format()</code></strong> method formats a date according to the locale and formatting options of this {{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}} object.</p>
+<p>The <strong><code>Intl.DateTimeFormat.prototype.format()</code></strong> method formats a date according to the locale and formatting options of this {{jsxref("Intl.DateTimeFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-format.html", "taller")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,8 +25,8 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>date</var></code></dt>
- <dd>The date to format.</dd>
+	<dt><code><var>date</var></code></dt>
+	<dd>The date to format.</dd>
 </dl>
 
 <h2 id="Description">Description</h2>
@@ -84,27 +85,27 @@ let formattedDate = Intl.DateTimeFormat(undefined, {
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.datetimeformat.prototype.format', 'Intl.DateTimeFormat.format')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.datetimeformat.prototype.format', 'Intl.DateTimeFormat.format')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.DateTimeFormat.format")}}</p>
+<div>{{Compat("javascript.builtins.Intl.DateTimeFormat.format")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Global_Objects/DateTimeFormat", "Intl.DateTimeFormat")}}</li>
- <li>{{jsxref("Date.prototype.toLocaleString()")}}</li>
- <li>{{jsxref("Date.prototype.toLocaleDateString()")}}</li>
- <li>{{jsxref("Date.prototype.toLocaleTimeString()")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
+	<li>{{jsxref("Date.prototype.toLocaleString()")}}</li>
+	<li>{{jsxref("Date.prototype.toLocaleDateString()")}}</li>
+	<li>{{jsxref("Date.prototype.toLocaleTimeString()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrange/index.html
@@ -2,23 +2,29 @@
 title: Intl.DateTimeFormat.prototype.formatRange()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange
 tags:
+  - DateTimeFormat
+  - Internationalization
+  - Intl
   - JavaScript
+  - Localization
   - Method
+  - Prototype
   - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>Intl.DateTimeFormat.prototype.formatRange()</code></strong> formats a date range in the most concise way based on the <strong><code>locale</code></strong> and <code><strong>options</strong></code> provided when instantiating {{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}} object.</p>
+<p>The <strong><code>Intl.DateTimeFormat.prototype.formatRange()</code></strong> formats a date range in the most concise way based on the <strong><code>locale</code></strong> and <code><strong>options</strong></code> provided when instantiating {{jsxref("Intl.DateTimeFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrange.html", "taller")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="notranslate"><code>Intl.DateTimeFormat.prototype.formatRange(<var>startDate, endDate</var>)</code></pre>
+<pre class="syntaxbox notranslate">Intl.DateTimeFormat.prototype.formatRange(<var>startDate</var>, <var>endDate</var>)</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Basic_formatRange_usage">Basic <code>formatRange</code> usage</h3>
+<h3 id="Basic_formatRange_usage">Basic formatRange usage</h3>
 
 <p>This method receives two {{jsxref("Date")}}s and formats the date range in the most concise way based on the <code>locale</code> and <code>options</code> provided when instantiating {{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}.</p>
 
@@ -59,27 +65,24 @@ console.log(fmt2.formatRange(date1, date3));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DateTimeFormat.formatRange', '#sec-intl.datetimeformat.prototype.formatRange', 'formatRange()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DateTimeFormat.formatRange', '#sec-intl.datetimeformat.prototype.formatRange', 'formatRange()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.DateTimeFormat.formatRange")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.DateTimeFormat.formatRange")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.html
@@ -2,24 +2,25 @@
 title: Intl.DateTimeFormat.prototype.formatRangeToParts()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRangeToParts
 tags:
+  - DateTimeFormat
   - Internationalization
+  - Intl
   - JavaScript
   - Localization
   - Method
+  - Prototype
   - Reference
-  - i18n
 ---
-<p>{{JSRef}}</p>
+<div>{{JSRef}}</div>
 
-<p>The <strong><code>Intl.DateTimeFormat.prototype.formatRangeToParts()</code></strong> method allows locale-specific tokens representing each part of the formatted date range produced by <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/prototype">DateTimeFormat</a></code> formatters.</p>
+<p>The <strong><code>Intl.DateTimeFormat.prototype.formatRangeToParts()</code></strong> method allows locale-specific tokens representing each part of the formatted date range produced by {{jsxref("Intl.DateTimeFormat")}} formatters.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formatrangetoparts.html", "taller")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="notranslate"><code>Intl.DateTimeFormat.prototype.formatRangeToParts(<var>startDate</var>, <var>endDate</var>)</code></pre>
+<pre class="syntaxbox notranslate">Intl.DateTimeFormat.prototype.formatRangeToParts(<var>startDate</var>, <var>endDate</var>)</pre>
 
 <h2 id="Examples">Examples</h2>
 
@@ -57,24 +58,25 @@ fmt.formatRangeToParts(date1, date2);
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DateTimeFormat.formatRange', '#sec-Intl.DateTimeFormat.prototype.formatRangeToParts', 'formatRangeToParts()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DateTimeFormat.formatRange', '#sec-Intl.DateTimeFormat.prototype.formatRangeToParts', 'formatRangeToParts()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.DateTimeFormat.formatRangeToParts")}}</p>
+<div>{{Compat("javascript.builtins.Intl.DateTimeFormat.formatRangeToParts")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DateTimeFormat.prototype.formatRange()")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat.prototype.formatRange()")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.html
@@ -6,12 +6,14 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>Intl.DateTimeFormat.prototype.formatToParts()</code></strong> method allows locale-aware formatting of strings produced by <code>DateTimeFormat</code> formatters.</p>
+<p>The <strong><code>Intl.DateTimeFormat.prototype.formatToParts()</code></strong> method allows locale-aware formatting of strings produced by {{jsxref("Intl.DateTimeFormat")}} formatters.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -20,8 +22,8 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>date</code> {{optional_inline}}</dt>
- <dd>The date to format.</dd>
+	<dt><code><var>date</var></code> {{optional_inline}}</dt>
+	<dd>The date to format.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -40,34 +42,34 @@ tags:
 <p>Possible types are the following:</p>
 
 <dl>
- <dt>day</dt>
- <dd>The string used for the day, for example "<code>17</code>".</dd>
- <dt>dayPeriod</dt>
- <dd>The string used for the day period, for example, "<code>AM</code>", "<code>PM</code>", "<code>in the morning</code>", or "<code>noon</code>"</dd>
- <dt>era</dt>
- <dd>The string used for the era, for example "<code>BC</code>" or "<code>AD</code>".</dd>
- <dt>fractionalSecond</dt>
- <dd>The string used for the fractional seconds, for example "<code>0</code>" or "<code>00</code>" or "<code>000</code>".</dd>
- <dt>hour</dt>
- <dd>The string used for the hour, for example "<code>3</code>" or "<code>03</code>".</dd>
- <dt>literal</dt>
- <dd>The string used for separating date and time values, for example "<code>/</code>", "<code>,</code>", "<code>o'clock</code>", "<code>de</code>", etc.</dd>
- <dt>minute</dt>
- <dd>The string used for the minute, for example "<code>00</code>".</dd>
- <dt>month</dt>
- <dd>The string used for the month, for example "<code>12</code>".</dd>
- <dt>relatedYear</dt>
- <dd>The string used for the related 4-digit Gregorian year, in the event that the calendar's representation would be a yearName instead of a year, for example "<code>2019</code>".</dd>
- <dt>second</dt>
- <dd>The string used for the second, for example "<code>07</code>" or "<code>42</code>".</dd>
- <dt>timeZoneName</dt>
- <dd>The string used for the name of the time zone, for example "<code>UTC</code>".</dd>
- <dt>weekday</dt>
- <dd>The string used for the weekday, for example "<code>M</code>", "<code>Monday</code>", or "<code>Montag</code>".</dd>
- <dt>year</dt>
- <dd>The string used for the year, for example "<code>2012</code>" or "<code>96</code>".</dd>
- <dt>yearName</dt>
- <dd>The string used for the yearName in relevant contexts, for example "<code>geng-zi</code>"</dd>
+	<dt>day</dt>
+	<dd>The string used for the day, for example "<code>17</code>".</dd>
+	<dt>dayPeriod</dt>
+	<dd>The string used for the day period, for example, "<code>AM</code>", "<code>PM</code>", "<code>in the morning</code>", or "<code>noon</code>"</dd>
+	<dt>era</dt>
+	<dd>The string used for the era, for example "<code>BC</code>" or "<code>AD</code>".</dd>
+	<dt>fractionalSecond</dt>
+	<dd>The string used for the fractional seconds, for example "<code>0</code>" or "<code>00</code>" or "<code>000</code>".</dd>
+	<dt>hour</dt>
+	<dd>The string used for the hour, for example "<code>3</code>" or "<code>03</code>".</dd>
+	<dt>literal</dt>
+	<dd>The string used for separating date and time values, for example "<code>/</code>", "<code>,</code>", "<code>o'clock</code>", "<code>de</code>", etc.</dd>
+	<dt>minute</dt>
+	<dd>The string used for the minute, for example "<code>00</code>".</dd>
+	<dt>month</dt>
+	<dd>The string used for the month, for example "<code>12</code>".</dd>
+	<dt>relatedYear</dt>
+	<dd>The string used for the related 4-digit Gregorian year, in the event that the calendar's representation would be a yearName instead of a year, for example "<code>2019</code>".</dd>
+	<dt>second</dt>
+	<dd>The string used for the second, for example "<code>07</code>" or "<code>42</code>".</dd>
+	<dt>timeZoneName</dt>
+	<dd>The string used for the name of the time zone, for example "<code>UTC</code>".</dd>
+	<dt>weekday</dt>
+	<dd>The string used for the weekday, for example "<code>M</code>", "<code>Monday</code>", or "<code>Montag</code>".</dd>
+	<dt>year</dt>
+	<dd>The string used for the year, for example "<code>2012</code>" or "<code>96</code>".</dd>
+	<dt>yearName</dt>
+	<dd>The string used for the yearName in relevant contexts, for example "<code>geng-zi</code>"</dd>
 </dl>
 
 <h2 id="Polyfill">Polyfill</h2>
@@ -209,31 +211,28 @@ df.formatToParts(date)
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.DateTimeFormat.prototype.formatToParts', 'Intl.DateTimeFormat.prototype.formatToParts')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.DateTimeFormat.prototype.formatToParts', 'Intl.DateTimeFormat.prototype.formatToParts')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.DateTimeFormat.formatToParts")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.DateTimeFormat.formatToParts")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</li>
- <li>{{jsxref("DateTimeFormat.format", "Intl.DateTimeFormat.prototype.format")}}</li>
- <li>{{jsxref("Date.prototype.toLocaleString()")}}</li>
- <li>{{jsxref("Date.prototype.toLocaleDateString()")}}</li>
- <li>{{jsxref("Date.prototype.toLocaleTimeString()")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
+	<li>{{jsxref("DateTimeFormat.format", "Intl.DateTimeFormat.prototype.format()")}}</li>
+	<li>{{jsxref("Date.prototype.toLocaleString()")}}</li>
+	<li>{{jsxref("Date.prototype.toLocaleDateString()")}}</li>
+	<li>{{jsxref("Date.prototype.toLocaleTimeString()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
 ---
 <div>{{JSRef}}</div>
@@ -14,36 +15,35 @@ tags:
 <p>The <strong><code>Intl.DateTimeFormat</code></strong> object enables language-sensitive date and time formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat()")}}</dt>
- <dd>Creates a new <code>Intl.DateTimeFormat</code> object.</dd>
+	<dt>{{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat()")}}</dt>
+	<dd>Creates a new <code>Intl.DateTimeFormat</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("DateTimeFormat.supportedLocalesOf", "Intl.DateTimeFormat.supportedLocalesOf()")}}</dt>
- <dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
+	<dt>{{jsxref("DateTimeFormat.supportedLocalesOf", "Intl.DateTimeFormat.supportedLocalesOf()")}}</dt>
+	<dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{jsxref("DateTimeFormat.format", "Intl.DateTimeFormat.prototype.format()")}}</dt>
- <dd>Getter function that formats a date according to the locale and formatting options of this {{jsxref("DateTimeFormat", "DateTimeFormat")}} object.</dd>
- <dt>{{jsxref("DateTimeFormat.formatToParts", "Intl.DateTimeFormat.prototype.formatToParts()")}}</dt>
- <dd>Returns an {{jsxref("Array")}} of objects representing the date string in parts that can be used for custom locale-aware formatting.</dd>
- <dt>{{jsxref("DateTimeFormat.resolvedOptions", "Intl.DateTimeFormat.prototype.resolvedOptions()")}}</dt>
- <dd>Returns a new object with properties reflecting the locale and formatting options computed during initialization of the object.</dd>
- <dt>{{jsxref("DateTimeFormat.formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}}</dt>
- <dd>This method receives two <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/">Dates</a> and formats the date range in the most concise way based on the locale and options provided when instantiating {{jsxref("DateTimeFormat", "DateTimeFormat")}}.</dd>
- <dt>{{jsxref("DateTimeFormat.formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}}</dt>
- <dd>This method receives two <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/">Dates</a> and returns an Array of objects containing the locale-specific tokens representing each part of the formatted date range.</dd>
+	<dt>{{jsxref("DateTimeFormat.format", "Intl.DateTimeFormat.prototype.format()")}}</dt>
+	<dd>Getter function that formats a date according to the locale and formatting options of this {{jsxref("DateTimeFormat", "DateTimeFormat")}} object.</dd>
+	<dt>{{jsxref("DateTimeFormat.formatToParts", "Intl.DateTimeFormat.prototype.formatToParts()")}}</dt>
+	<dd>Returns an {{jsxref("Array")}} of objects representing the date string in parts that can be used for custom locale-aware formatting.</dd>
+	<dt>{{jsxref("DateTimeFormat.resolvedOptions", "Intl.DateTimeFormat.prototype.resolvedOptions()")}}</dt>
+	<dd>Returns a new object with properties reflecting the locale and formatting options computed during initialization of the object.</dd>
+	<dt>{{jsxref("DateTimeFormat.formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}}</dt>
+	<dd>This method receives two <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/">Dates</a> and formats the date range in the most concise way based on the locale and options provided when instantiating {{jsxref("DateTimeFormat", "DateTimeFormat")}}.</dd>
+	<dt>{{jsxref("DateTimeFormat.formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}}</dt>
+	<dd>This method receives two <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/">Dates</a> and returns an Array of objects containing the locale-specific tokens representing each part of the formatted date range.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -169,16 +169,16 @@ console.log(usedOptions.timeZone);
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#datetimeformat-objects', 'Intl.DateTimeFormat')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#datetimeformat-objects', 'Intl.DateTimeFormat')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -188,5 +188,5 @@ console.log(usedOptions.timeZone);
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl")}}</li>
+	<li>{{jsxref("Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
@@ -6,16 +6,17 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>Intl.DateTimeFormat.prototype.resolvedOptions()</code></strong> method returns a new object with properties reflecting the locale and date and time formatting options computed during initialization of this {{jsxref("DateTimeFormat", "DateTimeFormat")}} object.</p>
+<p>The <code><strong>Intl.DateTimeFormat.prototype.resolvedOptions()</strong></code> method returns a new object with properties reflecting the locale and date and time formatting options computed during initialization of this {{jsxref("DateTimeFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-resolvedoptions.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -30,26 +31,26 @@ tags:
 <p>The resulting object has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>calendar</code></dt>
- <dd>E.g. "gregory"</dd>
- <dt><code>numberingSystem</code></dt>
- <dd>The values requested using the Unicode extension keys <code>"ca"</code> and <code>"nu"</code> or filled in as default values.</dd>
- <dt><code>timeZone</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument; {{jsxref("undefined")}} (representing the runtime's default time zone) if none was provided. Warning: Applications should not rely on {{jsxref("undefined")}} being returned, as future versions may return a {{jsxref("String")}} value identifying the runtime’s default time zone instead.</dd>
- <dt><code>hour12</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument or filled in as a default.</dd>
- <dt><code>weekday</code></dt>
- <dt><code>era</code></dt>
- <dt><code>year</code></dt>
- <dt><code>month</code></dt>
- <dt><code>day</code></dt>
- <dt><code>hour</code></dt>
- <dt><code>minute</code></dt>
- <dt><code>second</code></dt>
- <dt><code>timeZoneName</code></dt>
- <dd>The values resulting from format matching between the corresponding properties in the <code>options</code> argument and the available combinations and representations for date-time formatting in the selected locale. Some of these properties may not be present, indicating that the corresponding components will not be represented in formatted output.</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>calendar</code></dt>
+	<dd>E.g. "gregory"</dd>
+	<dt><code>numberingSystem</code></dt>
+	<dd>The values requested using the Unicode extension keys <code>"ca"</code> and <code>"nu"</code> or filled in as default values.</dd>
+	<dt><code>timeZone</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument; {{jsxref("undefined")}} (representing the runtime's default time zone) if none was provided. Warning: Applications should not rely on {{jsxref("undefined")}} being returned, as future versions may return a {{jsxref("String")}} value identifying the runtime’s default time zone instead.</dd>
+	<dt><code>hour12</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument or filled in as a default.</dd>
+	<dt><code>weekday</code></dt>
+	<dt><code>era</code></dt>
+	<dt><code>year</code></dt>
+	<dt><code>month</code></dt>
+	<dt><code>day</code></dt>
+	<dt><code>hour</code></dt>
+	<dt><code>minute</code></dt>
+	<dt><code>second</code></dt>
+	<dt><code>timeZoneName</code></dt>
+	<dd>The values resulting from format matching between the corresponding properties in the <code>options</code> argument and the available combinations and representations for date-time formatting in the selected locale. Some of these properties may not be present, indicating that the corresponding components will not be represented in formatted output.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -69,25 +70,24 @@ usedOptions.month;           // "numeric"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.datetimeformat.prototype.resolvedoptions', 'Intl.DateTimeFormat.prototype.resolvedOptions')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.datetimeformat.prototype.resolvedoptions', 'Intl.DateTimeFormat.prototype.resolvedOptions')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.DateTimeFormat.resolvedOptions")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.DateTimeFormat.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/supportedlocalesof/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Reference
 ---
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.DateTimeFormat.supportedLocalesOf()</code></strong> method returns an array containing those of the provided locales that are supported in date and time formatting without having to fall back to the runtime's default locale.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-supportedlocalesof.html","shorter")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,17 +24,17 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
 
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -60,16 +60,16 @@ console.log(Intl.DateTimeFormat.supportedLocalesOf(locales, options).join(', '))
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.datetimeformat.supportedlocalesof', 'Intl.DateTimeFormat.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.datetimeformat.supportedlocalesof', 'Intl.DateTimeFormat.supportedLocalesOf()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -79,5 +79,5 @@ console.log(Intl.DateTimeFormat.supportedLocalesOf(locales, options).join(', '))
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DateTimeFormat")}}</li>
+	<li>{{jsxref("Intl.DateTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/displaynames/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
 ---
 <div>{{JSRef}}</div>
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.DisplayNames()</code></strong> constructor creates {{jsxref("DisplayNames", "Intl.DisplayNames")}} objects that enable the consistent translation of language, region and script display names.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,48 +24,48 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code> {{optional_inline}}</dt>
- <dd>
- <p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page. The following Unicode extension key is allowed:</p>
-
- <dl>
-  <dt><code>nu</code></dt>
-  <dd>The numbering system to be used. Possible values include: <code>"arab"</code>, <code>"arabext"</code>, <code>"bali"</code>, <code>"beng"</code>, <code>"deva"</code>, <code>"fullwide"</code>, <code>"gujr"</code>, <code>"guru"</code>, <code>"hanidec"</code>, <code>"khmr"</code>, <code>"knda"</code>, <code>"laoo"</code>, <code>"latn"</code>, <code>"limb"</code>, <code>"mlym"</code>, <code>"mong"</code>, <code>"mymr"</code>, <code>"orya"</code>, <code>"tamldec"</code>, <code>"telu"</code>, <code>"thai"</code>, <code>"tibt"</code>.</dd>
- </dl>
- </dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object with some or all of the following properties:</p>
-
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
-  <dt><code>style</code></dt>
-  <dd>The formatting style to use, the default is "<code>long</code>".
-  <ul>
-   <li>"<code>narrow</code>"</li>
-   <li>"<code>short</code>"</li>
-   <li>"<code>long</code>"</li>
-  </ul>
-  </dd>
-  <dt><code>type</code></dt>
-  <dd>The type to use.
-  <ul>
-   <li>"<code>language</code>"</li>
-   <li>"<code>region</code>"</li>
-   <li>"<code>script</code>"</li>
-   <li>"<code>currency</code>"</li>
-  </ul>
-  </dd>
-  <dt><code>fallback</code></dt>
-  <dd>The fallback to use, the default is "<code>code</code>".
-  <ul>
-   <li>"<code>code</code>"</li>
-   <li>"<code>none</code>"</li>
-  </ul>
-  </dd>
- </dl>
- </dd>
+	<dt><code><var>locales</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page. The following Unicode extension key is allowed:</p>
+		
+		<dl>
+			<dt><code>nu</code></dt>
+			<dd>The numbering system to be used. Possible values include: "<code>arab</code>", "<code>arabext</code>", "<code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", "<code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", "<code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", "<code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", "<code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
+		</dl>
+	</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object with some or all of the following properties:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+			<dt><code>style</code></dt>
+			<dd>The formatting style to use, the default is "<code>long</code>".
+				<ul>
+					<li>"<code>narrow</code>"</li>
+					<li>"<code>short</code>"</li>
+					<li>"<code>long</code>"</li>
+				</ul>
+			</dd>
+			<dt><code>type</code></dt>
+			<dd>The type to use.
+				<ul>
+					<li>"<code>language</code>"</li>
+					<li>"<code>region</code>"</li>
+					<li>"<code>script</code>"</li>
+					<li>"<code>currency</code>"</li>
+				</ul>
+			</dd>
+			<dt><code>fallback</code></dt>
+			<dd>The fallback to use, the default is "<code>code</code>".
+				<ul>
+					<li>"<code>code</code>"</li>
+					<li>"<code>none</code>"</li>
+				</ul>
+			</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -81,16 +81,16 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DisplayNames', '#sec-intl-displaynames-constructor', 'the Intl.DisplayNames constructor')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DisplayNames', '#sec-intl-displaynames-constructor', 'the Intl.DisplayNames constructor')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -100,6 +100,6 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DisplayNames")}}</li>
- <li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
+	<li>{{jsxref("Intl.DisplayNames")}}</li>
+	<li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
 ---
 <div>{{JSRef}}</div>
@@ -14,30 +15,29 @@ tags:
 <p>The <strong><code>Intl.DisplayNames</code></strong> object enables the consistent translation of language, region and script display names.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("Intl/DisplayNames/DisplayNames", "Intl.DisplayNames()")}}</dt>
- <dd>Creates a new <code>Intl.DisplayNames</code> object.</dd>
+	<dt>{{jsxref("Intl/DisplayNames/DisplayNames", "Intl.DisplayNames()")}}</dt>
+	<dd>Creates a new <code>Intl.DisplayNames</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("Intl/DisplayNames/supportedLocalesOf", "Intl.DisplayNames.supportedLocalesOf()")}}</dt>
- <dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
+	<dt>{{jsxref("Intl/DisplayNames/supportedLocalesOf", "Intl.DisplayNames.supportedLocalesOf()")}}</dt>
+	<dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{jsxref("Intl/DisplayNames/of", "Intl.DisplayNames.prototype.of()")}}</dt>
- <dd>This method receives a <code>code</code> and returns a string based on the locale and options provided when instantiating <code>Intl.DisplayNames</code>.</dd>
- <dt>{{jsxref("Intl/DisplayNames/resolvedOptions", "Intl.DisplayNames.prototype.resolvedOptions()")}}</dt>
- <dd>Returns a new object with properties reflecting the locale and formatting options computed during initialization of the object.</dd>
+	<dt>{{jsxref("Intl/DisplayNames/of", "Intl.DisplayNames.prototype.of()")}}</dt>
+	<dd>This method receives a <code>code</code> and returns a string based on the locale and options provided when instantiating <code>Intl.DisplayNames</code>.</dd>
+	<dt>{{jsxref("Intl/DisplayNames/resolvedOptions", "Intl.DisplayNames.prototype.resolvedOptions()")}}</dt>
+	<dd>Returns a new object with properties reflecting the locale and formatting options computed during initialization of the object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -120,16 +120,16 @@ currencyNames.of('CNY'); // "人民幣"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DisplayNames', '#intl-displaynames-objects', 'DisplayNames')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DisplayNames', '#intl-displaynames-objects', 'DisplayNames')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -145,5 +145,5 @@ currencyNames.of('CNY'); // "人民幣"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl")}}</li>
+	<li>{{jsxref("Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/of/index.html
@@ -6,18 +6,17 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
   - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <code><strong>of</strong></code><strong><code>()</code></strong> method receives a code and returns a string based on the locale and options provided when instantiating Intl.DisplayNames.</p>
+<p>The <strong><code>Intl.DisplayNames.prototype.of()</code></strong> method receives a code and returns a string based on the locale and options provided when instantiating Intl.DisplayNames.</p>
 
-<div>
 <div>{{EmbedInteractiveExample("pages/js/intl-displaynames.html")}}</div>
-
-</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -26,15 +25,15 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><strong><code>code</code></strong></dt>
- <dd>The <code>code</code> to provide depends on the <code>type</code>:
- <ul>
-  <li>If the type is "region", code should be either an <a href="https://www.iso.org/iso-3166-country-codes.html" rel="nofollow">ISO-3166 two letters region code</a>, or a <a href="https://unstats.un.org/unsd/methodology/m49/" rel="nofollow">three digits UN M49 Geographic Regions</a>.</li>
-  <li>If the type is "script", code should be an <a href="http://unicode.org/iso15924/iso15924-codes.html" rel="nofollow">ISO-15924 four letters script code</a>.</li>
-  <li>If the type is "language", code should be a <em>languageCode</em> ["-" <em>scriptCode</em>] ["-" <em>regionCode</em> ] *("-" <em>variant</em> ) subsequence of the unicode_language_id grammar in <a href="http://unicode.org/reports/tr35/#Unicode_language_identifier" rel="nofollow">UTS 35's Unicode Language and Locale Identifiers grammar</a>. <em>languageCode</em> is either a two letters ISO 639-1 language code or a three letters ISO 639-2 language code.</li>
-  <li>If the type is "currency", code should be a <a href="https://www.iso.org/iso-4217-currency-codes.html" rel="nofollow">3-letter ISO 4217 currency code</a>.</li>
- </ul>
- </dd>
+	<dt><code><var>code</var></code></dt>
+	<dd>The <code><var>code</var></code> to provide depends on the <code>type</code>:
+		<ul>
+			<li>If the type is "region", code should be either an <a href="https://www.iso.org/iso-3166-country-codes.html" rel="nofollow">ISO-3166 two letters region code</a>, or a <a href="https://unstats.un.org/unsd/methodology/m49/" rel="nofollow">three digits UN M49 Geographic Regions</a>.</li>
+			<li>If the type is "script", code should be an <a href="http://unicode.org/iso15924/iso15924-codes.html" rel="nofollow">ISO-15924 four letters script code</a>.</li>
+			<li>If the type is "language", code should be a <em>languageCode</em> ["-" <em>scriptCode</em>] ["-" <em>regionCode</em> ] *("-" <em>variant</em> ) subsequence of the unicode_language_id grammar in <a href="http://unicode.org/reports/tr35/#Unicode_language_identifier" rel="nofollow">UTS 35's Unicode Language and Locale Identifiers grammar</a>. <em>languageCode</em> is either a two letters ISO 639-1 language code or a three letters ISO 639-2 language code.</li>
+			<li>If the type is "currency", code should be a <a href="https://www.iso.org/iso-4217-currency-codes.html" rel="nofollow">3-letter ISO 4217 currency code</a>.</li>
+		</ul>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -43,7 +42,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Using_the_of_method">Using the <code>of</code> method</h3>
+<h3 id="Using_the_of_method">Using the of method</h3>
 
 <pre class="brush: js notranslate">let regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
 regionNames.of('419'); // "Latin America"
@@ -59,24 +58,24 @@ currencyNames.of('EUR'); // "Euro"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DisplayNames', '#sec-Intl.DisplayNames.prototype.of', 'of()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DisplayNames', '#sec-Intl.DisplayNames.prototype.of', 'of()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.DisplayNames.of")}}</p>
+<div>{{Compat("javascript.builtins.Intl.DisplayNames.of")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DisplayNames")}}</li>
+	<li>{{jsxref("Intl.DisplayNames")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/resolvedoptions/index.html
@@ -2,9 +2,11 @@
 title: Intl.DisplayNames.prototype.resolvedOptions()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/resolvedOptions
 tags:
+  - DisplayNames
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
   - Reference
@@ -26,14 +28,14 @@ tags:
 <p>The object returned by <code>resolvedOptions()</code> has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>style</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value (<code>"long"</code>). Its value is either <code>"long"</code>, <code>"short"</code>, or <code>"narrow"</code>.</dd>
- <dt><code>type</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value (<code>"language"</code>). Its value is either <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, or <code>"currency"</code>.</dd>
- <dt><code>fallback</code></dt>
- <dd>The value provided for this property in the options argument of the constructor or the default value (<code>"code"</code>). Its value is either <code>"code"</code> or <code>"none"</code>.</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>style</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value ("<code>long</code>"). Its value is either "<code>long</code>", "<code>short</code>", or "<code>narrow</code>".</dd>
+	<dt><code>type</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value ("<code>language</code>"). Its value is either "<code>language</code>", "<code>region</code>", "<code>script</code>", or "<code>currency</code>".</dd>
+	<dt><code>fallback</code></dt>
+	<dd>The value provided for this property in the options argument of the constructor or the default value ("<code>code</code>"). Its value is either "<code>code</code>" or "<code>none</code>".</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -52,24 +54,24 @@ console.log(usedOptions.fallback); // "code"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DisplayNames', '#sec-Intl.DisplayNames.prototype.resolvedOptions', 'resolvedOptions()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DisplayNames', '#sec-Intl.DisplayNames.prototype.resolvedOptions', 'resolvedOptions()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.DisplayNames.resolvedOptions")}}</p>
+<div>{{Compat("javascript.builtins.Intl.DisplayNames.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DisplayNames")}}</li>
+	<li>{{jsxref("Intl.DisplayNames")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/displaynames/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/displaynames/supportedlocalesof/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Reference
 ---
@@ -20,17 +21,17 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
 
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -56,16 +57,16 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales, options).join(', '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.DisplayNames', '#sec-Intl.DisplayNames.supportedLocalesOf', 'Intl.DisplayNames.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.DisplayNames', '#sec-Intl.DisplayNames.supportedLocalesOf', 'Intl.DisplayNames.supportedLocalesOf()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -75,5 +76,5 @@ console.log(Intl.DisplayNames.supportedLocalesOf(locales, options).join(', '));
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.DisplayNames")}}</li>
+	<li>{{jsxref("Intl.DisplayNames")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/getcanonicallocales/index.html
@@ -6,22 +6,24 @@ tags:
   - Intl
   - JavaScript
   - Method
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>Intl.getCanonicalLocales()</code></strong> method returns an array containing the canonical locale names. Duplicates will be omitted and elements will be validated as structurally valid language tags.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-getcanonicallocales.html")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">Intl.getCanonicalLocales(locales)</pre>
+<pre class="syntaxbox notranslate">Intl.getCanonicalLocales(<var>locales</var>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>locales</code></dt>
- <dd>A list of {{jsxref("String")}} values for which to get the canonical locale names.</dd>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A list of {{jsxref("String")}} values for which to get the canonical locale names.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -46,27 +48,26 @@ Intl.getCanonicalLocales('EN_US');
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.getcanonicallocales', 'Intl.getCanonicalLocales')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.getcanonicallocales', 'Intl.getCanonicalLocales')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.getCanonicalLocales")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.getCanonicalLocales")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("NumberFormat.supportedLocalesOf", "Intl.NumberFormat.supportedLocalesOf()")}}</li>
- <li>{{jsxref("DateTimeFormat.supportedLocalesOf", "Intl.DateTimeFormat.supportedLocalesOf()")}}</li>
- <li>{{jsxref("Collator.supportedLocalesOf", "Intl.Collator.supportedLocalesOf()")}}</li>
+	<li>{{jsxref("NumberFormat.supportedLocalesOf", "Intl.NumberFormat.supportedLocalesOf()")}}</li>
+	<li>{{jsxref("DateTimeFormat.supportedLocalesOf", "Intl.DateTimeFormat.supportedLocalesOf()")}}</li>
+	<li>{{jsxref("Collator.supportedLocalesOf", "Intl.Collator.supportedLocalesOf()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.html
@@ -14,29 +14,29 @@ tags:
 <h2 id="Constructor_properties">Constructor properties</h2>
 
 <dl>
- <dt>{{jsxref("Global_Objects/Intl/Collator/Collator", "Intl.Collator()")}}</dt>
- <dd>Constructor for collators, which are objects that enable language-sensitive string comparison.</dd>
- <dt>{{jsxref("Global_Objects/Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat()")}}</dt>
- <dd>Constructor for objects that enable language-sensitive date and time formatting.</dd>
- <dt>{{jsxref("Global_Objects/Intl/DisplayNames/DisplayNames", "Intl.DisplayNames()")}}</dt>
- <dd>Constructor for objects that enable the consistent translation of language, region and script display names.</dd>
- <dt>{{jsxref("Global_Objects/Intl/ListFormat/ListFormat", "Intl.ListFormat()")}}</dt>
- <dd>Constructor for objects that enable language-sensitive list formatting.</dd>
- <dt>{{jsxref("Global_Objects/Intl/Locale/Locale", "Intl.Locale()")}}</dt>
- <dd>Constructor for objects that represents a Unicode locale identifier.</dd>
- <dt>{{jsxref("Global_Objects/Intl/NumberFormat/NumberFormat", "Intl.NumberFormat()")}}</dt>
- <dd>Constructor for objects that enable language-sensitive number formatting.</dd>
- <dt>{{jsxref("Global_Objects/Intl/PluralRules/PluralRules", "Intl.PluralRules()")}}</dt>
- <dd>Constructor for objects that enable plural-sensitive formatting and language-specific rules for plurals.</dd>
- <dt>{{jsxref("Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat", "Intl.RelativeTimeFormat()")}}</dt>
- <dd>Constructor for objects that enable language-sensitive relative time formatting.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/Collator/Collator", "Intl.Collator()")}}</dt>
+	<dd>Constructor for collators, which are objects that enable language-sensitive string comparison.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat()")}}</dt>
+	<dd>Constructor for objects that enable language-sensitive date and time formatting.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/DisplayNames/DisplayNames", "Intl.DisplayNames()")}}</dt>
+	<dd>Constructor for objects that enable the consistent translation of language, region and script display names.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/ListFormat/ListFormat", "Intl.ListFormat()")}}</dt>
+	<dd>Constructor for objects that enable language-sensitive list formatting.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/Locale/Locale", "Intl.Locale()")}}</dt>
+	<dd>Constructor for objects that represents a Unicode locale identifier.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/NumberFormat/NumberFormat", "Intl.NumberFormat()")}}</dt>
+	<dd>Constructor for objects that enable language-sensitive number formatting.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/PluralRules/PluralRules", "Intl.PluralRules()")}}</dt>
+	<dd>Constructor for objects that enable plural-sensitive formatting and language-specific rules for plurals.</dd>
+	<dt>{{jsxref("Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat", "Intl.RelativeTimeFormat()")}}</dt>
+	<dd>Constructor for objects that enable language-sensitive relative time formatting.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("Intl.getCanonicalLocales()")}}</dt>
- <dd>Returns canonical locale names.</dd>
+	<dt>{{jsxref("Intl.getCanonicalLocales()")}}</dt>
+	<dd>Returns canonical locale names.</dd>
 </dl>
 
 <h2 id="Locale_identification_and_negotiation">Locale identification and negotiation</h2>
@@ -50,20 +50,20 @@ tags:
 <p>A Unicode BCP 47 locale identifier consists of</p>
 
 <ol>
- <li>a language code,</li>
- <li>(optionally) a script code,</li>
- <li>(optionally) a region (or country) code,</li>
- <li>(optionally) one or more variant codes, and</li>
- <li>(optionally) one or more extension sequences,</li>
+	<li>a language code,</li>
+	<li>(optionally) a script code,</li>
+	<li>(optionally) a region (or country) code,</li>
+	<li>(optionally) one or more variant codes, and</li>
+	<li>(optionally) one or more extension sequences,</li>
 </ol>
 
 <p>with all present components separated by hyphens.  Locale identifiers are case-insensitive ASCII.  However, it's conventional to use title case (first letter capitalized, successive letters lower case) for script code, upper case for region codes, and lower case for everything else.  For example:</p>
 
 <ul>
- <li><code>"hi"</code>: Hindi (language)</li>
- <li><code>"de-AT"</code>: German (language) as used in Austria (region)</li>
- <li><code>"zh-Hans-CN"</code>: Chinese (language) written in simplified characters (script) as used in China (region)</li>
- <li><code>"en-emodeng"</code>: English (language) in the "Early modern English" dialect (variant)</li>
+	<li>"<code>hi</code>": Hindi (language)</li>
+	<li>"<code>de-AT</code>": German (language) as used in Austria (region)</li>
+	<li>"<code>zh-Hans-CN</code>": Chinese (language) written in simplified characters (script) as used in China (region)</li>
+	<li>"<code>en-emodeng</code>": English (language) in the "Early modern English" dialect (variant)</li>
 </ul>
 
 <p>The subtags identifying languages, scripts, regions (including countries), and (rarely used) variants in Unicode BCP 47 locale identifiers are registered in the <a href="http://www.iana.org/assignments/language-subtag-registry">IANA Language Subtag Registry</a>.  This registry is periodically updated over time, and implementations may not always be up to date, so be careful not to rely too much on tags being universally supported.</p>
@@ -71,10 +71,10 @@ tags:
 <p>BCP 47 also allows for extensions, each consisting of a single digit or letter (other than <code>"x"</code>) and one or more two- to eight-letter or digit tags, all separated by hyphens. JavaScript internationalization functions use the <code>"u"</code> (Unicode) extension, which can be used to request additional customization of {{jsxref("Collator")}}, {{jsxref("NumberFormat")}}, or {{jsxref("DateTimeFormat")}} objects. Examples:</p>
 
 <ul>
- <li><code>"de-DE-u-co-phonebk"</code>: Use the phonebook variant of the German sort order, which interprets umlauted vowels as corresponding character pairs: ä → ae, ö → oe, ü → ue.</li>
- <li><code>"th-TH-u-nu-thai"</code>: Use Thai digits (๐, ๑, ๒, ๓, ๔, ๕, ๖, ๗, ๘, ๙) in number formatting.</li>
- <li><code>"ja-JP-u-ca-japanese"</code>: Use the Japanese calendar in date and time formatting, so that 2013 is expressed as the year 25 of the Heisei period, or 平成25.</li>
- <li><code>"en-GB-u-ca-islamic"</code>: use British English with the Islamic (Hijri) calendar, where the Gregorian date 14 October, 2017 is the Hijri date 24 Muharram, 1439.</li>
+	<li>"<code>de-DE-u-co-phonebk</code>": Use the phonebook variant of the German sort order, which interprets umlauted vowels as corresponding character pairs: ä → ae, ö → oe, ü → ue.</li>
+	<li>"<code>th-TH-u-nu-thai</code>": Use Thai digits (๐, ๑, ๒, ๓, ๔, ๕, ๖, ๗, ๘, ๙) in number formatting.</li>
+	<li>"<code>ja-JP-u-ca-japanese</code>": Use the Japanese calendar in date and time formatting, so that 2013 is expressed as the year 25 of the Heisei period, or 平成25.</li>
+	<li>"<code>en-GB-u-ca-islamic</code>": use British English with the Islamic (Hijri) calendar, where the Gregorian date 14 October, 2017 is the Hijri date 24 Muharram, 1439.</li>
 </ul>
 
 <p>Other BCP 47 extension tags can be found in the <a href="https://github.com/unicode-org/cldr/tree/master/common/bcp47">Unicode CLDR Project</a>.</p>
@@ -118,47 +118,44 @@ log("de-DE");
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#intl-object', 'Intl')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#intl-object', 'Intl')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>Introduction: <a href="https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html">The ECMAScript Internationalization API</a></li>
- <li>Constructors
-  <ul>
-   <li>{{jsxref("Collator", "Intl.Collator")}}</li>
-   <li>{{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</li>
-   <li>{{jsxref("ListFormat", "Intl.ListFormat")}}</li>
-   <li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
-   <li>{{jsxref("PluralRules", "Intl.PluralRules")}}</li>
-   <li>{{jsxref("RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
-   <li>{{jsxref("Locale", "Intl.Locale")}}</li>
-  </ul>
- </li>
- <li>Methods
-  <ul>
-   <li>{{jsxref("String.prototype.localeCompare()")}}</li>
-   <li>{{jsxref("Number.prototype.toLocaleString()")}}</li>
-   <li>{{jsxref("Date.prototype.toLocaleString()")}}</li>
-   <li>{{jsxref("Date.prototype.toLocaleDateString()")}}</li>
-   <li>{{jsxref("Date.prototype.toLocaleTimeString()")}}</li>
-  </ul>
- </li>
+	<li>Introduction: <a href="https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html">The ECMAScript Internationalization API</a></li>
+	<li>Constructors
+		<ul>
+			<li>{{jsxref("Collator", "Intl.Collator")}}</li>
+			<li>{{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</li>
+			<li>{{jsxref("ListFormat", "Intl.ListFormat")}}</li>
+			<li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
+			<li>{{jsxref("PluralRules", "Intl.PluralRules")}}</li>
+			<li>{{jsxref("RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
+			<li>{{jsxref("Locale", "Intl.Locale")}}</li>
+		</ul>
+	</li>
+	<li>Methods
+		<ul>
+			<li>{{jsxref("String.prototype.localeCompare()")}}</li>
+			<li>{{jsxref("Number.prototype.toLocaleString()")}}</li>
+			<li>{{jsxref("Date.prototype.toLocaleString()")}}</li>
+			<li>{{jsxref("Date.prototype.toLocaleDateString()")}}</li>
+			<li>{{jsxref("Date.prototype.toLocaleTimeString()")}}</li>
+		</ul>
+	</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/format/index.html
@@ -6,14 +6,17 @@ tags:
   - Intl
   - JavaScript
   - ListFormat
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>format()</code></strong> method returns a string with a language-specific representation of the list.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-listformat.html", "taller")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -22,8 +25,8 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>list</var></code></dt>
- <dd>An iterable object, such as an Array</dd>
+	<dt><code><var>list</var></code></dt>
+	<dd>An iterable object, such as an Array.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -55,24 +58,24 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.prototype.format', 'format()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.prototype.format', 'format()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.ListFormat.format")}}</p>
+<div>{{Compat("javascript.builtins.Intl.ListFormat.format")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("ListFormat", "Intl.ListFormat")}}</li>
+	<li>{{jsxref("Intl.ListFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.html
@@ -6,8 +6,10 @@ tags:
   - Intl
   - JavaScript
   - ListFormat
+  - Localization
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
@@ -21,7 +23,7 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>list</code></dt>
+ <dt><code><var>list</var></code></dt>
  <dd>An {{jsxref("Array")}} of values to be formatted according to a locale.</dd>
 </dl>
 
@@ -33,9 +35,9 @@ tags:
 
 <p>Whereas {{jsxref("ListFormat.prototype.format()", "Intl.ListFormat.prototype.format()")}} returns a string being the formatted version of the list (according to the given locale and style options), <code>formatToParts()</code> returns an array of the different components of the formatted string.</p>
 
-<p>Each element of the resulting array has two properties: <code>type</code> and <code>value</code>. The <code>type</code> property may be either <code>"element"</code>, which refers to a value from the list, or <code>"literal"</code> which refers to a linguistic construct. The <code>value</code> property gives the content, as a string, of the token.</p>
+<p>Each element of the resulting array has two properties: <code>type</code> and <code>value</code>. The <code>type</code> property may be either "<code>element</code>", which refers to a value from the list, or "<code>literal</code>" which refers to a linguistic construct. The <code>value</code> property gives the content, as a string, of the token.</p>
 
-<p>The locale and style options used for formatting are given when constructing the {{jsxref("ListFormat", "Intl.ListFormat")}} instance.</p>
+<p>The locale and style options used for formatting are given when constructing the {{jsxref("Intl.ListFormat")}} instance.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -57,28 +59,28 @@ console.table(myListFormat.formatToParts(fruits));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.prototype.formatToParts', 'formatToParts()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.prototype.formatToParts', 'formatToParts()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.ListFormat.formatToParts")}}</p>
+<div>{{Compat("javascript.builtins.Intl.ListFormat.formatToParts")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("ListFormat", "Intl.ListFormat")}}</li>
- <li>{{jsxref("ListFormat.prototype.format()", "Intl.ListFormat.prototype.format()")}}</li>
- <li>{{jsxref("RelativeTimeFormat.formatToParts()", "Intl.RelativeTimeFormat.prototype.formatToParts()")}}</li>
- <li>{{jsxref("NumberFormat.formatToParts()", "Intl.NumberFormat.prototype.formatToParts()")}}</li>
- <li>{{jsxref("DateTimeFormat.formatToParts()", "Intl.DateTimeFormat.prototype.formatToParts()")}}</li>
+	<li>{{jsxref("Intl.ListFormat")}}</li>
+	<li>{{jsxref("ListFormat.prototype.format()", "Intl.ListFormat.prototype.format()")}}</li>
+	<li>{{jsxref("RelativeTimeFormat.formatToParts()", "Intl.RelativeTimeFormat.prototype.formatToParts()")}}</li>
+	<li>{{jsxref("NumberFormat.formatToParts()", "Intl.NumberFormat.prototype.formatToParts()")}}</li>
+	<li>{{jsxref("DateTimeFormat.formatToParts()", "Intl.DateTimeFormat.prototype.formatToParts()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.html
@@ -15,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.ListFormat</code></strong> object enables language-sensitive list formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-listformat.html", "taller")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/listformat/index.html
@@ -14,8 +14,7 @@ tags:
 <p>The <strong><code>Intl.ListFormat()</code></strong> constructor creates {{jsxref("ListFormat", "Intl.ListFormat")}} objects that enable language-sensitive list formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-listformat.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.html
@@ -8,10 +8,11 @@ tags:
   - ListFormat
   - Method
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <code><strong>Intl.ListFormat.prototype.resolvedOptions()</strong></code> method returns a new object with properties reflecting the locale and style formatting options computed during the construction of the current {{jsxref("ListFormat")}} object.</p>
+<p>The <strong><code>Intl.ListFormat.prototype.resolvedOptions()</code></strong> method returns a new object with properties reflecting the locale and style formatting options computed during the construction of the current {{jsxref("ListFormat")}} object.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -26,12 +27,12 @@ tags:
 <p>The object returned by <code>resolvedOptions()</code> has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>style</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value (<code>"long"</code>). Its value is either <code>"long"</code>, <code>"short"</code>, or <code>"narrow"</code>.</dd>
- <dt><code>type</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value (<code>"conjunction"</code>). Its value is either <code>"conjunction"</code>, <code>"disjunction"</code>, or <code>"unit"</code>.</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>style</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value ("<code>long</code>"). Its value is either "<code>long</code>", "<code>short</code>", or "<code>narrow</code>".</dd>
+	<dt><code>type</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument of the constructor or the default value ("<code>conjunction</code>"). Its value is either "<code>conjunction</code>", "<code>disjunction</code>", or "<code>unit</code>".</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -49,28 +50,28 @@ console.log(usedOptions.type);   // "conjunction" (the default value)
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.prototype.resolvedOptions', 'resolvedOptions()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.prototype.resolvedOptions', 'resolvedOptions()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.ListFormat.resolvedOptions")}}</p>
+<div>{{Compat("javascript.builtins.Intl.ListFormat.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("ListFormat", "Intl.ListFormat")}}</li>
- <li>{{jsxref("NumberFormat.prototype.resolvedOptions()", "Intl.NumberFormat.prototype.resolvedOptions()")}}</li>
- <li>{{jsxref("Collator.prototype.resolvedOptions()", "Intl.Collator.prototype.resolvedOptions()")}}</li>
- <li>{{jsxref("DateTimeFormat.prototype.resolvedOptions()", "Intl.DateTimeFormat.prototype.resolvedOptions()")}}</li>
- <li>{{jsxref("PluralRules.prototype.resolvedOptions()", "Intl.PluralRules.prototype.resolvedOptions()")}}</li>
+	<li>{{jsxref("Intl.ListFormat")}}</li>
+	<li>{{jsxref("NumberFormat.prototype.resolvedOptions()", "Intl.NumberFormat.prototype.resolvedOptions()")}}</li>
+	<li>{{jsxref("Collator.prototype.resolvedOptions()", "Intl.Collator.prototype.resolvedOptions()")}}</li>
+	<li>{{jsxref("DateTimeFormat.prototype.resolvedOptions()", "Intl.DateTimeFormat.prototype.resolvedOptions()")}}</li>
+	<li>{{jsxref("PluralRules.prototype.resolvedOptions()", "Intl.PluralRules.prototype.resolvedOptions()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/supportedlocalesof/index.html
@@ -20,17 +20,17 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
 
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -56,16 +56,16 @@ console.log(Intl.ListFormat.supportedLocalesOf(locales, options).join(', '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.supportedLocalesOf', 'Intl.ListFormat.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('Intl.ListFormat', '#sec-Intl.ListFormat.supportedLocalesOf', 'Intl.ListFormat.supportedLocalesOf()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -75,5 +75,5 @@ console.log(Intl.ListFormat.supportedLocalesOf(locales, options).join(', '));
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.ListFormat")}}</li>
+	<li>{{jsxref("Intl.ListFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/basename/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/basename/index.html
@@ -3,8 +3,11 @@ title: Intl.Locale.prototype.baseName
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/baseName
 tags:
   - Internationalization
+  - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -66,5 +69,5 @@ console.log(dutch.baseName); // Prints out "nl-Latn-NL"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li>{{jsxref("Locale", "Intl.Locale")}}</li>
+	<li>{{jsxref("Intl.Locale")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.html
@@ -3,8 +3,11 @@ title: Intl.Locale.prototype.calendar
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar
 tags:
   - Internationalization
+  - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -130,16 +133,16 @@ console.log(frBuddhist.calendar); // Prints "buddhist"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.calendar')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.calendar')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -149,6 +152,6 @@ console.log(frBuddhist.calendar); // Prints "buddhist"
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li><a href="https://www.unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifiers</a></li>
+	<li>{{jsxref("Locale", "Intl.Locale")}}</li>
+	<li><a href="https://www.unicode.org/reports/tr35/#UnicodeCalendarIdentifier">Unicode Calendar Identifiers</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -22,31 +24,31 @@ tags:
 <h3 id="caseFirst_values"><code>caseFirst</code> values</h3>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Value</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>upper</code></td>
-   <td>Upper case to be sorted before lower case.</td>
-  </tr>
-  <tr>
-   <td><code>lower</code></td>
-   <td>Lower case to be sorted before upper case.</td>
-  </tr>
-  <tr>
-   <td><code>false</code></td>
-   <td>No special case ordering.</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Value</th>
+			<th scope="col">Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><code>upper</code></td>
+			<td>Upper case to be sorted before lower case.</td>
+		</tr>
+		<tr>
+			<td><code>lower</code></td>
+			<td>Lower case to be sorted before upper case.</td>
+		</tr>
+		<tr>
+			<td><code>false</code></td>
+			<td>No special case ordering.</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Setting_the_caseFirst_value_via_the_locale_string">Setting the <code>caseFirst</code> value via the locale string</h3>
+<h3 id="Setting_the_caseFirst_value_via_the_locale_string">Setting the caseFirst value via the locale string</h3>
 
 <p>In the <a href="https://www.unicode.org/reports/tr35/" rel="noopener">Unicode locale string spec</a>, the values that <code>caseFirst</code> represents correspond to the key <code>kf</code>. <code>kf</code> is treated as a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the <code>-u</code> extension key. Thus, the <code>caseFirst</code> value can be added to the inital locale identifier string that is passed into the <code>Locale</code> constructor. To add the <code>caseFirst</code> value, first add the <code>-u</code> extension key to the string. Next, add the <code>-kf</code> extension key to indicate that you are adding a value for <code>caseFirst</code>. Finally, add the <code>caseFirst</code> value to the string.</p>
 
@@ -63,16 +65,16 @@ console.log(us12hour.caseFirst); // Prints "lower"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.caseFirst')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.caseFirst')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -82,6 +84,6 @@ console.log(us12hour.caseFirst); // Prints "lower"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li><a href="https://github.com/unicode-org/cldr/blob/master/common/bcp47/collation.xml#L49">Unicode case first collation spec</a></li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li><a href="https://github.com/unicode-org/cldr/blob/master/common/bcp47/collation.xml#L49">Unicode case first collation spec</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -22,98 +24,97 @@ tags:
 <h3 id="Valid_collation_types">Valid collation types</h3>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Collation Type</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>big5han</td>
-   <td>Pinyin ordering for Latin, big5 charset ordering for CJK characters (used in Chinese)</td>
-  </tr>
-  <tr>
-   <td>compat</td>
-   <td>A previous version of the ordering, for compatibility</td>
-  </tr>
-  <tr>
-   <td>dict</td>
-   <td>Dictionary style ordering (such as in Sinhala)</td>
-  </tr>
-  <tr>
-   <td>
-    <div class="notecard warning">
-    <p>The <code>direct</code> collation type has been deprected. Do not use.</p>
-    </div>
-
-    <p>direct</p>
-   </td>
-   <td>Binary code point order (used in Hindi)</td>
-  </tr>
-  <tr>
-   <td>ducet</td>
-   <td>The default Unicode collation element table order</td>
-  </tr>
-  <tr>
-   <td>emoji</td>
-   <td>Recommended ordering for emoji characters</td>
-  </tr>
-  <tr>
-   <td>eor</td>
-   <td>European ordering rules</td>
-  </tr>
-  <tr>
-   <td>gb2312</td>
-   <td>Pinyin ordering for Latin, gb2312han charset ordering for CJK characters (used in Chinese)</td>
-  </tr>
-  <tr>
-   <td>phonebk</td>
-   <td>Phonebook style ordering (such as in German)</td>
-  </tr>
-  <tr>
-   <td>phonetic</td>
-   <td>Phonetic ordering (sorting based on pronunciation)</td>
-  </tr>
-  <tr>
-   <td>pinyin</td>
-   <td>Pinyin ordering for Latin and for CJK characters (used in Chinese)</td>
-  </tr>
-  <tr>
-   <td>reformed</td>
-   <td>Reformed ordering (such as in Swedish)</td>
-  </tr>
-  <tr>
-   <td>search</td>
-   <td>Special collation type for string search</td>
-  </tr>
-  <tr>
-   <td>searchjl</td>
-   <td>Special collation type for Korean initial consonant search</td>
-  </tr>
-  <tr>
-   <td>standard</td>
-   <td>Default ordering for each language</td>
-  </tr>
-  <tr>
-   <td>stroke</td>
-   <td>Pinyin ordering for Latin, stroke order for CJK characters (used in Chinese)</td>
-  </tr>
-  <tr>
-   <td>trad</td>
-   <td>Traditional style ordering (such as in Spanish)</td>
-  </tr>
-  <tr>
-   <td>unihan</td>
-   <td>Pinyin ordering for Latin, Unihan radical-stroke ordering for CJK characters (used in Chinese)</td>
-  </tr>
-  <tr>
-   <td>zhuyin</td>
-   <td>
-    <p>Pinyin ordering for Latin, zhuyin order for Bopomofo and CJK characters (used in Chinese)</p>
-   </td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Collation Type</th>
+			<th scope="col">Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>big5han</td>
+			<td>Pinyin ordering for Latin, big5 charset ordering for CJK characters (used in Chinese)</td>
+		</tr>
+		<tr>
+			<td>compat</td>
+			<td>A previous version of the ordering, for compatibility</td>
+		</tr>
+		<tr>
+			<td>dict</td>
+			<td>Dictionary style ordering (such as in Sinhala)</td>
+		</tr>
+		<tr>
+			<td>
+				<div class="notecard warning">
+					<p>The <code>direct</code> collation type has been deprected. Do not use.</p>
+				</div>
+				<p>direct</p>
+			</td>
+			<td>Binary code point order (used in Hindi)</td>
+		</tr>
+		<tr>
+			<td>ducet</td>
+			<td>The default Unicode collation element table order</td>
+		</tr>
+		<tr>
+			<td>emoji</td>
+			<td>Recommended ordering for emoji characters</td>
+		</tr>
+		<tr>
+			<td>eor</td>
+			<td>European ordering rules</td>
+		</tr>
+		<tr>
+			<td>gb2312</td>
+			<td>Pinyin ordering for Latin, gb2312han charset ordering for CJK characters (used in Chinese)</td>
+		</tr>
+		<tr>
+			<td>phonebk</td>
+			<td>Phonebook style ordering (such as in German)</td>
+		</tr>
+		<tr>
+			<td>phonetic</td>
+			<td>Phonetic ordering (sorting based on pronunciation)</td>
+		</tr>
+		<tr>
+			<td>pinyin</td>
+			<td>Pinyin ordering for Latin and for CJK characters (used in Chinese)</td>
+		</tr>
+		<tr>
+			<td>reformed</td>
+			<td>Reformed ordering (such as in Swedish)</td>
+		</tr>
+		<tr>
+			<td>search</td>
+			<td>Special collation type for string search</td>
+		</tr>
+		<tr>
+			<td>searchjl</td>
+			<td>Special collation type for Korean initial consonant search</td>
+		</tr>
+		<tr>
+			<td>standard</td>
+			<td>Default ordering for each language</td>
+		</tr>
+		<tr>
+			<td>stroke</td>
+			<td>Pinyin ordering for Latin, stroke order for CJK characters (used in Chinese)</td>
+		</tr>
+		<tr>
+			<td>trad</td>
+			<td>Traditional style ordering (such as in Spanish)</td>
+		</tr>
+		<tr>
+			<td>unihan</td>
+			<td>Pinyin ordering for Latin, Unihan radical-stroke ordering for CJK characters (used in Chinese)</td>
+		</tr>
+		<tr>
+			<td>zhuyin</td>
+			<td>
+				<p>Pinyin ordering for Latin, zhuyin order for Bopomofo and CJK characters (used in Chinese)</p>
+			</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Examples">Examples</h2>
@@ -138,24 +139,24 @@ console.log(configColl.collation); // Prints "emoji"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.collation')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.collation')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.Locale.collation")}}</p>
+<div>{{Compat("javascript.builtins.Intl.Locale.collation")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
+	<li>{{jsxref("Intl.Locale")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -20,30 +22,30 @@ tags:
 <h3 id="Valid_hour_cycle_types">Valid hour cycle types</h3>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Hour cycle type</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>h12</code></td>
-   <td>Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am.</td>
-  </tr>
-  <tr>
-   <td><code>h23</code></td>
-   <td>Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00.</td>
-  </tr>
-  <tr>
-   <td><code>h11</code></td>
-   <td>Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am.</td>
-  </tr>
-  <tr>
-   <td><code>h24</code></td>
-   <td>Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00.</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Hour cycle type</th>
+			<th scope="col">Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><code>h12</code></td>
+			<td>Hour system using 1–12; corresponds to 'h' in patterns. The 12 hour clock, with midnight starting at 12:00 am.</td>
+		</tr>
+		<tr>
+			<td><code>h23</code></td>
+			<td>Hour system using 0–23; corresponds to 'H' in patterns. The 24 hour clock, with midnight starting at 0:00.</td>
+		</tr>
+		<tr>
+			<td><code>h11</code></td>
+			<td>Hour system using 0–11; corresponds to 'K' in patterns. The 12 hour clock, with midnight starting at 0:00 am.</td>
+		</tr>
+		<tr>
+			<td><code>h24</code></td>
+			<td>Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00.</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Examples">Examples</h2>
@@ -67,16 +69,16 @@ console.log(us12hour.hourCycle); // Prints "h12"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.hourCycle')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.hourCycle')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -86,6 +88,6 @@ console.log(us12hour.hourCycle); // Prints "h12"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li><a href="https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier">Unicode Hour Cycle extension key spec</a></li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li><a href="https://www.unicode.org/reports/tr35/#UnicodeHourCycleIdentifier">Unicode Hour Cycle extension key spec</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/index.html
@@ -14,8 +14,7 @@ tags:
 <p><span class="seoSummary">The <strong><code>Intl.Locale</code></strong> object is a standard built-in property of the Intl object that represents a Unicode locale identifier.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -38,16 +40,16 @@ console.log(langObj.language); // Prints "es"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.language')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.language')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -57,6 +59,6 @@ console.log(langObj.language); // Prints "es"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Locale")}}</li>
- <li><a href="https://www.unicode.org/reports/tr35/#unicode_language_subtag_validity">Unicode language subtag specification</a></li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li><a href="https://www.unicode.org/reports/tr35/#unicode_language_subtag_validity">Unicode language subtag specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.html
@@ -14,8 +14,7 @@ tags:
 <p><span class="seoSummary">The <strong><code>Intl.Locale</code></strong> constructor is a standard built-in property of the Intl object that represents a Unicode locale identifier.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/maximize/index.html
@@ -2,9 +2,10 @@
 title: Intl.Locale.prototype.maximize()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/maximize
 tags:
-  - Internationaliztion
+  - Internationalization
   - Intl
   - JavaScript
+  - Locale
   - Method
   - Prototype
   - Reference
@@ -14,12 +15,11 @@ tags:
 <p><span class="seoSummary">The <strong><code>Intl.Locale.prototype.maximize()</code></strong> method gets the most likely values for the language, script, and region of the locale based on existing values.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale-prototype-maximize.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><code><em>locale</em>.maximize()</code></pre>
+<pre class="syntaxbox"><var>locale</var>.maximize()</pre>
 
 <h3 id="Return_value">Return value</h3>
 
@@ -49,29 +49,26 @@ console.log(myLocMaximized.toString()); </pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.maximize')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+		<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.maximize')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.Locale.maximize")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.Locale.maximize")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li>{{jsxref("Locale/baseName", "Locale.baseName")}}</li>
- <li><a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Unicode's Likely Subtags spec</a></li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li>{{jsxref("Locale/baseName", "Intl.Locale.baseName")}}</li>
+	<li><a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Unicode's Likely Subtags spec</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.html
@@ -14,20 +14,19 @@ tags:
 <p><span class="seoSummary">The <strong><code>Intl.Locale.prototype.minimize()</code></strong> method attempts to remove information about the locale that would be added by calling {{jsxref("Locale/maximize", "Locale.maximize()")}}.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale-prototype-minimize.html", "taller")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><code><em>locale</em>.minimize()</code></pre>
+<pre class="syntaxbox"><em>locale</em>.minimize()</pre>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Locale", "Locale")}} instance whose <code>baseName</code> property returns the result of the <a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm executed against <code><em>locale.baseName</em></code>. </p>
+<p>A {{jsxref("Locale", "Locale")}} instance whose <code>baseName</code> property returns the result of the <a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm executed against <em>{{jsxref("Locale/baseName", "locale.baseName")}}</em>.</p>
 
 <h2 id="Description">Description</h2>
 
-<p>This method carries out the reverse of {{jsxref("Locale/maximize", "maximize()")}}, removing any language, script, or region subtags from the locale language identifier (essentially the contents of <code>baseName</code>). This is useful when there are superfluous subtags in the language identifier; for instance, "en-Latn" can be simplified to "en", since "Latn" is the only script used to write English. <code>minimize()</code> only affects the main subtags that comprise the <a href="https://www.unicode.org/reports/tr35/#Language_Locale_Field_Definitions">language identifier</a>: language, script, and region subtags. Other subtags after the "-u" in the locale identifier are called extension subtags and are not affected by the <code>minimize()</code> method. Examples of these subtags include {{jsxref("Locale/hourCycle", "Locale.hourCycle")}}, {{jsxref("Locale/calendar", "Locale.calendar")}}, and {{jsxref("Locale/numeric", "Locale.numeric")}}.</p>
+<p>This method carries out the reverse of {{jsxref("Locale/maximize", "maximize()")}}, removing any language, script, or region subtags from the locale language identifier (essentially the contents of <code>baseName</code>). This is useful when there are superfluous subtags in the language identifier; for instance, "en-Latn" can be simplified to "en", since "Latn" is the only script used to write English. <code>minimize()</code> only affects the main subtags that comprise the <a href="https://www.unicode.org/reports/tr35/#Language_Locale_Field_Definitions">language identifier</a>: language, script, and region subtags. Other subtags after the "-u" in the locale identifier are called extension subtags and are not affected by the <code>minimize()</code> method. Examples of these subtags include {{jsxref("Locale/hourCycle", "Locale.hourCycle")}}, {{jsxref("Locale/calendar", "Locale.calendar")}}, and {{jsxref("Locale/numeric", "Locale.numeric")}}.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -50,28 +49,25 @@ console.log(myLocMinimized.toString());</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.minimize')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.minimize')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.Locale.minimize")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.Locale.minimize")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li>{{jsxref("Locale/baseName", "Intl.Locale.baseName")}}</li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li>{{jsxref("Locale/baseName", "Intl.Locale.baseName")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -18,356 +20,358 @@ tags:
 <p>A numeral system is a system for expressing numbers. The <code>numberingSystem</code> property helps to represent the different numeral systems used by various countries, regions, and cultures around the world. As with most internationalization schemas, the numeral systems that can be represented in a <code>Locale</code> object by <code>numberingSystem</code> are standardized by Unicode. A table of the standard Unicode numeral systems can be seen below.</p>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th>Value</th>
-   <th>Description</th>
-  </tr>
-  <tr>
-   <td>adlm</td>
-   <td>Adlam digits</td>
-  </tr>
-  <tr>
-   <td>ahom</td>
-   <td>Ahom digits</td>
-  </tr>
-  <tr>
-   <td>arab</td>
-   <td>Arabic-Indic digits</td>
-  </tr>
-  <tr>
-   <td>arabext</td>
-   <td>Extended Arabic-Indic digits</td>
-  </tr>
-  <tr>
-   <td>armn</td>
-   <td>Armenian upper case numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>armnlow</td>
-   <td>Armenian lower case numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>bali</td>
-   <td>Balinese digits</td>
-  </tr>
-  <tr>
-   <td>beng</td>
-   <td>Bengali digits</td>
-  </tr>
-  <tr>
-   <td>bhks</td>
-   <td>Bhaiksuki digits</td>
-  </tr>
-  <tr>
-   <td>brah</td>
-   <td>Brahmi digits</td>
-  </tr>
-  <tr>
-   <td>cakm</td>
-   <td>Chakma digits</td>
-  </tr>
-  <tr>
-   <td>cham</td>
-   <td>Cham digits</td>
-  </tr>
-  <tr>
-   <td>cyrl</td>
-   <td>Cyrillic numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>deva</td>
-   <td>Devanagari digits</td>
-  </tr>
-  <tr>
-   <td>ethi</td>
-   <td>Ethiopic numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>finance</td>
-   <td>Financial numerals — may be algorithmic</td>
-  </tr>
-  <tr>
-   <td>fullwide</td>
-   <td>Full width digits</td>
-  </tr>
-  <tr>
-   <td>geor</td>
-   <td>Georgian numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>gong</td>
-   <td>Gunjala Gondi digits</td>
-  </tr>
-  <tr>
-   <td>gonm</td>
-   <td>Masaram Gondi digits</td>
-  </tr>
-  <tr>
-   <td>grek</td>
-   <td>Greek upper case numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>greklow</td>
-   <td>Greek lower case numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>gujr</td>
-   <td>Gujarati digits</td>
-  </tr>
-  <tr>
-   <td>guru</td>
-   <td>Gurmukhi digits</td>
-  </tr>
-  <tr>
-   <td>hanidays</td>
-   <td>Han-character day-of-month numbering for lunar/other traditional calendars</td>
-  </tr>
-  <tr>
-   <td>hanidec</td>
-   <td>Positional decimal system using Chinese number ideographs as digits</td>
-  </tr>
-  <tr>
-   <td>hans</td>
-   <td>Simplified Chinese numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>hansfin</td>
-   <td>Simplified Chinese financial numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>hant</td>
-   <td>Traditional Chinese numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>hantfin</td>
-   <td>Traditional Chinese financial numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>hebr</td>
-   <td>Hebrew numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>hmng</td>
-   <td>Pahawh Hmong digits</td>
-  </tr>
-  <tr>
-   <td>hmnp</td>
-   <td>Nyiakeng Puachue Hmong digits</td>
-  </tr>
-  <tr>
-   <td>java</td>
-   <td>Javanese digits</td>
-  </tr>
-  <tr>
-   <td>jpan</td>
-   <td>Japanese numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>jpanfin</td>
-   <td>Japanese financial numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>jpanyear</td>
-   <td>Japanese first-year Gannen numbering for Japanese calendar</td>
-  </tr>
-  <tr>
-   <td>kali</td>
-   <td>Kayah Li digits</td>
-  </tr>
-  <tr>
-   <td>khmr</td>
-   <td>Khmer digits</td>
-  </tr>
-  <tr>
-   <td>knda</td>
-   <td>Kannada digits</td>
-  </tr>
-  <tr>
-   <td>lana</td>
-   <td>Tai Tham Hora (secular) digits</td>
-  </tr>
-  <tr>
-   <td>lanatham</td>
-   <td>Tai Tham (ecclesiastical) digits</td>
-  </tr>
-  <tr>
-   <td>laoo</td>
-   <td>Lao digits</td>
-  </tr>
-  <tr>
-   <td>latn</td>
-   <td>Latin digits</td>
-  </tr>
-  <tr>
-   <td>lepc</td>
-   <td>Lepcha digits</td>
-  </tr>
-  <tr>
-   <td>limb</td>
-   <td>Limbu digits</td>
-  </tr>
-  <tr>
-   <td>mathbold</td>
-   <td>Mathematical bold digits</td>
-  </tr>
-  <tr>
-   <td>mathdbl</td>
-   <td>Mathematical double-struck digits</td>
-  </tr>
-  <tr>
-   <td>mathmono</td>
-   <td>Mathematical monospace digits</td>
-  </tr>
-  <tr>
-   <td>mathsanb</td>
-   <td>Mathematical sans-serif bold digits</td>
-  </tr>
-  <tr>
-   <td>mathsans</td>
-   <td>Mathematical sans-serif digits</td>
-  </tr>
-  <tr>
-   <td>mlym</td>
-   <td>Malayalam digits</td>
-  </tr>
-  <tr>
-   <td>modi</td>
-   <td>Modi digits</td>
-  </tr>
-  <tr>
-   <td>mong</td>
-   <td>Mongolian digits</td>
-  </tr>
-  <tr>
-   <td>mroo</td>
-   <td>Mro digits</td>
-  </tr>
-  <tr>
-   <td>mtei</td>
-   <td>Meetei Mayek digits</td>
-  </tr>
-  <tr>
-   <td>mymr</td>
-   <td>Myanmar digits</td>
-  </tr>
-  <tr>
-   <td>mymrshan</td>
-   <td>Myanmar Shan digits</td>
-  </tr>
-  <tr>
-   <td>mymrtlng</td>
-   <td>Myanmar Tai Laing digits</td>
-  </tr>
-  <tr>
-   <td>native</td>
-   <td>Native digits</td>
-  </tr>
-  <tr>
-   <td>newa</td>
-   <td>Newa digits</td>
-  </tr>
-  <tr>
-   <td>nkoo</td>
-   <td>N'Ko digits</td>
-  </tr>
-  <tr>
-   <td>olck</td>
-   <td>Ol Chiki digits</td>
-  </tr>
-  <tr>
-   <td>orya</td>
-   <td>Oriya digits</td>
-  </tr>
-  <tr>
-   <td>osma</td>
-   <td>Osmanya digits</td>
-  </tr>
-  <tr>
-   <td>rohg</td>
-   <td>Hanifi Rohingya digits</td>
-  </tr>
-  <tr>
-   <td>roman</td>
-   <td>Roman upper case numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>romanlow</td>
-   <td>Roman lowercase numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>saur</td>
-   <td>Saurashtra digits</td>
-  </tr>
-  <tr>
-   <td>shrd</td>
-   <td>Sharada digits</td>
-  </tr>
-  <tr>
-   <td>sind</td>
-   <td>Khudawadi digits</td>
-  </tr>
-  <tr>
-   <td>sinh</td>
-   <td>Sinhala Lith digits</td>
-  </tr>
-  <tr>
-   <td>sora</td>
-   <td>Sora_Sompeng digits</td>
-  </tr>
-  <tr>
-   <td>sund</td>
-   <td>Sundanese digits</td>
-  </tr>
-  <tr>
-   <td>takr</td>
-   <td>Takri digits</td>
-  </tr>
-  <tr>
-   <td>talu</td>
-   <td>New Tai Lue digits</td>
-  </tr>
-  <tr>
-   <td>taml</td>
-   <td>Tamil numerals — algorithmic</td>
-  </tr>
-  <tr>
-   <td>tamldec</td>
-   <td>Modern Tamil decimal digits</td>
-  </tr>
-  <tr>
-   <td>telu</td>
-   <td>Telugu digits</td>
-  </tr>
-  <tr>
-   <td>thai</td>
-   <td>Thai digits</td>
-  </tr>
-  <tr>
-   <td>tirh</td>
-   <td>Tirhuta digits</td>
-  </tr>
-  <tr>
-   <td>tibt</td>
-   <td>Tibetan digits</td>
-  </tr>
-  <tr>
-   <td>traditio</td>
-   <td>Traditional numerals — may be algorithmic</td>
-  </tr>
-  <tr>
-   <td>vaii</td>
-   <td>Vai digits</td>
-  </tr>
-  <tr>
-   <td>wara</td>
-   <td>Warang Citi digits</td>
-  </tr>
-  <tr>
-   <td>wcho</td>
-   <td>Wancho digits</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th>Value</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>adlm</td>
+			<td>Adlam digits</td>
+		</tr>
+		<tr>
+			<td>ahom</td>
+			<td>Ahom digits</td>
+		</tr>
+		<tr>
+			<td>arab</td>
+			<td>Arabic-Indic digits</td>
+		</tr>
+		<tr>
+			<td>arabext</td>
+			<td>Extended Arabic-Indic digits</td>
+		</tr>
+		<tr>
+			<td>armn</td>
+			<td>Armenian upper case numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>armnlow</td>
+			<td>Armenian lower case numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>bali</td>
+			<td>Balinese digits</td>
+		</tr>
+		<tr>
+			<td>beng</td>
+			<td>Bengali digits</td>
+		</tr>
+		<tr>
+			<td>bhks</td>
+			<td>Bhaiksuki digits</td>
+		</tr>
+		<tr>
+			<td>brah</td>
+			<td>Brahmi digits</td>
+		</tr>
+		<tr>
+			<td>cakm</td>
+			<td>Chakma digits</td>
+		</tr>
+		<tr>
+			<td>cham</td>
+			<td>Cham digits</td>
+		</tr>
+		<tr>
+			<td>cyrl</td>
+			<td>Cyrillic numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>deva</td>
+			<td>Devanagari digits</td>
+		</tr>
+		<tr>
+			<td>ethi</td>
+			<td>Ethiopic numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>finance</td>
+			<td>Financial numerals — may be algorithmic</td>
+		</tr>
+		<tr>
+			<td>fullwide</td>
+			<td>Full width digits</td>
+		</tr>
+		<tr>
+			<td>geor</td>
+			<td>Georgian numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>gong</td>
+			<td>Gunjala Gondi digits</td>
+		</tr>
+		<tr>
+			<td>gonm</td>
+			<td>Masaram Gondi digits</td>
+		</tr>
+		<tr>
+			<td>grek</td>
+			<td>Greek upper case numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>greklow</td>
+			<td>Greek lower case numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>gujr</td>
+			<td>Gujarati digits</td>
+		</tr>
+		<tr>
+			<td>guru</td>
+			<td>Gurmukhi digits</td>
+		</tr>
+		<tr>
+			<td>hanidays</td>
+			<td>Han-character day-of-month numbering for lunar/other traditional calendars</td>
+		</tr>
+		<tr>
+			<td>hanidec</td>
+			<td>Positional decimal system using Chinese number ideographs as digits</td>
+		</tr>
+		<tr>
+			<td>hans</td>
+			<td>Simplified Chinese numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>hansfin</td>
+			<td>Simplified Chinese financial numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>hant</td>
+			<td>Traditional Chinese numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>hantfin</td>
+			<td>Traditional Chinese financial numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>hebr</td>
+			<td>Hebrew numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>hmng</td>
+			<td>Pahawh Hmong digits</td>
+		</tr>
+		<tr>
+			<td>hmnp</td>
+			<td>Nyiakeng Puachue Hmong digits</td>
+		</tr>
+		<tr>
+			<td>java</td>
+			<td>Javanese digits</td>
+		</tr>
+		<tr>
+			<td>jpan</td>
+			<td>Japanese numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>jpanfin</td>
+			<td>Japanese financial numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>jpanyear</td>
+			<td>Japanese first-year Gannen numbering for Japanese calendar</td>
+		</tr>
+		<tr>
+			<td>kali</td>
+			<td>Kayah Li digits</td>
+		</tr>
+		<tr>
+			<td>khmr</td>
+			<td>Khmer digits</td>
+		</tr>
+		<tr>
+			<td>knda</td>
+			<td>Kannada digits</td>
+		</tr>
+		<tr>
+			<td>lana</td>
+			<td>Tai Tham Hora (secular) digits</td>
+		</tr>
+		<tr>
+			<td>lanatham</td>
+			<td>Tai Tham (ecclesiastical) digits</td>
+		</tr>
+		<tr>
+			<td>laoo</td>
+			<td>Lao digits</td>
+		</tr>
+		<tr>
+			<td>latn</td>
+			<td>Latin digits</td>
+		</tr>
+		<tr>
+			<td>lepc</td>
+			<td>Lepcha digits</td>
+		</tr>
+		<tr>
+			<td>limb</td>
+			<td>Limbu digits</td>
+		</tr>
+		<tr>
+			<td>mathbold</td>
+			<td>Mathematical bold digits</td>
+		</tr>
+		<tr>
+			<td>mathdbl</td>
+			<td>Mathematical double-struck digits</td>
+		</tr>
+		<tr>
+			<td>mathmono</td>
+			<td>Mathematical monospace digits</td>
+		</tr>
+		<tr>
+			<td>mathsanb</td>
+			<td>Mathematical sans-serif bold digits</td>
+		</tr>
+		<tr>
+			<td>mathsans</td>
+			<td>Mathematical sans-serif digits</td>
+		</tr>
+		<tr>
+			<td>mlym</td>
+			<td>Malayalam digits</td>
+		</tr>
+		<tr>
+			<td>modi</td>
+			<td>Modi digits</td>
+		</tr>
+		<tr>
+			<td>mong</td>
+			<td>Mongolian digits</td>
+		</tr>
+		<tr>
+			<td>mroo</td>
+			<td>Mro digits</td>
+		</tr>
+		<tr>
+			<td>mtei</td>
+			<td>Meetei Mayek digits</td>
+		</tr>
+		<tr>
+			<td>mymr</td>
+			<td>Myanmar digits</td>
+		</tr>
+		<tr>
+			<td>mymrshan</td>
+			<td>Myanmar Shan digits</td>
+		</tr>
+		<tr>
+			<td>mymrtlng</td>
+			<td>Myanmar Tai Laing digits</td>
+		</tr>
+		<tr>
+			<td>native</td>
+			<td>Native digits</td>
+		</tr>
+		<tr>
+			<td>newa</td>
+			<td>Newa digits</td>
+		</tr>
+		<tr>
+			<td>nkoo</td>
+			<td>N'Ko digits</td>
+		</tr>
+		<tr>
+			<td>olck</td>
+			<td>Ol Chiki digits</td>
+		</tr>
+		<tr>
+			<td>orya</td>
+			<td>Oriya digits</td>
+		</tr>
+		<tr>
+			<td>osma</td>
+			<td>Osmanya digits</td>
+		</tr>
+		<tr>
+			<td>rohg</td>
+			<td>Hanifi Rohingya digits</td>
+		</tr>
+		<tr>
+			<td>roman</td>
+			<td>Roman upper case numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>romanlow</td>
+			<td>Roman lowercase numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>saur</td>
+			<td>Saurashtra digits</td>
+		</tr>
+		<tr>
+			<td>shrd</td>
+			<td>Sharada digits</td>
+		</tr>
+		<tr>
+			<td>sind</td>
+			<td>Khudawadi digits</td>
+		</tr>
+		<tr>
+			<td>sinh</td>
+			<td>Sinhala Lith digits</td>
+		</tr>
+		<tr>
+			<td>sora</td>
+			<td>Sora_Sompeng digits</td>
+		</tr>
+		<tr>
+			<td>sund</td>
+			<td>Sundanese digits</td>
+		</tr>
+		<tr>
+			<td>takr</td>
+			<td>Takri digits</td>
+		</tr>
+		<tr>
+			<td>talu</td>
+			<td>New Tai Lue digits</td>
+		</tr>
+		<tr>
+			<td>taml</td>
+			<td>Tamil numerals — algorithmic</td>
+		</tr>
+		<tr>
+			<td>tamldec</td>
+			<td>Modern Tamil decimal digits</td>
+		</tr>
+		<tr>
+			<td>telu</td>
+			<td>Telugu digits</td>
+		</tr>
+		<tr>
+			<td>thai</td>
+			<td>Thai digits</td>
+		</tr>
+		<tr>
+			<td>tirh</td>
+			<td>Tirhuta digits</td>
+		</tr>
+		<tr>
+			<td>tibt</td>
+			<td>Tibetan digits</td>
+		</tr>
+		<tr>
+			<td>traditio</td>
+			<td>Traditional numerals — may be algorithmic</td>
+		</tr>
+		<tr>
+			<td>vaii</td>
+			<td>Vai digits</td>
+		</tr>
+		<tr>
+			<td>wara</td>
+			<td>Warang Citi digits</td>
+		</tr>
+		<tr>
+			<td>wcho</td>
+			<td>Wancho digits</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Examples">Examples</h2>
@@ -390,16 +394,16 @@ console.log(us12hour.numberingSystem); // Prints "latn"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.numberingSystem')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.numberingSystem')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -409,6 +413,6 @@ console.log(us12hour.numberingSystem); // Prints "latn"
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li><a href="https://github.com/unicode-org/cldr/blob/master/common/supplemental/numberingSystems.xml">Details on the standard Unicode numeral systems</a></li>
+	<li>{{jsxref("Locale", "Intl.Locale")}}</li>
+	<li><a href="https://github.com/unicode-org/cldr/blob/master/common/supplemental/numberingSystems.xml">Details on the standard Unicode numeral systems</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -19,7 +21,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Setting_the_numeric_value_via_the_locale_string">Setting the <code>numeric</code> value via the locale string</h3>
+<h3 id="Setting_the_numeric_value_via_the_locale_string">Setting the numeric value via the locale string</h3>
 
 <p>In the <a href="https://www.unicode.org/reports/tr35/" rel="noopener">Unicode locale string spec</a>, the values that <code>numeric</code> represents correspond to the key <code>kn</code>. <code>kn</code> is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the <code>-u</code> extension key. Thus, the <code>numeric</code> value can be added to the inital locale identifier string that is passed into the {{jsxref("Locale/Locale", "Locale")}} constructor. To set the <code>numeric</code> value, first add the <code>-u</code> extension key to the string. Next, add the <code>-kn</code> extension key to indicate that you are adding a value for <code>numeric</code>. Finally, add the <code>numeric</code> value to the string. If you want to set <code>numeric</code> to <code>true</code>, adding the <code>kn</code> key will suffice. To set the value to <code>false</code>, you must specify in by adding "<code>false</code>" after the <code>kn</code> key.</p>
 
@@ -37,16 +39,16 @@ console.log(us12hour.numeric); // Prints "true"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.numeric')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.numeric')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -56,5 +58,5 @@ console.log(us12hour.numeric); // Prints "true"
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
+	<li>{{jsxref("Intl.Locale")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -38,16 +40,16 @@ console.log(regionObj.region); // Prints "FR"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.region')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.region')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -57,6 +59,6 @@ console.log(regionObj.region); // Prints "FR"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li><a href="https://www.unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html">Unicode region chart</a></li>
+	<li>{{jsxref("Locale", "Intl.Locale")}}</li>
+	<li><a href="https://www.unicode.org/cldr/charts/latest/supplemental/territory_containment_un_m_49.html">Unicode region chart</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.html
@@ -6,6 +6,8 @@ tags:
   - Intl
   - JavaScript
   - Property
+  - Locale
+  - Localization
   - Prototype
   - Reference
 ---
@@ -38,16 +40,16 @@ console.log(scriptObj.script); // Prints "Latn"</pre>
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.script')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.script')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -57,6 +59,6 @@ console.log(scriptObj.script); // Prints "Latn"</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li><a href="https://www.unicode.org/reports/tr35/#unicode_script_subtag_validity">Unicode's script subtag specification</a></li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li><a href="https://www.unicode.org/reports/tr35/#unicode_script_subtag_validity">Unicode's script subtag specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.html
@@ -2,8 +2,10 @@
 title: Intl.Locale.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Locale/toString
 tags:
+  - Internationalization
   - Intl
   - JavaScript
+  - Locale
   - Method
   - Prototype
   - Reference
@@ -13,20 +15,19 @@ tags:
 <p><span class="seoSummary">The <strong><code>Intl.Locale.prototype.toString()</code></strong> returns the Locale's full <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">locale identifier string</a>.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-locale-prototype-tostring.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><code><em>locale</em>.toString()</code></pre>
+<pre class="syntaxbox"><var>locale</var>.toString()</pre>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>The <em>locale</em>'s Unicode locale identifier string.</p>
+<p>The <var>locale</var>'s Unicode locale identifier string.</p>
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>Locale</code> object is a JavaScript representation of a concept Unicode locale identifier. Information about a particular locale (language, script, calendar type, etc.) can be encoded in a locale identifier string. To make it easier to work with these locale identifiers, the <code>Locale</code> object was introduced to JavaScript. Calling the <code>toString</code> method on a Locale object will return the identifier string for that particular Locale. The <code>toString</code> method allows <code>Locale</code> instances to be provided as an argument to existing <code>Intl</code> constructors, serialized in JSON, or any other context where an exact string representation is useful.</p>
+<p>The <code><var>locale</var></code> object is a JavaScript representation of a concept Unicode locale identifier. Information about a particular locale (language, script, calendar type, etc.) can be encoded in a locale identifier string. To make it easier to work with these locale identifiers, the <code><var>locale</var></code> object was introduced to JavaScript. Calling the <code>toString</code> method on a Locale object will return the identifier string for that particular Locale. The <code>toString</code> method allows <code><var>locale</var></code> instances to be provided as an argument to existing <code>Intl</code> constructors, serialized in JSON, or any other context where an exact string representation is useful.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -40,28 +41,25 @@ console.log(myLocale.toString()); // Prints "fr-Latn-FR-u-ca-gregory-hc-h24"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.toString')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.Locale.prototype.toString')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.Locale.toString")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.Locale.toString")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Locale", "Intl.Locale")}}</li>
- <li>{{jsxref("Locale/baseName", "Intl.Locale.baseName")}}</li>
+	<li>{{jsxref("Intl.Locale")}}</li>
+	<li>{{jsxref("Locale/baseName", "Intl.Locale.baseName")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.html
@@ -5,25 +5,28 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - NumberFormat
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>Intl.NumberFormat.prototype.format()</code></strong> method formats a number according to the locale and formatting options of this {{jsxref("NumberFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-format.html", "taller")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate"><code><var>numberFormat</var>.format(<var>number</var>)</code></pre>
+<pre class="syntaxbox notranslate"><var>numberFormat</var>.format(<var>number</var>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>number</code></dt>
- <dd>A {{jsxref("Number")}} or {{jsxref("BigInt")}} to format.</dd>
+	<dt><code><var>number</var></code></dt>
+	<dd>A {{jsxref("Number")}} or {{jsxref("BigInt")}} to format.</dd>
 </dl>
 
 <h2 id="Description">Description</h2>
@@ -32,7 +35,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Using_format">Using <code>format</code></h3>
+<h3 id="Using_format">Using format</h3>
 
 <p>Use the <code>format</code> getter function for formatting a single currency value, here for Russia:</p>
 
@@ -42,7 +45,7 @@ console.log(numberFormat.format(654321.987));
 // → "654 321,99 руб."
 </pre>
 
-<h3 id="Using_format_with_map">Using <code>format</code> with <code>map</code></h3>
+<h3 id="Using_format_with_map">Using format with map</h3>
 
 <p>Use the <code>format</code> getter function for formatting all numbers in an array. Note that the function is bound to the {{jsxref("NumberFormat")}} from which it was obtained, so it can be passed directly to {{jsxref("Array.prototype.map")}}. This is considered a historical artefact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.</p>
 
@@ -56,26 +59,25 @@ console.log(formatted.join('; '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.prototype.format', 'Intl.NumberFormat.prototype.format')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.prototype.format', 'Intl.NumberFormat.prototype.format')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.NumberFormat.format")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.NumberFormat.format")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
- <li>{{jsxref("Number.prototype.toLocaleString()")}}</li>
+	<li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
+	<li>{{jsxref("Number.prototype.toLocaleString()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.html
@@ -5,9 +5,11 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - NumberFormat
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
@@ -15,12 +17,12 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">Intl.NumberFormat.prototype.formatToParts(number)</pre>
+<pre class="syntaxbox notranslate">Intl.NumberFormat.prototype.formatToParts(<var>number</var>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>number</code> {{optional_inline}}</dt>
+ <dt><code><var>number</var></code> {{optional_inline}}</dt>
  <dd>A {{jsxref("Number")}} or {{jsxref("BigInt")}} to format.</dd>
 </dl>
 
@@ -41,30 +43,30 @@ tags:
 <p>Possible types are the following:</p>
 
 <dl>
- <dt>currency</dt>
- <dd>The currency string, such as the symbols "$" and "€" or the name "Dollar", "Euro" depending on how <code>currencyDisplay</code> is specified.</dd>
- <dt>decimal</dt>
- <dd>The decimal separator string (".").</dd>
- <dt>fraction</dt>
- <dd>The fraction number.</dd>
- <dt>group</dt>
- <dd>The group separator string (",").</dd>
- <dt>infinity</dt>
- <dd>The {{jsxref("Infinity")}} string ("∞").</dd>
- <dt>integer</dt>
- <dd>The integer number.</dd>
- <dt>literal</dt>
- <dd>Any literal strings or whitespace in the formatted number.</dd>
- <dt>minusSign</dt>
- <dd>The minus sign string ("-").</dd>
- <dt>nan</dt>
- <dd>The {{jsxref("NaN")}} string ("NaN").</dd>
- <dt>plusSign</dt>
- <dd>The plus sign string ("+").</dd>
- <dt>percentSign</dt>
- <dd>The percent sign string ("%").</dd>
- <dt>unit</dt>
- <dd>The unit string, such as the "l" or "litres", depending on how <code>unitDisplay</code> is specified.</dd>
+	<dt>currency</dt>
+	<dd>The currency string, such as the symbols "$" and "€" or the name "Dollar", "Euro" depending on how <code>currencyDisplay</code> is specified.</dd>
+	<dt>decimal</dt>
+	<dd>The decimal separator string (".").</dd>
+	<dt>fraction</dt>
+	<dd>The fraction number.</dd>
+	<dt>group</dt>
+	<dd>The group separator string (",").</dd>
+	<dt>infinity</dt>
+	<dd>The {{jsxref("Infinity")}} string ("∞").</dd>
+	<dt>integer</dt>
+	<dd>The integer number.</dd>
+	<dt>literal</dt>
+	<dd>Any literal strings or whitespace in the formatted number.</dd>
+	<dt>minusSign</dt>
+	<dd>The minus sign string ("-").</dd>
+	<dt>nan</dt>
+	<dd>The {{jsxref("NaN")}} string ("NaN").</dd>
+	<dt>plusSign</dt>
+	<dd>The plus sign string ("+").</dd>
+	<dt>percentSign</dt>
+	<dd>The percent sign string ("%").</dd>
+	<dt>unit</dt>
+	<dd>The unit string, such as the "l" or "litres", depending on how <code>unitDisplay</code> is specified.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -118,29 +120,26 @@ formatter.format(number);
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.prototype.formattoparts', 'Intl.NumberFormat.prototype.formatToParts')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.prototype.formattoparts', 'Intl.NumberFormat.prototype.formatToParts')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.NumberFormat.formatToParts")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.NumberFormat.formatToParts")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
- <li>{{jsxref("NumberFormat.format", "Intl.NumberFormat.prototype.format")}}</li>
- <li>Formatting dates: {{jsxref("DateTimeFormat.formatToParts", "Intl.DateTimeFormat.prototype.formatToParts()")}}</li>
+	<li>{{jsxref("Intl.NumberFormat")}}</li>
+	<li>{{jsxref("NumberFormat.format", "Intl.NumberFormat.prototype.format")}}</li>
+	<li>Formatting dates: {{jsxref("DateTimeFormat.formatToParts", "Intl.DateTimeFormat.prototype.formatToParts()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - NumberFormat
   - Reference
 ---
@@ -14,32 +15,31 @@ tags:
 <p>The <strong><code>Intl.NumberFormat</code></strong> object enables language-sensitive number formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-numberformat.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("Intl/NumberFormat/NumberFormat", "Intl.NumberFormat()")}}</dt>
- <dd>Creates a new <code>NumberFormat</code> object.</dd>
+	<dt>{{jsxref("Intl/NumberFormat/NumberFormat", "Intl.NumberFormat()")}}</dt>
+	<dd>Creates a new <code>NumberFormat</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("NumberFormat.supportedLocalesOf", "Intl.NumberFormat.supportedLocalesOf()")}}</dt>
- <dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
+	<dt>{{jsxref("NumberFormat.supportedLocalesOf", "Intl.NumberFormat.supportedLocalesOf()")}}</dt>
+	<dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{jsxref("NumberFormat.format", "Intl.NumberFormat.prototype.format()")}}</dt>
- <dd>Getter function that formats a number according to the locale and formatting options of this {{jsxref("NumberFormat")}} object.</dd>
- <dt>{{jsxref("NumberFormat.formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}}</dt>
- <dd>Returns an {{jsxref("Array")}} of objects representing the number string in parts that can be used for custom locale-aware formatting.</dd>
- <dt>{{jsxref("NumberFormat.resolvedOptions", "Intl.NumberFormat.prototype.resolvedOptions()")}}</dt>
- <dd>Returns a new object with properties reflecting the locale and collation options computed during initialization of the object.</dd>
+	<dt>{{jsxref("NumberFormat.format", "Intl.NumberFormat.prototype.format()")}}</dt>
+	<dd>Getter function that formats a number according to the locale and formatting options of this {{jsxref("NumberFormat")}} object.</dd>
+	<dt>{{jsxref("NumberFormat.formatToParts", "Intl.NumberFormat.prototype.formatToParts()")}}</dt>
+	<dd>Returns an {{jsxref("Array")}} of objects representing the number string in parts that can be used for custom locale-aware formatting.</dd>
+	<dt>{{jsxref("NumberFormat.resolvedOptions", "Intl.NumberFormat.prototype.resolvedOptions()")}}</dt>
+	<dd>Returns a new object with properties reflecting the locale and collation options computed during initialization of the object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -124,16 +124,16 @@ console.log((16).toLocaleString('en-GB', {
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#numberformat-objects', 'Intl.NumberFormat')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#numberformat-objects', 'Intl.NumberFormat')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -143,5 +143,5 @@ console.log((16).toLocaleString('en-GB', {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl")}}</li>
+	<li>{{jsxref("Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - NumberFormat
   - Reference
 ---
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.NumberFormat()</code></strong> constructor creates {{jsxref("NumberFormat", "Intl.NumberFormat")}} objects that enable language-sensitive number formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-numberformat.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -25,96 +25,95 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code> {{optional_inline}}</dt>
- <dd>
- <p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page. The following Unicode extension key is allowed:</p>
+	<dt><code><var>locales</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page. The following Unicode extension key is allowed:</p>
+		
+		<dl>
+			<dt><code>nu</code></dt>
+			<dd>The numbering system to be used. Possible values include: "<code>adlm</code>", "<code>ahom</code>", "<code>arab</code>", "<code>arabext</code>", "<code>bali</code>", "<code>beng</code>", "<code>bhks</code>", "<code>brah</code>", "<code>cakm</code>", "<code>cham</code>", "<code>deva</code>", "<code>diak</code>", "<code>fullwide</code>", "<code>gong</code>", "<code>gonm</code>", "<code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>hmng</code>", "<code>hmnp</code>", "<code>java</code>", "<code>kali</code>", "<code>khmr</code>", "<code>knda</code>", "<code>lana</code>", "<code>lanatham</code>", "<code>laoo</code>", "<code>latn</code>", "<code>lepc</code>", "<code>limb</code>", "<code>mathbold</code>", "<code>mathdbl</code>", "<code>mathmono</code>", "<code>mathsanb</code>", "<code>mathsans</code>", "<code>mlym</code>", "<code>modi</code>", "<code>mong</code>", "<code>mroo</code>", "<code>mtei</code>", "<code>mymr</code>", "<code>mymrshan</code>", "<code>mymrtlng</code>", "<code>newa</code>", "<code>nkoo</code>", "<code>olck</code>", "<code>orya</code>", "<code>osma</code>", "<code>rohg</code>", "<code>saur</code>", "<code>segment</code>", "<code>shrd</code>", "<code>sind</code>", "<code>sinh</code>", "<code>sora</code>", "<code>sund</code>", "<code>takr</code>", "<code>talu</code>", "<code>tamldec</code>", "<code>telu</code>", "<code>thai</code>", "<code>tibt</code>", "<code>tirh</code>", "<code>vaii</code>", "<code>wara</code>", "<code>wcho</code>".  — see the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem">standard Unicode numeral systems list</a>.</dd>
+		</dl>
+	</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object with some or all of the following properties:</p>
+		
+		<dl>
+			<dt><code>compactDisplay</code></dt>
+			<dd>Only used when <code>notation</code> is "<code>compact</code>". Takes either "<code>short</code>" (default) or "<code>long</code>".</dd>
+			<dt><code>currency</code></dt>
+			<dd>The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "<code>USD</code>" for the US dollar, "<code>EUR</code>" for the euro, or "<code>CNY</code>" for the Chinese RMB — see the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">Current currency &amp; funds code list</a>. There is no default value; if the <code>style</code> is "<code>currency</code>", the <code>currency</code> property must be provided.</dd>
+			<dt><code>currencyDisplay</code></dt>
+			<dd>How to display the currency in currency formatting. Possible values are:
+				<ul>
+					<li>"<code>symbol</code>" to use a localized currency symbol such as €, this is the default value,</li>
+					<li>"<code>narrowSymbol</code>" to use a narrow format symbol ("$100" rather than "US$100"),</li>
+					<li>"<code>code</code>" to use the ISO currency code,</li>
+					<li>"<code>name</code>" to use a localized currency name such as "<code>dollar</code>",</li>
+				</ul>
+			</dd>
+			<dt><code>currencySign</code></dt>
+			<dd>In many locales, accounting format means to wrap the number with parentheses instead of appending a minus sign. You can enable this formatting by setting the <code>currencySign</code> option to "<code>accounting</code>". The default value is "<code>standard</code>".</dd>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+			<dt><code>notation</code></dt>
+			<dd>The formatting that should be displayed for the number, the defaults is "<code>standard</code>"
+				<ul>
+					<li>"<code>standard</code>" plain number formatting</li>
+					<li>"<code>scientific</code>" return the order-of-magnitude for formatted number.</li>
+					<li>"<code>engineering</code>" return the exponent of ten when divisible by three</li>
+					<li>"<code>compact</code>" string representing exponent, defaults is using the "short" form.</li>
+				</ul>
+			</dd>
+			<dt><code>numberingSystem</code></dt>
+			<dd>Numbering System. Possible values include: "<code>arab</code>", "<code>arabext</code>", " <code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", " <code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", " <code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", " <code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", " <code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
+			<dt><code>signDisplay</code></dt>
+			<dd>When to display the sign for the number; defaults to "<code>auto</code>"
+				<ul>
+					<li>"<code>auto</code>" sign display for negative numbers only</li>
+					<li>"<code>never</code>" never display sign</li>
+					<li>"<code>always</code>" always display sign</li>
+					<li>"<code>exceptZero</code>" sign display for positive and negative numbers, but not zero</li>
+				</ul>
+			</dd>
+			<dt><code>style</code></dt>
+			<dd>The formatting style to use , the default is "<code>decimal</code>".
+				<ul>
+					<li>"<code>decimal</code>" for plain number formatting.</li>
+					<li>"<code>currency</code>" for currency formatting.</li>
+					<li>"<code>percent</code>" for percent formatting</li>
+					<li>"<code>unit</code>" for unit formatting</li>
+				</ul>
+			</dd>
+			<dt><code>unit</code></dt>
+			<dd>The unit to use in <code>unit</code> formatting, Possible values are core unit identifiers, defined in <a href="http://unicode.org/reports/tr35/tr35-general.html#Unit_Elements" rel="nofollow">UTS #35, Part 2, Section 6</a>. A <a href="https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier" rel="nofollow">subset</a> of units from the <a href="https://github.com/unicode-org/cldr/blob/master/common/validity/unit.xml">full list</a> was selected for use in ECMAScript. Pairs of simple units can be concatenated with "<code>-per-</code>" to make a compound unit. There is no default value; if the <code>style</code> is "<code>unit</code>", the <code>unit</code> property must be provided.</dd>
+			<dt><code>unitDisplay</code></dt>
+			<dd>The unit formatting style to use in <code>unit</code> formatting, the defaults is "<code>short</code>".
+				<ul>
+					<li>"<code>long</code>" (e.g., <code>16 litres</code>)</li>
+					<li>"<code>short</code>" (e.g., <code>16 l</code>)</li>
+					<li>"<code>narrow</code>" (e.g., <code>16l</code>)</li>
+				</ul>
+			</dd>
+			<dt><code>useGrouping</code></dt>
+			<dd>Whether to use grouping separators, such as thousands separators or thousand/lakh/crore separators. Possible values are true and false; the default is true.</dd>
+		</dl>
+		
+		<p>The following properties fall into two groups: <code>minimumIntegerDigits</code>, <code>minimumFractionDigits</code>, and <code>maximumFractionDigits</code> in one group, <code>minimumSignificantDigits</code> and <code>maximumSignificantDigits</code> in the other. If at least one property from the second group is defined, then the first group is ignored.</p>
 
- <dl>
-  <dt><code>nu</code></dt>
-  <dd>The numbering system to be used. Possible values include: "<code>adlm</code>", "<code>ahom</code>", "<code>arab</code>", "<code>arabext</code>", "<code>bali</code>", "<code>beng</code>", "<code>bhks</code>", "<code>brah</code>", "<code>cakm</code>", "<code>cham</code>", "<code>deva</code>", "<code>diak</code>", "<code>fullwide</code>", "<code>gong</code>", "<code>gonm</code>", "<code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>hmng</code>", "<code>hmnp</code>", "<code>java</code>", "<code>kali</code>", "<code>khmr</code>", "<code>knda</code>", "<code>lana</code>", "<code>lanatham</code>", "<code>laoo</code>", "<code>latn</code>", "<code>lepc</code>", "<code>limb</code>", "<code>mathbold</code>", "<code>mathdbl</code>", "<code>mathmono</code>", "<code>mathsanb</code>", "<code>mathsans</code>", "<code>mlym</code>", "<code>modi</code>", "<code>mong</code>", "<code>mroo</code>", "<code>mtei</code>", "<code>mymr</code>", "<code>mymrshan</code>", "<code>mymrtlng</code>", "<code>newa</code>", "<code>nkoo</code>", "<code>olck</code>", "<code>orya</code>", "<code>osma</code>", "<code>rohg</code>", "<code>saur</code>", "<code>segment</code>", "<code>shrd</code>", "<code>sind</code>", "<code>sinh</code>", "<code>sora</code>", "<code>sund</code>", "<code>takr</code>", "<code>talu</code>", "<code>tamldec</code>", "<code>telu</code>", "<code>thai</code>", "<code>tibt</code>", "<code>tirh</code>", "<code>vaii</code>", "<code>wara</code>", "<code>wcho</code>".  — see the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem">standard Unicode numeral systems list</a>.</dd>
- </dl>
- </dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object with some or all of the following properties:</p>
-
- <dl>
-  <dt><code>compactDisplay</code></dt>
-  <dd>Only used when <code>notation</code> is "<code>compact</code>". Takes either "<code>short</code>" (default) or "<code>long</code>".</dd>
-  <dt><code>currency</code></dt>
-  <dd>The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "<code>USD</code>" for the US dollar, "<code>EUR</code>" for the euro, or "<code>CNY</code>" for the Chinese RMB — see the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">Current currency &amp; funds code list</a>. There is no default value; if the <code>style</code> is "<code>currency</code>", the <code>currency</code> property must be provided.</dd>
-  <dt><code>currencyDisplay</code></dt>
-  <dd>How to display the currency in currency formatting. Possible values are:
-  <ul>
-   <li>"<code>symbol</code>" to use a localized currency symbol such as €, this is the default value,</li>
-   <li>"<code>narrowSymbol</code>" to use a narrow format symbol ("$100" rather than "US$100"),</li>
-   <li>"<code>code</code>" to use the ISO currency code,</li>
-   <li>"<code>name</code>" to use a localized currency name such as "<code>dollar</code>",</li>
-  </ul>
-  </dd>
-  <dt><code>currencySign</code></dt>
-  <dd>In many locales, accounting format means to wrap the number with parentheses instead of appending a minus sign. You can enable this formatting by setting the <code>currencySign</code> option to "<code>accounting</code>". The default value is "<code>standard</code>".</dd>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
-  <dt><code>notation</code></dt>
-  <dd>The formatting that should be displayed for the number, the defaults is "<code>standard</code>"
-  <ul>
-   <li>"<code>standard</code>" plain number formatting</li>
-   <li>"<code>scientific</code>" return the order-of-magnitude for formatted number.</li>
-   <li>"<code>engineering</code>" return the exponent of ten when divisible by three</li>
-   <li>"<code>compact</code>" string representing exponent, defaults is using the "short" form.</li>
-  </ul>
-  </dd>
-  <dt><code>numberingSystem</code></dt>
-  <dd>Numbering System. Possible values include: "<code>arab</code>", "<code>arabext</code>", " <code>bali</code>", "<code>beng</code>", "<code>deva</code>", "<code>fullwide</code>", " <code>gujr</code>", "<code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", " <code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "<code>limb</code>", "<code>mlym</code>", " <code>mong</code>", "<code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", " <code>telu</code>", "<code>thai</code>", "<code>tibt</code>".</dd>
-  <dt><code>signDisplay</code></dt>
-  <dd>When to display the sign for the number; defaults to "<code>auto</code>"
-  <ul>
-   <li>"<code>auto</code>" sign display for negative numbers only</li>
-   <li>"<code>never</code>" never display sign</li>
-   <li>"<code>always</code>" always display sign</li>
-   <li>"<code>exceptZero</code>" sign display for positive and negative numbers, but not zero</li>
-  </ul>
-  </dd>
-  <dt><code>style</code></dt>
-  <dd>The formatting style to use , the default is "<code>decimal</code>".
-  <ul>
-   <li>"<code>decimal</code>" for plain number formatting.</li>
-   <li>"<code>currency</code>" for currency formatting.</li>
-   <li>"<code>percent</code>" for percent formatting</li>
-   <li>"<code>unit</code>" for unit formatting</li>
-  </ul>
-  </dd>
-  <dt><code>unit</code></dt>
-  <dd>The unit to use in <code>unit</code> formatting, Possible values are core unit identifiers, defined in <a href="http://unicode.org/reports/tr35/tr35-general.html#Unit_Elements" rel="nofollow">UTS #35, Part 2, Section 6</a>. A <a href="https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier" rel="nofollow">subset</a> of units from the <a href="https://github.com/unicode-org/cldr/blob/master/common/validity/unit.xml">full list</a> was selected for use in ECMAScript. Pairs of simple units can be concatenated with "<code>-per-</code>" to make a compound unit. There is no default value; if the <code>style</code> is "<code>unit</code>", the <code>unit</code> property must be provided.</dd>
-  <dt><code>unitDisplay</code></dt>
-  <dd>The unit formatting style to use in <code>unit</code> formatting, the defaults is "<code>short</code>".
-  <ul>
-   <li>"<code>long</code>" (e.g., <code>16 litres</code>)</li>
-   <li>"<code>short</code>" (e.g., <code>16 l</code>)</li>
-   <li>"<code>narrow</code>" (e.g., <code>16l</code>)</li>
-  </ul>
-  </dd>
-  <dt><code>useGrouping</code></dt>
-  <dd>Whether to use grouping separators, such as thousands separators or thousand/lakh/crore separators. Possible values are true and false; the default is true.</dd>
- </dl>
- </dd>
- <dd>
- <p>The following properties fall into two groups: <code>minimumIntegerDigits</code>, <code>minimumFractionDigits</code>, and <code>maximumFractionDigits</code> in one group, <code>minimumSignificantDigits</code> and <code>maximumSignificantDigits</code> in the other. If at least one property from the second group is defined, then the first group is ignored.</p>
-
- <dl>
-  <dt><code>minimumIntegerDigits</code></dt>
-  <dd>The minimum number of integer digits to use. Possible values are from 1 to 21; the default is 1.</dd>
-  <dt><code>minimumFractionDigits</code></dt>
-  <dd>The minimum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number and percent formatting is 0; the default for currency formatting is the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information).</dd>
-  <dt><code>maximumFractionDigits</code></dt>
-  <dd>The maximum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number formatting is the larger of <code>minimumFractionDigits</code> and 3; the default for currency formatting is the larger of <code>minimumFractionDigits</code> and the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information); the default for percent formatting is the larger of <code>minimumFractionDigits</code> and 0.</dd>
-  <dt><code>minimumSignificantDigits</code></dt>
-  <dd>The minimum number of significant digits to use. Possible values are from 1 to 21; the default is 1.</dd>
-  <dt><code>maximumSignificantDigits</code></dt>
-  <dd>The maximum number of significant digits to use. Possible values are from 1 to 21; the default is 21.</dd>
- </dl>
- </dd>
+		<dl>
+			<dt><code>minimumIntegerDigits</code></dt>
+			<dd>The minimum number of integer digits to use. Possible values are from 1 to 21; the default is 1.</dd>
+			<dt><code>minimumFractionDigits</code></dt>
+			<dd>The minimum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number and percent formatting is 0; the default for currency formatting is the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information).</dd>
+			<dt><code>maximumFractionDigits</code></dt>
+			<dd>The maximum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number formatting is the larger of <code>minimumFractionDigits</code> and 3; the default for currency formatting is the larger of <code>minimumFractionDigits</code> and the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information); the default for percent formatting is the larger of <code>minimumFractionDigits</code> and 0.</dd>
+			<dt><code>minimumSignificantDigits</code></dt>
+			<dd>The minimum number of significant digits to use. Possible values are from 1 to 21; the default is 1.</dd>
+			<dt><code>maximumSignificantDigits</code></dt>
+			<dd>The maximum number of significant digits to use. Possible values are from 1 to 21; the default is 21.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -229,16 +228,16 @@ new Intl.NumberFormat('en-GB', {
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl-numberformat-constructor', 'Intl.NumberFormat constructor')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl-numberformat-constructor', 'Intl.NumberFormat constructor')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -248,6 +247,6 @@ new Intl.NumberFormat('en-GB', {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.NumberFormat")}}</li>
- <li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
+	<li>{{jsxref("Intl.NumberFormat")}}</li>
+	<li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.html
@@ -5,19 +5,22 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - NumberFormat
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>Intl.NumberFormat.prototype.resolvedOptions()</code></strong> method returns a new object with properties reflecting the locale and number formatting options computed during initialization of this {{jsxref("NumberFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-resolvedoptions.html")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><code><var>numberFormat</var>.resolvedOptions()</code></pre>
+<pre class="syntaxbox"><var>numberFormat</var>.resolvedOptions()</pre>
 
 <h3 id="Return_value">Return value</h3>
 
@@ -28,34 +31,36 @@ tags:
 <p>The resulting object has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>numberingSystem</code></dt>
- <dd>The value provided for this properties in the <code>options</code> argument, if present, or the value requested using the Unicode extension key <code>"nu"</code> or filled in as a default.</dd>
- <dt><code>notation</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument, if present, or <code>"standard</code> filled in as a default.</dd>
- <dt><code>compactDisplay</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument, or <code>"short"</code> filled in as a default. <br>
- This property is only present if the <code>notation</code> is set to "compact". </dd>
- <dt><code>signDisplay</code></dt>
- <dd>The value provided for this property in the <code>options</code> argument, or <code>"auto"</code> filled in as a default. </dd>
- <dt><code>useGrouping</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults.</dd>
- <dt><code>currency</code></dt>
- <dt><code>currencyDisplay</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are only present if <code>style</code> is <code>"currency"</code>.</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>numberingSystem</code></dt>
+	<dd>The value provided for this properties in the <code>options</code> argument, if present, or the value requested using the Unicode extension key "<code>nu</code>" or filled in as a default.</dd>
+	<dt><code>notation</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument, if present, or "<code>standard</code>" filled in as a default.</dd>
+	<dt><code>compactDisplay</code></dt>
+	<dd>
+		The value provided for this property in the <code>options</code> argument, or "<code>short</code>" filled in as a default. <br>
+		This property is only present if the <code>notation</code> is set to "compact". 
+	</dd>
+	<dt><code>signDisplay</code></dt>
+	<dd>The value provided for this property in the <code>options</code> argument, or "<code>auto</code>" filled in as a default. </dd>
+	<dt><code>useGrouping</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults.</dd>
+	<dt><code>currency</code></dt>
+	<dt><code>currencyDisplay</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are only present if <code>style</code> is "<code>currency</code>".</dd>
 </dl>
 
 <p>Only one of the following two groups of properties is included:</p>
 
 <dl>
- <dt><code>minimumIntegerDigits</code></dt>
- <dt><code>minimumFractionDigits</code></dt>
- <dt><code>maximumFractionDigits</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if neither <code>minimumSignificantDigits</code> nor <code>maximumSignificantDigits</code> was provided in the <code>options</code> argument.</dd>
- <dt><code>minimumSignificantDigits</code></dt>
- <dt><code>maximumSignificantDigits</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if at least one of them was provided in the <code>options</code> argument.</dd>
+	<dt><code>minimumIntegerDigits</code></dt>
+	<dt><code>minimumFractionDigits</code></dt>
+	<dt><code>maximumFractionDigits</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if neither <code>minimumSignificantDigits</code> nor <code>maximumSignificantDigits</code> was provided in the <code>options</code> argument.</dd>
+	<dt><code>minimumSignificantDigits</code></dt>
+	<dt><code>maximumSignificantDigits</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if at least one of them was provided in the <code>options</code> argument.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -79,25 +84,24 @@ usedOptions.useGrouping;           // true
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.prototype.resolvedoptions', 'Intl.NumberFormat.prototype.resolvedOptions')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.prototype.resolvedoptions', 'Intl.NumberFormat.prototype.resolvedOptions')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.NumberFormat.resolvedOptions")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.NumberFormat.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
+	<li>{{jsxref("NumberFormat", "Intl.NumberFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/supportedlocalesof/index.html
@@ -5,6 +5,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - NumberFormat
   - Reference
@@ -14,8 +15,7 @@ tags:
 <p>The <strong><code>Intl.NumberFormat.supportedLocalesOf()</code></strong> method returns an array containing those of the provided locales that are supported in number formatting without having to fall back to the runtime's default locale.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-numberformat-prototype-supportedlocalesof.html","shorter")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,17 +24,17 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
-
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -60,16 +60,16 @@ console.log(Intl.NumberFormat.supportedLocalesOf(locales, options).join(', '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.supportedlocalesof', 'Intl.NumberFormat.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.numberformat.supportedlocalesof', 'Intl.NumberFormat.supportedLocalesOf()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -79,5 +79,5 @@ console.log(Intl.NumberFormat.supportedLocalesOf(locales, options).join(', '));
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.NumberFormat")}}</li>
+	<li>{{jsxref("Intl.NumberFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - PluralRules
   - Reference
 ---
@@ -16,24 +17,24 @@ tags:
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("PluralRules.PluralRules()", "Intl.PluralRules()")}}</dt>
- <dd>Creates a new <code>Intl.PluralRules</code> object.</dd>
+	<dt>{{jsxref("PluralRules.PluralRules()", "Intl.PluralRules()")}}</dt>
+	<dd>Creates a new <code>Intl.PluralRules</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("PluralRules.supportedLocalesOf", "Intl.PluralRules.supportedLocalesOf()")}}</dt>
- <dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
+	<dt>{{jsxref("PluralRules.supportedLocalesOf", "Intl.PluralRules.supportedLocalesOf()")}}</dt>
+	<dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{jsxref("PluralRules.resolvedOptions", "Intl.PluralRules.prototype.resolvedOptions()")}}</dt>
- <dd>Returns a new object with properties reflecting the locale and collation options computed during initialization of the object.</dd>
- <dt>{{jsxref("PluralRules.select", "Intl.PluralRules.prototype.select()")}}</dt>
- <dd>Returns a {{jsxref("String")}} indicating which plural rule to use for locale-aware formatting.</dd>
+	<dt>{{jsxref("PluralRules.resolvedOptions", "Intl.PluralRules.prototype.resolvedOptions()")}}</dt>
+	<dd>Returns a new object with properties reflecting the locale and collation options computed during initialization of the object.</dd>
+	<dt>{{jsxref("PluralRules.select", "Intl.PluralRules.prototype.select()")}}</dt>
+	<dd>Returns a {{jsxref("String")}} indicating which plural rule to use for locale-aware formatting.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -63,16 +64,16 @@ new Intl.PluralRules('ar-EG').select(18);
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#pluralrules-objects', 'Intl.PluralRules')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#pluralrules-objects', 'Intl.PluralRules')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -82,5 +83,5 @@ new Intl.PluralRules('ar-EG').select(18);
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl")}}</li>
+	<li>{{jsxref("Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/pluralrules/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/pluralrules/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - PluralRules
   - Reference
 ---
@@ -21,42 +22,41 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code> {{optional_inline}}</dt>
- <dd>
- <p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</p>
- </dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object with some or all of the following properties:</p>
+	<dt><code><var>locales</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</p>
+	</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object with some or all of the following properties:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+			<dt><code>type</code></dt>
+			<dd>The type to use. Possible values are:
+				<ul>
+					<li>"<code>cardinal</code>" for cardinal numbers (refering to the quantity of things). This is the default value.</li>
+					<li>"<code>ordinal</code>" for ordinal number (refering to the ordering or ranking of things, e.g. "1st", "2nd", "3rd" in English).</li>
+				</ul>
+			</dd>
+		</dl>
+		
+		<p>The following properties fall into two groups: <code>minimumIntegerDigits</code>, <code>minimumFractionDigits</code>, and <code>maximumFractionDigits</code> in one group, <code>minimumSignificantDigits</code> and <code>maximumSignificantDigits</code> in the other. If at least one property from the second group is defined, then the first group is ignored.</p>
 
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
-  <dt><code>type</code></dt>
-  <dd>The type to use. Possible values are:
-  <ul>
-   <li>"<code>cardinal</code>" for cardinal numbers (refering to the quantity of things). This is the default value.</li>
-   <li>"<code>ordinal</code>" for ordinal number (refering to the ordering or ranking of things, e.g. "1st", "2nd", "3rd" in English).</li>
-  </ul>
-  </dd>
- </dl>
-
- <p>The following properties fall into two groups: <code>minimumIntegerDigits</code>, <code>minimumFractionDigits</code>, and <code>maximumFractionDigits</code> in one group, <code>minimumSignificantDigits</code> and <code>maximumSignificantDigits</code> in the other. If at least one property from the second group is defined, then the first group is ignored.</p>
- </dd>
- <dd>
- <dl>
-  <dt><code>minimumIntegerDigits</code></dt>
-  <dd>The minimum number of integer digits to use. Possible values are from 1 to 21; the default is 1.</dd>
-  <dt><code>minimumFractionDigits</code></dt>
-  <dd>The minimum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number and percent formatting is 0; the default for currency formatting is the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information).</dd>
-  <dt><code>maximumFractionDigits</code></dt>
-  <dd>The maximum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number formatting is the larger of <code>minimumFractionDigits</code> and 3; the default for currency formatting is the larger of <code>minimumFractionDigits</code> and the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information); the default for percent formatting is the larger of <code>minimumFractionDigits</code> and 0.</dd>
-  <dt><code>minimumSignificantDigits</code></dt>
-  <dd>The minimum number of significant digits to use. Possible values are from 1 to 21; the default is 1.</dd>
-  <dt><code>maximumSignificantDigits</code></dt>
-  <dd>The maximum number of significant digits to use. Possible values are from 1 to 21; the default is 21.</dd>
- </dl>
- </dd>
+		<dl>
+			<dt><code>minimumIntegerDigits</code></dt>
+			<dd>The minimum number of integer digits to use. Possible values are from 1 to 21; the default is 1.</dd>
+			<dt><code>minimumFractionDigits</code></dt>
+			<dd>The minimum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number and percent formatting is 0; the default for currency formatting is the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information).</dd>
+			<dt><code>maximumFractionDigits</code></dt>
+			<dd>The maximum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number formatting is the larger of <code>minimumFractionDigits</code> and 3; the default for currency formatting is the larger of <code>minimumFractionDigits</code> and the number of minor unit digits provided by the <a href="http://www.currency-iso.org/en/home/tables/table-a1.html">ISO 4217 currency code list</a> (2 if the list doesn't provide that information); the default for percent formatting is the larger of <code>minimumFractionDigits</code> and 0.</dd>
+			<dt><code>minimumSignificantDigits</code></dt>
+			<dd>The minimum number of significant digits to use. Possible values are from 1 to 21; the default is 1.</dd>
+			<dt><code>maximumSignificantDigits</code></dt>
+			<dd>The maximum number of significant digits to use. Possible values are from 1 to 21; the default is 21.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -100,16 +100,16 @@ pr.select(42);
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl-pluralrules-constructor', 'Intl.PluralRules() constructor')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl-pluralrules-constructor', 'Intl.PluralRules() constructor')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -119,6 +119,6 @@ pr.select(42);
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.PluralRules")}}</li>
- <li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
+	<li>{{jsxref("Intl.PluralRules")}}</li>
+	<li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.html
@@ -5,9 +5,11 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - PluralRules
   - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
@@ -15,7 +17,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox"><code><var>pluralRule</var>.resolvedOptions()</code></pre>
+<pre class="syntaxbox"><var>pluralRule</var>.resolvedOptions()</pre>
 
 <h3 id="Return_value">Return value</h3>
 
@@ -26,24 +28,24 @@ tags:
 <p>The resulting object has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>pluralCategories</code></dt>
- <dd>An {{jsxref("Array")}} of plural categories used by the given locale, seleced from the list <code>"zero"</code>, <code>"one"</code>, <code>"two"</code>, <code>"few"</code>, <code>"many"</code> and <code>"other"</code>.</dd>
- <dt><code>type</code></dt>
- <dd>The type used (<code>cardinal</code> or <code>ordinal</code>).</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>pluralCategories</code></dt>
+	<dd>An {{jsxref("Array")}} of plural categories used by the given locale, seleced from the list "<code>zero</code>", "<code>one</code>", "<code>two</code>", "<code>few</code>", "<code>many</code>" and "<code>other</code>".</dd>
+	<dt><code>type</code></dt>
+	<dd>The type used (<code>cardinal</code> or <code>ordinal</code>).</dd>
 </dl>
 
 <p>Only one of the following two groups of properties is included:</p>
 
 <dl>
- <dt><code>minimumIntegerDigits</code></dt>
- <dt><code>minimumFractionDigits</code></dt>
- <dt><code>maximumFractionDigits</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if neither <code>minimumSignificantDigits</code> nor <code>maximumSignificantDigits</code> was provided in the <code>options</code> argument.</dd>
- <dt><code>minimumSignificantDigits</code></dt>
- <dt><code>maximumSignificantDigits</code></dt>
- <dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if at least one of them was provided in the <code>options</code> argument.</dd>
+	<dt><code>minimumIntegerDigits</code></dt>
+	<dt><code>minimumFractionDigits</code></dt>
+	<dt><code>maximumFractionDigits</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if neither <code>minimumSignificantDigits</code> nor <code>maximumSignificantDigits</code> was provided in the <code>options</code> argument.</dd>
+	<dt><code>minimumSignificantDigits</code></dt>
+	<dt><code>maximumSignificantDigits</code></dt>
+	<dd>The values provided for these properties in the <code>options</code> argument or filled in as defaults. These properties are present only if at least one of them was provided in the <code>options</code> argument.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -64,25 +66,24 @@ usedOptions.type;                  // "cardinal"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.pluralrules.prototype.resolvedoptions', 'Intl.PluralRules.prototype.resolvedOptions')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.pluralrules.prototype.resolvedoptions', 'Intl.PluralRules.prototype.resolvedOptions')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.PluralRules.resolvedOptions")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.PluralRules.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("PluralRules", "Intl.PluralRules")}}</li>
+	<li>{{jsxref("PluralRules", "Intl.PluralRules")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/select/index.html
@@ -5,27 +5,30 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - PluralRules
+  - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>Intl.PluralRules.prototype.select</code></strong> method returns a String indicating which plural rule to use for locale-aware formatting.</p>
+<p>The <strong><code>Intl.PluralRules.prototype.select()</code></strong> method returns a string indicating which plural rule to use for locale-aware formatting.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate"><code><var>pluralCategory = pluralRule</var>.select(<var>number</var>)</code></pre>
+<pre class="syntaxbox notranslate"><var>pluralCategory = pluralRule</var>.select(<var>number</var>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>number</code></dt>
+ <dt><code><var>number</var></code></dt>
  <dd>The number to get a plural rule for.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A <code>string</code> representing the pluralization category of the <code>number</code>, can be one of <code>zero</code>, <code>one</code>, <code>two</code>, <code>few</code>, <code>many</code> or <code>other</code>.</p>
+<p>A string representing the pluralization category of the <code>number</code>, can be one of <code>zero</code>, <code>one</code>, <code>two</code>, <code>few</code>, <code>many</code> or <code>other</code>.</p>
 
 <h2 id="Description">Description</h2>
 
@@ -54,27 +57,24 @@ new Intl.PluralRules('ar-EG').select(18);
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.pluralrules.prototype.select', 'Intl.PluralRules.select()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.pluralrules.prototype.select', 'Intl.PluralRules.select()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.PluralRules.select")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.PluralRules.select")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("PluralRules", "Intl.PluralRules")}}</li>
+	<li>{{jsxref("Intl.PluralRules")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/supportedlocalesof/index.html
@@ -5,6 +5,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - PluralRules
   - Reference
@@ -15,22 +16,22 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">Intl.PluralRules.supportedLocalesOf(<var>locales</var>[, <var>options</var>])</pre>
+<pre class="syntaxbox notranslate">Intl.PluralRules.supportedLocalesOf(<var>locales</var>[, <var>options</var>])</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
-
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -56,16 +57,16 @@ console.log(Intl.PluralRules.supportedLocalesOf(locales, options).join(', '));
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.pluralrules.supportedlocalesof', 'Intl.PluralRules.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.pluralrules.supportedlocalesof', 'Intl.PluralRules.supportedLocalesOf()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -75,5 +76,5 @@ console.log(Intl.PluralRules.supportedLocalesOf(locales, options).join(', '));
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.PluralRules")}}</li>
+	<li>{{jsxref("Intl.PluralRules")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.html
@@ -2,10 +2,12 @@
 title: Intl.RelativeTimeFormat.prototype.format()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format
 tags:
-  - IntI
   - Internationalization
+  - Intl
   - JavaScript
+  - Localization
   - Method
+  - Prototype
   - Reference
   - RelativeTimeFormat
 ---
@@ -14,8 +16,7 @@ tags:
 <p>The <strong><code>Intl.RelativeTimeFormat.prototype.format()</code></strong> method formats a <code>value</code> and <code>unit</code> according to the locale and formatting options of this {{jsxref("Intl.RelativeTimeFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-format.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,10 +25,10 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>value</var></code></dt>
- <dd>Numeric value to use in the internationalized relative time message.</dd>
- <dt><code><var>unit</var></code></dt>
- <dd>Unit to use in the relative time internationalized message. Possible values are: "<code>year</code>", "<code>quarter</code>", "<code>month</code>", "<code>week</code>", "<code>day</code>", "<code>hour</code>", "<code>minute</code>", "<code>second</code>". Plural forms are also permitted.</dd>
+	<dt><code><var>value</var></code></dt>
+	<dd>Numeric value to use in the internationalized relative time message.</dd>
+	<dt><code><var>unit</var></code></dt>
+	<dd>Unit to use in the relative time internationalized message. Possible values are: "<code>year</code>", "<code>quarter</code>", "<code>month</code>", "<code>week</code>", "<code>day</code>", "<code>hour</code>", "<code>minute</code>", "<code>second</code>". Plural forms are also permitted.</dd>
 </dl>
 
 <h2 id="Description">Description</h2>
@@ -76,28 +77,24 @@ rtf.format(1, "day");
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.RelativeTimeFormat.prototype.format', 'RelativeTimeFormat.format()')}}</td>
-   <td>Stage 4</td>
-   <td></td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.RelativeTimeFormat.prototype.format', 'RelativeTimeFormat.format()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.builtins.Intl.RelativeTimeFormat.format")}}</p>
+<div>{{Compat("javascript.builtins.Intl.RelativeTimeFormat.format")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.RelativeTimeFormat")}}</li>
+	<li>{{jsxref("Intl.RelativeTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.html
@@ -5,27 +5,30 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
   - RelativeTimeFormat
 ---
 <div>{{JSRef}}</div>
 
-<p>The <code>Intl.RelativeTimeFormat.prototype.formatToParts()</code> method returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.</p>
+<p>The <strong><code>Intl.RelativeTimeFormat.prototype.formatToParts()</code></strong> method returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-formattoparts.html")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code>RelativeTimeFormat.formatToParts(value, unit)</code></pre>
+<pre class="brush: js">RelativeTimeFormat.formatToParts(value, unit)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code>value</code></dt>
- <dd>Numeric value to use in the internationalized relative time message.</dd>
- <dt><code>unit</code></dt>
- <dd>Unit to use in the relative time internationalized message. Possible values are: <code>"year"</code>, <code>"quarter"</code>, <code>"month", "week", "day", "hour", "minute", "second"</code>. Plural forms are also permitted.</dd>
+	<dt><code>value</code></dt>
+	<dd>Numeric value to use in the internationalized relative time message.</dd>
+	<dt><code>unit</code></dt>
+	<dd>Unit to use in the relative time internationalized message. Possible values are: "<code>year</code>", "<code>quarter</code>", "<code>month</code>", "<code>week</code>", "<code>day</code>", "<code>hour</code>", "<code>minute</code>", "<code>second</code>". Plural forms are also permitted.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -54,29 +57,24 @@ rtf.formatToParts(100, "day");
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.RelativeTimeFormat.prototype.formatToParts', 'RelativeTimeFormat.formatToParts()')}}</td>
-   <td>Stage 4</td>
-   <td></td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.RelativeTimeFormat.prototype.formatToParts', 'RelativeTimeFormat.formatToParts()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.RelativeTimeFormat.formatToParts")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.RelativeTimeFormat.formatToParts")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
+	<li>{{jsxref("RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - RelativeTimeFormat
   - Reference
 ---
@@ -14,32 +15,31 @@ tags:
 <p>The <strong><code>Intl.RelativeTimeFormat</code></strong> object enables language-sensitive relative time formatting.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-relativetimeformat.html")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
- <dt>{{jsxref("Intl/RelativeTimeFormat/RelativeTimeFormat", "Intl.RelativeTimeFormat()")}}</dt>
- <dd>Creates a new <code>Intl.RelativeTimeFormat</code> object.</dd>
+	<dt>{{jsxref("Intl/RelativeTimeFormat/RelativeTimeFormat", "Intl.RelativeTimeFormat()")}}</dt>
+	<dd>Creates a new <code>Intl.RelativeTimeFormat</code> object.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
- <dt>{{jsxref("RelativeTimeFormat.supportedLocalesOf", "Intl.RelativeTimeFormat.supportedLocalesOf()")}}</dt>
- <dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
+	<dt>{{jsxref("RelativeTimeFormat.supportedLocalesOf", "Intl.RelativeTimeFormat.supportedLocalesOf()")}}</dt>
+	<dd>Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{jsxref("RelativeTimeFormat.format", "Intl.RelativeTimeFormat.prototype.format()")}}</dt>
- <dd>Formats a <code>value</code> and a <code>unit</code> according to the locale and formatting options of the given {{jsxref("Intl.RelativeTimeFormat")}} object.</dd>
- <dt>{{jsxref("RelativeTimeFormat.formatToParts", "Intl.RelativeTimeFormat.prototype.formatToParts()")}}</dt>
- <dd>Returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.</dd>
- <dt>{{jsxref("RelativeTimeFormat.resolvedOptions", "Intl.RelativeTimeFormat.prototype.resolvedOptions()")}}</dt>
- <dd>Returns a new object with properties reflecting the locale and formatting options computed during initialization of the object.</dd>
+	<dt>{{jsxref("RelativeTimeFormat.format", "Intl.RelativeTimeFormat.prototype.format()")}}</dt>
+	<dd>Formats a <code>value</code> and a <code>unit</code> according to the locale and formatting options of the given {{jsxref("Intl.RelativeTimeFormat")}} object.</dd>
+	<dt>{{jsxref("RelativeTimeFormat.formatToParts", "Intl.RelativeTimeFormat.prototype.formatToParts()")}}</dt>
+	<dd>Returns an {{jsxref("Array")}} of objects representing the relative time format in parts that can be used for custom locale-aware formatting.</dd>
+	<dt>{{jsxref("RelativeTimeFormat.resolvedOptions", "Intl.RelativeTimeFormat.prototype.resolvedOptions()")}}</dt>
+	<dd>Returns a new object with properties reflecting the locale and formatting options computed during initialization of the object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -87,16 +87,16 @@ rtf.formatToParts(100, "day");
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#relativetimeformat-objects', 'RelativeTimeFormat')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#relativetimeformat-objects', 'RelativeTimeFormat')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -106,6 +106,6 @@ rtf.formatToParts(100, "day");
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl")}}</li>
- <li><a href="https://developers.google.com/web/updates/2018/10/intl-relativetimeformat">The Intl.RelativeTimeFormat API</a></li>
+	<li>{{jsxref("Intl")}}</li>
+	<li><a href="https://developers.google.com/web/updates/2018/10/intl-relativetimeformat">The Intl.RelativeTimeFormat API</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/relativetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/relativetimeformat/index.html
@@ -7,6 +7,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Reference
   - RelativeTimeFormat
 ---
@@ -21,36 +22,36 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code> {{optional_inline}}</dt>
- <dd>
- <p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</p>
- </dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object with some or all of the following properties:</p>
-
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
-  <dt><code>numeric</code></dt>
-  <dd>
-   The format of output message. Possible values are:
-   <ul>
-    <li>"<code>always</code>" (default, e.g., <code>1 day ago</code>),</li>
-    <li>or "<code>auto</code>" (e.g., <code>yesterday</code>). The "<code>auto</code>" value allows to not always have to use numeric values in the output.</li>
-   </ul>
-  </dd>
-  <dt><code>style</code></dt>
-  <dd>
-   The length of the internationalized message. Possible values are:
-   <ul>
-    <li>"<code>long</code>" (default, e.g., <code>in 1 month</code>)</li>
-    <li>"<code>short</code>" (e.g., <code>in 1 mo.</code>),</li>
-    <li>or "<code>narrow</code>" (e.g., <code>in 1 mo.</code>). The narrow style could be similar to the short style for some locales.</li>
-   </ul>
-  </dd>
- </dl>
- </dd>
+	<dt><code><var>locales</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>A string with a BCP 47 language tag, or an array of such strings. For the general form and interpretation of the <code><var>locales</var></code> argument, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</p>
+	</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object with some or all of the following properties:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Global_Objects/Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+			<dt><code>numeric</code></dt>
+			<dd>
+				The format of output message. Possible values are:
+				<ul>
+					<li>"<code>always</code>" (default, e.g., <code>1 day ago</code>),</li>
+					<li>or "<code>auto</code>" (e.g., <code>yesterday</code>). The "<code>auto</code>" value allows to not always have to use numeric values in the output.</li>
+				</ul>
+			</dd>
+			<dt><code>style</code></dt>
+			<dd>
+				The length of the internationalized message. Possible values are:
+				<ul>
+					<li>"<code>long</code>" (default, e.g., <code>in 1 month</code>)</li>
+					<li>"<code>short</code>" (e.g., <code>in 1 mo.</code>),</li>
+					<li>or "<code>narrow</code>" (e.g., <code>in 1 mo.</code>). The narrow style could be similar to the short style for some locales.</li>
+				</ul>
+			</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -95,16 +96,16 @@ rtf.format(1, "day");
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl-relativetimeformat-constructor', 'RelativeTimeFormat()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl-relativetimeformat-constructor', 'RelativeTimeFormat()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -114,7 +115,7 @@ rtf.format(1, "day");
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.RelativeTimeFormat")}}</li>
- <li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
- <li><a href="https://developers.google.com/web/updates/2018/10/intl-relativetimeformat">The Intl.RelativeTimeFormat API</a></li>
+	<li>{{jsxref("Intl.RelativeTimeFormat")}}</li>
+	<li>{{jsxref("Global_Objects/Intl", "Intl")}}</li>
+	<li><a href="https://developers.google.com/web/updates/2018/10/intl-relativetimeformat">The Intl.RelativeTimeFormat API</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.html
@@ -6,8 +6,10 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Prototype
+  - Reference
   - RelativeTimeFormat
 ---
 <div>{{JSRef}}</div>
@@ -15,6 +17,7 @@ tags:
 <p>The <strong><code>Intl.RelativeTimeFormat.prototype.resolvedOptions()</code></strong> method returns a new object with properties reflecting the locale and relative time formatting options computed during initialization of this {{jsxref("RelativeTimeFormat")}} object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-resolvedoptions.html")}}</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -29,25 +32,25 @@ tags:
 <p>The resulting object has the following properties:</p>
 
 <dl>
- <dt><code>locale</code></dt>
- <dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
- <dt><code>style</code></dt>
- <dd>The length of the internationalized message. Possible values are:
- <ul>
-  <li><code>"long"</code> (default, e.g., <code>in 1 month</code>)</li>
-  <li><code>"short"</code> (e.g., <code>in 1 mo.</code>),</li>
-  <li>or <code>"narrow"</code> (e.g., <code>in 1 mo.</code>). The narrow style could be similar to the short style for some locales.</li>
- </ul>
- </dd>
- <dt><code>numeric</code></dt>
- <dd>The format of output message. Possible values are:
- <ul>
-  <li><code>"always"</code> (default, e.g., <code>1 day ago</code>),</li>
-  <li>or <code>"auto"</code> (e.g., <code>yesterday</code>). The <code>"auto"</code> value allows to not always have to use numeric values in the output.</li>
- </ul>
- </dd>
- <dt><code>numberingSystem</code></dt>
- <dd>The value requested using the Unicode extension key <code>"nu"</code> or filled in as a default.</dd>
+	<dt><code>locale</code></dt>
+	<dd>The BCP 47 language tag for the locale actually used. If any Unicode extension values were requested in the input BCP 47 language tag that led to this locale, the key-value pairs that were requested and are supported for this locale are included in <code>locale</code>.</dd>
+	<dt><code>style</code></dt>
+	<dd>The length of the internationalized message. Possible values are:
+		<ul>
+			<li>"<code>long</code>" (default, e.g., <code>in 1 month</code>)</li>
+			<li>"<code>short</code>" (e.g., <code>in 1 mo.</code>),</li>
+			<li>or "<code>narrow</code>" (e.g., <code>in 1 mo.</code>). The narrow style could be similar to the short style for some locales.</li>
+		</ul>
+	</dd>
+	<dt><code>numeric</code></dt>
+	<dd>The format of output message. Possible values are:
+		<ul>
+			<li>"<code>always</code>" (default, e.g., <code>1 day ago</code>),</li>
+			<li>or "<code>auto</code>" (e.g., <code>yesterday</code>). The "<code>auto</code>" value allows to not always have to use numeric values in the output.</li>
+		</ul>
+	</dd>
+	<dt><code>numberingSystem</code></dt>
+	<dd>The value requested using the Unicode extension key "<code>nu</code>" or filled in as a default.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
@@ -66,29 +69,24 @@ usedOptions.numberingSystem; // "latn"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-intl.relativetimeformat.prototype.resolvedoptions', 'RelativeTimeFormat.resolvedOptions()')}}</td>
-   <td>Stage 4</td>
-   <td></td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-intl.relativetimeformat.prototype.resolvedoptions', 'RelativeTimeFormat.resolvedOptions()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-<p>{{Compat("javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions")}}</p>
-</div>
+<div>{{Compat("javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions")}}</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
+	<li>{{jsxref("RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.html
@@ -6,6 +6,7 @@ tags:
   - Internationalization
   - Intl
   - JavaScript
+  - Localization
   - Method
   - Reference
   - RelativeTimeFormat
@@ -15,8 +16,7 @@ tags:
 <p>The <strong><code>Intl.RelativeTimeFormat.supportedLocalesOf()</code></strong> method returns an array containing those of the provided locales that are supported in date and time formatting without having to fall back to the runtime's default locale.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-relativetimeformat-prototype-supportedlocalesof.html","shorter")}}</div>
-
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
+<!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -25,17 +25,17 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>locales</var></code></dt>
- <dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>
- <p>An object that may have the following property:</p>
-
- <dl>
-  <dt><code>localeMatcher</code></dt>
-  <dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
- </dl>
- </dd>
+	<dt><code><var>locales</var></code></dt>
+	<dd>A string with a BCP 47 language tag, or an array of such strings. For the general form of the <code><var>locales</var></code> argument, see the {{jsxref("Intl", "Intl", "#Locale_identification_and_negotiation", 1)}} page.</dd>
+	<dt><code><var>options</var></code> {{optional_inline}}</dt>
+	<dd>
+		<p>An object that may have the following property:</p>
+		
+		<dl>
+			<dt><code>localeMatcher</code></dt>
+			<dd>The locale matching algorithm to use. Possible values are "<code>lookup</code>" and "<code>best fit</code>"; the default is "<code>best fit</code>". For information about this option, see the {{jsxref("Intl", "Intl", "#Locale_negotiation", 1)}} page.</dd>
+		</dl>
+	</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -61,16 +61,16 @@ console.log(Intl.RelativeTimeFormat.supportedLocalesOf(locales, options).join(',
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.RelativeTimeFormat.supportedLocalesOf', 'RelativeTimeFormat.supportedLocalesOf()')}}</td>
-  </tr>
- </tbody>
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('ES Int Draft', '#sec-Intl.RelativeTimeFormat.supportedLocalesOf', 'RelativeTimeFormat.supportedLocalesOf()')}}</td>
+		</tr>
+	</tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -80,5 +80,5 @@ console.log(Intl.RelativeTimeFormat.supportedLocalesOf(locales, options).join(',
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("Intl.RelativeTimeFormat")}}</li>
+	<li>{{jsxref("Intl.RelativeTimeFormat")}}</li>
 </ul>


### PR DESCRIPTION
- Adjust indents
- Adjust tags
- changed hidden-div of interactive-examples instruction into html comment