### PR TITLE
Remove outdated specs from global attributes page

### DIFF
--- a/files/en-us/web/html/global_attributes/index.html
+++ b/files/en-us/web/html/global_attributes/index.html
@@ -130,49 +130,11 @@ tags:
  <thead>
   <tr>
    <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName("HTML WHATWG", "dom.html#global-attributes", "Global attributes")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS Shadow Parts", "#exposing")}}</td>
-   <td>{{Spec2("CSS Shadow Parts")}}</td>
-   <td>Added the <code>part</code> and <code>exportparts</code> global attributes.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.2", "dom.html#global-attributes", "Global attributes")}}</td>
-   <td>{{Spec2("HTML5.2")}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. From {{SpecName("HTML5.1")}}, <code>itemid</code>, <code>itemprop</code>, <code>itemref</code>, <code>itemscope</code>, and <code>itemtype</code> have been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "dom.html#global-attributes", "Global attributes")}}</td>
-   <td>{{Spec2("HTML5.1")}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. From {{SpecName("HTML5 W3C")}}, <code>contextmenu</code>, <code>draggable</code>, <code>dropzone</code>, and <code>spellcheck</code> have been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "dom.html#global-attributes", "Global attributes")}}</td>
-   <td>{{Spec2("HTML5 W3C")}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. From {{SpecName("HTML4.01")}}, the concept of global attributes is introduced and the <code>dir</code>, <code>lang</code>, <code>style</code>, <code>id</code>, <code>class</code>, <code>tabindex</code>, <code>accesskey</code>, and <code>title</code> are now true global attributes.<br>
-    <code>xml:lang</code> which was initially part of XHTML, is now also part of HTML.<br>
-    <code>hidden</code>, <code>data-*</code>, <code>contenteditable</code>, and <code>translate</code> have been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML4.01")}}</td>
-   <td>{{Spec2("HTML4.01")}}</td>
-   <td>There are no global attributes defined. Several attributes that will become global attributes in subsequent specifications are defined on a subset of elements.<br>
-    <code>class</code> and <code>style</code> are supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("param")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}}, and {{HTMLElement("title")}}.<br>
-    <code>dir</code> is supported on all elements but {{HTMLElement("applet")}}, {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("bdo")}}, {{HTMLElement("br")}}, {{HTMLElement("frame")}}, {{HTMLElement("frameset")}}, {{HTMLElement("iframe")}}, {{HTMLElement("param")}}, and {{HTMLElement("script")}}.<br>
-    <code>id</code> is supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}}, and {{HTMLElement("title")}}.<br>
-    <code>lang</code> is supported on all elements but {{HTMLElement("applet")}}, {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("br")}}, {{HTMLElement("frame")}}, {{HTMLElement("frameset")}}, {{HTMLElement("iframe")}}, {{HTMLElement("param")}}, and {{HTMLElement("script")}}.<br>
-    <code>tabindex</code> is only supported on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("button")}}, {{HTMLElement("object")}}, {{HTMLElement("select")}}, and {{HTMLElement("textarea")}}.<br>
-    <code>accesskey</code> is only supported on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("button")}}, {{HTMLElement("input")}}, {{HTMLElement("label")}}, {{HTMLElement("legend")}} and {{HTMLElement("textarea")}}.<br>
-    <code>title</code> is supported on all elements but {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("head")}}, {{HTMLElement("html")}}, {{HTMLElement("meta")}}, {{HTMLElement("param")}}, {{HTMLElement("script")}}, and {{HTMLElement("title")}}.</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
Forgot to do this in https://github.com/mdn/content/pull/1101

I don't think the historic information is useful anymore. If behavior changed and it affects authors, we usually record it in browser-compat-data.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#specifications 