### PR TITLE
Fix CORS problem in the “XHR: loadend event” article

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/loadend_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/loadend_event/index.html
@@ -32,7 +32,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Event handler property</th>
-   <td>{{domxref("XMLHttpRequestEventTarget/onloadend", "onloadend")}}</td>
+   <td><code>onloadend</code></td>
   </tr>
  </tbody>
 </table>
@@ -100,15 +100,15 @@ function runXHR(url) {
 }
 
 xhrButtonSuccess.addEventListener('click', () =&gt; {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg');
+    runXHR('https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json');
 });
 
 xhrButtonError.addEventListener('click', () =&gt; {
-    runXHR('https://somewhere.org/i-dont-exist');
+    runXHR('http://i-dont-exist');
 });
 
 xhrButtonAbort.addEventListener('click', () =&gt; {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg').abort();
+    runXHR('https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json').abort();
 });</pre>
 
 <h4 id="Result">Result</h4>
@@ -142,5 +142,5 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <ul>
  <li>Related events: {{domxref("XMLHttpRequest/loadstart_event", "loadstart")}}, {{domxref("XMLHttpRequest/load_event", "load")}}, {{domxref("XMLHttpRequest/progress_event", "progress")}}, {{domxref("XMLHttpRequest/error_event", "error")}}, {{domxref("XMLHttpRequest/abort_event", "abort")}}</li>
- <li><a href="/en-US/docs/DOM/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress">Monitoring progress</a></li>
+ <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress">Monitoring progress</a></li>
 </ul>


### PR DESCRIPTION
This change replaces https://mdn.mozillademos.org URLs in the “XHR: loadend event” article with https://raw.githubusercontent.com/mdn/content URLs.

Otherwise, without this change, the examples the URLs are in do not work as expected, due to the fact the https://mdn.mozillademos.org URL responses are actually 302 redirects (to https://media.prod.mdn.mozit.cloud URLs), and those 302s have no Access-Control-Allow-Origin header.

https://raw.githubusercontent.com/mdn/content/main/files/en-us/_wikihistory.json has the Access-Control-Allow-Origin header and is also a sufficiently large enough
resource (3.2M) to be useful in a demonstration for progress events.

This change also fixes a couple of 404s.

Fixes https://github.com/mdn/content/issues/1024
Related: https://github.com/mdn/content/issues/709