### PR TITLE
"Usage Notes" section fix

### DIFF
--- a/files/en-us/web/api/window/innerheight/index.html
+++ b/files/en-us/web/api/window/innerheight/index.html
@@ -42,7 +42,7 @@ tags:
 
 <p>To obtain the height of the window minus its horizontal scroll bar and any borders, use
   the root {{HTMLElement("html")}} element's {{domxref("Element.clientHeight",
-  "clientHeight()")}} property instead.</p>
+  "clientHeight")}} property instead.</p>
 
 <p>Both <code>innerHeight</code> and <code>innerWidth</code> are available on any window
   or any object that behaves like a window, such as a tab or frame.</p>


### PR DESCRIPTION
"element's clientHeight()" has been changed into "element's clientHeight" as `clientHeight` is not a method but a property.