### PR TITLE
fix: angle brackets in IDs/anchors

### DIFF
--- a/files/en-us/learn/html/tables/advanced/index.html
+++ b/files/en-us/learn/html/tables/advanced/index.html
@@ -38,7 +38,7 @@ tags:
  </tbody>
 </table>
 
-<h2 id="Adding_a_caption_to_your_table_with_&lt;caption&gt;">Adding a caption to your table with &lt;caption&gt;</h2>
+<h2 id="Adding_a_caption_to_your_table_with_caption">Adding a caption to your table with &lt;caption&gt;</h2>
 
 <p>You can give your table a caption by putting it inside a {{htmlelement("caption")}} element and nesting that inside the {{htmlelement("table")}} element. You should put it just below the opening <code>&lt;table&gt;</code> tag.</p>
 

--- a/files/en-us/mozilla/projects/nss/deprecated_ssl_functions/index.html
+++ b/files/en-us/mozilla/projects/nss/deprecated_ssl_functions/index.html
@@ -24,7 +24,7 @@ tags:
       <td><a class="external" href="/NSS/SSL_functions/sslfnc.html#1084747"><code>SSL_CipherPrefSetDefault</code></a></td>
     </tr>
     <tr>
-      <td><a class="external" href="/NSS/SSL_functions/sslfnc.html##1206365"><code>SSL_EnableDefault</code></a></td>
+      <td><a class="external" href="/NSS/SSL_functions/sslfnc.html#1206365"><code>SSL_EnableDefault</code></a></td>
       <td><a class="external" href="http://mxr.mozilla.org/security/ident?i=SSL_EnableDefault">MXR</a></td>
       <td><a class="external" href="/NSS/SSL_functions/sslfnc.html#1068466"><code>SSL_OptionSetDefault</code></a></td>
     </tr>

--- a/files/en-us/web/api/htmlelement/change_event/index.html
+++ b/files/en-us/web/api/htmlelement/change_event/index.html
@@ -47,7 +47,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="&lt;select&gt;_element">&lt;select&gt; element</h3>
+<h3 id="select_element">&lt;select&gt; element</h3>
 
 <div id="select-example">
 <h4 id="HTML">HTML</h4>

--- a/files/en-us/web/api/htmlselectelement/index.html
+++ b/files/en-us/web/api/htmlselectelement/index.html
@@ -110,7 +110,7 @@ console.log(select.selectedIndex); // 1
 console.log(select.options[select.selectedIndex].value) // Second
 </pre>
 
-<p>A better way to track changes to the user's selection is to watch for the {{domxref("HTMLElement/change_event", "change")}} event to occur on the <code>&lt;select&gt;</code>. This will tell you when the value changes, and you can then update anything you need to. See <a href="/en-US/docs/Web/API/HTMLElement/change_event#&lt;select&gt;_element">the example provided</a> in the documentation for the <code>change</code> event for details.</p>
+<p>A better way to track changes to the user's selection is to watch for the {{domxref("HTMLElement/change_event", "change")}} event to occur on the <code>&lt;select&gt;</code>. This will tell you when the value changes, and you can then update anything you need to. See <a href="/en-US/docs/Web/API/HTMLElement/change_event#select_element">the example provided</a> in the documentation for the <code>change</code> event for details.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/validitystate/typemismatch/index.html
+++ b/files/en-us/web/api/validitystate/typemismatch/index.html
@@ -8,7 +8,7 @@ tags:
   - Property
   - Reference
 ---
-<p>{{draft}}The read-only <strong><code>typeMismatch</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code><a href="/en-US/docs/Web/HTML/Element/input#&lt;input&gt;_types">type</a></code> attribute.</p>
+<p>{{draft}}The read-only <strong><code>typeMismatch</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code><a href="/en-US/docs/Web/HTML/Element/input#input_types">type</a></code> attribute.</p>
 
 <p>If the <code>type</code> attribute expects specific strings, such as the {{HTMLElement("input/email", "email")}} and {{HTMLElement("input/url", "url")}} types and the value don't doesn't conform to the constraints set by the type, the <code>typeMismatch</code> property will be true.</p>
 

--- a/files/en-us/web/css/background-color/index.html
+++ b/files/en-us/web/css/background-color/index.html
@@ -53,12 +53,12 @@ background-color: transparent;
 background-color: transparent;
 </pre>
 
