### PR TITLE
Fix markup error in “Using the aria-value*” docs

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemax_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemax_attribute/index.html
@@ -48,7 +48,7 @@ tags:
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-1.html">WAI-ARIA Authoring Practices: Horizontal Slider Example</a></li>
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html">WAI-ARIA Authoring Practices: Horizontal Multi-Thumb Slider Example</a></li>
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-2.html">WAI-ARIA Authoring Practices: Slider Examples with aria-orientation and aria-valuetext</a></li>
-   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></li>
    <li><a class="external" href="https://dequeuniversity.com/library/aria/slider-multirange">Deque Code Library of Accessibility Examples: Slider (Multirange)</a></li>
   </ul>
  </dd>

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuemin_attribute/index.html
@@ -45,7 +45,7 @@ tags:
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-1.html">WAI-ARIA Authoring Practices: Horizontal Slider Example</a></li>
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html">WAI-ARIA Authoring Practices: Horizontal Multi-Thumb Slider Example</a></li>
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-2.html">WAI-ARIA Authoring Practices: Slider Examples with aria-orientation and aria-valuetext</a></li>
-   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></li>
    <li><a class="external" href="https://dequeuniversity.com/library/aria/slider-multirange">Deque Code Library of Accessibility Examples: Slider (Multirange)</a></li>
   </ul>
  </dd>

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuenow_attribute/index.html
@@ -49,7 +49,7 @@ tags:
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-1.html">WAI-ARIA Authoring Practices: Horizontal Slider Example</a></li>
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html">WAI-ARIA Authoring Practices: Horizontal Multi-Thumb Slider Example</a></li>
    <li><a class="external" href="https://w3c.github.io/aria-practices/examples/slider/slider-2.html">WAI-ARIA Authoring Practices: Slider Examples with aria-orientation and aria-valuetext</a></li>
-   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></>
+   <li><a class="external" href="https://dequeuniversity.com/library/aria/slider">Deque Code Library of Accessibility Examples: Slider</a></li>
    <li><a class="external" href="https://dequeuniversity.com/library/aria/slider-multirange">Deque Code Library of Accessibility Examples: Slider (Multirange)</a></li>
   </ul>
  </dd>


### PR DESCRIPTION
This change fixes a markup error introduced in c08b089.