### PR TITLE
Fix: standardize <section> usage

### DIFF
--- a/files/en-us/glossary/index.html
+++ b/files/en-us/glossary/index.html
@@ -39,7 +39,7 @@ tags:
 <div class="hidden">
 <h2 id="Subnav">Subnav</h2>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><strong><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a></strong>{{ListSubpagesForSidebar("/en-us/docs/Glossary", 1)}}</li>
 </ol>

--- a/files/en-us/glossary/number/index.html
+++ b/files/en-us/glossary/number/index.html
@@ -25,7 +25,7 @@ tags:
  <li>The JavaScript global object {{jsxref("Number")}}</li>
 </ul>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/glossary/symbol/index.html
+++ b/files/en-us/glossary/symbol/index.html
@@ -95,7 +95,7 @@ alert(_Sym.description); // Sym</pre>
  <li>{{jsxref("Object.getOwnPropertySymbols()")}}</li>
 </ul>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ul>
  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
 

--- a/files/en-us/mozilla/add-ons/webextensions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/index.html
@@ -14,7 +14,6 @@ tags:
 
 <h2 id="Key_resources">Key resources</h2>
 
-<section class="cleared" id="sect1">
 <dl>
  <dt><span>Guides</span></dt>
  <dd>Whether you’re just beginning or looking for more advanced advice, learn about how extensions work and use the WebExtensions API from our extensive range of <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/What_are_WebExtensions">tutorials and guides</a>.</dd>
@@ -70,10 +69,3 @@ tags:
 <p>Get full details about the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json">manifest keys</a>, including all their properties and settings. There’s also detailed information on the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json">compatibility</a> of each key with the major browsers.</p>
 </div>
 </div>
-
-<div class="SnapLinksContainer" style="margin-left: 0px; margin-top: 0px; display: none;">
-<div class="SL_SelectionRect">
-<div class="SL_SelectionLabel"></div>
-</div>
-</div>
-</section>

--- a/files/en-us/mozilla/firefox/releases/36/index.html
+++ b/files/en-us/mozilla/firefox/releases/36/index.html
@@ -106,8 +106,6 @@ tags:
  <li>Support for Media Source Extensions (MSE) is activated by default in non-build releases (Nightly and Developer Edition only) ({{bug(1000686)}}). It keeps being preffed off on Beta and Release version.</li>
 </ul>
 
-<section id="sect13"> </section>
-
 <h3 id="MathML">MathML</h3>
 
 <p><em>No change.</em></p>

--- a/files/en-us/web/accessibility/aria/index.html
+++ b/files/en-us/web/accessibility/aria/index.html
@@ -54,7 +54,6 @@ function updateProgress(percentComplete) {
 
 <p>It is also important to test your authored ARIA with actual assistive technology. Much as how browser emulators and simulators are not an effective solution for testing full support, proxy assistive technology solutions aren't sufficient to fully guarantee functionality.</p>
 
-<section id="sect1">
 <div class="row topicpage-table">
 <div class="section">
 <h2 class="Documentation" id="Tutorials">Tutorials</h2>
@@ -119,13 +118,12 @@ function updateProgress(percentComplete) {
 <p><a href="/en-US/docs/Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs">File ARIA bugs on browsers, screen readers, and JavaScript libraries.</a></p>
 </div>
 </div>
-</section>
 
 <h2 id="Related_Topics">Related topics</h2>
 
 <p><a href="/en-US/docs/Accessibility">Accessibility</a>, <a href="/en-US/docs/AJAX">AJAX</a>, <a href="/en-US/docs/Web/JavaScript">JavaScript</a></p>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/Guide">Web Development</a></li>
  <li><a href="/en-US/docs/Mozilla/Accessibility">Accessibility and Mozilla</a></li>

--- a/files/en-us/web/accessibility/aria/roles/feed_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/feed_role/index.html
@@ -50,7 +50,6 @@ tags:
  </li>
 </ol>
 
-<section class="notoc" id="sect1">
 <h3 id="Keyboard_interaction">Keyboard interaction</h3>
 
 <p>Supporting the following, or a similar, interface is recommended when focus is inside the feed:</p>
@@ -63,9 +62,7 @@ tags:
 </ul>
 
 <p>If a feed is nested within a feed, such as a comments feed within a feed of blog posts, the convention is to tab into the nested feed with the <kbd>Tab</kbd> key and to provide another key, such as  <kbd>Alt + Page Down</kbd>, to navigate from an 'outer' article to the first item in that article's nested feed. Navigate between the nested feed and main feed with <kbd>Control + End</kbd> , moving focus from the inner feed to the next article in the outer feed.</p>
-</section>
 
-<section class="notoc" id="sect2">
 <h3 id="WAI-ARIA_roles_states_and_properties"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles, states, and properties</h3>
 
 <dl>
@@ -78,7 +75,6 @@ tags:
  <dt>article</dt>
  <dd>Each section of content in a feed should be contained in an <code>&lt;article&gt;</code> or element with role <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Article_Role">article</a>. Each <code>article</code> should have an <a class="property-reference" href="https://w3c.github.io/aria/#aria-labelledby">aria-labelledby</a> referring to the article title or other child that can serve as a distinguishing label. Each article should preferably have <a class="property-reference" href="https://w3c.github.io/aria/#aria-describedby">aria-describedby</a> referring to one or more elements inside the article that serve as the primary content of the article. Each <code>article</code> element has <a class="property-reference" href="https://w3c.github.io/aria/#aria-posinset">aria-posinset</a> set to a value that represents its position in the feed and an <a class="property-reference" href="https://w3c.github.io/aria/#aria-setsize">aria-setsize</a> set to a value that represents either the total number of articles that have been loaded or the total number in the feed, depending on which value is more helpful to users. If the total number in the feed is not known, set <code>aria-setsize="-1"</code>.</dd>
 </dl>
-</section>
 </div>
 
 <h3 id="Required_JavaScript_features">Required JavaScript features</h3>

--- a/files/en-us/web/accessibility/aria/roles/index.html
+++ b/files/en-us/web/accessibility/aria/roles/index.html
@@ -79,7 +79,7 @@ tags:
 
 <h6 id="Subnav">Subnav</h6>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
 </ol>

--- a/files/en-us/web/accessibility/index.html
+++ b/files/en-us/web/accessibility/index.html
@@ -66,5 +66,3 @@ tags:
  <li><a href="/en-US/docs/Web/Guide">Developer guides</a></li>
  <li><a href="/en-US/docs/Mozilla/Accessibility">Accessibility and Mozilla</a></li>
 </ul>
-
-<section id="Quick_Links"></section>

--- a/files/en-us/web/api/presentation_api/index.html
+++ b/files/en-us/web/api/presentation_api/index.html
@@ -48,7 +48,6 @@ tags:
 
 <p>Example codes below highlight the usage of main features of the Presentation API: <code>controller.html</code> implements the controller and <code>presentation.html</code> implements the presentation. Both pages are served from the domain <code>http://example.org</code> (<code>http://example.org/controller.html</code> and <code>http://example.org/presentation.html</code>). These examples assume that the controlling page is managing one presentation at a time. Please refer to the comments in the code examples for further details.</p>
 
-<section id="monitor-availability-of-presentation-displays-example">
 <h3 id="Monitor_availability_of_presentation_displays">Monitor availability of presentation displays</h3>
 
 <div class="example">
@@ -82,9 +81,7 @@ tags:
   });
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
-<section id="starting-a-new-presentation-example">
 <h3 id="Starting_a_new_presentation">Starting a new presentation</h3>
 
 <div class="example">