-<p>The <code>background-color</code> property is specified as a single <code><a href="#&lt;color&gt;">&lt;color&gt;</a></code> value.</p>
+<p>The <code>background-color</code> property is specified as a single <code><a href="#color">&lt;color&gt;</a></code> value.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
-	<dt><a id="&lt;color&gt;"></a>{{cssxref("&lt;color&gt;")}}</dt>
+	<dt><a id="color"></a>{{cssxref("&lt;color&gt;")}}</dt>
 	<dd>The uniform color of the background. It is rendered behind any {{cssxref("background-image")}} that is specified, although the color will still be visible through any transparency in the image.</dd>
 </dl>
 

--- a/files/en-us/web/css/background-position/index.html
+++ b/files/en-us/web/css/background-position/index.html
@@ -46,12 +46,12 @@ background-position: initial;
 background-position: unset;
 </pre>
 
-<p>The <code>background-position</code> property is specified as one or more <code><a href="#&lt;position&gt;">&lt;position&gt;</a></code> values, separated by commas.</p>
+<p>The <code>background-position</code> property is specified as one or more <code><a href="#position">&lt;position&gt;</a></code> values, separated by commas.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="&lt;position&gt;"><code>&lt;position&gt;</code></dt>
+ <dt id="position"><code>&lt;position&gt;</code></dt>
  <dd>A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be <code>center</code>. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s).</dd>
  <dd>
  <p><strong>1-value syntax:</strong> the value may be:</p>

--- a/files/en-us/web/css/background/index.html
+++ b/files/en-us/web/css/background/index.html
@@ -53,34 +53,34 @@ background: no-repeat center/80% url("../img/image.png");
 <ul>
  <li>Each layer may include zero or one occurrences of any of the following values:
   <ul>
-   <li><code><a href="#&lt;attachment&gt;">&lt;attachment&gt;</a></code></li>
-   <li><code><a href="#&lt;bg-image&gt;">&lt;bg-image&gt;</a></code></li>
-   <li><code><a href="#&lt;position&gt;">&lt;position&gt;</a></code></li>
-   <li><code><a href="#&lt;bg-size&gt;">&lt;bg-size&gt;</a></code></li>
-   <li><code><a href="#&lt;repeat-style&gt;">&lt;repeat-style&gt;</a></code></li>
+   <li><code><a href="#attachment">&lt;attachment&gt;</a></code></li>
+   <li><code><a href="#bg-image">&lt;bg-image&gt;</a></code></li>
+   <li><code><a href="#position">&lt;position&gt;</a></code></li>
+   <li><code><a href="#bg-size">&lt;bg-size&gt;</a></code></li>
+   <li><code><a href="#repeat-style">&lt;repeat-style&gt;</a></code></li>
   </ul>
  </li>
- <li>The <code><a href="#&lt;bg-size&gt;">&lt;bg-size&gt;</a></code> value may only be included immediately after <code><a href="#&lt;position&gt;">&lt;position&gt;</a></code>, separated with the '/' character, like this: "<code>center/80%</code>".</li>
- <li>The <code><a href="#&lt;box&gt;">&lt;box&gt;</a></code> value may be included zero, one, or two times. If included once, it sets both {{cssxref("background-origin")}} and {{cssxref("background-clip")}}. If it is included twice, the first occurrence sets {{cssxref("background-origin")}}, and the second sets {{cssxref("background-clip")}}.</li>
- <li>The <code><a href="#&lt;background-color&gt;">&lt;background-color&gt;</a></code> value may only be included in the last layer specified.</li>
+ <li>The <code><a href="#bg-size">&lt;bg-size&gt;</a></code> value may only be included immediately after <code><a href="#position">&lt;position&gt;</a></code>, separated with the '/' character, like this: "<code>center/80%</code>".</li>
+ <li>The <code><a href="#box">&lt;box&gt;</a></code> value may be included zero, one, or two times. If included once, it sets both {{cssxref("background-origin")}} and {{cssxref("background-clip")}}. If it is included twice, the first occurrence sets {{cssxref("background-origin")}}, and the second sets {{cssxref("background-clip")}}.</li>
+ <li>The <code><a href="#background-color">&lt;background-color&gt;</a></code> value may only be included in the last layer specified.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="&lt;attachment&gt;"><code>&lt;attachment&gt;</code></dt>
+ <dt id="attachment"><code>&lt;attachment&gt;</code></dt>
  <dd>See {{cssxref("background-attachment")}}</dd>
- <dt id="&lt;box&gt;"><code>&lt;box&gt;</code></dt>
+ <dt id="box"><code>&lt;box&gt;</code></dt>
  <dd>See {{cssxref("background-clip")}} and {{cssxref("background-origin")}}</dd>
