### PR TITLE
Fix: replace "<br />" with "<br>"

### DIFF
--- a/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.html
+++ b/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.html
@@ -176,8 +176,8 @@ tags:
  <dd>· User visible page content in small chunks ( <code>{{htmlelement('header')}}</code>/ <code>{{htmlelement('main')}}/</code> <code>{{htmlelement('table')}}</code>) that can be displayed without waiting for the full page to download.
  <dl>
   <dt>· <code>{{htmlelement('script')}} </code>...</dt>
-  <dd>Any scripts which will be used to perform interactivity. Interaction scripts typically can only run after the page has completely loaded and all necessary objects have been initialized. There is no need to load these scripts before the page content. That only slows down the initial appearance of the page load.<br />
-  Minimize the number of files for performance while keeping unrelated JavaScript in separate files for maintenance.<br />
+  <dd>Any scripts which will be used to perform interactivity. Interaction scripts typically can only run after the page has completely loaded and all necessary objects have been initialized. There is no need to load these scripts before the page content. That only slows down the initial appearance of the page load.<br>
+  Minimize the number of files for performance while keeping unrelated JavaScript in separate files for maintenance.<br>
   If any images are used for rollover effects, you should preload them here after the page content has downloaded.</dd>
  </dl>
  </dd>

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.html
@@ -221,7 +221,7 @@ tags:
 
 <dl>
  <dt>{{domxref("CanvasRenderingContext2D.transform", "transform(a, b, c, d, e, f)")}}</dt>
- <dd>Multiplies the current transformation matrix with the matrix described by its arguments. The transformation matrix is described by: <math><semantics><mrow><mo>[</mo><mtable columnalign="center center center" rowspacing="0.5ex"><mtr><mtd><mi>a</mi></mtd><mtd><mi>c</mi></mtd><mtd><mi>e</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd><mtd><mi>d</mi></mtd><mtd><mi>f</mi></mtd></mtr><mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd></mtr></mtable><mo>]</mo></mrow><annotation encoding="TeX">\left[ \begin{array}{ccc} a &amp; c &amp; e \\ b &amp; d &amp; f \\ 0 &amp; 0 &amp; 1 \end{array} \right]</annotation></semantics></math><br />
+ <dd>Multiplies the current transformation matrix with the matrix described by its arguments. The transformation matrix is described by: <math><semantics><mrow><mo>[</mo><mtable columnalign="center center center" rowspacing="0.5ex"><mtr><mtd><mi>a</mi></mtd><mtd><mi>c</mi></mtd><mtd><mi>e</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd><mtd><mi>d</mi></mtd><mtd><mi>f</mi></mtd></mtr><mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd></mtr></mtable><mo>]</mo></mrow><annotation encoding="TeX">\left[ \begin{array}{ccc} a &amp; c &amp; e \\ b &amp; d &amp; f \\ 0 &amp; 0 &amp; 1 \end{array} \right]</annotation></semantics></math><br>
  If any of the arguments are <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a></code> the transformation matrix must be marked as infinite instead of the method throwing an exception.</dd>
 </dl>
 

--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.html
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.html
@@ -46,7 +46,7 @@ history.pushState(stateObj, "page 2", "bar.html")
 
 <dl>
  <dt><strong>state object</strong> </dt>
- <dd>The state object is a JavaScript object which is associated with the new history entry created by <code>pushState()</code>. Whenever the user navigates to the new state, a <code>popstate</code> event is fired, and the <code>state</code> property of the event contains a copy of the history entry's state object.<br />
+ <dd>The state object is a JavaScript object which is associated with the new history entry created by <code>pushState()</code>. Whenever the user navigates to the new state, a <code>popstate</code> event is fired, and the <code>state</code> property of the event contains a copy of the history entry's state object.<br>
 The state object can be anything that can be serialized. Because Firefox saves state objects to the user's disk so they can be restored after the user restarts the browser, we impose a size limit of 640k characters on the serialized representation of a state object. If you pass a state object whose serialized representation is larger than this to <code>pushState()</code>, the method will throw an exception. If you need more space than this, you're encouraged to use <code>sessionStorage</code> and/or <code>localStorage</code>.</dd>
  <dt><strong>title</strong></dt>
  <dd><a href="https://github.com/whatwg/html/issues/2174">All browsers but Safari currently ignore this parameter</a>, although they may use it in the future. Passing the empty string here should be safe against future changes to the method. Alternatively, you could pass a short title for the state to which you're moving.</dd>

