### PR TITLE
Fix: replace <samp> with <code>

### DIFF
--- a/files/en-us/glossary/site/index.html
+++ b/files/en-us/glossary/site/index.html
@@ -6,7 +6,7 @@ tags:
   - Security
   - WebMechanics
 ---
-<p>The <em>site</em> of a piece of web content is determined by the <em>registrable domain</em> of the host within the origin. This is computed by consulting a <em>Public Suffix List</em> to find the portion of the host which is counted as the <em>public suffix</em> (e.g. <samp>com</samp>, <samp>org</samp> or <samp>co.uk</samp>).</p>
+<p>The <em>site</em> of a piece of web content is determined by the <em>registrable domain</em> of the host within the origin. This is computed by consulting a <em>Public Suffix List</em> to find the portion of the host which is counted as the <em>public suffix</em> (e.g. <code>com</code>, <code>org</code> or <code>co.uk</code>).</p>
 
 <p>The concept of a <em>site</em> is used in <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives">SameSite cookies</a>, as well as a web application's <a href="/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)">Cross-Origin Resource Policy</a>.</p>
 

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.html
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.html
@@ -279,7 +279,7 @@ let resetButton;</pre>
 
 <pre class="brush: js notranslate">checkGuess();</pre>
 
-<p>After pressing <kbd>Return</kbd>/<kbd>Enter</kbd>, you should see an alert come up that says "<samp>I am a placeholder</samp>"; we have defined a function in our code that creates an alert whenever we call it.</p>
+<p>After pressing <kbd>Return</kbd>/<kbd>Enter</kbd>, you should see an alert come up that says <code>I am a placeholder</code>; we have defined a function in our code that creates an alert whenever we call it.</p>
 
 <div class="note">
 <p><strong>Note</strong>: You'll learn a lot more about functions <a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">later in the course</a>.</p>
