### PR TITLE
Use correct macros & add tutorial to landing page

### DIFF
--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.html
@@ -2,7 +2,7 @@
 title: Setup
 slug: Web/API/WebRTC_API/build_a_phone_with_peerjs/setup
 ---
-<p>{{WebRTCSidebar}} {{NextMenu("Web/API/WebRTC_API/build_a_phone_with_peerjs", "Web/API/WebRTC_API/build_a_phone_with_peerjs/Build_the_Server")}}</p>
+<p>{{WebRTCSidebar}} {{PreviousMenuNext("Web/API/WebRTC_API/build_a_phone_with_peerjs", "Web/API/WebRTC_API/build_a_phone_with_peerjs/Build_the_Server")}}</p>
 
 <p id="3f63">So let’s set things up. First you’ll need to run <code>mkdir audio_app</code><br>
  and then <code>cd audio_app</code> &amp; finally you’ll want to create a new app by running <code>yarn init</code> . Follow the prompts, give a name, version, description, etc to your project. Next install the dependencies:</p>
@@ -36,4 +36,4 @@ slug: Web/API/WebRTC_API/build_a_phone_with_peerjs/setup
 
 <p>To finish up the setup, you’ll want to copy the <a href="https://gist.github.com/578d692e4700dfe2c9d239c80bbdbabc" rel="noopener nofollow">HTML</a> &amp; <a href="https://gist.github.com/b4498288b86ddce995603546a64abb29" rel="noopener nofollow">CSS</a> files I mentioned before, into your project folder.</p>
 
-<p>{{NextMenu("Web/API/WebRTC_API/build_a_phone_with_peerjs", "Web/API/WebRTC_API/build_a_phone_with_peerjs/Build_the_Server")}}</p>
+<p>{{PreviousMenuNext("Web/API/WebRTC_API/build_a_phone_with_peerjs", "Web/API/WebRTC_API/build_a_phone_with_peerjs/Build_the_Server")}}</p>

--- a/files/en-us/web/api/webrtc_api/index.html
+++ b/files/en-us/web/api/webrtc_api/index.html
@@ -212,6 +212,8 @@ tags:
  <dd>This article shows how to use WebRTC to access the camera on a computer or mobile phone with WebRTC support and take a photo with it.</dd>
  <dt><a href="/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample">A simple RTCDataChannel sample</a></dt>
  <dd>The {{DOMxRef("RTCDataChannel")}} interface is a feature which lets you open a channel between two peers over which you may send and receive arbitrary data. The API is intentionally similar to the <a href="/en-US/docs/Web/API/WebSocket_API">WebSocket API</a>, so that the same programming model can be used for each.</dd>
+ <dt><a href="/en-US/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs">Building an internet connected phone with Peer.js</a></dt>
+ <dd>This tutorial is a step-by-step guide on how to build a phone using Peer.js</dd>
 </dl>
 
 <h2 id="Resources">Resources</h2>


### PR DESCRIPTION
I added the tutorial to the WebRTC API page's index and swapped out one of the macros as it was wrong.