### PR TITLE
Replace/remove more oaa-accessibility.org 404s

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_test_cases/index.html
+++ b/files/en-us/web/accessibility/aria/aria_test_cases/index.html
@@ -9,7 +9,7 @@ tags:
 
 <div class="warning">The information on this page is out of date: It was last updated November 2010. However, the information might still be useful for some readers.<br>
 <br>
-For more up-to-date examples, see the <a class="external" href="http://oaa-accessibility.org/">OpenAjaxAlliance ARIA examples page</a>. Or copy-paste: http://oaa-accessibility.org/examples/</div>
+For more up-to-date examples, see the WAI-ARIA Authoring Practices <a class="external" href="https://w3c.github.io/aria-practices/examples/">Index of ARIA Design Pattern Examples</a>.</div>
 
 <p>For each example we test the "Expected" results with assistive technologies, for each browser that AT supports WAI-ARIA in. Where a failure occurs we will test the browser for API incorrectness, using tools such as MSAA Inspect. This must be done in order to determine where to file a bug (browser or AT).</p>
 

--- a/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.html
+++ b/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.html
@@ -135,7 +135,7 @@ tags:
 
 <p>This technique involves binding a single event handler to the container widget and using the <code>aria-activedescendant</code> to track a "virtual" focus. (For more information about ARIA, see this <a class="external text" href="/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets" rel="nofollow">overview of accessible web applications and widgets</a>.)</p>
 
-<p>The <code>aria-activedescendant</code> property identifies the ID of the descendent element that currently has the virtual focus. The event handler on the container must respond to key and mouse events by updating the value of <code>aria-activedescendant</code> and ensuring that the current item is styled appropriately (for example, with a border or background color). See the source code of this <a class="external text" href="http://www.oaa-accessibility.org/example/28/" rel="nofollow">ARIA radiogroup example</a> for a direct illustration of how this works.</p>
+<p>The <code>aria-activedescendant</code> property identifies the ID of the descendent element that currently has the virtual focus. The event handler on the container must respond to key and mouse events by updating the value of <code>aria-activedescendant</code> and ensuring that the current item is styled appropriately (for example, with a border or background color).</p>
 
 <h3 id="General_Guidelines">General Guidelines</h3>
 


### PR DESCRIPTION
This replaces one general http://www.oaa-accessibility.org/example link (now 404) with a link to https://w3c.github.io/aria-practices/examples/ (WAI-ARIA Authoring Practices: Index of ARIA Design Pattern Examples), and removes another http://www.oaa-accessibility.org/example link which has no replacement.