--- a/files/en-us/web/api/window/open/obsolete_features/index.html
+++ b/files/en-us/web/api/window/open/obsolete_features/index.html
@@ -5,13 +5,17 @@ slug: Web/API/Window/open/Obsolete_features
 <p>This page lists the obsolete <code>windowFeatures</code> parameter of <a href="/en-US/docs/Web/API/Window/open">window.open</a> function.</p>
 
 <dl>
- <dt><code>directories</code> {{obsolete_inline("2")}}</dt>
- <dd>Obsolete synonym of personalbar. In IE, it rendered the Links bar. Supported in Gecko up to 1.9.2 and in IE up to 6.</dd>
- <dt><code>fullscreen</code></dt>
- <dd>This feature no longer works in MSIE 6 SP2 the way it worked in MSIE 5.x. The Windows taskbar, as well as the titlebar and the status bar of the window are not visible, nor accessible when fullscreen is enabled in MSIE 5.x.<br />
-<code>fullscreen</code> always upsets users with large monitor screen or with dual monitor screen. Forcing <code>fullscreen</code> onto other users is also extremely unpopular and is considered an outright rude attempt to impose web author's viewing preferences onto users.<br />
-<code>fullscreen</code> does not really work in MSIE 6 SP2.</dd>
- <dt><code>personalbar</code> {{obsolete_inline("76")}}</dt>
- <dd>If this feature is on, then the new secondary window renders the Personal Toolbar in Netscape 6.x, Netscape 7.x and Mozilla browser. It renders the Bookmarks Toolbar in Firefox. In addition to the Personal Toolbar, Mozilla browser will render the Site Navigation Bar if such toolbar is visible, present in the parent window.<br />
-Mozilla and Firefox users can force new windows to always render the Personal Toolbar/Bookmarks toolbar by setting <code>dom.disable_window_open_feature.personalbar</code> to <var>true</var> in <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config">about:config</a> or in their <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js">user.js file</a>.</dd>
+  <dt><code>directories</code> {{obsolete_inline("2")}}</dt>
+  <dd>Obsolete synonym of personalbar. In IE, it rendered the Links bar. Supported in Gecko up to 1.9.2 and in IE up to 6.</dd>
+  <dt><code>fullscreen</code></dt>
+  <dd>
+    This feature no longer works in MSIE 6 SP2 the way it worked in MSIE 5.x. The Windows taskbar, as well as the titlebar and the status bar of the window are not visible, nor accessible when fullscreen is enabled in MSIE 5.x.<br>
+    <code>fullscreen</code> always upsets users with large monitor screen or with dual monitor screen. Forcing <code>fullscreen</code> onto other users is also extremely unpopular and is considered an outright rude attempt to impose web author's viewing preferences onto users.<br>
+    <code>fullscreen</code> does not really work in MSIE 6 SP2.
+  </dd>
+  <dt><code>personalbar</code> {{obsolete_inline("76")}}</dt>
+  <dd>
+    If this feature is on, then the new secondary window renders the Personal Toolbar in Netscape 6.x, Netscape 7.x and Mozilla browser. It renders the Bookmarks Toolbar in Firefox. In addition to the Personal Toolbar, Mozilla browser will render the Site Navigation Bar if such toolbar is visible, present in the parent window.<br>
+    Mozilla and Firefox users can force new windows to always render the Personal Toolbar/Bookmarks toolbar by setting <code>dom.disable_window_open_feature.personalbar</code> to <var>true</var> in <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#about_config">about:config</a> or in their <a href="http://support.mozilla.com/en-US/kb/Editing+configuration+files#user_js">user.js file</a>.
+  </dd>
 </dl>

--- a/files/en-us/web/xpath/functions/id/index.html
+++ b/files/en-us/web/xpath/functions/id/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt><code><em>expression</em></code></dt>
- <dd>If <code><em>expression</em></code> is a node-set, then the string value of each node in the node-set is treated as an individual id. The returned node set is the nodes corresponding to those ids.<br />
+ <dd>If <code><em>expression</em></code> is a node-set, then the string value of each node in the node-set is treated as an individual id. The returned node set is the nodes corresponding to those ids.<br>
 If <code><em>expression</em></code> is a string, or anything other than a node-set, then <code><em>expression</em></code> is treated as a space-separated list of ids. The returned node set is the nodes corresponding to those ids.</dd>
 </dl>
 


### PR DESCRIPTION
Replace `<br />` with `<br>`.

These were found by [`html-validate`](https://www.npmjs.com/package/html-validate) rule `empty-heading`.