### PR TITLE
Update spec tables for HTML global attributes

### DIFF
--- a/files/en-us/web/html/global_attributes/accesskey/index.html
+++ b/files/en-us/web/html/global_attributes/accesskey/index.html
@@ -95,35 +95,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML5.2', "editing.html#the-accesskey-attribute", "accesskey")}}</td>
-   <td>{{Spec2('HTML5.2')}}</td>
-   <td>More realistic behavior described for what is implemented in reality.</td>
-  </tr>
-  <tr>
    <td>{{SpecName('HTML WHATWG', "interaction.html#the-accesskey-attribute", "accesskey")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest W3C {{SpecName('HTML5.1')}} spec.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "editing.html#the-accesskey-attribute", "accesskey")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>No change from {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "editing.html#the-accesskey-attribute", "accesskey")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>From {{SpecName('HTML4.01')}}, several characters can now be set as the <code>accesskey</code>. Also, it can be set on any element.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', "interact/forms.html#h-17.11.2", "accesskey")}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Only supported on {{ HTMLElement("a") }}, {{ HTMLElement("area") }}, {{ HTMLElement("button") }}, {{ HTMLElement("input") }}, {{ HTMLElement("label") }}, {{ HTMLElement("legend") }} and {{ HTMLElement("textarea") }}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/class/index.html
+++ b/files/en-us/web/html/global_attributes/class/index.html
@@ -22,28 +22,9 @@ tags:
 	<tbody>
 		<tr>
 			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
 		</tr>
 		<tr>
 			<td>{{SpecName('HTML WHATWG', "elements.html#classes", "class")}}</td>
-			<td>{{Spec2('HTML WHATWG')}}</td>
-			<td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5.1', "elements.html#classes", "class")}}</td>
-			<td>{{Spec2('HTML5.1')}}</td>
-			<td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML5 W3C', "elements.html#classes", "class")}}</td>
-			<td>{{Spec2('HTML5 W3C')}}</td>
-			<td>Snapshot of {{SpecName('HTML WHATWG')}}. From {{SpecName('HTML4.01')}}, <code>class</code> is now a true global attribute.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('HTML4.01', "struct/global.html#h-7.5.2", "class")}}</td>
-			<td>{{Spec2('HTML4.01')}}</td>
-			<td>Supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("param")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}}, and {{HTMLElement("title")}}.</td>
 		</tr>
 	</tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/contenteditable/index.html
