### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
@@ -18,7 +18,7 @@ tags:
 <p>It has no affect on filter functions, which operate in the {{Glossary("sRGB")}} color space.</p>
 </div>
 
-<p class="note"><strong>Note:</strong> As a presentation attribute, <code>color-interpolation</code> can be used as a CSS property.</p>
+<p class="note"><strong>Note:</strong> As a presentation attribute, <code>color-interpolation-filters</code> can be used as a CSS property.</p>
 
 <p>As a presentation attribute, it can be applied to any element but it only has an effect on the following eighteen elements: {{SVGElement("feSpotLight")}}, {{SVGElement("feBlend")}}, {{SVGElement("feColorMatrix")}}, {{SVGElement("feComponentTransfer")}}, {{SVGElement("feComposite")}}, {{SVGElement("feConvolveMatrix")}}, {{SVGElement("feDiffuseLighting")}}, {{SVGElement("feDisplacementMap")}}, {{SVGElement("feDropShadow")}}, {{SVGElement("feFlood")}}, {{SVGElement("feGaussianBlur")}}, {{SVGElement("feImage")}}, {{SVGElement("feMerge")}}, {{SVGElement("feMorphology")}}, {{SVGElement("feOffset")}}, {{SVGElement("feSpecularLighting")}}, {{SVGElement("feTile")}}, {{SVGElement("feTurbulence")}}</p>
 


### PR DESCRIPTION
Replace `color-interpolation` (unrelated to the current document) by `color-interpolation-filters` (the attribute for the current document).