### PR TITLE
Typo fix in “Image file type and format guide”

### DIFF
--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -113,7 +113,7 @@ tags:
 
 <div id="table-of-less-used-image-file-types">
 <div class="note">
-<p><strong>Note:</strong> The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virually zero market share).</p>
+<p><strong>Note:</strong> The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).</p>
 </div>
 </div>
 


### PR DESCRIPTION
This change also fixes the typo in the HTML/Element/img article, where
the same content is transcluded.

Fixes https://github.com/mdn/content/issues/894