### PR TITLE
Correcting the spec for box-sizing

### DIFF
--- a/files/en-us/web/css/box-sizing/index.html
+++ b/files/en-us/web/css/box-sizing/index.html
@@ -115,8 +115,8 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('CSS3 Basic UI', '#box-sizing', 'box-sizing')}}</td>
-   <td>{{Spec2('CSS3 Basic UI')}}</td>
+   <td>{{SpecName('CSS3 Sizing', '#box-sizing', 'box-sizing')}}</td>
+   <td>{{Spec2('CSS3 Sizing')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>


### PR DESCRIPTION
The `box-sizing` property is now part of CSS Sizing and not CSS Basic UI, fixing the link to the spec.

I have also changed the group in the data in this PR: https://github.com/mdn/data/pull/462