+++ b/files/en-us/web/html/global_attributes/contenteditable/index.html
@@ -40,30 +40,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName("HTML WHATWG", "editing.html#attr-contenteditable", "contenteditable")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>No change from latest snapshot, {{SpecName("HTML5.2")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2", "editing.html#making-document-regions-editable-the-contenteditable-content-attribute", "contenteditable")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}, no change from {{SpecName("HTML5.1")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "editing.html#making-document-regions-editable-the-contenteditable-content-attribute", "contenteditable")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}, no change from {{SpecName("HTML5 W3C")}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "editing.html#attr-contenteditable", "contenteditable")}}</td>
-   <td>{{Spec2("HTML5 W3C")}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}, initial definition.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/dir/index.html
+++ b/files/en-us/web/html/global_attributes/dir/index.html
@@ -52,28 +52,9 @@ tags:
  <tbody>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
   <tr>
    <td>{{SpecName('HTML WHATWG', "dom.html#the-dir-attribute", "dir")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-dir-attribute", "dir")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-dir-attribute", "dir")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, from {{SpecName('HTML4.01')}} it added the <code>auto</code> value, and is now a true global attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', "dirlang.html#h-8.2", "dir")}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Supported on all elements but {{HTMLElement("applet")}}, {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("bdo")}}, {{HTMLElement("br")}}, {{HTMLElement("frame")}}, {{HTMLElement("frameset")}}, {{HTMLElement("iframe")}}, {{HTMLElement("param")}}, and {{HTMLElement("script")}}.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/draggable/index.html
+++ b/files/en-us/web/html/global_attributes/draggable/index.html
@@ -29,25 +29,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName("HTML WHATWG", "interaction.html#the-draggable-attribute", "draggable")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2", "interaction.html#the-draggable-attribute", "draggable")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>No change</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "editing.html#the-draggable-attribute", "draggable")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/id/index.html
+++ b/files/en-us/web/html/global_attributes/id/index.html
@@ -32,28 +32,9 @@ tags:
  <tbody>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
   <tr>
    <td>{{SpecName('HTML WHATWG', "dom.html#the-id-attribute", "id")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-id-attribute", "id")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-id-attribute", "id")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, now accept <code>'_'</code>, <code>'-'</code> and <code>'.'</code> if not at the beginning of the id. It is also a true global attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', 'struct/global.html#adef-id', 'id')}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}}, and {{HTMLElement("title")}}.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/is/index.html
+++ b/files/en-us/web/html/global_attributes/is/index.html
@@ -40,15 +40,11 @@ customElements.define('word-count', WordCount, { extends: 'p' });</pre>
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName('HTML WHATWG', "custom-elements.html#attr-is", "is")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/itemid/index.html
+++ b/files/en-us/web/html/global_attributes/itemid/index.html
@@ -71,15 +71,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName('HTML WHATWG', "microdata.html#attr-itemid", "itemid")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/itemprop/index.html
+++ b/files/en-us/web/html/global_attributes/itemprop/index.html
@@ -434,20 +434,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML Microdata', "#dfn-attr-itemprop", "itemprop")}}</td>
-   <td>{{Spec2('HTML Microdata')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
    <td>{{SpecName('HTML WHATWG', "microdata.html#names:-the-itemprop-attribute", "itemprop")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/itemref/index.html
+++ b/files/en-us/web/html/global_attributes/itemref/index.html
@@ -57,20 +57,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML Microdata', "#dfn-itemref", "itemref")}}</td>
-   <td>{{Spec2('HTML Microdata')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
    <td>{{SpecName('HTML WHATWG', "microdata.html#attr-itemref", "itemref")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/itemscope/index.html
+++ b/files/en-us/web/html/global_attributes/itemscope/index.html
@@ -249,20 +249,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML Microdata', "#dfn-itemscope", "itemscope")}}</td>
-   <td>{{Spec2('HTML Microdata')}}</td>
-   <td></td>
-  </tr>
-  <tr>
    <td>{{SpecName('HTML WHATWG', "microdata.html#attr-itemscope", "itemscope")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/itemtype/index.html
+++ b/files/en-us/web/html/global_attributes/itemtype/index.html
@@ -214,20 +214,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML Microdata', "#dfn-itemtype", "itemtype")}}</td>
-   <td>{{Spec2('HTML Microdata')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
    <td>{{SpecName('HTML WHATWG', "microdata.html#attr-itemtype", "itemprop")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/part/index.html
+++ b/files/en-us/web/html/global_attributes/part/index.html
@@ -19,15 +19,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName("CSS Shadow Parts", "#part-attr", "part")}}</td>
-   <td>{{Spec2('CSS Shadow Parts')}}</td>
-   <td></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/slot/index.html
+++ b/files/en-us/web/html/global_attributes/slot/index.html
@@ -18,20 +18,14 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName('HTML WHATWG', "dom.html#attr-slot", "slot attribute")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{SpecName('DOM WHATWG', "#dom-element-slot", "slot attribute")}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/style/index.html
+++ b/files/en-us/web/html/global_attributes/style/index.html
@@ -24,33 +24,9 @@ tags:
  <tbody>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
   <tr>
    <td>{{SpecName('HTML WHATWG', "dom.html#the-style-attribute", "style")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-style-attribute", "style")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-style-attribute", "style")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}. From {{SpecName("HTML4.01")}}, it is now a true global attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', 'present/styles.html#h-14.2.2', 'style')}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("param")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}}, and {{HTMLElement("title")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Style", "", "")}}</td>
-   <td>{{Spec2("CSS3 Style")}}</td>
-   <td>Defines the content of the <code>style</code> attribute.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/tabindex/index.html
+++ b/files/en-us/web/html/global_attributes/tabindex/index.html
@@ -49,30 +49,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName('HTML WHATWG', "interaction.html#attr-tabindex", "tabindex")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "editing.html#the-tabindex-attribute", "tabindex")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "editing.html#attr-tabindex", "tabindex")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}. From {{SpecName("HTML4.01")}}, the attribute is now supported on all elements (global attributes).</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', 'interact/forms.html#adef-tabindex', 'tabindex')}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Only supported on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("button")}}, {{HTMLElement("input")}}, {{HTMLElement("object")}}, {{HTMLElement("select")}}, and {{HTMLElement("textarea")}}.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/title/index.html
+++ b/files/en-us/web/html/global_attributes/title/index.html
@@ -83,30 +83,11 @@ multiline title"&gt;example&lt;/abbr&gt;.&lt;/p&gt;</pre>
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName('HTML WHATWG', "dom.html#the-title-attribute", "title")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-title-attribute", "title")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-title-attribute", "title")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}. From {{SpecName("HTML4.01")}}, it is now a true global attribute.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', 'struct/global.html#adef-title', 'title')}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("param")}}, {{HTMLElement("script")}}, and {{HTMLElement("title")}}.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/translate/index.html
+++ b/files/en-us/web/html/global_attributes/translate/index.html
@@ -32,18 +32,9 @@ tags:
  <tbody>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
   <tr>
    <td>{{SpecName('HTML WHATWG', "dom.html#attr-translate", "translate")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-translate-attribute", "translate")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
Removes outdated specs. 
See also `spec_urls` in BCD which @sideshowbarker and I worked on in https://github.com/mdn/browser-compat-data/pull/8064

https://github.com/mdn/browser-compat-data/blob/master/html/global_attributes.json