### PR TITLE
removing experimental status

### DIFF
--- a/files/en-us/web/css/row-gap/index.html
+++ b/files/en-us/web/css/row-gap/index.html
@@ -6,7 +6,6 @@ tags:
   - CSS Flexible Boxes
   - CSS Grid
   - CSS Property
-  - Non-standard
   - Reference
   - 'recipe:css-property'
   - row-gap
@@ -52,8 +51,6 @@ row-gap: unset;
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Flex_layout">Flex layout</h3>
-
-<p>{{SeeCompatTable}}</p>
 
 <h4 id="HTML">HTML</h4>
 


### PR DESCRIPTION
The `row-gap` property isn't experimental and also has implementations in Firefox and Chrome for flexbox so removing the status and also the SeeCompatTable macro.