### PR TITLE
adding a path() example

### DIFF
--- a/files/en-us/web/css/path()/index.html
+++ b/files/en-us/web/css/path()/index.html
@@ -32,6 +32,12 @@ tags:
 path(evenodd,"M 10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80");
 </pre>
 
+<h3 id="Use_in_offset_path">Use as the value of offset-path</h3>
+
+<p>The <code>path()</code> function is used to create a path for the item to travel round. Changing any of the values will cause the path to not neatly run round the circle.</p>
+
+<p>{{EmbedGHLiveSample("css-examples/path/offset-path.html", '100%', 960)}}</p>
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">


### PR DESCRIPTION
In https://github.com/mdn/sprints/issues/2162 @chrisdavidmills asked for an example for the path() page. This PR adds an example.

Page: https://developer.mozilla.org/en-US/docs/Web/CSS/path()