### PR TITLE
Update “Using the aria-invalid attribute” link

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-invalid_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-invalid_attribute/index.html
@@ -101,7 +101,7 @@ tags:
 
 <h4 id="Working_Examples">Working Examples:</h4>
 
-<p><a class="external" href="http://www.oaa-accessibility.org/examplep/alert1/">Alert <code>role</code> example</a> (uses the <code>aria-invalid</code> attribute)</p>
+<p><a class="external" href="https://www.w3.org/WAI/WCAG21/working-examples/aria-invalid-data-format/">Forms: Using aria-invalid to identify failed fields</a></p>
 
 <h3 id="Notes">Notes </h3>
 


### PR DESCRIPTION
This change replaces a link to a 404 resource formerly at http://www.oaa-accessibility.org with a link to corresponding resource under https://www.w3.org/WAI/WCAG21/working-examples