- <dt id="&lt;background-color&gt;"><code>&lt;background-color&gt;</code></dt>
+ <dt id="background-color"><code>&lt;background-color&gt;</code></dt>
  <dd>See {{cssxref("background-color")}}</dd>
- <dt id="&lt;bg-image&gt;"><code>&lt;bg-image&gt;</code></dt>
+ <dt id="bg-image"><code>&lt;bg-image&gt;</code></dt>
  <dd>See {{Cssxref("background-image")}}</dd>
- <dt id="&lt;position&gt;"><code>&lt;position&gt;</code></dt>
+ <dt id="position"><code>&lt;position&gt;</code></dt>
  <dd>See {{cssxref("background-position")}}</dd>
- <dt id="&lt;repeat-style&gt;"><code>&lt;repeat-style&gt;</code></dt>
+ <dt id="repeat-style"><code>&lt;repeat-style&gt;</code></dt>
  <dd>See {{cssxref("background-repeat")}}</dd>
- <dt id="&lt;bg-size&gt;"><code>&lt;bg-size&gt;</code></dt>
+ <dt id="bg-size"><code>&lt;bg-size&gt;</code></dt>
  <dd>See {{cssxref("background-size")}}.</dd>
 </dl>
 

--- a/files/en-us/web/css/cursor/index.html
+++ b/files/en-us/web/css/cursor/index.html
@@ -40,9 +40,9 @@ cursor: initial;
 cursor: unset;
 </pre>
 
-<p>The <code>cursor</code> property is specified as zero or more <code><a href="#&lt;url&gt;">&lt;url&gt;</a></code> values, separated by commas, followed by a single mandatory <a href="#Keyword_values">keyword value</a>. Each <code>&lt;url&gt;</code> should point to an image file. The browser will try to load the first image specified, falling back to the next if it can't, and falling back to the keyword value if no images could be loaded (or if none were specified).</p>
+<p>The <code>cursor</code> property is specified as zero or more <code><a href="#url">&lt;url&gt;</a></code> values, separated by commas, followed by a single mandatory <a href="#Keyword_values">keyword value</a>. Each <code>&lt;url&gt;</code> should point to an image file. The browser will try to load the first image specified, falling back to the next if it can't, and falling back to the keyword value if no images could be loaded (or if none were specified).</p>
 
-<p>Each <code>&lt;url&gt;</code> may be optionally followed by a pair of space-separated numbers, which represent <code><a href="#&lt;x&gt; &lt;y&gt;">&lt;x&gt;&lt;y&gt;</a></code> coordinates. These will set the cursor's hotspot, relative to the top-left corner of the image.</p>
+<p>Each <code>&lt;url&gt;</code> may be optionally followed by a pair of space-separated numbers, which represent <code><a href="#x_y">&lt;x&gt;&lt;y&gt;</a></code> coordinates. These will set the cursor's hotspot, relative to the top-left corner of the image.</p>
 
 <p>For example, this specifies two images using <code>&lt;url&gt;</code> values, providing <code>&lt;x&gt;&lt;y&gt;</code> coordinates for the second one, and falling back to the <code>progress</code> keyword value if neither image can be loaded:</p>
 
@@ -51,9 +51,9 @@ cursor: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="&lt;url&gt;">&lt;url&gt;</code></dt>
+ <dt><code id="url">&lt;url&gt;</code></dt>
  <dd>A <code>url(…)</code> or a comma separated list <code>url(…), url(…), …</code>, pointing to an image file. More than one {{cssxref("&lt;url&gt;")}} may be provided as fallbacks, in case some cursor image types are not supported. A non-URL fallback (one or more of the keyword values) <em>must</em> be at the end of the fallback list. See <a href="/en-US/docs/Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property">Using URL values for the cursor property</a> for more details.</dd>
- <dt><code id="&lt;x&gt; &lt;y&gt;">&lt;x&gt;</code> <code>&lt;y&gt;</code> {{experimental_inline}}</dt>
+ <dt><code id="x_y">&lt;x&gt;</code> <code>&lt;y&gt;</code> {{experimental_inline}}</dt>
  <dd>Optional x- and y-coordinates. Two unitless nonnegative numbers less than 32.</dd>
  <dt><span id="Keyword_values">Keyword values</span></dt>
  <dd>

--- a/files/en-us/web/css/flex-basis/index.html
+++ b/files/en-us/web/css/flex-basis/index.html
@@ -40,12 +40,12 @@ flex-basis: initial;
 flex-basis: unset;
 </pre>
 
