### PR TITLE
Update the HTML details element

### DIFF
--- a/files/en-us/web/html/element/details/index.html
+++ b/files/en-us/web/html/element/details/index.html
@@ -82,7 +82,8 @@ tags:
 
 <dl>
  <dt>{{htmlattrdef("open")}}</dt>
- <dd>This Boolean attribute indicates whether or not the details — that is, the contents of the <code>&lt;details&gt;</code> element — are currently visible. The default, <code>false</code>, means the details are not visible.</dd>
+ <dd>This Boolean attribute indicates whether or not the details — that is, the contents of the <code>&lt;details&gt;</code> element — are currently visible. By default this attribute is absent which means the details are not visible.<br>
+ Note that you have to remove this attribute entirely to make the details hidden. <code>open="false"</code> makes the details visible because this attribute is Boolean.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>
@@ -175,9 +176,14 @@ details &gt; p {
   margin: 0;
   box-shadow: 3px 3px 4px black;
 }
-</pre>
+
+details[open] > summary {
+  background-color: #ccf;
+}</pre>
 
 <p>This CSS creates a look similar to a tabbed interface, where clicking the tab opens it to reveal its contents.</p>
+
+<p>The selector <code>details[open]</code> can be used to style the element which is open.</p>
 
 <h4 id="HTML">HTML</h4>
 

--- a/files/en-us/web/html/element/details/index.html
+++ b/files/en-us/web/html/element/details/index.html
@@ -82,8 +82,11 @@ tags:
 
 <dl>
  <dt>{{htmlattrdef("open")}}</dt>
- <dd>This Boolean attribute indicates whether or not the details — that is, the contents of the <code>&lt;details&gt;</code> element — are currently visible. By default this attribute is absent which means the details are not visible.<br>
- Note that you have to remove this attribute entirely to make the details hidden. <code>open="false"</code> makes the details visible because this attribute is Boolean.</dd>
+ <dd>
+ <p>This Boolean attribute indicates whether or not the details — that is, the contents of the <code>&lt;details&gt;</code> element — are currently visible. The details are shown when this attribute exists, or hidden when this attribute is absent. By default this attribute is absent which means the details are not visible. </p>
+ 
+ <p class="note"><strong>Note:</strong> You have to remove this attribute entirely to make the details hidden. <code>open="false"</code> makes the details visible because this attribute is Boolean.</p>
+</dd>
 </dl>
 
 <h2 id="Events">Events</h2>


### PR DESCRIPTION
* Fixed the description of the open attribute. If the "false" value is set on this attribute, this element opens.
* Added a new style which uses the details[open] selector in an example - https://github.com/mdn/content/issues/239