### PR TITLE
fix(firefox-85): fix ref to `touch-action` property

### DIFF
--- a/files/en-us/mozilla/firefox/releases/85/index.html
+++ b/files/en-us/mozilla/firefox/releases/85/index.html
@@ -29,7 +29,7 @@ tags:
 
 <ul>
   <li>The {{cssxref(":focus-visible")}} pseudo-class is now enabled. ({{bug(1445482)}}). </li>
-  <li>The <code>pinch-zoom</code> value for the {{cssxref(":touch-action")}} property is now enabled. ({{bug(1329241)}}). </li>
+  <li>The <code>pinch-zoom</code> value for the {{cssxref("touch-action")}} property is now enabled. ({{bug(1329241)}}). </li>
 </ul>
 
 <h4 id="Removals_3">Removals</h4>


### PR DESCRIPTION
by trimming the leading colon