-<p>The <code>flex-basis</code> property is specified as either the keyword <code><a href="#content">content</a></code> or a <code><a href="#&lt;'width'>">&lt;'width'&gt;</a></code>.</p>
+<p>The <code>flex-basis</code> property is specified as either the keyword <code><a href="#content">content</a></code> or a <code><a href="#width">&lt;'width'&gt;</a></code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="&lt;'width'&gt;">&lt;'width'&gt;</code></dt>
+ <dt><code id="width">&lt;'width'&gt;</code></dt>
  <dd>An absolute {{cssxref("&lt;length&gt;")}}, a {{cssxref("&lt;percentage&gt;")}} of the parent flex container's main size property, or the keyword <code>auto</code>. Negative values are invalid. Defaults to <code>auto</code>.</dd>
  <dt><code id="content">content</code></dt>
  <dd>Indicates automatic sizing, based on the flex item’s content.</dd>

--- a/files/en-us/web/css/flex-grow/index.html
+++ b/files/en-us/web/css/flex-grow/index.html
@@ -27,12 +27,12 @@ flex-grow: initial;
 flex-grow: unset;
 </pre>
 
-<p>The <code>flex-grow</code> property is specified as a single <code><a href="#&lt;number&gt;">&lt;number&gt;</a></code>.</p>
+<p>The <code>flex-grow</code> property is specified as a single <code><a href="#number">&lt;number&gt;</a></code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="&lt;number&gt;"><code>&lt;number&gt;</code></a></dt>
+ <dt><a id="number"><code>&lt;number&gt;</code></a></dt>
  <dd>See {{cssxref("&lt;number&gt;")}}. Negative values are invalid. Defaults to 0.</dd>
 </dl>
 

--- a/files/en-us/web/css/flex-shrink/index.html
+++ b/files/en-us/web/css/flex-shrink/index.html
@@ -31,12 +31,12 @@ flex-shrink: initial;
 flex-shrink: unset;
 </pre>
 
-<p>The <code>flex-shrink</code> property is specified as a single <code><a href="#&lt;number&gt;">&lt;number&gt;</a></code>.</p>
+<p>The <code>flex-shrink</code> property is specified as a single <code><a href="#number">&lt;number&gt;</a></code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code id="&lt;number&gt;">&lt;number&gt;</code></dt>
+ <dt><code id="number">&lt;number&gt;</code></dt>
  <dd>See {{cssxref("&lt;number&gt;")}}. Negative values are invalid. Defaults to 1.</dd>
 </dl>
 

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -62,7 +62,7 @@ flex: unset;
  <li><strong>One-value syntax:</strong> the value must be one of:
 
   <ul>
-   <li>a <code>&lt;number&gt;</code>: In this case it is interpreted as <code>flex: &lt;number&gt; 1 0</code>; the <code><a href="#&lt;'flex-shrink'>">&lt;flex-shrink&gt;</a></code> value is assumed to be 1 and the <code><a href="#&lt;'flex-basis'>">&lt;flex-basis&gt;</a></code> value is assumed to be <code>0</code>.</li>
+   <li>a <code>&lt;number&gt;</code>: In this case it is interpreted as <code>flex: &lt;number&gt; 1 0</code>; the <code><a href="#flex-shrink">&lt;flex-shrink&gt;</a></code> value is assumed to be 1 and the <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code> value is assumed to be <code>0</code>.</li>
    <li>one of the keywords: <code><a href="#none">none</a></code>, <code><a href="#auto">auto</a></code>, or <code>initial</code>.</li>
   </ul>
  </li>
@@ -70,22 +70,22 @@ flex: unset;
   <ul>
    <li>The first value must be:
     <ul>
-     <li>a {{cssxref("&lt;number&gt;")}} and it is interpreted as <code><a href="#&lt;'flex-grow'>">&lt;flex-grow&gt;</a></code>.</li>
+     <li>a {{cssxref("&lt;number&gt;")}} and it is interpreted as <code><a href="flex-grow">&lt;flex-grow&gt;</a></code>.</li>
     </ul>
    </li>
    <li>The second value must be one of:
     <ul>
