### PR TITLE
Fix: remove <code> and <span> from some <pre>

### DIFF
--- a/files/en-us/web/api/audiotrack/language/index.html
+++ b/files/en-us/web/api/audiotrack/language/index.html
@@ -26,8 +26,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js notranslate">var <em>audioTrackLanguage</em> = <em>AudioTrack</em>.language;</pre>
+<pre class="brush: js notranslate">var <em>audioTrackLanguage</em> = <em>AudioTrack</em>.language;</pre>
 
 <h3 id="Value">Value</h3>
 
@@ -49,24 +48,23 @@ tags:
 <p>This could then be used to build a user interface for selecting the language the user
   would like to listen to while watching a movie, for example.</p>
 
-<div class="codecopy codecopy-lg">
-  <pre class="brush: js line-numbers  language-js"><code class="language-js"><span class="keyword token">function</span> getAvailableLanguages<span class="punctuation token">(</span>el<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-  <span class="keyword token">var</span> trackList <span class="operator token">=</span> <span class="punctuation token">[</span><span class="punctuation token">]</span><span class="punctuation token">;</span>
-  <span class="keyword token">const</span> wantedKinds <span class="operator token">=</span> <span class="punctuation token">[</span>
-    <span class="string token">"main"</span><span class="punctuation token">,</span> <span class="string token">"translation"</span>
-  <span class="punctuation token">]</span><span class="punctuation token">;</span>
+<pre class="brush: js line-numbers language-js">function getAvailableLanguages(el) {
+  var trackList = [];
+  const wantedKinds = [
+    "main", "translation"
+  ];
 
-  el<span class="punctuation token">.</span>audioTracks<span class="punctuation token">.</span><span class="function token">forEach</span><span class="punctuation token">(</span><span class="keyword token">function</span><span class="punctuation token">(</span>track<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    <span class="keyword token">if</span> <span class="punctuation token">(</span>wantedKinds<span class="punctuation token">.</span><span class="function token">includes</span><span class="punctuation token">(</span>track<span class="punctuation token">.</span>kind<span class="punctuation token">)</span><span class="punctuation token">)</span> <span class="punctuation token">{</span>
-      trackList<span class="punctuation token">.</span><span class="function token">push</span><span class="punctuation token">(</span><span class="punctuation token">{</span>
-        id<span class="punctuation token">:</span> track<span class="punctuation token">.</span>id<span class="punctuation token">,</span>
-        kind<span class="punctuation token">:</span> track<span class="punctuation token">.</span>kind<span class="punctuation token">,</span>
-        language<span class="punctuation token">:</span> track<span class="punctuation token">.language</span>
-      <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-    <span class="punctuation token">}</span>
-  <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-  <span class="keyword token">return</span> trackList<span class="punctuation token">;</span>
-<span class="punctuation token">}</span></code></pre>
+  el.audioTracks.forEach(function(track) {
+    if (wantedKinds.includes(track.kind)) {
+      trackList.push({
+        id: track.id,
+        kind: track.kind,
+        language: track.language
+      });
+    }
+  });
+  return trackList;
+}</pre>
 
   <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.html
@@ -33,21 +33,21 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js line-numbers  language-js"><code class="language-js"><span class="keyword token">const</span> queueingStrategy <span class="operator token">=</span> <span class="keyword token">new</span> ByteLength<span class="class-name token">QueuingStrategy</span><span class="punctuation token">(</span><span class="punctuation token">{</span> highWaterMark<span class="punctuation token">:</span> <span class="number token">1</span> <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+<pre class="brush: js line-numbers  language-js">const queueingStrategy = new ByteLengthQueuingStrategy({ highWaterMark: 1 });
 
-<span class="keyword token">const</span> readableStream <span class="operator token">=</span> <span class="keyword token">new</span> Readable<span class="class-name token">Stream</span><span class="punctuation token">(</span><span class="punctuation token">{</span>
-  <span class="function token">start</span><span class="punctuation token">(</span>controller<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    <span class="punctuation token">.</span><span class="punctuation token">.</span><span class="punctuation token">.</span>
-  <span class="punctuation token">}</span><span class="punctuation token">,</span>
-  pull<span class="punctuation token">(controller</span><span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    <span class="punctuation token">.</span><span class="punctuation token">.</span><span class="punctuation token">.</span>
-  <span class="punctuation token">}</span><span class="punctuation token">,</span>
-  <span class="function token">cancel</span><span class="punctuation token">(</span>err<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    console<span class="punctuation token">.</span><span class="function token">log</span><span class="punctuation token">(</span><span class="string token">"stream error:"</span><span class="punctuation token">,</span> err<span class="punctuation token">)</span><span class="punctuation token">;</span>
-  <span class="punctuation token">}</span>
-<span class="punctuation token">}</span><span class="punctuation token">,</span> queueingStrategy<span class="punctuation token">)</span><span class="punctuation token">;</span>
+const readableStream = new ReadableStream({
+  start(controller) {
+    ...
+  },
+  pull(controller) {
+    ...
+  },
+  cancel(err) {
+    console.log("stream error:", err);
+  }
+}, queueingStrategy);
 
-<span class="keyword token">var</span> size <span class="operator token">=</span> queueingStrategy<span class="punctuation token">.</span><span class="function token">size</span><span class="punctuation token">(</span><span class="punctuation token">chunk)</span></code>;</pre>
+var size = queueingStrategy.size(chunk);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/console/timelog/index.html
+++ b/files/en-us/web/api/console/timelog/index.html
@@ -22,8 +22,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate">console.timeLog(<em>label</em>);
-</pre>
+<pre class="brush: js notranslate">console.timeLog(<em>label</em>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -40,19 +39,17 @@ tags:
 
 <p>If an existing <code>label</code> is included:</p>
 
-<pre><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body"><span class="objectBox objectBox-string">timer name: 1242ms</span></span></span></span></pre>
+<pre>timer name: 1242ms</pre>
 
 <h3 id="Exceptions">Exceptions</h3>
 
 <p>If there is no running timer, <code>timeLog()</code> returns the warning:</p>
 
-<pre><span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">Timer “default” doesn’t exist.</span></span></span></pre>
+<pre>Timer “default” doesn’t exist.</pre>
 
-<p><span class="message-body-wrapper"><span class="message-flex-body"><span
-        class="devtools-monospace message-body">If a label parameter is included, but
-        there is no corresponding timer:</span></span></span></p>
+<p>If a label parameter is included, but there is no corresponding timer:</p>
 
-<pre> <span class="message-body-wrapper"><span class="message-flex-body"><span class="devtools-monospace message-body">Timer “timer name” doesn’t exist.</span></span></span> </pre>
+<pre> Timer “timer name” doesn’t exist. </pre>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/index.html
@@ -33,22 +33,22 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js line-numbers  language-js"><code class="language-js"><span class="keyword token">const</span> queueingStrategy <span class="operator token">=</span> <span class="keyword token">new</span> <span class="class-name token">CountQueuingStrategy</span><span class="punctuation token">(</span><span class="punctuation token">{</span> highWaterMark<span class="punctuation token">:</span> <span class="number token">1</span> <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+<pre class="brush: js line-numbers  language-js">const queueingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
 
-<span class="keyword token">const</span> writableStream <span class="operator token">=</span> <span class="keyword token">new</span> <span class="class-name token">WritableStream</span><span class="punctuation token">(</span><span class="punctuation token">{</span>
-  <span class="comment token">// Implement the sink</span>
-  <span class="function token">write</span><span class="punctuation token">(</span>chunk<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    <span class="punctuation token">...</span>
-  <span class="punctuation token">}</span><span class="punctuation token">,</span>
-  <span class="function token">close</span><span class="punctuation token">(</span><span class="punctuation token">)</span> <span class="punctuation token">{</span>
+const writableStream = new WritableStream({
+  // Implement the sink
+  write(chunk) {
     ...
-  <span class="punctuation token">}</span><span class="punctuation token">,</span>
-  <span class="function token">abort</span><span class="punctuation token">(</span>err<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-    console<span class="punctuation token">.</span><span class="function token">log</span><span class="punctuation token">(</span><span class="string token">"Sink error:"</span><span class="punctuation token">,</span> err<span class="punctuation token">)</span><span class="punctuation token">;</span>
-  <span class="punctuation token">}</span>
-<span class="punctuation token">}</span><span class="punctuation token">,</span> queueingStrategy<span class="punctuation token">)</span><span class="punctuation token">;
+  },
+  close() {
+    ...
+  },
+  abort(err) {
+    console.log("Sink error:", err);
+  }
+}, queueingStrategy);
 
-var size = queueingStrategy.size()</span></code>;
+var size = queueingStrategy.size();
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/credential/index.html
+++ b/files/en-us/web/api/credential/index.html
@@ -41,13 +41,13 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js notranslate line-numbers language-js"><code class="language-js"><span class="keyword token">let</span> pwdCredential <span class="operator token">=</span> <span class="keyword token">new</span> <span class="class-name token">PasswordCredential</span><span class="punctuation token">(</span><span class="punctuation token">{</span>
-  id<span class="punctuation token">:</span> <span class="string token">"example-username"</span><span class="punctuation token">, // Username/ID</span>
-  name<span class="punctuation token">:</span> <span class="string token">"John Doe"</span><span class="punctuation token">, // Display name</span>
-  password<span class="punctuation token">:</span> <span class="string token">"correct horse battery staple" // Password</span>
-<span class="punctuation token">}</span><span class="punctuation token">);
+<pre class="brush: js notranslate line-numbers language-js">let pwdCredential = new PasswordCredential({
+  id: "example-username", // Username/ID
+  name: "John Doe", // Display name
+  password: "correct horse battery staple" // Password
+});
 
-console.assert(</span>pwdCredential<span class="punctuation token">.type === "password");</span></code>
+console.assert(pwdCredential.type === "password");
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.html
+++ b/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.html
@@ -51,7 +51,7 @@ tags:
 
 <h3 id="JavaScript_Content">JavaScript Content</h3>
 
-<pre class="brush: js notranslate"><span>  function change() {
+<pre class="brush: js notranslate">function change() {
     // document.getElementsByTagName("H2") returns a NodeList of the &lt;h2&gt;
     // elements in the document, and the first is number 0:
 
@@ -72,7 +72,7 @@ tags:
     // and put the paragraph on the end of the document by appending it to
     // the BODY (which is the parent of para)
     para.parentNode.appendChild(newElement);
-  }</span></pre>
+  }</pre>
 
 <p>{{ EmbedLiveSample('A_simple_example', 800, 300) }}</p>
 

--- a/files/en-us/web/api/eventsource/message_event/index.html
+++ b/files/en-us/web/api/eventsource/message_event/index.html
@@ -37,15 +37,15 @@ tags:
 
 <p>In this basic example, an <code>EventSource</code> is created to receive events from the server; a page with the name <code>sse.php</code> is responsible for generating the events.</p>
 
-<pre class="brush: js line-numbers language-js notranslate"><code class="language-js"><span class="keyword token">var</span> evtSource <span class="operator token">=</span> <span class="keyword token">new</span> <span class="class-name token">EventSource</span><span class="punctuation token">(</span><span class="string token">'sse.php'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> eventList <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'ul'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+<pre class="brush: js line-numbers language-js notranslate">var evtSource = new EventSource('sse.php');
+var eventList = document.querySelector('ul');
 
-evtSource<span class="punctuation token">.</span><span class="function function-variable token">addEventListener('message',</span> <span class="punctuation token">(</span><span class="parameter token">e</span><span class="punctuation token">) =&gt;</span> <span class="punctuation token">{</span>
-  <span class="keyword token">var</span> newElement <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">createElement</span><span class="punctuation token">(</span><span class="string token">"li"</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+evtSource.addEventListener('message', (e) =&gt; {
+  var newElement = document.createElement("li");
 
-  newElement<span class="punctuation token">.</span>textContent <span class="operator token">=</span> <span class="string token">"message: "</span> <span class="operator token">+</span> e<span class="punctuation token">.</span>data<span class="punctuation token">;</span>
-  eventList<span class="punctuation token">.</span><span class="function token">appendChild</span><span class="punctuation token">(</span>newElement<span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="punctuation token">});</span></code></pre>
+  newElement.textContent = "message: " + e.data;
+  eventList.appendChild(newElement);
+});</pre>
 
 <h3 id="onmessage_equivalent">onmessage equivalent</h3>
 

--- a/files/en-us/web/api/filereader/onerror/index.html
+++ b/files/en-us/web/api/filereader/onerror/index.html
@@ -4,17 +4,17 @@ slug: Web/API/FileReader/onerror
 ---
 <p>The <a href="/en-US/docs/Web/API/FileReader">FileReader</a> onerror handler receives an Event object, not an Error object, as a parameter, but an error can be accessed from the FileReader object, as <code><a href="/en-US/docs/Web/API/FileReader/error">instanceOfFileReader.error</a></code></p>
 
-<pre class="brush:js line-numbers language-js notranslate"><code class="language-js"><span class="comment token">// Callback from a &lt;input type="file" onchange="onChange(event)"&gt;</span>
-<span class="keyword token">function</span> <span class="function token">onChange</span><span class="punctuation token">(</span>event<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-  <span class="keyword token">var</span> file <span class="operator token">=</span> event<span class="punctuation token">.</span>target<span class="punctuation token">.</span>files<span class="punctuation token">[</span><span class="number token">0</span><span class="punctuation token">]</span><span class="punctuation token">;</span>
-  <span class="keyword token">var</span> reader <span class="operator token">=</span> <span class="keyword token">new</span> <span class="class-name token">FileReader</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-  reader<span class="punctuation token">.onerror </span><span class="operator token">=</span> <span class="keyword token">function</span><span class="punctuation token">(</span>event<span class="punctuation token">)</span> <span class="punctuation token">{
-    alert("Failed to read file!\n\n" + reader.error);</span>
-    <span class="punctuation token">reader.abort(); // (...does this do anything useful in an onerror handler?)</span>
-  <span class="punctuation token">}</span><span class="punctuation token">;</span>
+<pre class="brush: js line-numbers language-js notranslate">// Callback from a &lt;input type="file" onchange="onChange(event)"&gt;
+function onChange(event) {
+  var file = event.target.files[0];
+  var reader = new FileReader();
+  reader.onerror = function(event) {
+    alert("Failed to read file!\n\n" + reader.error);
+    reader.abort(); // (...does this do anything useful in an onerror handler?)
+  };
 
-  reader<span class="punctuation token">.</span><span class="function token">readAsText</span><span class="punctuation token">(</span>file<span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="punctuation token">}</span></code>
+  reader.readAsText(file);
+}
 </pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -28,13 +28,14 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js line-numbers  language-js"><code class="language-js">window<span class="punctuation token">.</span><span class="function token">addEventListener</span><span class="punctuation token">(</span><span class="string token">"gamepadconnected"</span><span class="punctuation token">,</span> <span class="keyword token">function</span><span class="punctuation token">(</span>e<span class="punctuation token">)</span> <span class="punctuation token">{
-  if(</span>!e<span class="punctuation token">.</span>gamepad<span class="punctuation token">.displayId) {
-    </span>console<span class="punctuation token">.</span><span class="function token">log</span><span class="punctuation token">(</span><span class="string token">'Gamepad connected'</span><span class="punctuation token">)</span><span class="punctuation token">;
-  } else {</span>
-    console<span class="punctuation token">.</span><span class="function token">log</span><span class="punctuation token">(</span><span class="string token">'Gamepad connected, associated with VR display ' +</span> e<span class="punctuation token">.</span>gamepad<span class="punctuation token">.displayId</span><span class="punctuation token">)</span><span class="punctuation token">;
-  }</span>
-<span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code></pre>
+<pre class="brush: js line-numbers language-js">window.addEventListener("gamepadconnected", function(e) {
+  if(!e.gamepad.displayId) {
+    console.log('Gamepad connected');
+  } else {
+    console.log('Gamepad connected, associated with VR display ' + e.gamepad.displayId);
+  }
+});
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/gamepadbutton/pressed/index.html
+++ b/files/en-us/web/api/gamepadbutton/pressed/index.html
@@ -20,8 +20,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate"><span class="idlInterface" id="idl-def-GamepadButton"><span class="idlAttribute">var isPressed = navigator.getGamepads()[0].pressed;
-</span></span></pre>
+<pre class="brush: js notranslate">var isPressed = navigator.getGamepads()[0].pressed;</pre>
 
 <h2 id="Example">Example</h2>
 


### PR DESCRIPTION
This commit cleans up examples in 10 files, including removing 300 `<span>`, few `<code>` and `<div>` tags.