### PR TITLE
Fix: remove newline causing MacroNotFoundError

### DIFF
--- a/files/en-us/web/api/node/removechild/index.html
+++ b/files/en-us/web/api/node/removechild/index.html
@@ -138,8 +138,7 @@ while (element.firstChild) {
 
 <h2 id="Notes">Notes</h2>
 
-<p>Unlike {{domxref ("Node.cloneNode()")}} the return value preserves the {{domxref
-  ("EventListener")}}s.</p>
+<p>Unlike {{domxref("Node.cloneNode()")}} the return value preserves the {{domxref("EventListener")}}s.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Because of that newline the renderer was looking for macro called `domxref\n` with a newline instead of `domxref`.