### PR TITLE
Fix: remove class editable

### DIFF
--- a/files/en-us/mozilla/developer_guide/build_instructions/old_thunderbird_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/old_thunderbird_build/index.html
@@ -47,9 +47,9 @@ slug: Mozilla/Developer_guide/Build_Instructions/Old_Thunderbird_build
 
 <div class="warning">On some types of network connections, "hg clone" might fail because it gets interrupted. It is faster and more efficient to use <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial/Bundles">Mercurial bundles</a> instead the first time you fetch the complete repo. In this case, you need a bundle for comm-central, and a bundle for mozilla-central. Unbundle mozilla-central into a "mozilla" subdirectory of your comm-central repo after unbundling comm-central. (Make sure the unbundled folder's name is now "mozilla" and not "mozilla-central"). Then run "python client.py checkout"  to ensure you are up-to-date.</div>
 
-<p class="editable">The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. For more on getting the source code, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
+<p>The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. For more on getting the source code, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
 
-<h2 class="editable" id="Build_configuration">Build configuration</h2>
+<h2 id="Build_configuration">Build configuration</h2>
 
 <p>To build Thunderbird, you need to add a file named <code>mozconfig</code> to the root directory of the comm-central checkout that contains the following line:</p>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/building_on_os2_using_mercurial/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/os2_build_prerequisites/building_on_os2_using_mercurial/index.html
@@ -39,7 +39,7 @@ hgext.win32text =
 [decode]
 **.cmd = dumbdecode:
 **/os2/README.* = dumbdecode:</pre>
-<h2 class="editable" id="Getting_sources_and_building">Getting sources and building</h2>
+<h2 id="Getting_sources_and_building">Getting sources and building</h2>
 <h3 id="Mercurial-based_checkout">Mercurial-based "checkout"</h3>
 <p>Detailed instructions for checking out the code can be found elsewhere: for <a href="/En/Developer_Guide/Source_Code/Mercurial#Checking_out_a_source_tree" title="Mozilla Source Code (Mercurial): checking out a source tree">mozilla-central</a> (or <a href="/En/Developer_Guide/Source_Code/Mercurial#mozilla-1.9.1_(Firefox_3.1)">mozilla-1.9.1</a>, both are Firefox-only) and of <a class="internal" href="/En/Developer_Guide/Source_Code/Getting_comm-central#Checking_out_a_source_tree" title="comm-central source code (Mercurial): checking out a source tree">comm-central</a> (SeaMonkey and Thunderbird). Note that the instructions for comm-central include getting the code of mozilla (mozilla-central or mozilla-1.9.1), i.e. Firefox code and all backend code, which will be set up in a subdirectory <code>mozilla</code> of the directory to which you clone comm-central.</p>
 <p>Basically you do this to get the code:</p>

--- a/files/en-us/mozilla/developer_guide/build_instructions/simple_instantbird_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/simple_instantbird_build/index.html
@@ -51,11 +51,11 @@ tags:
 
 <div class="warning"><strong>Note:</strong> Unless you have a very good network connection, "hg clone" might fail because it gets interrupted. It is faster and more efficient to use <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial/Bundles">Mercurial bundles</a> instead the first time you fetch the complete repo. In this case, you need a bundle for comm-central, and a bundle for mozilla-central. Unbundle mozilla-central into a "mozilla" subdirectory of your comm-central repo after unbundling comm-central. Then run <span style="color: #ffff00;">python client.py checkout</span> to ensure you are up-to-date.</div>
 
-<p class="editable">The source code requires 1.5GB of free space or more.</p>
+<p>The source code requires 1.5GB of free space or more.</p>
 
-<p class="editable">For more on getting the source code, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
+<p>For more on getting the source code, see the page <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a>.</p>
 
-<h2 class="editable" id="Build_configuration">Build configuration</h2>
+<h2 id="Build_configuration">Build configuration</h2>
 
 <p>By default, the build system creates a release build of Instantbird roughly equivalent to the official Instantbird release builds. If that's not exactly what you want, there are many build configuration options to choose from, although it's <strong>strongly</strong> recommended that you only use options that you fully understand. The normal way to specify build options is to place them in a file called '.mozconfig' at the root of your mozilla source tree, i.e. your comm-central repo. For example, to create a debug build instead of a release build, that file would contain:</p>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/simple_thunderbird_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/simple_thunderbird_build/index.html
