### PR TITLE
Fix: escape raw characters in HTML

### DIFF
--- a/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.html
+++ b/files/en-us/learn/javascript/objects/adding_bouncing_balls_features/index.html
@@ -79,7 +79,7 @@ tags:
 		<pre class="brush: js">
 Ball.prototype.collisionDetect = function() {
   for (let j = 0; j &lt; balls.length; j++) {
-    if (!(this === balls[j]) && balls[j].exists) {
+    if (!(this === balls[j]) &amp;&amp; balls[j].exists) {
       const dx = this.x - balls[j].x;
       const dy = this.y - balls[j].y;
       const distance = Math.sqrt(dx * dx + dy * dy);

--- a/files/en-us/web/api/baseaudiocontext/state/index.html
+++ b/files/en-us/web/api/baseaudiocontext/state/index.html
@@ -50,7 +50,7 @@ the audio context's state changes to "interrupted" and needs to be resumed. For 
 <pre class="brush: js">
 function play() {
   if (audioCtx.state === 'interrupted') {
-    audioCtx.resume().then(() => play());
+    audioCtx.resume().then(() =&gt; play());
     return;
   }
   // ... rest of the play() function

--- a/files/en-us/web/api/csstransition/index.html
+++ b/files/en-us/web/api/csstransition/index.html
@@ -48,7 +48,7 @@ tags:
 }</pre>
 
 <pre class="brush: js notranslate">const item = document.querySelector(".box");
-item.addEventListener('transitionrun', () => {
+item.addEventListener('transitionrun', () =&gt; {
   let animations = document.querySelector(".box").getAnimations();
   console.log(animations[0]);
 });</pre>

--- a/files/en-us/web/api/csstransition/transitionproperty/index.html
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.html
@@ -39,7 +39,7 @@ tags:
 }</pre>
 
 <pre class="brush: js notranslate">const item = document.querySelector(".box");
-item.addEventListener('transitionrun', () => {
+item.addEventListener('transitionrun', () =&gt; {
   let animations = document.querySelector(".box").getAnimations();
   console.log(animations[0].propertyName);
 });</pre>

--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.html
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.html
@@ -56,7 +56,7 @@ tags:
 <p>The following function returns true if <code>beforeinput</code>, and thus <code>getTargetRanges</code>, is supported.</p>
 
 <pre class="brush: js notranslate">function isBeforeInputEventAvailable() {
-  return window.InputEvent && typeof InputEvent.prototype.getTargetRanges === "function";
+  return window.InputEvent &amp;&amp; typeof InputEvent.prototype.getTargetRanges === "function";
 }
 </pre>
 

--- a/files/en-us/web/api/inputevent/gettargetranges/index.html
+++ b/files/en-us/web/api/inputevent/gettargetranges/index.html
@@ -34,7 +34,7 @@ tags:
 <p>The following function returns true if <code>beforeinput</code>, and thus <code>getTargetRanges</code>, is supported.</p>
 
 <pre class="brush: js notranslate">function isBeforeInputEventAvailable() {
-  return window.InputEvent && typeof InputEvent.prototype.getTargetRanges === "function";
+  return window.InputEvent &amp;&amp; typeof InputEvent.prototype.getTargetRanges === "function";
 }
 </pre>
 

--- a/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
@@ -1181,7 +1181,7 @@ var SliderManager = (function SliderManager() {
 		this.min = min;
 		this.max = max &gt; 0 ? max : 100;
 		this.step = step === 0 ? 1 : step;
-		this.value = value &lt;= max && value >= min ? value : (min + max) / 2 | 0;
+		this.value = value &lt;= max &amp;&amp; value &gt;= min ? value : (min + max) / 2 | 0;
 		this.snap = snap === "true" ? true : false;
 		this.topic = topic;
 		this.node = node;


### PR DESCRIPTION
Escape raw characters in HTML.

These were found by [`html-validate`](https://www.npmjs.com/package/html-validate) rule `no-raw-characters`.