### PR TITLE
Fix: empty header tags

### DIFF
--- a/files/en-us/games/visual_js_ge/index.html
+++ b/files/en-us/games/visual_js_ge/index.html
@@ -42,8 +42,6 @@ npm install nodemailer@0.7.0</pre>
 
 };</pre>
 
-<h3 id="sect1"> </h3>
-
 <h2 id="local_node.js_application_tools_(uses_in_developer_mode_only)">local node.js application tools (uses in developer mode only)</h2>
 
 <p>The following section provides information about the tools involved in Visual-JS game engine.</p>

--- a/files/en-us/glossary/gif/index.html
+++ b/files/en-us/glossary/gif/index.html
@@ -14,7 +14,3 @@ tags:
 <ul>
  <li>{{Interwiki("wikipedia", "GIF")}} on Wikipedia</li>
 </ul>
-
-
-
-<h2 id="sect1"> </h2>

--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
@@ -381,8 +381,6 @@ interface SpeechSynthesis {
 <p><span><strong>Note:</strong> The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)</span></p>
 </div>
 
-<h3 id="sect1"></h3>
-
 <h2 id="Special_methods">Special methods</h2>
 
 <p>Some methods are not listed as regular methods in WebIDL but instead as special keywords, which translate to specific standard JavaScript methods.</p>

--- a/files/en-us/mozilla/projects/nss/nss_tech_notes/nss_tech_note4/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_tech_notes/nss_tech_note4/index.html
@@ -34,9 +34,6 @@ way.<br>
                 If SSL server, this will get you the
 server's    cert handle <br>
 
-<h4 id="sect1"><br>
-       </h4>
-
 <h4 id="Don't_forget_to_clean_up_the_cert_handle_when_you're_done_with_it">Don't forget to clean up the cert handle when you're done with it</h4>
        <i>void CERT_DestroyCertificate(CERTCertificate *cert);</i><br>
        <br>

--- a/files/en-us/mozilla/projects/nss/reference/troubleshoot.html/index.html
+++ b/files/en-us/mozilla/projects/nss/reference/troubleshoot.html/index.html
@@ -6,9 +6,9 @@ slug: Mozilla/Projects/NSS/Reference/troubleshoot.html
 <p>Newsgroup: <a href="nntp://news.mozilla.org/mozilla.dev.tech.crypto">mozilla.dev.tech.crypto</a></p>
 <p>This page summarizes information on troubleshooting the NSS and JSS build and test systems, including known problems and configuration suggestions.</p>
 <p>If you have suggestions for this page, please post them to <a href="nntp://news.mozilla.org/mozilla.dev.tech.crypto">mozilla.dev.tech.crypto</a>.</p>
-<h3 id="sect1"> </h3>
-<hr>
-<p>Building NSS</p>
+
+<h3>Building NSS</h3>
+
 <ul>
  <li>Having /usr/ucb/bin in the path before /usr/ccs/bin breaks the build on 64-bit Solaris.</li>
  <li>The Solaris compiler needs to be workshop-5.0 or greater.</li>
@@ -24,15 +24,13 @@ slug: Mozilla/Projects/NSS/Reference/troubleshoot.html
   <p>In this case remember to set USE_64=1</p>
  </li>
 </ul>
-<h3 id="sect2"> </h3>
-<hr>
-<p>Testing NSS</p>
-<ul>
- <li>The SSL stress test opens 2,048 TCP connections in quick succession. Kernel data structures may remain allocated for these connections for up to two minutes. Some systems may not be configured to allow this many simultaneous connections by default; if the stress tests fail, try increasing the number of simultaneous sockets supported.</li>
-</ul>
-<h3 id="sect3"> </h3>
-<hr>
-<p>Building JSS</p>
+
+<h3>Testing NSS</h3>
+
+<p>The SSL stress test opens 2,048 TCP connections in quick succession. Kernel data structures may remain allocated for these connections for up to two minutes. Some systems may not be configured to allow this many simultaneous connections by default; if the stress tests fail, try increasing the number of simultaneous sockets supported.</p>
+
+<h3>Building JSS</h3>
+
 <ul>
  <li><b>Windows Only:</b> The shell invoked by gmake, <code>shmsdos.exe</code>, is likely to crash when invoking some Java tools on Windows. The current workaround is to use some other shell in place of <code>shmsdos</code>, such as <code>sh.exe</code>, which should be distributed with the <a href="http://sourceware.cygnus.com/cygwin/download.html">Cygnus toolkit</a> you installed to build NSS. The change is unfortunately rather drastic: to trick gmake, you rename the shell program.
   <blockquote>