-     <li>a {{cssxref("&lt;number&gt;")}}: then it is interpreted as <code><a href="#&lt;'flex-shrink'>">&lt;flex-shrink&gt;</a></code>.</li>
-     <li>a valid value for {{cssxref("width")}}: then it is interpreted as <code><a href="#&lt;'flex-basis'>">&lt;flex-basis&gt;</a></code>.</li>
+     <li>a {{cssxref("&lt;number&gt;")}}: then it is interpreted as <code><a href="#flex-shrink">&lt;flex-shrink&gt;</a></code>.</li>
+     <li>a valid value for {{cssxref("width")}}: then it is interpreted as <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code>.</li>
     </ul>
    </li>
   </ul>
  </li>
  <li><strong>Three-value syntax:</strong> the values must be in the following order:
   <ol>
-   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="#&lt;'flex-grow'>">&lt;flex-grow&gt;</a></code>.</li>
-   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="#&lt;'flex-grow'>">&lt;flex-shrink&gt;</a></code>.</li>
-   <li>a valid value for {{cssxref("width")}} for <code><a href="#&lt;'flex-basis'>">&lt;flex-basis&gt;</a></code>.</li>
+   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="flex-grow">&lt;flex-grow&gt;</a></code>.</li>
+   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="flex-shrink">&lt;flex-shrink&gt;</a></code>.</li>
+   <li>a valid value for {{cssxref("width")}} for <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code>.</li>
   </ol>
  </li>
 </ul>

--- a/files/en-us/web/css/font-family/index.html
+++ b/files/en-us/web/css/font-family/index.html
@@ -49,7 +49,7 @@ font-family: initial;
 font-family: unset;
 </pre>
 
-<p>The <code>font-family</code> property lists one or more font families, separated by commas. Each font family is specified as either a <code><a href="#&lt;family-name&gt;">&lt;family-name&gt;</a></code> or a <code><a href="#&lt;generic-name&gt;">&lt;generic-name&gt;</a></code> value.</p>
+<p>The <code>font-family</code> property lists one or more font families, separated by commas. Each font family is specified as either a <code><a href="#family-name">&lt;family-name&gt;</a></code> or a <code><a href="#generic-name">&lt;generic-name&gt;</a></code> value.</p>
 
 <p>The example below lists two font families, the first with a <code>&lt;family-name&gt;</code> and the second with a <code>&lt;generic-name&gt;</code>:</p>
 
@@ -58,9 +58,9 @@ font-family: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="&lt;family-name&gt;"><code>&lt;family-name&gt;</code></a></dt>
+ <dt><a id="family-name"><code>&lt;family-name&gt;</code></a></dt>
  <dd>The name of a font family. For example, "Times" and "Helvetica" are font families. Font family names containing whitespace should be quoted.</dd>
- <dt><a id="&lt;generic-name&gt;"><code>&lt;generic-name&gt;</code></a></dt>
+ <dt><a id="generic-name"><code>&lt;generic-name&gt;</code></a></dt>
  <dd>
  <p>Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names are keywords and must not be quoted. A generic font family should be the last item in the list of font family names. The following keywords are defined:</p>
 

--- a/files/en-us/web/css/line-height-step/index.html
+++ b/files/en-us/web/css/line-height-step/index.html
@@ -21,13 +21,13 @@ line-height-step: 18pt;
 <p>The <code>line-height-step</code> property is specified as any one of the following:</p>
 
 <ul>
- <li>a <code><a href="#&lt;length&gt;">&lt;length&gt;</a></code>.</li>
+ <li>a <code><a href="#length">&lt;length&gt;</a></code>.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="&lt;length&gt;"><code>&lt;length&gt;</code></a></dt>
+ <dt><a id="length"><code>&lt;length&gt;</code></a></dt>
  <dd>The specified {{cssxref("&lt;length&gt;")}} is used in the calculation of the line box height step.</dd>
 </dl>
 

--- a/files/en-us/web/css/line-height/index.html
+++ b/files/en-us/web/css/line-height/index.html
@@ -45,9 +45,9 @@ line-height: unset;
 <p>The <code>line-height</code> property is specified as any one of the following:</p>
 
 <ul>
- <li>a <code><a href="#&lt;number&gt;">&lt;number&gt;</a></code></li>
- <li>a <code><a href="#&lt;length&gt;">&lt;length&gt;</a></code></li>
- <li>a <code><a href="#&lt;percentage&gt;">&lt;percentage&gt;</a></code></li>
+ <li>a <code><a href="#number">&lt;number&gt;</a></code></li>
+ <li>a <code><a href="#length">&lt;length&gt;</a></code></li>
+ <li>a <code><a href="#percentage">&lt;percentage&gt;</a></code></li>
  <li>the keyword <code><a href="#normal">normal</a></code>.</li>
 </ul>
 
