### PR TITLE
Rename Document.currentScript→document.currentScript

### DIFF
--- a/files/en-us/web/api/document/currentscript/index.html
+++ b/files/en-us/web/api/document/currentscript/index.html
@@ -46,7 +46,7 @@ tags:
   <tbody>
     <tr>
       <td>{{SpecName("HTML WHATWG", "dom.html#dom-document-currentscript",
-        "Document.currentScript")}}</td>
+        "currentScript")}}</td>
       <td>{{Spec2("HTML WHATWG")}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/document/currentscript/index.html
+++ b/files/en-us/web/api/document/currentscript/index.html
@@ -1,5 +1,5 @@
 ---
-title: Document.currentScript
+title: document.currentScript
 slug: Web/API/Document/currentScript
 tags:
 - API
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p>The <code><strong>Document.currentScript</strong></code> property returns the {{HTMLElement("script")}} element whose script is currently being processed and <a href="https://github.com/whatwg/html/issues/997">isn't a JavaScript module</a>. (For modules use <a href="/en-US/docs/Web/JavaScript/Reference/Statements/import.meta">import.meta</a> instead.)</p>
+<p>The <code><strong>document.currentScript</strong></code> property returns the {{HTMLElement("script")}} element whose script is currently being processed and <a href="https://github.com/whatwg/html/issues/997">isn't a JavaScript module</a>. (For modules use <a href="/en-US/docs/Web/JavaScript/Reference/Statements/import.meta">import.meta</a> instead.)</p>
 
 <p>It's important to note that this will not reference the {{HTMLElement("script")}}
   element if the code in the script is being called as a callback or event handler; it

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -552,7 +552,7 @@ tags:
 <p>Mozilla defines a set of non-standard properties made only for XUL content:</p>
 
 <dl>
- <dt>{{DOMxRef("Document.currentScript")}} {{Non-standard_Inline}}</dt>
+ <dt>{{DOMxRef("document.currentScript")}}</dt>
  <dd>Returns the {{HTMLElement("script")}} element that is currently executing.</dd>
  <dt>{{DOMxRef("Document.documentURIObject")}}</dt>
  <dd>(<strong>Mozilla add-ons only!</strong>) Returns the {{Interface("nsIURI")}} object representing the URI of the document. This property only has special meaning in privileged JavaScript code (with UniversalXPConnect privileges).</dd>

--- a/files/en-us/web/api/document/onafterscriptexecute/index.html
+++ b/files/en-us/web/api/document/onafterscriptexecute/index.html
@@ -49,5 +49,5 @@ document.addEventListener('afterscriptexecute', finished, true);
 
 <ul>
   <li>{{domxref("Document.onbeforescriptexecute")}}</li>
-  <li>{{domxref("Document.currentScript")}}</li>
+  <li>{{domxref("document.currentScript")}}</li>
 </ul>

--- a/files/en-us/web/api/document/onbeforescriptexecute/index.html
+++ b/files/en-us/web/api/document/onbeforescriptexecute/index.html
@@ -48,6 +48,6 @@ document.addEventListener("beforescriptexecute", starting, true);
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>{{domxref("Document.onafterscriptexecute")}}</li>
-  <li>{{domxref("Document.currentScript")}}</li>
+ <li>{{domxref("Document.onafterscriptexecute")}}</li>
+ <li>{{domxref("document.currentScript")}}</li>
 </ul>

--- a/files/en-us/web/api/document/onbeforescriptexecute/index.html
+++ b/files/en-us/web/api/document/onbeforescriptexecute/index.html
@@ -48,6 +48,6 @@ document.addEventListener("beforescriptexecute", starting, true);
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{domxref("Document.onafterscriptexecute")}}</li>
- <li>{{domxref("document.currentScript")}}</li>
+  <li>{{domxref("Document.onafterscriptexecute")}}</li>
+  <li>{{domxref("document.currentScript")}}</li>
 </ul>


### PR DESCRIPTION
Noticed while working on https://github.com/mdn/content/issues/1042