### PR TITLE
Replace more oaa-accessibility.org example links

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemax_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemax_attribute/index.html
@@ -34,11 +34,32 @@ tags:
 
 <h4 id="Working_Examples">Working Examples:</h4>
 
-<ul>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/progressbar1/">Progressbar example</a></li>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/slider1/">Slider example</a></li>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/spinbutton1/">Spinbutton example</a></li>
-</ul>
+<dl>
+ <dt>progressbar<dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/progress-bar-bounded">Deque Code Library of Accessibility Examples: Progress Bar (Bounded)</a></li>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/progress-bar-unbounded">Deque Code Library of Accessibility Examples: Progress Bar (Unbounded)</a></li>
+  </ul>
+ </dd>
+ <dt>slider</dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-1.html">WAI-ARIA Authoring Practices: Horizontal Slider Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html">WAI-ARIA Authoring Practices: Horizontal Multi-Thumb Slider Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-2.html">WAI-ARIA Authoring Practices: Slider Examples with aria-orientation and aria-valuetext</a></li>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider-multirange">Deque Code Library of Accessibility Examples: Slider (Multirange)</a></li>
+  </ul>
+ </dd>
+ <dt>spinbutton</dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/spinbutton/datepicker-spinbuttons.html">WAI-ARIA Authoring Practices: Date Picker Spin Button Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/toolbar/toolbar.html">WAI-ARIA Authoring Practices: Toolbar Example</a></li>
+  </ul>
+ </dd>
+</dl>
 
 <h3 id="Notes">Notes </h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
@@ -31,11 +31,32 @@ tags:
 
 <h4 id="Working_Examples">Working Examples:</h4>
 
-<ul>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/progressbar1/">Progressbar example</a></li>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/slider1/">Slider example</a></li>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/spinbutton1/">Spinbutton example</a></li>
-</ul>
+<dl>
+ <dt>progressbar<dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/progress-bar-bounded">Deque Code Library of Accessibility Examples: Progress Bar (Bounded)</a></li>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/progress-bar-unbounded">Deque Code Library of Accessibility Examples: Progress Bar (Unbounded)</a></li>
+  </ul>
+ </dd>
+ <dt>slider</dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-1.html">WAI-ARIA Authoring Practices: Horizontal Slider Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html">WAI-ARIA Authoring Practices: Horizontal Multi-Thumb Slider Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-2.html">WAI-ARIA Authoring Practices: Slider Examples with aria-orientation and aria-valuetext</a></li>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider-multirange">Deque Code Library of Accessibility Examples: Slider (Multirange)</a></li>
+  </ul>
+ </dd>
+ <dt>spinbutton</dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/spinbutton/datepicker-spinbuttons.html">WAI-ARIA Authoring Practices: Date Picker Spin Button Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/toolbar/toolbar.html">WAI-ARIA Authoring Practices: Toolbar Example</a></li>
+  </ul>
+ </dd>
+</dl>
 
 <h3 id="Notes">Notes </h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
@@ -35,11 +35,32 @@ tags:
 
 <h4 id="Working_Examples">Working Examples:</h4>
 
-<ul>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/progressbar1/">Progressbar example</a></li>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/slider1/">Slider example</a></li>
- <li><a class="external" href="http://www.oaa-accessibility.org/examplep/spinbutton1/">Spinbutton example</a></li>
-</ul>
+<dl>
+ <dt>progressbar<dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/progress-bar-bounded">Deque Code Library of Accessibility Examples: Progress Bar (Bounded)</a></li>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/progress-bar-unbounded">Deque Code Library of Accessibility Examples: Progress Bar (Unbounded)</a></li>
+  </ul>
+ </dd>
+ <dt>slider</dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-1.html">WAI-ARIA Authoring Practices: Horizontal Slider Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html">WAI-ARIA Authoring Practices: Horizontal Multi-Thumb Slider Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-2.html">WAI-ARIA Authoring Practices: Slider Examples with aria-orientation and aria-valuetext</a></li>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider-multirange">Deque Code Library of Accessibility Examples: Slider (Multirange)</a></li>
+  </ul>
+ </dd>
+ <dt>spinbutton</dt>
+ <dd>
+  <ul>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/spinbutton/datepicker-spinbuttons.html">WAI-ARIA Authoring Practices: Date Picker Spin Button Example</a></li>
+   <li><a class="external" href="https://w3c.github.io/aria-practices/examples/toolbar/toolbar.html">WAI-ARIA Authoring Practices: Toolbar Example</a></li>
+  </ul>
+ </dd>
+</dl>
 
 <h3 id="Notes">Notes </h3>
 


### PR DESCRIPTION
In the “Using the aria-value*” articles, this replaces links to http://www.oaa-accessibility.org/examplep resources with links to corresponding https://w3c.github.io/aria-practices/examples and https://dequeuniversity.com/library/aria resources.