### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/web/svg/element/radialgradient/index.html
+++ b/files/en-us/web/svg/element/radialgradient/index.html
@@ -54,13 +54,13 @@ tags:
  <dd>This attribute defines the y coordinate of the start circle of the radial gradient.<br>
  <small><em>Value type</em>: <a href="/docs/Web/SVG/Content_type#Length"><strong>&lt;length&gt;</strong></a> ; <em>Default value</em>: Same as <code>cy</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("gradientUnits")}}</dt>
- <dd>This attribute defines the coordinate system for attributes <code>x1</code>, <code>x2</code>, <code>y1</code>, <code>y2</code><br>
+ <dd>This attribute defines the coordinate system for attributes <code>cx</code>, <code>cy</code>, <code>r</code>, <code>fx</code>, <code>fy</code>, <code>fr</code><br>
  <small><em>Value type</em>: <code>userSpaceOnUse</code>|<code>objectBoundingBox</code> ; <em>Default value</em>: <code>objectBoundingBox</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt id="attr-cx">{{SVGAttr("gradientTransform")}}</dt>
  <dd>This attribute provides additional <a href="/docs/Web/SVG/Attribute/transform">transformation</a> to the gradient coordinate system.<br>
  <small><em>Value type</em>: <strong><a href="/docs/Web/SVG/Content_type#Transform-list">&lt;transform-list&gt;</a></strong> ; <em>Default value</em>: <em>identity transform</em>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("href")}}</dt>
- <dd>This attribute defines a reference to another <code>&lt;linearGradient&gt;</code> element that will be used as a template.<br>
+ <dd>This attribute defines a reference to another <code>&lt;radialGradient&gt;</code> element that will be used as a template.<br>
  <small><em>Value type</em>: <a href="/docs/Web/SVG/Content_type#URL"><strong>&lt;URL&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt>{{SVGAttr("r")}}</dt>
  <dd>This attribute defines the radius of the end circle of the radial gradient. The gradient will be drawn such that the 100% {{SVGElement('stop','gradient stop')}} is mapped to the perimeter of the end circle.<br>
@@ -69,7 +69,7 @@ tags:
  <dd>This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient.<br>
  <small><em>Value type</em>: <code>pad</code>|<code>reflect</code>|<code>repeat</code> ; <em>Default value</em>: <code>pad</code>; <em>Animatable</em>: <strong>yes</strong></small></dd>
  <dt id="attr-xlink">{{SVGAttr("xlink:href")}}</dt>
- <dd>{{Deprecated_Header("SVG2")}}An <a href="/en/SVG/Content_type#IRI">&lt;IRI&gt;</a> reference to another <code>&lt;linearGradient&gt;</code> element that will be used as a template.<br>
+ <dd>{{Deprecated_Header("SVG2")}}An <a href="/en/SVG/Content_type#IRI">&lt;IRI&gt;</a> reference to another <code>&lt;radialGradient&gt;</code> element that will be used as a template.<br>
  <small><em>Value type</em>: <a href="/docs/Web/SVG/Content_type#IRI"><strong>&lt;IRI&gt;</strong></a> ; <em>Default value</em>: none; <em>Animatable</em>: <strong>yes</strong></small></dd>
 </dl>
 


### PR DESCRIPTION
Replace `linearGradient`, `x1`, `x2`, `y1`, `y2` (all unrelated to the current document) by `radialGradient`, `cx`, `cy`, `r`, `fx`, `fy`, `fr` (element and its attributes for the current document).