@@ -50,4 +48,3 @@ slug: Mozilla/Projects/NSS/Reference/troubleshoot.html
   </blockquote>
   Making this change will probably break other builds you are  making on the same machine. You may need to switch the shell back and forthdepending on which product you are building. We will try to provide a moreconvenient solution in the future. If you have the MKS toolkit installed,  the &lt;tt&gt;sh.exe&lt;/tt&gt; that comes with this toolkit can be used as well.</li>
 </ul>
-

--- a/files/en-us/mozilla/projects/nss/ssl_functions/sslfnc.html/index.html
+++ b/files/en-us/mozilla/projects/nss/ssl_functions/sslfnc.html/index.html
@@ -2068,8 +2068,6 @@ slug: Mozilla/Projects/NSS/SSL_functions/sslfnc.html
  <li><a id="1089046"> If the function cannot obtain a certificate, <code>SECFailure</code>. </a></li>
 </ul>
 
-<h5 id="sect1"></h5>
-
 <h4 id="NSS_GetClientAuthData"> <a id="1106762"> NSS_GetClientAuthData </a></h4>
 
 <p><a id="1111069"> Callback function that a client application can use to get the client's private key and certificate when authentication is requested by a remote server. </a></p>

--- a/files/en-us/tools/page_inspector/how_to/view_background_images/index.html
+++ b/files/en-us/tools/page_inspector/how_to/view_background_images/index.html
@@ -4,8 +4,8 @@ slug: Tools/Page_Inspector/How_to/View_background_images
 ---
 <div>{{ToolsSidebar}}</div><p>In the <a href="/en-US/docs/Tools/Page_Inspector/UI_Tour#Rules_view">Rules view</a>, you can see a preview of images specified using <a href="/en-US/docs/Web/CSS/background-image">background-image</a>. Just hover over the rule:</p>
 
-<h4 id="sect1"><img alt="" src="https://mdn.mozillademos.org/files/11215/css-image-preview.png" style="display: block; height: 422px; margin-left: auto; margin-right: auto; width: 585px;"></h4>
+<img alt="" src="https://mdn.mozillademos.org/files/11215/css-image-preview.png" style="display: block; height: 422px; margin-left: auto; margin-right: auto; width: 585px;">
 
 <p>From Firefox 41, if you right-click the image declaration, you'll see an option to copy the image as a data: URL:</p>
 
-<p><img alt="" src="https://mdn.mozillademos.org/files/11213/css-copy-image-data-url.png" style="display: block; height: 254px; margin-left: auto; margin-right: auto; width: 587px;"></p>
+<img alt="" src="https://mdn.mozillademos.org/files/11213/css-copy-image-data-url.png" style="display: block; height: 254px; margin-left: auto; margin-right: auto; width: 587px;">

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.html
@@ -688,15 +688,9 @@ function draw() {
 
 <h5 id="Output">Output</h5>
 
-<table class="standard-table">
-	<tbody>
-		<tr>
-			<td>
-			<h2 id="sect1"><a href="https://kunalverma94.github.io/pokemon/snake.html"><img alt="Snake game" src="https://kunalverma94.github.io/view/images/snake.jpg" style="height: 400px; width: 600px;"></a></h2>
-			</td>
-		</tr>
-	</tbody>
-</table>
+<a href="https://kunalverma94.github.io/pokemon/snake.html">
+  <img alt="Snake game" src="https://kunalverma94.github.io/view/images/snake.jpg" style="height: 400px; width: 600px;">
+</a>
 
 <h2 id="Other_examples">Other examples</h2>
 


### PR DESCRIPTION
Remove empty headers (`<h1>`, `<h2>`, `<h3>`, etc. tags which don't contain any actual text. 

These were found by [`html-validate`](https://www.npmjs.com/package/html-validate) rule `empty-heading`.