@@ -56,11 +56,11 @@ line-height: unset;
 <dl>
  <dt><code id="normal">normal</code></dt>
  <dd>Depends on the user agent. Desktop browsers (including Firefox) use a default value of roughly <strong><code>1.2</code></strong>, depending on the element's <code>font-family</code>.</dd>
- <dt><code id="&lt;number&gt;">&lt;number&gt;</code> (unitless)</dt>
+ <dt><code id="number">&lt;number&gt;</code> (unitless)</dt>
  <dd>The used value is this unitless {{cssxref("&lt;number&gt;")}} multiplied by the element's own font size. The computed value is the same as the specified <code>&lt;number&gt;</code>. In most cases, <strong>this is the preferred way</strong> to set <code>line-height</code> and avoid unexpected results due to inheritance.</dd>
- <dt><code id="&lt;length&gt;">&lt;length&gt;</code></dt>
+ <dt><code id="length">&lt;length&gt;</code></dt>
  <dd>The specified {{cssxref("&lt;length&gt;")}} is used in the calculation of the line box height. Values given in <strong>em</strong> units may produce unexpected results (see example below).</dd>
- <dt><code id="&lt;percentage&gt;">&lt;percentage&gt;</code></dt>
+ <dt><code id="percentage">&lt;percentage&gt;</code></dt>
  <dd>Relative to the font size of the element itself. The computed value is this {{cssxref("&lt;percentage&gt;")}} multiplied by the element's computed font size. <strong>Percentage</strong> values may produce unexpected results (see the second example below).</dd>
  <dt><code id="-moz-block-height">-moz-block-height</code> {{non-standard_inline}}</dt>
  <dd>Sets the line height to the content height of the current block.</dd>

--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -47,9 +47,9 @@ list-style-type: unset;
 <p>The list-style-type property may be defined as any one of:</p>
 
 <ul>
- <li>a <code><a href="#&lt;custom-ident&gt;">&lt;custom-ident&gt;</a></code> value</li>
+ <li>a <code><a href="#custom-ident">&lt;custom-ident&gt;</a></code> value</li>
  <li>a <code><a href="#symbols()">symbols()</a></code> value</li>
- <li>a <code><a href="#&lt;string&gt;">&lt;string&gt;</a></code> value</li>
+ <li>a <code><a href="#string">&lt;string&gt;</a></code> value</li>
  <li>the keyword <code><a href="#none">none</a></code>.</li>
 </ul>
 
@@ -63,11 +63,11 @@ list-style-type: unset;
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><a id="&lt;custom-ident&gt;">{{cssxref("custom-ident", "&lt;custom-ident&gt;")}}</a></dt>
+ <dt><a id="custom-ident">{{cssxref("custom-ident", "&lt;custom-ident&gt;")}}</a></dt>
  <dd>A identifier matching the value of a {{cssxref("@counter-style")}} or one of the predefined styles:</dd>
  <dt><a id="symbols()">{{cssxref("symbols()")}}</a></dt>
  <dd>Defines an anonymous style of the list.</dd>
- <dt><a id="&lt;string&gt;">{{cssxref("&lt;string&gt;")}}</a></dt>
+ <dt><a id="string">{{cssxref("&lt;string&gt;")}}</a></dt>
  <dd>The specified string will be used as the item's marker.</dd>
  <dt><a id="none"><code>none</code></a></dt>
  <dd>No item marker is shown.</dd>

--- a/files/en-us/web/css/mask-size/index.html
+++ b/files/en-us/web/css/mask-size/index.html
@@ -64,14 +64,14 @@ mask-size: unset;
  <li>If two values are given, the first sets width and the second sets height.</li>
 </ul>
 
-<p>Each value can be a <code><a href="#length">&lt;length&gt;</a></code>, a <code><a href="#&lt;percentage&gt;">&lt;percentage&gt;</a></code>, or <code><a href="#auto">auto</a></code>.</p>
+<p>Each value can be a <code><a href="#length">&lt;length&gt;</a></code>, a <code><a href="#percentage">&lt;percentage&gt;</a></code>, or <code><a href="#auto">auto</a></code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt><code>&lt;length&gt;</code></dt>
+ <dt><code id="length">&lt;length&gt;</code></dt>
  <dd>A <code>{{cssxref("&lt;length&gt;")}}</code> value scales the mask image to the specified length in the corresponding dimension. Negative lengths are not allowed.</dd>