@@ -438,7 +438,7 @@ greeting;</pre>
  <li>The first line (line 2 above) declares a variable called <code>userGuess</code> and sets its value to the current value entered inside the text field. We also run this value through the built-in <code>Number()</code> constructor, just to make sure the value is definitely a number.</li>
  <li>Next, we encounter our first conditional code block (lines 3–5 above). A conditional code block allows you to run code selectively, depending on whether a certain condition is true or not. It looks a bit like a function, but it isn't. The simplest form of conditional block starts with the keyword <code>if</code>, then some parentheses, then some curly braces. Inside the parentheses we include a test. If the test returns <code>true</code>, we run the code inside the curly braces. If not, we don't, and move on to the next bit of code. In this case the test is testing whether the <code>guessCount</code> variable is equal to <code>1</code> (i.e. whether this is the player's first go or not):
   <pre class="brush: js notranslate">guessCount === 1</pre>
-  If it is, we make the guesses paragraph's text content equal to "<samp>Previous guesses: </samp>". If not, we don't.</li>
+  If it is, we make the guesses paragraph's text content equal to <code>Previous guesses: </code>. If not, we don't.</li>
  <li>Line 6 appends the current <code>userGuess</code> value onto the end of the <code>guesses</code> paragraph, plus a blank space so there will be a space between each guess shown.</li>
  <li>The next block (lines 8–24 above) does a few checks:
   <ul>
@@ -526,7 +526,7 @@ greeting;</pre>
 
 <pre class="brush: js notranslate">for (let i = 1 ; i &lt; 21 ; i++) { console.log(i) }</pre>
 
-<p>What happened? The numbers <samp>1</samp> to <samp>20</samp> were printed out in your console. This is because of the loop. A <code>for</code> loop takes three input values (arguments):</p>
+<p>What happened? The numbers <code>1</code> to <code>20</code> were printed out in your console. This is because of the loop. A <code>for</code> loop takes three input values (arguments):</p>
 
 <ol>
  <li><strong>A starting value</strong>: In this case we are starting a count at 1, but this could be any number you like. You could replace the letter <code>i</code> with any name you like too, but <code>i</code> is used as a convention because it's short and easy to remember.</li>

--- a/files/en-us/web/http/cross-origin_resource_policy_(corp)/index.html
+++ b/files/en-us/web/http/cross-origin_resource_policy_(corp)/index.html
@@ -13,18 +13,18 @@ tags:
 <p class="summary">CORP is an additional layer of protection beyond the default {{Glossary("same-origin policy")}}. Cross-Origin Resource Policy complements <a href="https://fetch.spec.whatwg.org/#corb">Cross-Origin Read Blocking</a> (CORB), which is a mechanism to prevent some cross-origin reads by default.</p>
 
 <div class="notecard note">
-<p>The policy is only effective for <a href="https://fetch.spec.whatwg.org/#concept-request-mode"><samp>no-cors</samp></a> requests, which are issued by default for CORS-safelisted methods/headers.</p>
+<p>The policy is only effective for <a href="https://fetch.spec.whatwg.org/#concept-request-mode"><code>no-cors</code></a> requests, which are issued by default for CORS-safelisted methods/headers.</p>
 </div>
 
 <p>As this policy is expressed via a <em><a href="/en-US/docs/Glossary/Response_header">response header</a></em>, the actual request is not prevented—rather, the browser prevents the <em>result</em> from being leaked by stripping the response body.</p>
 
 <h2 id="History">History</h2>
 
-<p>The concept was originally proposed in 2012 (as <samp>From-Origin</samp>), but <a href="https://github.com/whatwg/fetch/issues/687">resurrected</a> in Q2 of 2018 and implemented in Safari and Chromium.</p>
+<p>The concept was originally proposed in 2012 (as <code>From-Origin</code>), but <a href="https://github.com/whatwg/fetch/issues/687">resurrected</a> in Q2 of 2018 and implemented in Safari and Chromium.</p>
 
 <p>In early 2018, two side-channel hardware vulnerabilities known as <em>Meltdown</em> and <em>Spectre</em> were disclosed. These vulnerabilities allowed sensitive data disclosure due to a race condition which arose as part of speculative execution functionality, designed to improve performance.</p>
 
-<p>In response, Chromium shipped <a href="https://fetch.spec.whatwg.org/#corb">Cross-Origin Read Blocking</a>, which automatically protects certain resources (of <samp>Content-Type</samp> HTML, JSON and XML) against cross-origin reads. If the application does not serve a <a href="/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options"><code>no-sniff</code> directive</a>, Chromium will attempt to guess the <samp>Content-Type</samp> and apply the protection anyway.</p>
+<p>In response, Chromium shipped <a href="https://fetch.spec.whatwg.org/#corb">Cross-Origin Read Blocking</a>, which automatically protects certain resources (of <code>Content-Type</code> HTML, JSON and XML) against cross-origin reads. If the application does not serve a <a href="/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options"><code>no-sniff</code> directive</a>, Chromium will attempt to guess the <code>Content-Type</code> and apply the protection anyway.</p>
 
 <p>Cross-Origin Resource Policy is an opt-in response header which can protect <em>any</em> resource; there is no need for browsers to sniff MIME types.</p>
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -380,7 +380,7 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 <p>It's easy to find the correspondences by looking at the <a href="https://hg.mozilla.org/releases">Mercurial repository names</a>: repositories starting by <code>mozilla-b2g</code> are the release repositories for Firefox OS, and have both Firefox OS and Gecko versions in their names.</p>
 </div>
 
-<p>Firefox OS has a four-digit version number: <samp>X.X.X.Y</samp>. The first two digits are owned by the Mozilla product team and denote versions with new features (eg: v1.1, 1.2, etc). The third digit is incremented with regular version tags (about every 6 weeks) for security updates, and the fourth is owned by the OEM.</p>
+<p>Firefox OS has a four-digit version number: <code>X.X.X.Y</code>. The first two digits are owned by the Mozilla product team and denote versions with new features (eg: v1.1, 1.2, etc). The third digit is incremented with regular version tags (about every 6 weeks) for security updates, and the fourth is owned by the OEM.</p>
 
 <h2 id="Firefox_for_iOS">Firefox for iOS</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -337,7 +337,7 @@ const obj2 = copy(obj1) // obj2 looks like obj1 now
 
 <h3 id="Modifying_the_array_during_iteration">Modifying the array during iteration</h3>
 
-<p>The following example logs <samp>one</samp>, <samp>two</samp>, <samp>four</samp>.</p>
+<p>The following example logs <code>one</code>, <code>two</code>, <code>four</code>.</p>
 
 <p>When the entry containing the value <code>two</code> is reached, the first entry of the
   whole array is shifted off—resulting in all remaining entries moving up one position.

--- a/files/en-us/web/javascript/reference/global_objects/error/stack/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/stack/index.html
@@ -55,25 +55,25 @@ a('first call, firstarg');
 
 <p>Starting with Firefox 30 and later containing the column number:</p>
 
-<pre class="brush: plain notranslate"><samp>trace@file:///C:/example.html:9:17
+<pre class="brush: plain notranslate">trace@file:///C:/example.html:9:17
 b@file:///C:/example.html:16:13
 a@file:///C:/example.html:19:13
-@file:///C:/example.html:21:9</samp></pre>
+@file:///C:/example.html:21:9</pre>
 
 <p>Firefox 14 to Firefox 29:</p>
 
-<pre class="brush: plain notranslate"><samp>trace@file:///C:/example.html:9
+<pre class="brush: plain notranslate">trace@file:///C:/example.html:9
 b@file:///C:/example.html:16
 a@file:///C:/example.html:19
-@file:///C:/example.html:21</samp></pre>
+@file:///C:/example.html:21</pre>
 
 <p>Firefox 13 and earlier would instead produce the following text:</p>
 
-<pre class="brush: plain notranslate"><samp>Error("myError")@:0
+<pre class="brush: plain notranslate">Error("myError")@:0
 trace()@file:///C:/example.html:9
 b(3,4,"\n\n",(void 0),[object Object])@file:///C:/example.html:16
 a("first call, firstarg")@file:///C:/example.html:19
-@file:///C:/example.html:21</samp></pre>
+@file:///C:/example.html:21</pre>
 
 <h3 id="Stack_of_evaled_code">Stack of eval'ed code</h3>
 


### PR DESCRIPTION
Markdown can easily represent `<code>` tag with backtick symbol \` so let's use this tag instead of `<samp>`.

Also, `<samp>` is unnecessary within `<pre>`.