### PR TITLE
SSE: add a reference to the Mercure protocol

### DIFF
--- a/files/en-us/web/api/server-sent_events/index.html
+++ b/files/en-us/web/api/server-sent_events/index.html
@@ -58,6 +58,7 @@ tags:
 <h3 id="Tools">Tools</h3>
 
 <ul>
+ <li><a href="https://mercure.rocks">Mercure: a real-time communication protocol (publish-subscribe) built on top of SSE</a></li>
  <li><a href="https://github.com/EventSource/eventsource">EventSource polyfill for Node.js</a></li>
  <li>Remy Sharp’s <a class="link-https" href="https://github.com/remy/polyfills/blob/master/EventSource.js">EventSource polyfill</a></li>
  <li>Yaffle’s <a class="link-https" href="https://github.com/Yaffle/EventSource">EventSource polyfill</a></li>


### PR DESCRIPTION
Add a reference to [Mercure](https://mercure.rocks), a real-time communication protocol (publish-subscribe) built on top of SSE.