- <dt><code>&lt;percentage&gt;</code></dt>
+ <dt><code id="percentage">&lt;percentage&gt;</code></dt>
  <dd>A {{cssxref("&lt;percentage&gt;")}} value scales the mask image in the corresponding dimension to the specified percentage of the mask positioning area, which is determined by the value of {{cssxref("mask-origin")}}. The mask positioning area is, by default, the area containing the content of the box and its padding; the area may also be changed to just the content or to the area containing borders, padding and content. Negative percentages are not allowed.</dd>
  <dt><a id="auto"><code>auto</code></a></dt>
  <dd>A keyword that scales the mask image in the corresponding directions in order to maintain its intrinsic proportion.</dd>

--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -30,8 +30,8 @@ white-space: nowrap;</pre>
 
 <ul>
  <li>one of the keyword values: <code><a href="#clip">clip</a></code>, <code><a href="#ellipsis">ellipsis</a></code>, <code><a href="#fade">fade</a></code></li>
- <li>the function <code><a href="#fade(_&lt;length&gt;_|_&lt;percentage&gt;_)">fade()</a></code>, which is passed a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} to control the fade distance</li>
- <li>a <code><a href="#&lt;string&gt;">&lt;string&gt;</a></code>.</li>
+ <li>the function <code><a href="#fade_length_percentage">fade()</a></code>, which is passed a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} to control the fade distance</li>
+ <li>a <code><a href="#string">&lt;string&gt;</a></code>.</li>
 </ul>
 
 <h3 id="Values">Values</h3>
@@ -41,11 +41,11 @@ white-space: nowrap;</pre>
  <dd>The default for this property. This keyword value will truncate the text at the limit of the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">content area</a>, therefore the truncation can happen in the middle of a character. To clip at the transition between characters you can specify <code>text-overflow</code> as an empty string, if that is supported in your target browsers: <code>text-overflow: '';</code>.</dd>
  <dt id="ellipsis"><code>ellipsis</code></dt>
  <dd>This keyword value will display an ellipsis (<code>'…'</code>, <code style="text-transform: uppercase;">U+2026 Horizontal Ellipsis</code>) to represent clipped text. The ellipsis is displayed inside the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">content area</a>, decreasing the amount of text displayed. If there is not enough space to display the ellipsis, it is clipped.</dd>
- <dt id="&lt;string&gt;"><code>&lt;string&gt;</code> {{experimental_inline}}</dt>
+ <dt id="string"><code>&lt;string&gt;</code> {{experimental_inline}}</dt>
  <dd>The {{cssxref("&lt;string&gt;")}} to be used to represent clipped text. The string is displayed inside the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">content area</a>, shortening the size of the displayed text. If there is not enough space to display the string itself, it is clipped.</dd>
  <dt id="fade"><code>fade</code> {{experimental_inline}}</dt>
  <dd>This keyword clips the overflowing inline content and applies a fade-out effect near the edge of the line box with complete transparency at the edge.</dd>
- <dt id="fade(_&lt;length&gt;_|_&lt;percentage&gt;_)"><code>fade( &lt;length&gt; | &lt;percentage&gt; )</code> {{experimental_inline}}</dt>
+ <dt id="fade_length_percentage"><code>fade( &lt;length&gt; | &lt;percentage&gt; )</code> {{experimental_inline}}</dt>
  <dd>This function clips the overflowing inline content and applies a fade-out effect near the edge of the line box with complete transparency at the edge.</dd>
  <dd>The argument determines the distance over which the fade effect is applied. The {{cssxref("&lt;percentage&gt;")}} is resolved against the width of the line box. Values lower than <code>0</code> are clipped to <code>0</code>. Values greater than the width of the line box are clipped to the width of the line box.</dd>
 </dl>

--- a/files/en-us/web/css/text-size-adjust/index.html
+++ b/files/en-us/web/css/text-size-adjust/index.html
@@ -33,7 +33,7 @@ text-size-adjust: unset;
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>text-size-adjust</code> property is specified as <code><a href="#none">none</a></code>, <code><a href="#auto">auto</a></code>, or a <code><a href="#&lt;percentage&gt;">&lt;percentage&gt;</a></code>.</p>
+<p>The <code>text-size-adjust</code> property is specified as <code><a href="#none">none</a></code>, <code><a href="#auto">auto</a></code>, or a <code><a href="#percentage">&lt;percentage&gt;</a></code>.</p>
 
 <h3 id="Values">Values</h3>
 
@@ -42,7 +42,7 @@ text-size-adjust: unset;
  <dd>Disables the browser's inflation algorithm.</dd>
  <dt id="auto"><code>auto</code></dt>
  <dd>Enables the browser's inflation algorithm. This value is used to cancel a <code>none</code> value previously set with CSS.</dd>
