### PR TITLE
corrected three typos

### DIFF
--- a/files/en-us/learn/css/building_blocks/the_box_model/index.html
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.html
@@ -23,7 +23,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Objective:</th>
-   <td>To learn about the CSS Box Model, what makes up the box model and how to switch to the alternate model.</td>
+   <td>To learn about the CSS Box Model, what makes up the box model and how to switch to the alternative model.</td>
   </tr>
  </tbody>
 </table>
@@ -98,7 +98,7 @@ tags:
 
 <h2 id="What_is_the_CSS_box_model">What is the CSS box model?</h2>
 
-<p>The full CSS box model applies to block boxes, inline boxes only use some of the behavior defined in the box model. The model defines how the different parts of a box — margin, border, padding, and content — work together to create a box that you can see on the page. To add some additional complexity, there is a standard and an alternate box model.</p>
+<p>The full CSS box model applies to block boxes, inline boxes only use some of the behavior defined in the box model. The model defines how the different parts of a box — margin, border, padding, and content — work together to create a box that you can see on the page. To add some additional complexity, there is a standard and an alternative box model.</p>
 
 <h3 id="Parts_of_a_box">Parts of a box</h3>
 
@@ -142,7 +142,7 @@ tags:
 
 <p>You might think it is rather inconvenient to have to add up the border and padding to get the real size of the box, and you would be right! For this reason, CSS had an alternative box model introduced some time after the standard box model. Using this model, any width is the width of the visible box on the page, therefore the content area width is that width minus the width for the padding and border. The same CSS as used above would give the below result (width = 350px, height = 150px).</p>
 
-<p><img alt="Showing the size of the box when the alternate box model is being used." src="https://mdn.mozillademos.org/files/16557/alternate-box-model.png" style="height: 240px; width: 440px;"></p>
+<p><img alt="Showing the size of the box when the alternative box model is being used." src="https://mdn.mozillademos.org/files/16557/alternate-box-model.png" style="height: 240px; width: 440px;"></p>
 
 <p>By default, browsers use the standard box model. If you want to turn on the alternative model for an element you do so by setting <code>box-sizing: border-box</code> on it. By doing this you are telling the browser to take the border box as the area defined by any size you set.</p>
 


### PR DESCRIPTION
I've corrected three typos; the article is about the alternative box-model, not the alternate box model. There is one more typo at line 170, though (still alternate instead of alternative); however, being that the name of a class, and since an exercise is embed right after, I'm afraid that changing it may cause problems.