### PR TITLE
Fix Manifest member code examples

### DIFF
--- a/files/en-us/web/manifest/dir/index.html
+++ b/files/en-us/web/manifest/dir/index.html
@@ -45,7 +45,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: json" dir="rtl"><code>"dir": "rtl",
+<pre class="brush: json"><code>"dir": "rtl",
 "lang": "ar",
 "short_name": "!أنا من التطبيق"</code></pre>
 

--- a/files/en-us/web/manifest/lang/index.html
+++ b/files/en-us/web/manifest/lang/index.html
@@ -25,7 +25,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: json" dir="rtl">"lang": "en-US"</pre>
+<pre class="brush: json">"lang": "en-US"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/manifest/name/index.html
+++ b/files/en-us/web/manifest/name/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>Right-to-left <code>name</code> in Arabic:</p>
 
-<pre class="brush: json" dir="rtl"><code>"dir": "rtl",
+<pre class="brush: json"><code>"dir": "rtl",
 "lang": "ar",
 "name": "!أنا من التطبيق"</code></pre>
 

--- a/files/en-us/web/manifest/orientation/index.html
+++ b/files/en-us/web/manifest/orientation/index.html
@@ -48,7 +48,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: json">  "orientation": "portrait-primary"</pre>
+<pre class="brush: json">"orientation": "portrait-primary"</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/manifest/short_name/index.html
+++ b/files/en-us/web/manifest/short_name/index.html
@@ -32,10 +32,10 @@ tags:
 
 <p><code>short_name</code> in Arabic, which will be displayed right-to-left:</p>
 
-<pre class="brush: json" dir="rtl"><code>"dir": "rtl",
-"lang": "ar",
-"nam</code>e": "تطبيق رائع",
-"short_name": "رائع"
+<pre class="brush: json">&quot;dir&quot;: &quot;rtl&quot;,
+&quot;lang&quot;: &quot;ar&quot;,
+&quot;name&quot;: &quot;تطبيق رائع&quot;,
+&quot;short_name&quot;: &quot;رائع&quot;
 </pre>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Unless I'm missing something it doesn't make sense to display the pre blocks in rtl.

See here:
- https://developer.mozilla.org/en-US/docs/Web/Manifest/dir#example
- https://developer.mozilla.org/en-US/docs/Web/Manifest/lang#examples
- etc.

The additional short_name changes were done by the flaw fixes button.