- <dt id="&lt;percentage&gt;"><code>&lt;percentage&gt;</code></dt>
+ <dt id="percentage"><code>&lt;percentage&gt;</code></dt>
  <dd>Enables the browser's inflation algorithm, specifying a percentage value with which to increase the font size.</dd>
 </dl>
 

--- a/files/en-us/web/css/transform/index.html
+++ b/files/en-us/web/css/transform/index.html
@@ -58,14 +58,14 @@ transform: initial;
 transform: unset;
 </pre>
 
-<p>The <code>transform</code> property may be specified as either the keyword value <code><a href="#none">none</a></code> or as one or more <code><a href="#&lt;transform-function&gt;">&lt;transform-function&gt;</a></code> values.</p>
+<p>The <code>transform</code> property may be specified as either the keyword value <code><a href="#none">none</a></code> or as one or more <code><a href="#transform-function">&lt;transform-function&gt;</a></code> values.</p>
 
 <p>If {{cssxref("transform-function/perspective", "perspective()")}} is one of multiple function values, it must be listed first.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="&lt;transform-function&gt;">{{cssxref("&lt;transform-function&gt;")}}</dt>
+ <dt id="transform-function">{{cssxref("&lt;transform-function&gt;")}}</dt>
  <dd>One or more of the <a href="/en-US/docs/Web/CSS/transform-function">CSS transform functions</a> to be applied. The transform functions are multiplied in order from left to right, meaning that composite transforms are effectively applied in order from right to left.</dd>
  <dt id="none"><code>none</code></dt>
  <dd>Specifies that no transform should be applied.</dd>

--- a/files/en-us/web/css/z-index/index.html
+++ b/files/en-us/web/css/z-index/index.html
@@ -38,14 +38,14 @@ z-index: initial;
 z-index: unset;
 </pre>
 
-<p>The <code>z-index</code> property is specified as either the keyword <code><a href="#auto">auto</a></code> or an <code><a href="#&lt;integer&gt;">&lt;integer&gt;</a></code>.</p>
+<p>The <code>z-index</code> property is specified as either the keyword <code><a href="#auto">auto</a></code> or an <code><a href="#integer">&lt;integer&gt;</a></code>.</p>
 
 <h3 id="Values">Values</h3>
 
 <dl>
  <dt><a id="auto"><code>auto</code></a></dt>
  <dd>The box does not establish a new local stacking context. The stack level of the generated box in the current stacking context is the same as its parent's box.</dd>
- <dt><a id="&lt;integer&gt;"><code>&lt;integer&gt;</code></a></dt>
+ <dt><a id="integer"><code>&lt;integer&gt;</code></a></dt>
  <dd>This {{cssxref("&lt;integer&gt;")}} is the stack level of the generated box in the current stacking context. The box also establishes a local stacking context in which its stack level is <code>0</code>. This means that the z-indexes of descendants are not compared to the z-indexes of elements outside this element.</dd>
 </dl>
 

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -21,7 +21,7 @@ tags:
 
 <div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
-<h2 id="&lt;input&gt;_types">&lt;input&gt; types</h2>
+<h2 id="input_types">&lt;input&gt; types</h2>
 
 <p>How an <code>&lt;input&gt;</code> works varies considerably depending on the value of its {{htmlattrxref("type", "input")}} attribute, hence the different types are covered in their own separate reference pages. If this attribute is not specified, the default type adopted is <code>text</code>.</p>
 

--- a/files/en-us/web/html/element/table/index.html
+++ b/files/en-us/web/html/element/table/index.html
@@ -613,7 +613,7 @@ tr:last-child td {
 <p>This helps people navigating with the aid of assistive technology such as a screen reader, people experiencing low vision conditions, and people with cognitive concerns.</p>
 
 <ul>
- <li><a href="/en-US/docs/Learn/HTML/Tables/Advanced#Adding_a_caption_to_your_table_with_&lt;caption&gt;">MDN Adding a caption to your table with &lt;caption&gt;</a></li>
+ <li><a href="/en-US/docs/Learn/HTML/Tables/Advanced#Adding_a_caption_to_your_table_with_caption">MDN Adding a caption to your table with &lt;caption&gt;</a></li>
  <li><a href="https://www.w3.org/WAI/tutorials/tables/caption-summary/">Caption &amp; Summary • Tables • W3C WAI Web Accessibility Tutorials</a></li>
 </ul>
 


### PR DESCRIPTION
These are also used in the `{{cssref(...)}}` macros, but I left those