### PR TITLE
Update “Using the aria-required attribute” link

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.html
@@ -44,7 +44,7 @@ tags:
 
 <h4 id="Working_Examples">Working Examples:</h4>
 
-<p><a class="external" href="http://www.oaa-accessibility.org/examplep/tooltip1/">Tooltip example</a> (includes the use of the <code>aria-required</code> attribute)</p>
+<p><a class="external" href="https://w3c.github.io/aria-practices/examples/accordion/accordion.html">WAI-ARIA Authoring Practices: Accordion Example</a> (includes the use of the <code>aria-required</code> attribute)</p>
 
 <h3 id="Notes">Notes </h3>
 
@@ -56,7 +56,7 @@ tags:
  <li>Listbox</li>
  <li>Radiogroup</li>
  <li>Spinbutton</li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_textbox_role">Textbox</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role">Textbox</a></li>
  <li>Tree</li>
 </ul>
 
@@ -75,7 +75,7 @@ tags:
 <ul>
  <li><a class="external" href="https://www.w3.org/TR/wai-aria/#aria-required">WAI-ARIA specification for <code>aria-required</code></a></li>
  <li><a class="external" href="https://www.w3.org/TR/wai-aria-practices/#ariaform">WAI-ARIA Authoring Practices for forms</a></li>
- <li><a href="/en/HTML/HTML5/Constraint_validation">Constraint validation</a> in {{ HTMLVersionInline("5") }}</li>
+ <li><a href="/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation">Constraint validation</a> in HTML forms</li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
This change replaces a link to a 404 resource formerly at http://www.oaa-accessibility.org with a link to a corresponding https://w3c.github.io/aria-practices/examples resource.

This change also updates a couple of internal links to their current, correct locations.