### PR TITLE
clarify typedarray to nativearray example

### DIFF
--- a/files/en-us/web/javascript/typed_arrays/index.html
+++ b/files/en-us/web/javascript/typed_arrays/index.html
@@ -230,13 +230,15 @@ let amountDueView = new Float32Array(buffer, 20, 1);</pre>
 
 <h3 id="Conversion_to_normal_arrays">Conversion to normal arrays</h3>
 
-<p>After processing a typed array, it is sometimes useful to convert it back to a normal array in order to benefit from the {{jsxref("Array")}} prototype. This can be done using {{jsxref("Array.from()")}}, or using the following code where <code>Array.from()</code> is unsupported.</p>
+<p>After processing a typed array, it is sometimes useful to convert it back to a normal array in order to benefit from the {{jsxref("Array")}} prototype. This can be done using {{jsxref("Array.from()")}}</p>
 
-<pre class="brush:js">let typedArray = new Uint8Array([1, 2, 3, 4]),
-    normalArray = Array.prototype.slice.call(typedArray);
-normalArray.length === 4;
-normalArray.constructor === Array;
-</pre>
+<pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
+const nativeArray = Array.from(typedArray);</pre>
+
+<p>or using the following code where <code>Array.from()</code> is unsupported.</p>
+
+<pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
+const normalArray = Array.prototype.slice.call(typedArray);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/typed_arrays/index.html
+++ b/files/en-us/web/javascript/typed_arrays/index.html
@@ -235,6 +235,11 @@ let amountDueView = new Float32Array(buffer, 20, 1);</pre>
 <pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
 const nativeArray = Array.from(typedArray);</pre>
 
+<p>as well as the {{jsxref("operators/spread_syntax", "spread operator", "", 1)}}</p>
+
+<pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
+const nativeArray = [...typedArray];</pre>
+
 <p>or using the following code where <code>Array.from()</code> is unsupported.</p>
 
 <pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);

--- a/files/en-us/web/javascript/typed_arrays/index.html
+++ b/files/en-us/web/javascript/typed_arrays/index.html
@@ -233,12 +233,12 @@ let amountDueView = new Float32Array(buffer, 20, 1);</pre>
 <p>After processing a typed array, it is sometimes useful to convert it back to a normal array in order to benefit from the {{jsxref("Array")}} prototype. This can be done using {{jsxref("Array.from()")}}</p>
 
 <pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
-const nativeArray = Array.from(typedArray);</pre>
+const normalArray = Array.from(typedArray);</pre>
 
 <p>as well as the {{jsxref("operators/spread_syntax", "spread operator", "", 1)}}</p>
 
 <pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
-const nativeArray = [...typedArray];</pre>
+const normalArray = [...typedArray];</pre>
 
 <p>or using the following code where <code>Array.from()</code> is unsupported.</p>
 


### PR DESCRIPTION
At a glance the the old docs hide the normal way using `Array.from` and arguably highlighted to code block. Further, the code block had 2 superfluous lines.