### PR TITLE
Restore CSS inset-block doc to its proper state

### DIFF
--- a/files/en-us/web/css/inset-block/index.html
+++ b/files/en-us/web/css/inset-block/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>inset-inline</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the logical start and end offsets of an element in the inline direction, which maps to physical offsets depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("top")}} and {{cssxref("bottom")}}, or {{cssxref("right")}} and {{cssxref("left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
+<p>The <strong><code>inset-block</code></strong> <a href="/en-US/docs/Web/CSS" title="CSS">CSS</a> property defines the logical block start and end offsets of an element, which maps to physical offsets depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("top")}} and {{cssxref("bottom")}}, or {{cssxref("right")}} and {{cssxref("left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
 <pre class="brush:css no-line-numbers notranslate">/* &lt;length&gt; values */
 inset-inline: 3px 10px;
@@ -35,15 +35,15 @@ inset-inline: unset;
 <p>This property is a shorthand for the following CSS properties:</p>
 
 <ul>
- <li>{{cssxref("inset-inline-end")}}</li>
- <li>{{cssxref("inset-inline-start")}}</li>
+ <li>{{cssxref("inset-block-end")}}</li>
+ <li>{{cssxref("inset-block-start")}}</li>
 </ul>
 
 <h2 id="Syntax">Syntax</h2>
 
 <h3 id="Values">Values</h3>
 
-<p>The <code>inset-inline</code> property takes the same values as the {{cssxref("left")}} property.</p>
+<p>The <code>inset-block</code> property takes the same values as the {{cssxref("left")}} property.</p>
 
 <h2 id="Formal_definition">Formal definition</h2>
 
@@ -55,7 +55,7 @@ inset-inline: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Setting_inline_start_and_end_offsets">Setting inline start and end offsets</h3>
+<h3 id="Setting_block_start_and_end_offsets">Setting block start and end offsets</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -75,13 +75,13 @@ inset-inline: unset;
 .exampleText {
   writing-mode: vertical-lr;
   position: relative;
-  inset-inline: 20px 50px;
+  inset-block: 20px 50px;
   background-color: #c8c800;
 }</pre>
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample("Setting_inline_start_and_end_offsets", 140, 140)}}</p>
+<p>{{EmbedLiveSample("Setting_block_start_and_end_offsets", 140, 140)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -95,7 +95,7 @@ inset-inline: unset;
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName("CSS Logical Properties", "#propdef-inset-inline", "inset-inline")}}</td>
+   <td>{{SpecName("CSS Logical Properties", "#propdef-inset-block", "inset-block")}}</td>
    <td>{{Spec2("CSS Logical Properties")}}</td>
    <td>Initial definition</td>
   </tr>
@@ -104,13 +104,13 @@ inset-inline: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("css.properties.inset-inline")}}</p>
+<p>{{Compat("css.properties.inset-block")}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
  <li>The mapped physical properties: {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, and {{cssxref("left")}}</li>
  <li>The mapped physical shortcut: {{cssxref("inset")}}</li>
- <li>The mapped block shortcut: {{cssxref("inset-block")}}</li>
+ <li>The mapped inline shortcut: {{cssxref("inset-inline")}}</li>
  <li>{{cssxref("writing-mode")}}, {{cssxref("direction")}}, {{cssxref("text-orientation")}}</li>
 </ul>


### PR DESCRIPTION
https://github.com/mdn/content/commit/6ec6bf appears to have caused the CSS/inset-block article to be overwritten with the contents of the CSS/inset-inline article. This change reverts that overwrite, restoring the CSS/inset-block article to its previous state.

Fixes https://github.com/mdn/content/issues/1061