@@ -101,9 +98,7 @@ tags:
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
-<section id="reconnect-to-a-presentation-example">
 <h3 id="Reconnect_to_a_presentation">Reconnect to a presentation</h3>
 
 <div class="example">
@@ -128,9 +123,7 @@ tags:
   reconnectBtn.onclick = reconnect;
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
-<section id="presentation-initiation-by-the-controlling-ua-example">
 <h3 id="Presentation_initiation_by_the_controlling_UA">Presentation initiation by the controlling UA</h3>
 
 <div class="example">
@@ -145,9 +138,7 @@ tags:
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
-<section id="monitor-connection-s-state-and-exchange-data-example">
 <h3 id="Monitor_connections_state_and_exchange_data">Monitor connection's state and exchange data</h3>
 
 <div class="example">
@@ -222,9 +213,7 @@ tags:
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
-<section id="monitor-available-connection-s-and-say-hello">
 <h3 id="Monitor_available_connections_and_say_hello">Monitor available connection(s) and say hello</h3>
 
 <div class="example">
@@ -247,9 +236,7 @@ tags:
   });
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
-<section id="passing-locale-information-with-a-message">
 <h3 id="Passing_locale_information_with_a_message">Passing locale information with a message</h3>
 
 <div class="example">
@@ -272,7 +259,6 @@ tags:
   };
 </span><span class="hljs-tag">&lt;/<span class="hljs-name">script</span>&gt;</span></pre>
 </div>
-</section>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/exslt/index.html
+++ b/files/en-us/web/exslt/index.html
@@ -106,7 +106,7 @@ tags:
 
 <h2 id="Subnav">Subnav</h2>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
  <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/index.html
@@ -103,5 +103,3 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
  <li><a href="/en-US/docs/WebAssembly/Concepts">WebAssembly concepts</a></li>
  <li><a href="/en-US/docs/WebAssembly/Using_the_JavaScript_API">Using the WebAssembly JavaScript API</a></li>
 </ul>
-
-<section id="Quick_Links"></section>

--- a/files/en-us/web/svg/tutorial/tools_for_svg/index.html
+++ b/files/en-us/web/svg/tutorial/tools_for_svg/index.html
@@ -55,8 +55,6 @@ tags:
 
 <p>A newer JavaScript abstraction layer from the same author of Raphael JS. Snap.svg is designed for modern browsers and therefore supports the newest SVG features like masking, clipping, patterns, full gradients, groups. It does not support the older browsers that Raphael does.</p>
 
-<section id="sect1"> </section>
-
 <h2 id="Google_Docs">Google Docs</h2>
 
 <p>URL: <a class="external" href="http://www.google.com/google-d-s/drawings/">www.google.com/google-d-s/drawings/</a></p>

--- a/files/en-us/web/xpath/index.html
+++ b/files/en-us/web/xpath/index.html
@@ -70,7 +70,7 @@ tags:
 
 <h2 id="Subnav">Subnav</h2>
 
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
  <li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>

--- a/files/en-us/web/xslt/index.html
+++ b/files/en-us/web/xslt/index.html
@@ -7,7 +7,7 @@ tags:
   - XSLT
 ---
 <div>{{XSLTRef}}
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
  <li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>


### PR DESCRIPTION
After this PR, `<section>` tags are used only to display "quick links" and match pattern `<section id="Quick_links">`. We probably should lower-case the id eventually, but let's leave that for a separate large PR.