### PR TITLE
Fix typo in bookmarks.getChildren example: unfilled -> unfiled

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
@@ -52,7 +52,7 @@ function onRejected(error) {
   console.log(`An error: ${error}`);
 }
 
-var gettingChildren = browser.bookmarks.getChildren("unfilled_____");
+var gettingChildren = browser.bookmarks.getChildren("unfiled_____");
 gettingChildren.then(onFulfilled, onRejected);</pre>
 
 <p>{{WebExtExamples}}</p>


### PR DESCRIPTION
^ Self explanatory. <3 

(Thanks for making such a great resource!)