### PR TITLE
Fix: remove unnecessary <span> in headers

### DIFF
--- a/files/en-us/glossary/crlf/index.html
+++ b/files/en-us/glossary/crlf/index.html
@@ -19,7 +19,7 @@ tags:
 
 <p>A CR immediately followed by a LF (CRLF, <code>\r\n</code>, or <code>0x0D0A</code>) moves the cursor down to the next line and then to the beginning of the line.</p>
 
-<h2 id="Learn_moreEdit">Learn more<a class="button section-edit only-icon" href="/en-US/docs/Glossary/Smoke_Test$edit#Learn_more"><span>Edit</span></a></h2>
+<h2 id="Learn_more">Learn more</h2>
 
 <h3 id="General_knowledge">General knowledge</h3>
 

--- a/files/en-us/glossary/data_structure/index.html
+++ b/files/en-us/glossary/data_structure/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p><strong>Data structure</strong> is a particular way of organizing <em>data</em> so that it can be used efficiently.</p>
 
-<h2 id="Learn_moreEdit">Learn more<a class="button section-edit only-icon" href="/en-US/docs/Glossary/Accessibility$edit#Learn_more" rel="nofollow, noindex"><span>Edit</span></a></h2>
+<h2 id="Learn_more">Learn more</h2>
 
 <h3 class="highlight-spanned" id="General_knowledge"><span class="highlight-span">General knowledge</span></h3>
 

--- a/files/en-us/glossary/dtmf/index.html
+++ b/files/en-us/glossary/dtmf/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>Computers may make use of DTMF when dialing a modem, or when sending commands to a menu system for teleconferencing or other purposes.</p>
 
-<h2 id="Learn_moreEdit">Learn more<a class="button section-edit only-icon" href="/en-US/docs/Glossary/Smoke_Test$edit#Learn_more"><span>Edit</span></a></h2>
+<h2 id="Learn_more">Learn more</h2>
 
 <h3 id="General_knowledge">General knowledge</h3>
 

--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
@@ -60,7 +60,7 @@ tags:
 
 <pre class="syntaxbox" lang="en">interface HTMLMediaElement : <strong>HTMLElement</strong> {…}</pre>
 
-<p><span>The inheritance chain is listed automatically in the sidebar (using the \{{APIRef}} macro). It can also be added as an SVG image via the macro \{{InheritanceDiagram}}.</span></p>
+<p>The inheritance chain is listed automatically in the sidebar (using the \{{APIRef}} macro). It can also be added as an SVG image via the macro \{{InheritanceDiagram}}.</p>
 
 <h3 id="Mixins">Mixins</h3>
 
@@ -100,7 +100,7 @@ MyInterface includes MyMixin;</pre>
 </ul>
 
 <div class="notecard note">
-<p><span><strong>Note:</strong> Mixin names do not appear in a Web developer console. We shouldn't show them, but we currently do this as it saves us from duplicating content, which would lead to a maintenance issue. We do this if the mixin is only used in one interface. (Such cases are bugs in the relevant specs. They shouldn't be defined as mixins, but as partial interfaces.)</span></p>
+<p><strong>Note:</strong> Mixin names do not appear in a Web developer console. We shouldn't show them, but we currently do this as it saves us from duplicating content, which would lead to a maintenance issue. We do this if the mixin is only used in one interface. (Such cases are bugs in the relevant specs. They shouldn't be defined as mixins, but as partial interfaces.)</p>
 </div>
 
 <h3 id="Old_mixin_syntax">Old mixin syntax</h3>
@@ -114,7 +114,7 @@ MyInterface includes MyMixin;</pre>
 
 <pre class="syntaxbox" lang="en">MyInterface <strong>implements</strong> MyMixin;</pre>
 
-<h3 id="Availability_in_window_and_workers"><span>Availability in window and workers</span></h3>
+<h3 id="Availability_in_window_and_workers">Availability in window and workers</h3>
 
 <p>Availability in Web workers (of any type) and on the Window scope is defined using an annotation: <code>[Exposed=(Window,Worker)]</code>. The annotation applies to the partial interface it is listed with.</p>
 
@@ -175,10 +175,10 @@ interface SpeechSynthesis {
    readonly attribute boolean paused;
 };</pre>
 
-<p><span>Here <code>media.webspeech.synth.enabled</code> controls the <code>SpeechSynthesis</code> interface and its properties (the full listing has more than 3.)</span></p>
+<p>Here <code>media.webspeech.synth.enabled</code> controls the <code>SpeechSynthesis</code> interface and its properties (the full listing has more than 3.)</p>
 
 <div class="note notecard">
-<p><span><strong>Note:</strong> the default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)</span></p>
+<p><strong>Note:</strong> the default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)</p>
 </div>
 
 <h3 id="Available_only_in_system_code">Available only in system code</h3>
