### PR TITLE
Document enterkeyhint global attribute

### DIFF
--- a/files/en-us/web/html/global_attributes/enterkeyhint/index.html
+++ b/files/en-us/web/html/global_attributes/enterkeyhint/index.html
@@ -1,0 +1,114 @@
+---
+title: enterkeyhint
+slug: Web/HTML/Global_attributes/enterkeyhint
+tags:
+  - Global attributes
+  - HTML
+  - Reference
+---
+<div>{{HTMLSidebar("Global_attributes")}}</div>
+
+<p>The <strong><code>enterkeyhint</code></strong> <a href="/en-US/docs/Web/HTML/Global_attributes">global attribute</a> 
+is an enumerated attribute defining what action label (or icon) to present for the enter key on virtual keyboards.</p>
+
+<h2>Description</h2>
+<a href="/en-US/docs/Learn/Forms">Form controls</a> (such as <a href="/en-US/docs/Web/HTML/Element/textarea"><code>&lt;textarea&gt;</code></a>
+or <a href="/en-US/docs/Web/HTML/Element/input"><code>&lt;input&gt;</code></a> elements) or elements using 
+<a href="/en-US/docs/Web/HTML/Global_attributes/contenteditable"><code>contenteditable</code></a> can specify an 
+<a href="/en-US/docs/Web/HTML/Global_attributes/inputmode"><code>inputmode</code></a> attribute to control what  kind of virtual keyboard
+will be used. To further improve the user's experience, the enter key can be customized specifically by providing an <code>enterkeyhint</code>
+attribute indicating how the enter key should be labeled (or which icon should be shown). The enter key usually 
+represents what the user should do next; typical actions are: sending text, inserting a new line, or searching.</p>
+
+<p>If no <code>enterkeyhint</code> attribute is provided, the user agent might use contextual information from the 
+<a href="/en-US/docs/Web/HTML/Global_attributes/inputmode"><code>inputmode</code></a>, 
+<a href="/en-US/docs/Web/HTML/Element/input#input_types"><code>type</code></a>, 
+or <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern"><code>pattern</code></a>
+attributes to display a suitable enter key label (or icon).</p>
+
+<h3>Values</h3>
+
+<p>The <code>enterkeyhint</code> attribute is an enumerated attribute and only accepts the following values:</p>
+
+<table class="standard-table">
+  <colgroup>
+    <col style="width: 30%;">
+    <col style="width: 50%;">
+    <col style="width: 20%;">
+   </colgroup>
+  <thead>
+   <tr>
+    <th>Value</th>
+    <th>Description</th>
+    <th>Example label <br><small>(depends on user agent and user language)</small></th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <td><code>enterkeyhint="enter"</code></td>
+    <td>Typically inserting a new line.</td>
+    <td><kbd>↵</kbd></td>
+   </tr>
+   <tr>
+    <td><code>enterkeyhint="done"</code></td>
+    <td>Typically meaning there is nothing more to input and the input method editor (IME) will be closed.</td>
+    <td><kbd>Done</kbd></td>
+   </tr>
+   <tr>
+    <td><code>enterkeyhint="go"</code></td>
+    <td>Typically meaning to take the user to the target of the text they typed.</td>
+    <td><kbd>Open</kbd></td>
+   </tr>
+   <tr>
+    <td><code>enterkeyhint="next"</code></td>
+    <td>Typically taking the user to the next field that will accept text.</td>
+    <td><kbd>Next</kbd></td>
+   </tr>
+   <tr>
+    <td><code>enterkeyhint="previous"</code></td>
+    <td>Typically taking the user to the previous field that will accept text.</td>
+    <td><kbd>Previous</kbd></td>
+   </tr>
+   <tr>
+    <td><code>enterkeyhint="search"</code></td>
+    <td>Typically taking the user to the results of searching for the text they have typed.</td>
+    <td><kbd>Search</kbd></td>
+   </tr>
+   <tr>
+    <td><code>enterkeyhint="send"</code></td>
+    <td>Typically delivering the text to its target.</td>
+    <td><kbd>Send</kbd></td>
+   </tr>
+  </tbody>
+</table>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('HTML WHATWG', "interaction.html#attr-enterkeyhint", "enterkeyhint")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("html.global_attributes.enterkeyhint")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTMLElement/enterkeyhint"><code>HTMLElement.enterkeyhint</code></a> property reflecting this attribute</li>
+ <li><a href="/en-US/docs/Web/HTML/Global_attributes/inputmode"><code>inputmode</code></a> global attribute</li>
+ <li><a href="/en-US/docs/Web/HTML/Global_attributes/contenteditable"><code>contenteditable</code></a> global attribute</li>
+ <li><a href="/en-US/docs/Web/HTML/Element/input#input_types"><code>type</code></a> and 
+  <a href="/en-US/docs/Web/HTML/Element/input#htmlattrdefpattern"><code>pattern</code></a> attributes on 
+  <a href="/en-US/docs/Web/HTML/Element/input"><code>&lt;input&gt;</code></a> elements</li>
+</ul>

--- a/files/en-us/web/html/global_attributes/enterkeyhint/index.html
+++ b/files/en-us/web/html/global_attributes/enterkeyhint/index.html
@@ -11,6 +11,8 @@ tags:
 <p>The <strong><code>enterkeyhint</code></strong> <a href="/en-US/docs/Web/HTML/Global_attributes">global attribute</a> 
 is an enumerated attribute defining what action label (or icon) to present for the enter key on virtual keyboards.</p>
 
+<div>{{EmbedInteractiveExample("pages/tabbed/attribute-enterkeyhint.html","tabbed-shorter")}}</div>
+
 <h2>Description</h2>
 <a href="/en-US/docs/Learn/Forms">Form controls</a> (such as <a href="/en-US/docs/Web/HTML/Element/textarea"><code>&lt;textarea&gt;</code></a>
 or <a href="/en-US/docs/Web/HTML/Element/input"><code>&lt;input&gt;</code></a> elements) or elements using 

--- a/files/en-us/web/html/global_attributes/index.html
+++ b/files/en-us/web/html/global_attributes/index.html
@@ -63,6 +63,8 @@ tags:
   <li><code>false</code>, which indicates that the element may not be dragged.</li>
  </ul>
  </dd>
+ <dt><a href="/en-US/docs/Web/HTML/Global_attributes/enterkeyhint">{{HTMLAttrDef("enterkeyhint")}}</a></dt>
+ <dd>Hints what action label (or icon) to present for the enter key on virtual keyboards.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/exportparts">{{HTMLAttrDef("exportparts")}}</a> {{Experimental_Inline}}</dt>
  <dd>Used to transitively export shadow parts from a nested shadow tree into a containing light tree.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/hidden">{{HTMLAttrDef("hidden")}}</a></dt>

--- a/files/en-us/web/html/global_attributes/inputmode/index.html
+++ b/files/en-us/web/html/global_attributes/inputmode/index.html
@@ -62,4 +62,5 @@ tags:
 
 <ul>
  <li>All <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</li>
+ <li><a href="/en-US/docs/Web/HTML/Global_attributes/enterkeyhint"><code>enterkeyhint</code></a> global attribute</li>
 </ul>


### PR DESCRIPTION
Spec: https://html.spec.whatwg.org/multipage/interaction.html#attr-enterkeyhint

Will do the `HTMLELement.enterkeyhint` reflected property in a follow-up PR.

Other global attributes have nice interactive examples (see [spellcheck](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck)). I guess I could open a PR against interactive examples? Would anyone review that?