@@ -27,7 +27,7 @@ tags:
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mac_OS_X_Prerequisites">macOS Build Prerequisites</a></li>
 </ul>
 
-<h2 class="editable" id="MAPI_Headers">MAPI Headers</h2>
+<h2 id="MAPI_Headers">MAPI Headers</h2>
 
 <p>On Windows: check that the MAPI header files from <a href="https://www.microsoft.com/en-us/download/details.aspx?id=12905">https://www.microsoft.com/en-us/download/details.aspx?id=12905</a> are installed because the MAPI header files (except MAPI.h) are not bundled with Visual Studio 2017 (Windows SDK 10). You should copy 17 of the 18 header files to a Windows SDK include directory so that the build process will find the files, that is <code>C:\Program Files (x86)\Windows Kits\10\Include\10.0.nnnnn.0\shared</code>, where <code>nnnnn</code> is the highest number present on the system. Note that the downloaded Outlook 2010 MAPI Header Files contain 18 fies, of which only 17 are needed. Do <strong>not</strong> copy MAPI.h, it is already in C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\MAPI.h.</p>
 
@@ -64,11 +64,11 @@ cd source/
 hg clone https://hg.mozilla.org/comm-central comm/
 </pre>
 
-<p class="editable">The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. Instead of using <code>hg clone</code>, you can follow <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial/Bundles">these instructions</a> on downloading and "unpacking" a Mercurial bundle.</p>
+<p>The source code requires 3.6GB of free space or more and additionally 5GB or more for default build. Instead of using <code>hg clone</code>, you can follow <a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial/Bundles">these instructions</a> on downloading and "unpacking" a Mercurial bundle.</p>
 
-<p class="editable"><strong>Warning: The page </strong><a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a><strong> is 99% out of date!</strong> Only useful content is working with Github.</p>
+<p><strong>Warning: The page </strong><a href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Getting_comm-central">Getting comm-central Source Code Using Mercurial [en-US]</a><strong> is 99% out of date!</strong> Only useful content is working with Github.</p>
 
-<h2 class="editable" id="Build_configuration">Build configuration</h2>
+<h2 id="Build_configuration">Build configuration</h2>
 
 <p>To build Thunderbird, you need to add a file named <code>mozconfig</code> to the root directory of the mozilla-central checkout that contains the following line:</p>
 

--- a/files/en-us/mozilla/firefox/releases/14/index.html
+++ b/files/en-us/mozilla/firefox/releases/14/index.html
@@ -80,7 +80,7 @@ tags:
  <li>Added the new {{XULAttr("fullscreenbutton")}} attribute to the {{XULElem("window")}} element; setting this to <code>true</code> adds a button to the window's chrome to enable full screen mode.</li>
 </ul>
 