@@ -204,23 +204,23 @@ interface SpeechSynthesis {
 
 <pre class="syntaxbox">readonly attribute <strong>MediaError?</strong> error;</pre>
 
-<p><span>The property value is an object of type <code>MediaError</code>. The question mark (<code>'?'</code>) indicates that it can take a value of <code>null</code>, and the documentation must explain <em>when</em> this may occur. If no question mark is present, the <code>error</code> property can't be <code>null</code>.</span></p>
+<p>The property value is an object of type <code>MediaError</code>. The question mark (<code>'?'</code>) indicates that it can take a value of <code>null</code>, and the documentation must explain <em>when</em> this may occur. If no question mark is present, the <code>error</code> property can't be <code>null</code>.</p>
 
-<h3 id="Writing_permissions_on_the_property"><span>Writing permissions on the property</span></h3>
+<h3 id="Writing_permissions_on_the_property">Writing permissions on the property</h3>
 
 <pre class="syntaxbox"><strong>readonly</strong> attribute MediaError? error;</pre>
 
-<p><span>If the keyword <code>readonly</code> is present, the property can't be modified. It must be marked as read-only:</span></p>
+<p>If the keyword <code>readonly</code> is present, the property can't be modified. It must be marked as read-only:</p>
 
 <ul>
- <li><span>In the interface, by adding the \{{ReadOnlyInline}} macro next to its definition term.</span></li>
- <li><span>In the first sentence of its own page, by starting the description with: <em>The read-only <code><strong>HTMLMediaElement.error</strong></code> property…</em></span></li>
- <li><span>By adding the <code>Read-only</code> tag to its own page.</span></li>
- <li><span>By starting its description in the interface page with <em>Returns…</em></span></li>
+ <li>In the interface, by adding the \{{ReadOnlyInline}} macro next to its definition term.</li>
+ <li>In the first sentence of its own page, by starting the description with: <em>The read-only <code><strong>HTMLMediaElement.error</strong></code> property…</em></li>
+ <li>By adding the <code>Read-only</code> tag to its own page.</li>
+ <li>By starting its description in the interface page with <em>Returns…</em></li>
 </ul>
 
 <div class="note notecard">
-<p><span><em><strong>Note:</strong> Only read-only properties can be described as 'returning' a value. Non read-only properties can also be used to set a value.</em></span></p>
+<p><em><strong>Note:</strong> Only read-only properties can be described as 'returning' a value. Non read-only properties can also be used to set a value.</em></p>
 </div>
 
 <h3 id="Throwing_exceptions">Throwing exceptions</h3>
@@ -228,11 +228,11 @@ interface SpeechSynthesis {
 <pre class="syntaxbox" lang="en"><strong>[SetterThrows]</strong>
             attribute DOMString src;</pre>
 
-<p><span>In some cases, like when some values are illegal, setting a new value can lead to an exception being raised. This is marked using the <code>[SetterThrows]</code> annotation. When this happens, the Syntax section of the property page <em>must</em> have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.</span></p>
+<p>In some cases, like when some values are illegal, setting a new value can lead to an exception being raised. This is marked using the <code>[SetterThrows]</code> annotation. When this happens, the Syntax section of the property page <em>must</em> have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.</p>
 
-<p><span>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="https://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) raises a {{exception('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.</span></p>
+<p>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="https://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) raises a {{exception('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.</p>
 
-<p><span>It is uncommon to have getters throwing exceptions, though it happens in a few cases. In this case the <code>[GetterThrows]</code> annotation is used. Here also, the Syntax section of the property page <em>must</em> have an Exceptions subsection.</span></p>
+<p>It is uncommon to have getters throwing exceptions, though it happens in a few cases. In this case the <code>[GetterThrows]</code> annotation is used. Here also, the Syntax section of the property page <em>must</em> have an Exceptions subsection.</p>
 
 <pre class="syntaxbox"><code id="line-16">partial interface Blob {</code><code id="line-17">
 </code><code id="line-18">  <strong>[GetterThrows]</strong>
@@ -258,16 +258,16 @@ interface SpeechSynthesis {
 
 <p><em>Although this property is read-only, it will not throw if it is modified (even in strict mode); the setter is a no-operation and it will be ignored.</em></p>
 
-<h3 id="New_objects_or_references"><span>New objects or references</span></h3>
+<h3 id="New_objects_or_references">New objects or references</h3>
 
-<p><span>The return value of a property can be either a copy of an internal object, a newly created synthetic object, or a reference to an internal object.</span></p>
+<p>The return value of a property can be either a copy of an internal object, a newly created synthetic object, or a reference to an internal object.</p>
 
-<p><span>Basic objects with types like {{jsxref("String")}} (being an IDL <code>DOMString</code>, or other), {{jsxref("Number")}} (being an IDL <code>byte</code>, <code>octet</code>, <code>unsigned int</code>, or other), and {{jsxref("Boolean")}} are always copied and nothing special has to be noted about them (it is natural behavior expected by a JavaScript developer.)</span></p>
+<p>Basic objects with types like {{jsxref("String")}} (being an IDL <code>DOMString</code>, or other), {{jsxref("Number")}} (being an IDL <code>byte</code>, <code>octet</code>, <code>unsigned int</code>, or other), and {{jsxref("Boolean")}} are always copied and nothing special has to be noted about them (it is natural behavior expected by a JavaScript developer.)</p>
 
-<p><span>For interface objects, the default is to return a <em>reference</em> to the internal object. This has to be mentioned both in the short description in the interface page, and in the description in the specific sub-pages.</span></p>
+<p>For interface objects, the default is to return a <em>reference</em> to the internal object. This has to be mentioned both in the short description in the interface page, and in the description in the specific sub-pages.</p>
 
 <div class="note notecard">
-<p><span><strong>Note:</strong> The keyword <code>readonly</code> used with a property returning an object applies to the <u>reference</u> (the internal object cannot be changed.) The properties of the returned object can be changed, even if they are marked as read-only in the relevant interface.</span></p>
+<p><strong>Note:</strong> The keyword <code>readonly</code> used with a property returning an object applies to the <u>reference</u> (the internal object cannot be changed.) The properties of the returned object can be changed, even if they are marked as read-only in the relevant interface.</p>
 </div>
 
 <p>Sometimes an API must return a <em>new</em> object, or a <em>copy</em> of an internal one. This case is indicated in the WebIDL using the <code>[NewObject]</code> annotation.</p>
@@ -295,7 +295,7 @@ interface SpeechSynthesis {
  <dd>Returns a live \{{domxref("HTMLFormControlsCollection")}} containing…</dd>
 </dl>
 
-<h3 id="Availability_in_workers"><span>Availability in workers</span></h3>
+<h3 id="Availability_in_workers">Availability in workers</h3>
 
 <p>Individual property availability in workers is also found in the WebIDL. For a property, the default is the same availability as the <code>interface</code> (that is available to {{domxref('Window')}} context only if nothing special is marked) or as the <code>partial interface</code> it is defined in.</p>
 
@@ -312,10 +312,10 @@ interface SpeechSynthesis {
 <pre class="syntaxbox" lang="en"><strong>[Pref="media.webvtt.enabled"]</strong>
     readonly attribute TextTrackList? textTracks;</pre>
 
-<p><span>Here <code>media.webvtt.enabled</code> controls the <code>textTracks</code> property. </span></p>
+<p>Here <code>media.webvtt.enabled</code> controls the <code>textTracks</code> property.</p>
 
 <div class="note notecard">
-<p><span>The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another).</span></p>
+<p>The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another).</p>
 </div>
 
 <h2 id="Methods">Methods</h2>
@@ -340,22 +340,22 @@ interface SpeechSynthesis {
 
 <pre class="syntaxbox" lang="en">DOMString <strong>canPlayType</strong>(DOMString type);</pre>
 
-<p><span>The return value type is indicated first inside the parentheses — in the above case the value is an object of type <code>DOMString</code>. if followed by a question mark (<code>'?'</code>), a value of <code>null</code> can be returned too, and the documentation must explain <em>when</em> this may happen. If no question mark is present, like here,  the return value can't be <code>null</code>.</span></p>
+<p>The return value type is indicated first inside the parentheses — in the above case the value is an object of type <code>DOMString</code>. if followed by a question mark (<code>'?'</code>), a value of <code>null</code> can be returned too, and the documentation must explain <em>when</em> this may happen. If no question mark is present, like here,  the return value can't be <code>null</code>.</p>
 
-<p><span>The keyword <code>void</code> means that there is no return value. It is not a return value type. If the WebIDL entry reads <code>void</code>, the <em>Return value</em> section in the docs should contain only a simple <em>None</em>.</span></p>
+<p>The keyword <code>void</code> means that there is no return value. It is not a return value type. If the WebIDL entry reads <code>void</code>, the <em>Return value</em> section in the docs should contain only a simple <em>None</em>.</p>
 
 <h3 id="Throwing_exceptions_2">Throwing exceptions</h3>
 
 <pre class="syntaxbox" lang="en"><strong>[Throws]</strong>
    void fastSeek(double time);</pre>
 
-<p><span>Some methods can throw exceptions. This is marked using the <code>[Throws]</code> annotation. When this happens, the Syntax section of the method page <em>must</em> have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.</span></p>
+<p>Some methods can throw exceptions. This is marked using the <code>[Throws]</code> annotation. When this happens, the Syntax section of the method page <em>must</em> have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.</p>
 
-<p><span>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="https://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{exception('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.</span></p>
+<p>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="https://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{exception('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.</p>
 
-<p><span>Have a look at one of these <a href="/en-US/docs/Web/API/SubtleCrypto/importKey#Exceptions"><em>Exceptions</em> sections</a>.</span></p>
+<p>Have a look at one of these <a href="/en-US/docs/Web/API/SubtleCrypto/importKey#Exceptions"><em>Exceptions</em> sections</a>.</p>
 
-<h3 id="Availability_in_workers_2"><span>Availability in workers</span></h3>
+<h3 id="Availability_in_workers_2">Availability in workers</h3>
 
 <p>Individual method availability in workers is also found in the WebIDL. For a method, the default is the same availability as the <code>interface</code> (that is available to {{domxref('Window')}} context only if nothing special is marked) or as the <code>partial interface</code> it is defined it.</p>
 
@@ -374,10 +374,10 @@ interface SpeechSynthesis {
                           optional DOMString label = "",
                           optional DOMString language = "");</pre>
 
-<p><span>Here <code>media.webvtt.enabled</code> controls the <code>addTextTrack()</code> method. </span></p>
+<p>Here <code>media.webvtt.enabled</code> controls the <code>addTextTrack()</code> method.</p>
 
 <div class="note notecard">
-<p><span><strong>Note:</strong> The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)</span></p>
+<p><strong>Note:</strong> The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)</p>
 </div>
 
 <h2 id="Special_methods">Special methods</h2>
@@ -394,8 +394,8 @@ interface SpeechSynthesis {
 
 <p>A jsonifier is mapped to <code>toJSON()</code> and defined as:</p>
 
-<pre class="syntaxbox" lang="en"><strong>jsonifier;</strong> <span>// Gecko version</span><strong><span>
-serializer;</span></strong><span> // Standard version</span>
+<pre class="syntaxbox" lang="en"><strong>jsonifier;</strong> // Gecko version<strong>
+serializer;</strong> // Standard version
 </pre>
 
 <p>The <code>toJSON()</code> method is listed just like any other method of the interface and has its own sub-page (E.g. {{domxref("Performance.toJSON()")}})</p>
@@ -519,9 +519,9 @@ console.log(interfaceIdentifier.name);
   Exposed=(Window,Worker)]
     interface MessageChannel {…};</pre>
 
-<p><span>A constructor with the same interface is defined using the <code>Constructor</code> annotation on the interface. There can be parenthesis and a list of parameters or not (like in the above example.) We document all the unnamed constructors on a sub-page — for example the above is given the slug <em>Web/API/MessageChannel/MessageChannel</em> and the title <code>MessageChannel()</code>.</span></p>
+<p>A constructor with the same interface is defined using the <code>Constructor</code> annotation on the interface. There can be parenthesis and a list of parameters or not (like in the above example.) We document all the unnamed constructors on a sub-page — for example the above is given the slug <em>Web/API/MessageChannel/MessageChannel</em> and the title <code>MessageChannel()</code>.</p>
 
-<p><span>Another example of an unnamed constructor, with parameters:</span></p>
+<p>Another example of an unnamed constructor, with parameters:</p>
 
 <pre class="syntaxbox" lang="en">[<strong>Constructor</strong>(DOMString type, optional MessageEventInit eventInitDict),
  Exposed=(Window,Worker,System)]
@@ -539,13 +539,13 @@ console.log(interfaceIdentifier.name);
 <pre class="syntaxbox" lang="en">[<strong>NamedConstructor</strong>=Image(optional unsigned long width, optional unsigned long height)]
     interface HTMLImageElement : HTMLElement {…</pre>
 
-<p><span>A named constructor is a constructor that has a different name than that of its interface. For example<code> new Image(…)</code> creates a new <code>HTMLImageElement</code> object. They are defined in the WebIDL using the <code>NamedConstructor</code> annotation on the interface, followed by the name of the constructor after the equality sign (<code>'='</code>) and the parameter inside the parenthesis, in the same format as you'll see for methods.</span></p>
+<p>A named constructor is a constructor that has a different name than that of its interface. For example<code> new Image(…)</code> creates a new <code>HTMLImageElement</code> object. They are defined in the WebIDL using the <code>NamedConstructor</code> annotation on the interface, followed by the name of the constructor after the equality sign (<code>'='</code>) and the parameter inside the parenthesis, in the same format as you'll see for methods.</p>
 
-<p><span>There can be several named constructors for a specific interface, but this is extremely rare; in such a case we include one sub-page per name.</span></p>
+<p>There can be several named constructors for a specific interface, but this is extremely rare; in such a case we include one sub-page per name.</p>
 
-<h3 id="New_constructor_syntax"><span>New constructor syntax</span></h3>
+<h3 id="New_constructor_syntax">New constructor syntax</h3>
 
-<p><span>As of September 2019, WebIDL constructor syntax was updated. </span>Constructor syntax no longer involves an extended attribute on the interface:</p>
+<p>As of September 2019, WebIDL constructor syntax was updated. </span>Constructor syntax no longer involves an extended attribute on the interface:</p>
 
 <pre>[Constructor(DOMString str)]
     interface MyInterface {
@@ -566,7 +566,7 @@ console.log(interfaceIdentifier.name);
 
 <p>It is unlikely that <em>all</em> specs will be updated to use the new syntax, so you'll probably encounter both out in the wild. We will therefore continue to cover both types of syntax here.</p>
 
-<h3 id="Availability_in_workers_3"><span>Availability in workers</span></h3>
+<h3 id="Availability_in_workers_3">Availability in workers</h3>
 
 <p>Constructors have the same availability as the interface, or partial interface, they are defined on. The sub-page provides this information in the same way as for a method.</p>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/building_on_os2_using_mercurial/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/building_on_os2_using_mercurial/index.html
@@ -39,7 +39,7 @@ hgext.win32text =
 [decode]
 **.cmd = dumbdecode:
 **/os2/README.* = dumbdecode:</pre>
-<h2 class="editable" id="Getting_sources_and_building"><span>Getting sources and building</span></h2>
+<h2 class="editable" id="Getting_sources_and_building">Getting sources and building</h2>
 <h3 id="Mercurial-based_checkout">Mercurial-based "checkout"</h3>
 <p>Detailed instructions for checking out the code can be found elsewhere: for <a href="/En/Developer_Guide/Source_Code/Mercurial#Checking_out_a_source_tree" title="Mozilla Source Code (Mercurial): checking out a source tree">mozilla-central</a> (or <a href="/En/Developer_Guide/Source_Code/Mercurial#mozilla-1.9.1_(Firefox_3.1)">mozilla-1.9.1</a>, both are Firefox-only) and of <a class="internal" href="/En/Developer_Guide/Source_Code/Getting_comm-central#Checking_out_a_source_tree" title="comm-central source code (Mercurial): checking out a source tree">comm-central</a> (SeaMonkey and Thunderbird). Note that the instructions for comm-central include getting the code of mozilla (mozilla-central or mozilla-1.9.1), i.e. Firefox code and all backend code, which will be set up in a subdirectory <code>mozilla</code> of the directory to which you clone comm-central.</p>
 <p>Basically you do this to get the code:</p>

--- a/files/en-us/mozilla/developer_guide/coding_style/formatting_js_code_with_prettier_and_eslint/index.html
+++ b/files/en-us/mozilla/developer_guide/coding_style/formatting_js_code_with_prettier_and_eslint/index.html
@@ -133,7 +133,7 @@ $ ln -s $(pwd)/tools/lint/hooks_js_format.py .git/hooks/pre-commit</pre>
    }<br>
  }</kbd></p>
 
-<h2 id="Configuration"><span>Configuration</span></h2>
+<h2 id="Configuration">Configuration</h2>
 
 <p><strong>Code quality</strong> configurations for <a href="http://eslint.org">ESLint</a> are entirely determined by the options defined in <span class="message"><span class="content"><a href="https://dxr.mozilla.org/mozilla-central/source/.eslintrc">.eslintrc.js</a>.</span></span> However, <strong>coding style</strong> configurations are largely predetermined within <a href="https://prettier.io">Prettier</a> itself, and we only specify a minimal set of options in <span class="message"><span class="content"><a href="https://dxr.mozilla.org/mozilla-central/source/.prettierrc">.prettierrc</a></span></span>. Use of local overrides is not planned and not part of our guidelines.</p>
 
@@ -178,9 +178,9 @@ $ /path/to/js-format-merge/git-wrapper rebase &lt;upstream&gt;
 
 <p>The wrapper should clean up after itself, and the clone may be deleted after the rebase is complete.</p>
 
-<h2 id="Ignore_lists_for_blame"><span>Ignore lists for blame</span></h2>
+<h2 id="Ignore_lists_for_blame">Ignore lists for blame</h2>
 
-<p><span>To make sure that the blame/annotate features of Mercurial or git aren't affected. Two files are maintained to keep track of the reformatting commits.</span></p>
+<p>To make sure that the blame/annotate features of Mercurial or git aren't affected. Two files are maintained to keep track of the reformatting commits.</p>
 
 <h3 id="Mercurial_2">Mercurial</h3>
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -349,7 +349,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Pseudo-class_focus-visible"><span>Pseudo-class: :focus-visible</span></h3>
+<h3 id="Pseudo-class_focus-visible">Pseudo-class: :focus-visible</h3>
 
 <p>Allows focus styles to be applied to elements like buttons and form controls, only when they are focused using the keyboard (e.g. when tabbing between elements), and not when they are focused using a mouse or other pointing device. See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1617600">bug 1617600</a> for more details.</p>
 
@@ -1666,7 +1666,7 @@ tags:
 
 <p>[1] Support for zooming using the double-tap gesture was added in Firefox 76. The other gestures were added for Firefox 79.</p>
 
-<h4 id="Server-sent_events_in_Network_Monitor"><span>Server-sent events in Network Monitor</span></h4>
+<h4 id="Server-sent_events_in_Network_Monitor">Server-sent events in Network Monitor</h4>
 
 <p>The Network Monitor displays information for <a href="/en-US/docs/Web/API/Server-sent_events">server-sent</a> events. See {{bug(1405706)}}.</p>
 

--- a/files/en-us/mozilla/firefox/releases/53/index.html
+++ b/files/en-us/mozilla/firefox/releases/53/index.html
@@ -155,11 +155,11 @@ tags:
 
 <ul>
  <li>The <span id="summary_alias_container"><span id="short_desc_nonedit_display"><code>dom.details_element.enabled</code> pref — which controlled enabling/disabling {{htmlelement("details")}} and {{htmlelement("summary")}} element support in Firefox — has now been removed from <code>about:config</code>. These elements (which were first enabled by default in Firefox 49) can no longer be disabled. See {{bug(1271549)}}.</span></span></li>
- <li><span><span>The <code>mozapp</code> attribute of the {{htmlelement("iframe")}} element</span></span>/{{domxref("HTMLIFrameElement")}} interface has been removed — this was used to enable a Firefox OS app to be embedded in a moz <a href="/en-US/docs/Mozilla/Gecko/Chrome/API/Browser_API">Browser API</a> <code>&lt;iframe&gt;</code> ({{bug(1310845)}}).</li>
+ <li>The <code>mozapp</code> attribute of the {{htmlelement("iframe")}} element /{{domxref("HTMLIFrameElement")}} interface has been removed — this was used to enable a Firefox OS app to be embedded in a moz <a href="/en-US/docs/Mozilla/Gecko/Chrome/API/Browser_API">Browser API</a> <code>&lt;iframe&gt;</code> ({{bug(1310845)}}).</li>
  <li>The {{domxref("HTMLIFrameElement.setInputMethodActive()")}} method and <code>InputMethod</code> interface (used to set and manage IMEs on Firefox OS apps) has been removed ({{bug(1313169)}}).</li>
 </ul>
 
-<h3 id="CSS_2"><span><span>CSS</span></span></h3>
+<h3 id="CSS_2">CSS</h3>
 
 <ul>
  <li>Removed {{property_prefix("-moz")}} prefixed variant of {{cssxref(":dir", ":dir()")}} pseudo-class ({{bug(1270406)}}).</li>

--- a/files/en-us/mozilla/firefox/releases/79/index.html
+++ b/files/en-us/mozilla/firefox/releases/79/index.html
@@ -28,17 +28,17 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Tools/Debugger/How_to/Black_box_a_source">"Blackbox" a source file</a> is now called "ignore" a source file.  ({{bug(1642811)}})</li>
- <li><span><span>Inline preview is now available on <a href="/en-US/docs/Tools/Debugger/How_to/Breaking_on_exceptions">exceptions</a>. ({{bug(1581708)}})</span></span></li>
- <li><span><span>Items in the Watch Expressions and Scopes sections now have tooltips on hover, showing their values ({{bug(1631545)}})</span></span></li>
- <li><span><span>In the <a href="/en-US/docs/Tools/Debugger/UI_Tour#Call_stack">Call Stack section</a>, there is now a context menu option to <strong>Restart Frame</strong>, to execute the current stack frame from its beginning. ({{bug(1594467)}})</span></span></li>
+ <li>Inline preview is now available on <a href="/en-US/docs/Tools/Debugger/How_to/Breaking_on_exceptions">exceptions</a>. ({{bug(1581708)}})</li>
+ <li>Items in the Watch Expressions and Scopes sections now have tooltips on hover, showing their values ({{bug(1631545)}})</li>
+ <li>In the <a href="/en-US/docs/Tools/Debugger/UI_Tour#Call_stack">Call Stack section</a>, there is now a context menu option to <strong>Restart Frame</strong>, to execute the current stack frame from its beginning. ({{bug(1594467)}})</li>
 </ul>
 
-<h4 id="Other_tools"><span>Other tools</span></h4>
+<h4 id="Other_tools">Other tools</h4>
 
 <ul>
  <li>The new <a href="/en-US/docs/Tools/Application">Application panel</a> is now available, which initially provides inspection and debugging support for <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a> and <a href="/en-US/docs/Web/Manifest">web app manifests</a>.</li>
- <li><span><span>The Messages tab of the Network Monitor has been merged with the <a href="/en-US/docs/Tools/Network_Monitor/request_details#Response_tab">Responses tab</a>. ({{bug(1636421)}})</span></span></li>
- <li><span><span>The Accessibility Inspector is automatically turned on when you access its tab; you no longer need to explicitly enable it. ({{bug(1602075)}})</span></span></li>
+ <li>The Messages tab of the Network Monitor has been merged with the <a href="/en-US/docs/Tools/Network_Monitor/request_details#Response_tab">Responses tab</a>. ({{bug(1636421)}})</li>
+ <li>The Accessibility Inspector is automatically turned on when you access its tab; you no longer need to explicitly enable it. ({{bug(1602075)}})</li>
  <li>In <a href="/en-US/docs/Tools/Responsive_Design_Mode#Controlling_Responsive_Design_Mode">Responsive Design Mode</a>, when touch simulation is enabled, mouse-drag events are now interpreted as touch-drag or swipe events. ({{bug(1621781)}})</li>
  <li>When <a href="/en-US/docs/Tools/about:debugging#Connecting_to_a_remote_device">remote debugging</a>, the URL bar now has <strong>Back</strong> and <strong>Forward</strong> buttons to help with navigation on the remote browser. ({{bug(1639425)}})</li>
 </ul>

--- a/files/en-us/mozilla/projects/nss/nss_3.12.9_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.9_release_notes/index.html
@@ -25,12 +25,12 @@ tags:
 <div id="section_3">
  <h1 class="editable" id="New_in_NSS_3.12.9">New in NSS 3.12.9</h1>
  <div id="section_5">
-  <h3 class="editable" id="Removed_functions"><span>Removed functions</span></h3>
+  <h3 class="editable" id="Removed_functions">Removed functions</h3>
  </div>
  <div id="section_6">
-  <h3 class="editable" id="New_SSL_options"><span>New SSL options</span></h3>
+  <h3 class="editable" id="New_SSL_options">New SSL options</h3>
   <div id="section_7">
-   <h3 class="editable" id="New_error_codes"><span>New error codes</span></h3>
+   <h3 class="editable" id="New_error_codes">New error codes</h3>
   </div>
  </div>
 </div>

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
@@ -20,11 +20,11 @@ tags:
 
 <p>This attribute can be used with any typical HTML element; it is not limited to elements that have an ARIA <code>role</code> assigned.</p>
 
-<h3 class="editable" id="Value"><span>Value</span></h3>
+<h3 class="editable" id="Value">Value</h3>
 
 <p>string</p>
 
-<h3 class="editable" id="Possible_effects_on_user_agents_and_assistive_technology"><span>Possible effects on user agents and assistive technology </span></h3>
+<h3 class="editable" id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology</h3>
 
 <div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
 

--- a/files/en-us/web/api/clipboard/readtext/index.html
+++ b/files/en-us/web/api/clipboard/readtext/index.html
@@ -29,7 +29,7 @@ tags:
 
 <p>None.</p>
 
-<h3 id="Return_value"><span>Return value</span></h3>
+<h3 id="Return_value">Return value</h3>
 
 <p>A {{jsxref("Promise")}} that resolves with a {{domxref("DOMString")}} containing the textual contents of the clipboard. Returns an empty string if the clipboard is empty, does not contain text, or does not include a textual representation among the {{domxref("DataTransfer")}} objects representing the clipboard's contents.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
@@ -20,9 +20,9 @@ tags:
 <pre class="syntaxbox notranslate"><em>element</em>.onmouseout = <em>function</em>;
 </pre>
 
-<h2 class="editable" id="Example"><span><span>Example</span></span></h2>
+<h2 class="editable" id="Example">Example</h2>
 
-<p><span><span>This example adds an <code>onmouseout</code> and an <code>onmouseover</code> event to a paragraph. Try moving your mouse over and out of the element.</span></span></p>
+<p>This example adds an <code>onmouseout</code> and an <code>onmouseover</code> event to a paragraph. Try moving your mouse over and out of the element.</p>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
@@ -20,9 +20,9 @@ tags:
 <pre class="syntaxbox notranslate"><em>element</em>.onmouseover = <em>function</em>;
 </pre>
 
-<h2 class="editable" id="Example"><span>Example</span></h2>
+<h2 class="editable" id="Example">Example</h2>
 
-<p><span><span>This example adds an <code>onmouseover</code> and an <code>onmouseout</code> event to a paragraph. Try moving your mouse over and out of the element.</span></span></p>
+<p>This example adds an <code>onmouseover</code> and an <code>onmouseout</code> event to a paragraph. Try moving your mouse over and out of the element.</p>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/web/api/history/state/index.html
+++ b/files/en-us/web/api/history/state/index.html
@@ -34,7 +34,7 @@ history.pushState({name: 'Example'}, "pushState example", 'page3.html');
 // Now state has a value.
 console.log(`History.state after pushState: ${history.state}`);</pre>
 
-<h2 id="SpecificationsE">Specifications<a class="button section-edit only-icon" href="/en-US/docs/Web/API/History$edit#Specifications" rel="nofollow, noindex"><span>E</span></a></h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
  <tbody>

--- a/files/en-us/web/api/htmlselectelement/autofocus/index.html
+++ b/files/en-us/web/api/htmlselectelement/autofocus/index.html
@@ -18,7 +18,7 @@ tags:
 <p>Setting this property doesn't set the focus to the associated {{HTMLElement("select")}} element: it merely tells the browser to focus to it when <em>the element is inserted</em> in the document. Setting it after the insertion, that is most of the time after the document load, has no visible effect.</p>
 </div>
 
-<h2 id="Syntax">Syntax<a class="button section-edit only-icon" href="/en-US/docs/Web/API/HTMLSelectElement/type$edit#Syntax"><span>Edit</span></a></h2>
+<h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">aBool = aSelectElement.autofocus; // Get the value of autofocus
 aSelectElement.autofocus = aBool; // Set the value of autofocus

--- a/files/en-us/web/api/presentation_api/index.html
+++ b/files/en-us/web/api/presentation_api/index.html
@@ -49,7 +49,7 @@ tags:
 <p>Example codes below highlight the usage of main features of the Presentation API: <code>controller.html</code> implements the controller and <code>presentation.html</code> implements the presentation. Both pages are served from the domain <code>http://example.org</code> (<code>http://example.org/controller.html</code> and <code>http://example.org/presentation.html</code>). These examples assume that the controlling page is managing one presentation at a time. Please refer to the comments in the code examples for further details.</p>
 
 <section id="monitor-availability-of-presentation-displays-example">
-<h3 id="Monitor_availability_of_presentation_displays"><span>Monitor availability of presentation displays </span></h3>
+<h3 id="Monitor_availability_of_presentation_displays">Monitor availability of presentation displays</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
@@ -85,7 +85,7 @@ tags:
 </section>
 
 <section id="starting-a-new-presentation-example">
-<h3 id="Starting_a_new_presentation"><span>Starting a new presentation </span></h3>
+<h3 id="Starting_a_new_presentation">Starting a new presentation</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
@@ -104,7 +104,7 @@ tags:
 </section>
 
 <section id="reconnect-to-a-presentation-example">
-<h3 id="Reconnect_to_a_presentation"><span>Reconnect to a presentation </span></h3>
+<h3 id="Reconnect_to_a_presentation">Reconnect to a presentation</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
@@ -131,7 +131,7 @@ tags:
 </section>
 
 <section id="presentation-initiation-by-the-controlling-ua-example">
-<h3 id="Presentation_initiation_by_the_controlling_UA"><span>Presentation initiation by the controlling UA </span></h3>
+<h3 id="Presentation_initiation_by_the_controlling_UA">Presentation initiation by the controlling UA</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
@@ -148,7 +148,7 @@ tags:
 </section>
 
 <section id="monitor-connection-s-state-and-exchange-data-example">
-<h3 id="Monitor_connections_state_and_exchange_data"><span>Monitor connection's state and exchange data </span></h3>
+<h3 id="Monitor_connections_state_and_exchange_data">Monitor connection's state and exchange data</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>
@@ -225,7 +225,7 @@ tags:
 </section>
 
 <section id="monitor-available-connection-s-and-say-hello">
-<h3 id="Monitor_available_connections_and_say_hello"><span>Monitor available connection(s) and say hello </span></h3>
+<h3 id="Monitor_available_connections_and_say_hello">Monitor available connection(s) and say hello</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- presentation.html --&gt;</span>
@@ -250,7 +250,7 @@ tags:
 </section>
 
 <section id="passing-locale-information-with-a-message">
-<h3 id="Passing_locale_information_with_a_message"><span>Passing locale information with a message </span></h3>
+<h3 id="Passing_locale_information_with_a_message">Passing locale information with a message</h3>
 
 <div class="example">
 <pre class="brush: js"><span class="hljs-comment">&lt;!-- controller.html --&gt;</span>

--- a/files/en-us/web/api/rtcofferoptions/icerestart/index.html
+++ b/files/en-us/web/api/rtcofferoptions/icerestart/index.html
@@ -41,7 +41,7 @@ tags:
 
 <p>Fundamentally, this renegotiation is triggered by generating and using new values for the ICE username fragment ("ufrag")}}</p>
 
-<h2 id="Example"><span>Example</span></h2>
+<h2 id="Example">Example</h2>
 
 <p>This example shows a handler for the {{event("iceconnectionstatechange")}} event. It watches for the ICE connection state to transition to <code>"failed"</code>, which indicates that an ICE restart should be tried in order to attempt to bring the connection back up.</p>
 

--- a/files/en-us/web/css/_colon_active/index.html
+++ b/files/en-us/web/css/_colon_active/index.html
@@ -75,7 +75,7 @@ form button {
 
 <p>{{EmbedLiveSample('Active_form_elements')}}</p>
 
-<h2 id="Specifications"><span>Specifications</span></h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/css/frequency/index.html
+++ b/files/en-us/web/css/frequency/index.html
@@ -29,7 +29,7 @@ tags:
 <p><strong>Note:</strong> Although the number <code>0</code> is always the same regardless of unit, the unit may not be omitted. In other words, <code>0</code> is invalid and does not represent <code>0Hz</code> or <code>0kHz</code>. Though the units are case-insensitive, it is good practice to use a capital "H" for <code>Hz</code> and <code>kHz</code>, as specified in the <a class="external" href="https://en.wikipedia.org/wiki/International_System_of_Units">SI</a>.</p>
 </div>
 
-<h2 id="Examples"><span>Examples</span></h2>
+<h2 id="Examples">Examples</h2>
 
 <h3 id="Valid_frequency_values">Valid frequency values</h3>
 

--- a/files/en-us/web/javascript/guide/index.html
+++ b/files/en-us/web/javascript/guide/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>This Guide is divided into the following chapters.</p>
 
-<h2 id="Introduction"><span><a href="/en-US/docs/Web/JavaScript/Guide/Introduction">Introduction</a></span></h2>
+<h2 id="Introduction" href="/en-US/docs/Web/JavaScript/Guide/Introduction">Introduction</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Introduction#Where_to_find_JavaScript_information">About this guide</a></li>
@@ -23,7 +23,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Introduction#Hello_world">Hello World</a></li>
 </ul>
 
-<h2 id="Grammar_and_types"><span><a href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types">Grammar and types</a></span></h2>
+<h2 id="Grammar_and_types" href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types">Grammar and types</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Basics">Basic syntax &amp; comments</a></li>
@@ -34,7 +34,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Literals">Literals</a></li>
 </ul>
 
-<h2 id="Control_flow_and_error_handling"><span><a href="/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling">Control flow and error handling</a></span></h2>
+<h2 id="Control_flow_and_error_handling" href="/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling">Control flow and error handling</h2>
 
 <ul>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#if...else_statement">if...else</a></code></li>
@@ -43,7 +43,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#Utilizing_Error_objects">Error objects</a></li>
 </ul>
 
-<h2 id="Loops_and_iteration"><span><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration">Loops and iteration</a></span></h2>
+<h2 id="Loops_and_iteration" href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration">Loops and iteration</h2>
 
 <ul>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for_statement">for</a></code></li>
@@ -54,7 +54,7 @@ tags:
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement">for..of</a></code></li>
 </ul>
 
-<h2 id="Functions"><span><a href="/en-US/docs/Web/JavaScript/Guide/Functions">Functions</a></span></h2>
+<h2 id="Functions" href="/en-US/docs/Web/JavaScript/Guide/Functions">Functions</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Functions#Defining_functions">Defining functions</a></li>
@@ -65,7 +65,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Functions#Arrow_functions">Arrow functions</a></li>
 </ul>
 
-<h2 id="Expressions_and_operators"><span><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators">Expressions and operators</a></span></h2>
+<h2 id="Expressions_and_operators" href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators">Expressions and operators</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment_operators">Assignment</a> &amp; <a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Comparison_operators">Comparisons</a></li>
@@ -74,7 +74,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Conditional_(ternary)_operator">Conditional (ternary) operator</a></li>
 </ul>
 
-<h2 id="Numbers_and_dates"><span><a href="/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates">Numbers and dates</a></span></h2>
+<h2 id="Numbers_and_dates" href="/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates">Numbers and dates</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#Numbers">Number literals</a></li>
@@ -83,7 +83,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#Date_object"><code>Date</code> object</a></li>
 </ul>
 
-<h2 id="Text_formatting"><span><a href="/en-US/docs/Web/JavaScript/Guide/Text_formatting">Text formatting</a></span></h2>
+<h2 id="Text_formatting" href="/en-US/docs/Web/JavaScript/Guide/Text_formatting">Text formatting</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Text_formatting#String_literals">String literals</a></li>
@@ -93,14 +93,14 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">Regular Expressions</a></li>
 </ul>
 
-<h2 id="Indexed_collections"><span><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections">Indexed collections</a></span></h2>
+<h2 id="Indexed_collections" href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections">Indexed collections</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Array_object">Arrays</a></li>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Typed_Arrays">Typed arrays</a></li>
 </ul>
 
-<h2 id="Keyed_collections"><span><a href="/en-US/docs/Web/JavaScript/Guide/Keyed_collections">Keyed collections</a></span></h2>
+<h2 id="Keyed_collections" href="/en-US/docs/Web/JavaScript/Guide/Keyed_collections">Keyed collections</h2>
 
 <ul>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Keyed_collections#Map_object">Map</a></code></li>
@@ -109,7 +109,7 @@ tags:
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Keyed_collections#WeakSet_object">WeakSet</a></code></li>
 </ul>
 
-<h2 id="Working_with_objects"><span><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects">Working with objects</a></span></h2>
+<h2 id="Working_with_objects" href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects">Working with objects</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Objects_and_properties">Objects and properties</a></li>
@@ -118,7 +118,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Defining_getters_and_setters">Getter and setter</a></li>
 </ul>
 
-<h2 id="Details_of_the_object_model"><span><a href="/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model">Details of the object model</a></span></h2>
+<h2 id="Details_of_the_object_model" href="/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model">Details of the object model</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#Class-based_vs._prototype-based_languages">Prototype-based OOP</a></li>
@@ -126,7 +126,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#Property_inheritance_revisited">Inheritance</a></li>
 </ul>
 
-<h2 id="Promises"><span><a href="/en-US/docs/Web/JavaScript/Guide/Using_promises">Promises</a></span></h2>
+<h2 id="Promises" href="/en-US/docs/Web/JavaScript/Guide/Using_promises">Promises</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Using_promises#Guarantees">Guarantees</a></li>
@@ -136,7 +136,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Using_promises#Timing">Timing</a></li>
 </ul>
 
-<h2 id="Iterators_and_generators"><span><a href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterators and generators</a></span></h2>
+<h2 id="Iterators_and_generators" href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterators and generators</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Iterators">Iterators</a></li>
@@ -144,7 +144,7 @@ tags:
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators</a></li>
 </ul>
 
-<h2 id="Meta_programming"><span><a href="/en-US/docs/Web/JavaScript/Guide/Meta_programming">Meta programming</a></span></h2>
+<h2 id="Meta_programming" href="/en-US/docs/Web/JavaScript/Guide/Meta_programming">Meta programming" </h2>
 
 <ul>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Meta_programming#Proxies">Proxy</a></code></li>
@@ -153,7 +153,7 @@ tags:
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Meta_programming#Reflection">Reflect</a></code></li>
 </ul>
 
-<h2 id="JavaScript_modules"><span><a href="/en-US/docs/Web/JavaScript/Guide/Modules">JavaScript modules</a></span></h2>
+<h2 id="JavaScript_modules" href="/en-US/docs/Web/JavaScript/Guide/Modules">JavaScript modules</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Guide/Modules#Exporting_module_features">Exporting</a></li>

--- a/files/en-us/web/performance/lazy_loading/index.html
+++ b/files/en-us/web/performance/lazy_loading/index.html
@@ -12,11 +12,11 @@ tags:
   - Web Performance
   - rendering
 ---
-<p><span class="seoSummary"><strong>Lazy loading </strong><span>is a strategy to identify resources as non-blocking (non-critical) and load these only when needed. It's a way to shorten the length of the </span><a href="/en-US/docs/Web/Performance/Critical_rendering_path">critical rendering path</a><span>, which translates into reduced page load times.</span></span></p>
+<p><span class="seoSummary"><strong>Lazy loading</strong> is a strategy to identify resources as non-blocking (non-critical) and load these only when needed. It's a way to shorten the length of the <a href="/en-US/docs/Web/Performance/Critical_rendering_path">critical rendering path</a>, which translates into reduced page load times.</span></p>
 
 <p>Lazy loading can occur on different moments in the application, but it typically happens on some user interactions such as scrolling and navigation. </p>
 
-<h2 id="Overview"><span>Overview</span></h2>
+<h2 id="Overview">Overview</h2>
 
 <p>As the web has evolved, we have come to see huge increases in the number and size of assets sent to users.<br>
  Between 2011 and 2019, the median resource weight increased from <strong>~100KB</strong> to <strong>~400KB</strong> for desktop and <strong>~50KB</strong> to <strong>~350KB</strong> for mobile. While Image size has increased from <strong>~250KB</strong> to <strong>~900KB</strong> on desktop and <strong>~100KB</strong> to <strong>~850KB</strong> on mobile.</p>
@@ -28,7 +28,7 @@ tags:
 
 <p>Lazy loading can be applied to multiple resources and through multiple strategies.   </p>
 
-<h3 id="General">    General</h3>
+<h3 id="General">General</h3>
 
 <p id="Code_splitting"><strong>Code splitting</strong><br>
  JavaScript, CSS and HTML can be split into smaller chunks. This enables sending the minimal code required to provide value upfront, improving page-load times. The rest can be loaded on demand.</p>
@@ -38,12 +38,12 @@ tags:
  <li>    Dynamic splitting: separates code where <a href="/en-US/docs/Web/JavaScript/Reference/Statements/import">dynamic import()</a> statements are used</li>
 </ul>
 
-<h3 id="JavaScript">    JavaScript</h3>
+<h3 id="JavaScript">JavaScript</h3>
 
 <p><strong>Script type module</strong><br>
  Any script tag with <code>type="module"</code> is treated like a <a href="/en-US/docs/Web/JavaScript/Guide/Modules">JavaScript module</a> and is deferred by default.</p>
 
-<h3 id="CSS">    CSS</h3>
+<h3 id="CSS">CSS</h3>
 
 <p>By default, CSS is treated as a <a href="/en-US/docs/Web/Performance/Critical_rendering_path">render blocking</a> resource, so the browser won't render any processed content until the <a href="/en-US/docs/Web/API/CSS_Object_Model">CSSOM</a> is constructed. CSS must be thin, delivered as quickly as possible, and the usage media types and queries are advised to unblock rendering.</p>
 

--- a/files/en-us/web/security/mixed_content/index.html
+++ b/files/en-us/web/security/mixed_content/index.html
@@ -85,7 +85,7 @@ tags:
 </ul>
 </div>
 
-<h2 id="Warnings_in_Firefox_Web_Console"><span>Warnings in Firefox Web Console</span></h2>
+<h2 id="Warnings_in_Firefox_Web_Console">Warnings in Firefox Web Console</h2>
 
 <p>The Firefox Web Console displays a mixed content warning message in the Net pane when a page on your website has this issue. The mixed content resource that was loaded via HTTP will show up in red, along with the text "mixed content", which links to this page.</p>
 


### PR DESCRIPTION
This commit removes `<span>` without attributes in headers `<h[123456]>` across all content. Also, in affected files removes `<span>` in other contexts like in `<p>` and `<li>`.