-<h3 class="editable" id="Interfaces">Interfaces</h3>
+<h3 id="Interfaces">Interfaces</h3>
 
 <ul>
  <li>The {{interface("nsILocalFile")}} interface has been merged into {{interface("nsIFile")}} (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=682360">bug 682360</a>).</li>

--- a/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.html
+++ b/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.html
@@ -64,7 +64,7 @@ if (firstrun) {
 overlay chrome://browser/content/browser.xul chrome://myaddon/content/myaddon/overlay.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion&gt;=4.0
 </pre>
 <p>Note: the appversion has to be at least 2 digits long or it won't work with versions of Gecko before 1.8.0.13 and 1.8.1.5.</p>
-<h3 class="editable" id="Adding_a_button_by_default">Adding a button by default</h3>
+<h3 id="Adding_a_button_by_default">Adding a button by default</h3>
 <p>See: <a href="/en/Code_snippets/Toolbar#Adding_button_by_default">Adding a button by default</a></p>
 <h2 id="Appearance_differences">Appearance differences</h2>
 <ul>

--- a/files/en-us/mozilla/projects/nss/nss_3.12.5_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.5_release_notes/index.html
@@ -8,7 +8,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.5_release_notes
 
 <hr>
 <div id="section_1">
-<h1 class="editable" id="Introduction">Introduction</h1>
+<h1 id="Introduction">Introduction</h1>
 
 <p>Network Security Services (NSS) 3.12.5 is a patch release for NSS 3.12. The bug fixes in NSS 3.12.5 are described in the "<a href="https://dev.mozilla.jp/localmdc/localmdc_5125.html#bugsfixed">Bugs Fixed</a>" section below.</p>
 
@@ -16,7 +16,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.5_release_notes
 </div>
 
 <div id="section_2">
-<h1 class="editable" id="Distribution_Information">Distribution Information</h1>
+<h1 id="Distribution_Information">Distribution Information</h1>
 
 <p>The CVS tag for the NSS 3.12.5 release is <code>NSS_3_12_5_RTM</code>. </p>
 
@@ -39,10 +39,10 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_3">
-<h1 class="editable" id="New_in_NSS_3.12.5">New in NSS 3.12.5</h1>
+<h1 id="New_in_NSS_3.12.5">New in NSS 3.12.5</h1>
 
 <div id="section_4">
-<h3 class="editable" id="SSL3_TLS_Renegotiation_Vulnerability">SSL3 &amp; TLS Renegotiation Vulnerability</h3>
+<h3 id="SSL3_TLS_Renegotiation_Vulnerability">SSL3 &amp; TLS Renegotiation Vulnerability</h3>
 
 <p>See <a class="external" href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555" rel="external nofollow" title="http://cve.mitre.org/cgi-bin/cvename.cgi? data-cke-saved-name=CVE-2009-3555 name=CVE-2009-3555">CVE-2009-3555</a> and <a class="external" href="http://www.kb.cert.org/vuls/id/120541" rel="external nofollow" title="http://www.kb.cert.org/vuls/id/120541">US-CERT VU#120541</a> for more information about this security vulnerability.</p>
 
@@ -74,7 +74,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_5">
-<h3 class="editable" id="TLS_compression">TLS compression</h3>
+<h3 id="TLS_compression">TLS compression</h3>
 
 <ul>
  <li>Enable TLS compression with:
@@ -92,7 +92,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_6">
-<h3 class="editable" id="New_context_initialization_and_shutdown_functions">New context initialization and shutdown functions</h3>
+<h3 id="New_context_initialization_and_shutdown_functions">New context initialization and shutdown functions</h3>
 
 <ul>
  <li>See nss.h for details. The 2 new functions are:
@@ -112,7 +112,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_7">
-<h3 class="editable" id="Other_new_functions">Other new functions</h3>
+<h3 id="Other_new_functions">Other new functions</h3>
 
 <ul>
  <li><em>In secmod.h:</em>
@@ -132,7 +132,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_8">
-<h3 class="editable" id="Modified_functions">Modified functions</h3>
+<h3 id="Modified_functions">Modified functions</h3>
 
 <ul>
  <li>SGN_Update (see cryptohi.h)
@@ -149,7 +149,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_9">
-<h3 class="editable" id="Deprecated_headers">Deprecated headers</h3>
+<h3 id="Deprecated_headers">Deprecated headers</h3>
 
 <ul>
  <li>The header file key.h is deprecated. Please use keyhi.h instead.</li>
@@ -157,7 +157,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_10">
-<h3 class="editable" id="Additional_documentation">Additional documentation</h3>
+<h3 id="Additional_documentation">Additional documentation</h3>
 
 <ul>
  <li><em>In pk11pub.h:</em>
@@ -176,7 +176,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_11">
-<h3 class="editable" id="Environment_variables">Environment variables</h3>
+<h3 id="Environment_variables">Environment variables</h3>
 
 <ul>
  <li>NSS_FIPS
@@ -197,7 +197,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_12">
-<h1 class="editable" id="Bugs_Fixed">Bugs Fixed</h1>
+<h1 id="Bugs_Fixed">Bugs Fixed</h1>
 
 <p>The following bugs have been fixed in NSS 3.12.5.</p>
 
@@ -221,7 +221,7 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_13">
-<h1 class="editable" id="Documentation">Documentation</h1>
+<h1 id="Documentation">Documentation</h1>
 
 <p>For a list of the primary NSS documentation pages on mozilla.org, see <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/#documentation" rel="external nofollow" title="http://www.mozilla.org/projects/security/pki/nss/#documentation">NSS Documentation</a>. New and revised documents available since the release of NSS 3.11 include the following:</p>
 
@@ -234,13 +234,13 @@ cvs co -r NSS_3_12_5_RTM NSS</div>
 </div>
 
 <div id="section_14">
-<h1 class="editable" id="Compatibility">Compatibility</h1>
+<h1 id="Compatibility">Compatibility</h1>
 
 <p>NSS 3.12.5 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.5 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html" rel="external nofollow" title="http://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
 </div>
 
 <div id="section_15">
-<h1 class="editable" id="Feedback">Feedback</h1>
+<h1 id="Feedback">Feedback</h1>
 
 <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external nofollow" title="https://bugzilla.mozilla.org/">mozilla.org Bugzilla</a> (product NSS).</p>
 </div>

--- a/files/en-us/mozilla/projects/nss/nss_3.12.6_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.6_release_notes/index.html
@@ -7,12 +7,12 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
       <div>
        2010-03-03 <em>Newsgroup: <a class="link-news" href="news://news.mozilla.org/mozilla.dev.tech.crypto" rel="external" title="news://news.mozilla.org/mozilla.dev.tech.crypto">mozilla.dev.tech.crypto</a></em>
        <div id="section_1">
-        <h1 class="editable" id="Introduction">Introduction</h1>
+        <h1 id="Introduction">Introduction</h1>
         <p>Network Security Services (NSS) 3.12.6 is a patch release for NSS 3.12. The bug fixes in NSS 3.12.6 are described in the "<a href="http://mdn.beonex.com/en/NSS_3.12.6_release_notes.html#bugsfixed">Bugs Fixed</a>" section below.</p>
         <p>NSS 3.12.6 is tri-licensed under the MPL 1.1/GPL 2.0/LGPL 2.1. <a name="distribution"></a></p>
        </div>
        <div id="section_2">
-        <h1 class="editable" id="Distribution_Information">Distribution Information</h1>
+        <h1 id="Distribution_Information">Distribution Information</h1>
         <p>The CVS tag for the NSS 3.12.6 release is <code>NSS_3_12_6_RTM</code>.  NSS 3.12.6 requires <a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/" rel="external" title="http://www.mozilla.org/projects/nspr/release-notes/">NSPR 4.8.4</a>.<br>
          <br>
          See the <a href="http://mdn.beonex.com/en/NSS_3.12.6_release_notes.html#docs">Documentation</a> section for the build instructions.</p>
@@ -24,9 +24,9 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          <a name="new"></a></p>
        </div>
        <div id="section_3">
-        <h1 class="editable" id="New_in_NSS_3.12.6">New in NSS 3.12.6</h1>
+        <h1 id="New_in_NSS_3.12.6">New in NSS 3.12.6</h1>
         <div id="section_4">
-         <h3 class="editable" id="SSL3_TLS_Renegotiation_Indication_Extension_(RFC_5746)">SSL3 &amp; TLS Renegotiation Indication Extension (<a class="external" href="https://tools.ietf.org/html/rfc5746" rel="external" title="http://tools.ietf.org/html/rfc5746">RFC 5746</a>)</h3>
+         <h3 id="SSL3_TLS_Renegotiation_Indication_Extension_(RFC_5746)">SSL3 &amp; TLS Renegotiation Indication Extension (<a class="external" href="https://tools.ietf.org/html/rfc5746" rel="external" title="http://tools.ietf.org/html/rfc5746">RFC 5746</a>)</h3>
          <ul>
           <li>By default, NSS 3.12.6 uses the new TLS Renegotiation Indication Extension for TLS renegotiation but allows simple SSL/TLS connections (without renegotiation) with peers that don't support the TLS Renegotiation Indication Extension.
            <p>The behavior of NSS for renegotiation can be changed through API function calls, or with the following environment variables:</p>
@@ -80,7 +80,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          </ul>
         </div>
         <div id="section_5">
-         <h3 class="editable" id="TLS_Server_Name_Indication_for_servers">TLS Server Name Indication for servers</h3>
+         <h3 id="TLS_Server_Name_Indication_for_servers">TLS Server Name Indication for servers</h3>
          <ul>
           <li>TLS Server Name Indication (SNI) for servers is almost fully implemented in NSS 3.12.6.<br>
            See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=360421" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=360421">bug 360421</a> for details.<br>
@@ -115,7 +115,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          </ul>
         </div>
         <div id="section_6">
-         <h3 class="editable" id="New_functions">New functions</h3>
+         <h3 id="New_functions">New functions</h3>
          <ul>
           <li><em>in cert.h</em>
            <ul>
@@ -140,7 +140,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          </ul>
         </div>
         <div id="section_7">
-         <h3 class="editable" id="New_error_codes">New error codes</h3>
+         <h3 id="New_error_codes">New error codes</h3>
          <ul>
           <li><em>in sslerr.h</em>
            <ul>
@@ -151,7 +151,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          </ul>
         </div>
         <div id="section_8">
-         <h3 class="editable" id="New_types">New types</h3>
+         <h3 id="New_types">New types</h3>
          <ul>
           <li><em>in sslt.h</em>
            <ul>
@@ -161,7 +161,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
          </ul>
         </div>
         <div id="section_9">
-         <h3 class="editable" id="New_environment_variables">New environment variables</h3>
+         <h3 id="New_environment_variables">New environment variables</h3>
          <ul>
           <li>SQLITE_FORCE_PROXY_LOCKING
            <ul>
@@ -180,7 +180,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
         </div>
        </div>
        <div id="section_10">
-        <h1 class="editable" id="Bugs_Fixed">Bugs Fixed</h1>
+        <h1 id="Bugs_Fixed">Bugs Fixed</h1>
         <p>The following bugs have been fixed in NSS 3.12.6.</p>
         <ul>
          <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=275744" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=275744">Bug 275744</a>: Support for TLS compression RFC 3749</li>
@@ -218,7 +218,7 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
         <p><a name="docs"></a></p>
        </div>
        <div id="section_11">
-        <h1 class="editable" id="Documentation">Documentation</h1>
+        <h1 id="Documentation">Documentation</h1>
         <p>For a list of the primary NSS documentation pages on mozilla.org, see <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/#documentation" rel="external" title="http://www.mozilla.org/projects/security/pki/nss/#documentation">NSS Documentation</a>. New and revised documents available since the release of NSS 3.11 include the following:</p>
         <ul>
          <li><a href="http://mdn.beonex.com/en/NSS_reference/Building_and_installing_NSS/Build_instructions.html" rel="internal">Build Instructions</a></li>
@@ -227,11 +227,11 @@ slug: Mozilla/Projects/NSS/NSS_3.12.6_release_notes
         <p><a name="compatibility"></a></p>
        </div>
        <div id="section_12">
-        <h1 class="editable" id="Compatibility">Compatibility</h1>
+        <h1 id="Compatibility">Compatibility</h1>
         <p>NSS 3.12.6 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.6 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a class="external" href="https://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html" rel="external" title="http://www.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
        </div>
        <div id="section_13">
-        <h1 class="editable" id="Feedback">Feedback</h1>
+        <h1 id="Feedback">Feedback</h1>
         <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external" title="https://bugzilla.mozilla.org/">mozilla.org Bugzilla</a> (product NSS).</p>
        </div>
       </div>

--- a/files/en-us/mozilla/projects/nss/nss_3.12.9_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.12.9_release_notes/index.html
@@ -7,12 +7,12 @@ tags:
  2010-09-23
  <em>Newsgroup: <a class="link-news" href="news://news.mozilla.org/mozilla.dev.tech.crypto" rel="external" title="news://news.mozilla.org/mozilla.dev.tech.crypto">mozilla.dev.tech.crypto</a></em>
 <div id="section_1">
- <h1 class="editable" id="Introduction_2">Introduction</h1>
+ <h1 id="Introduction_2">Introduction</h1>
  <p><a name="Introduction">Network Security Services (NSS) 3.12.9 is a patch release for NSS 3.12. The bug fixes in NSS 3.12.9 are described in the "</a><a href="#bugsfixed">Bugs Fixed</a>" section below.</p>
  <p>NSS 3.12.9 is tri-licensed under the MPL 1.1/GPL 2.0/LGPL 2.1.</p>
 </div>
 <div id="section_2">
- <h1 class="editable" id="Distribution_Information"><a name="distribution">Distribution Information</a></h1>
+ <h1 id="Distribution_Information"><a name="distribution">Distribution Information</a></h1>
  <p><a name="distribution">The CVS tag for the NSS 3.12.9 release is <code>NSS_3.12.9_RTM</code>.  NSS 3.12.9 requires </a><a class="external" href="https://www.mozilla.org/projects/nspr/release-notes/nspr486.html" rel="external" title="http://www.mozilla.org/projects/nspr/release-notes/nspr486.html">NSPR 4.8.7</a>.<br>
   <br>
   See the <a href="#docs">Documentation</a> section for the build instructions.</p>
@@ -23,19 +23,19 @@ tags:
  <p>You also need to download the NSPR 4.8.7 binary distributions to get the NSPR 4.8.7 header files and shared libraries, which NSS 3.12.9 requires. NSPR 4.8.7 binary distributions are in <a class="link-https" href="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/" rel="external" title="https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/">https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v4.8.7/</a>.</p>
 </div>
 <div id="section_3">
- <h1 class="editable" id="New_in_NSS_3.12.9">New in NSS 3.12.9</h1>
+ <h1 id="New_in_NSS_3.12.9">New in NSS 3.12.9</h1>
  <div id="section_5">
-  <h3 class="editable" id="Removed_functions">Removed functions</h3>
+  <h3 id="Removed_functions">Removed functions</h3>
  </div>
  <div id="section_6">
-  <h3 class="editable" id="New_SSL_options">New SSL options</h3>
+  <h3 id="New_SSL_options">New SSL options</h3>
   <div id="section_7">
-   <h3 class="editable" id="New_error_codes">New error codes</h3>
+   <h3 id="New_error_codes">New error codes</h3>
   </div>
  </div>
 </div>
 <div id="section_8">
- <h1 class="editable" id="Bugs_Fixed">Bugs Fixed</h1>
+ <h1 id="Bugs_Fixed">Bugs Fixed</h1>
  <p>The following bugs have been fixed in NSS 3.12.9.</p>
  <ul>
   <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=609068" rel="external" title="https://bugzilla.mozilla.org/show_bug.cgi?id=609068">Bug 609068</a>: Implement J-PAKE in FreeBL</li>
@@ -58,7 +58,7 @@ tags:
  </ul>
 </div>
 <div id="section_9">
- <h1 class="editable" id="Documentation">Documentation</h1>
+ <h1 id="Documentation">Documentation</h1>
  <p>NSS Documentation. New and revised documents available since the release of NSS 3.11 include the following:</p>
  <ul>
   <li><a href="/en-US/nss-3.11.4/nss-3.11.4-build.html" rel="internal">Build Instructions for NSS 3.11.4 and above</a></li>
@@ -66,10 +66,10 @@ tags:
  </ul>
 </div>
 <div id="section_10">
- <h1 class="editable" id="Compatibility">Compatibility</h1>
+ <h1 id="Compatibility">Compatibility</h1>
  <p>NSS 3.12.9 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.12.9 shared libraries without recompiling or relinking.  Furthermore, applications that restrict their use of NSS APIs to the functions listed in <a href="/en-US/ref/nssfunctions.html" rel="internal">NSS Public Functions</a> will remain compatible with future versions of the NSS shared libraries. <a name="feedback"></a></p>
 </div>
 <div id="section_11">
- <h1 class="editable" id="Feedback">Feedback</h1>
+ <h1 id="Feedback">Feedback</h1>
  <p>Bugs discovered should be reported by filing a bug report with <a class="link-https" href="https://bugzilla.mozilla.org/" rel="external" title="https://bugzilla.mozilla.org/">mozilla.org Bugzilla</a> (product NSS).</p>
 </div>

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
@@ -20,11 +20,11 @@ tags:
 
 <p>This attribute can be used with any typical HTML element; it is not limited to elements that have an ARIA <code>role</code> assigned.</p>
 
-<h3 class="editable" id="Value">Value</h3>
+<h3 id="Value">Value</h3>
 
 <p>string</p>
 
-<h3 class="editable" id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology</h3>
+<h3 id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology</h3>
 
 <div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
@@ -20,7 +20,7 @@ tags:
 <pre class="syntaxbox notranslate"><em>element</em>.onmouseout = <em>function</em>;
 </pre>
 
-<h2 class="editable" id="Example">Example</h2>
+<h2 id="Example">Example</h2>
 
 <p>This example adds an <code>onmouseout</code> and an <code>onmouseover</code> event to a paragraph. Try moving your mouse over and out of the element.</p>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
@@ -20,7 +20,7 @@ tags:
 <pre class="syntaxbox notranslate"><em>element</em>.onmouseover = <em>function</em>;
 </pre>
 
-<h2 class="editable" id="Example">Example</h2>
+<h2 id="Example">Example</h2>
 
 <p>This example adds an <code>onmouseover</code> and an <code>onmouseout</code> event to a paragraph. Try moving your mouse over and out of the element.</p>
 

--- a/files/en-us/web/html/element/small/index.html
+++ b/files/en-us/web/html/element/small/index.html
@@ -50,7 +50,7 @@ tags:
  </tbody>
 </table>
 
-<h2 class="editable" id="Attributes">Attributes</h2>
+<h2 id="Attributes">Attributes</h2>
 
 <p>This element only includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 


### PR DESCRIPTION
Looks like class `editable` is a relic from the past does not do anything. It is stripped from the final output anyway, so let's remove it from the sources as well.