### PR TITLE
Fixing links in common questions

### DIFF
--- a/files/en-us/learn/common_questions/index.html
+++ b/files/en-us/learn/common_questions/index.html
@@ -19,150 +19,202 @@ tags:
 
 <p>This section covers Web mechanics —questions relating to general knowledge of the Web ecosystem and how it works.</p>
 
-<h3 id="How_does_the_Internet_work"><a href="/en-US/docs/Learn/Common_questions/How_does_the_Internet_work">How does the
-    Internet work?</a></h3>
+<h3 id="How_does_the_Internet_work">How does the Internet work?</h3>
 
 <p>The <strong>Internet</strong> is the backbone of the Web, the technical infrastructure that makes the Web possible.
   At its most basic, the Internet is a massive network of computers communicating with each other. This article
   discusses how it works, in broad terms.</p>
 
-<h3 id="What_is_the_difference_between_webpage_website_Web_server_and_search_engine"><a
-    href="/en-US/docs/Learn/Common_questions/Pages_sites_servers_and_search_engines">What is the difference between
-    webpage, website, Web server, and search engine?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/How_does_the_Internet_work">How does the Internet work?</a></strong></p>
+
+<h3 id="What_is_the_difference_between_webpage_website_Web_server_and_search_engine">What is the difference between
+    webpage, website, Web server, and search engine?</h3>
 
 <p>In this article we describe various Web-related concepts: webpages, websites, Web servers, and search engines. These
   terms are often a source of confusion for newcomers to the Web, or are used incorrectly. Let's discover what they
   actually mean!</p>
 
-<h3 id="What_are_hyperlinks"><a href="/en-US/docs/Learn/Common_questions/What_are_hyperlinks">What are hyperlinks?</a>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/Pages_sites_servers_and_search_engines">What is the difference between
+  webpage, website, Web server, and search engine?</a></strong></p>
+
+<h3 id="What_are_hyperlinks">What are hyperlinks?
 </h3>
 
 <p>In this article, we'll go over what hyperlinks are and why they matter.</p>
 
-<h3 id="What_is_a_URL"><a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">What is a URL?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/What_are_hyperlinks">What are hyperlinks?</a></strong></p>
+
+<h3 id="What_is_a_URL">What is a URL?</h3>
 
 <p>With {{Glossary("Hypertext")}} and {{Glossary("HTTP")}}, URL is a key concept when it comes to the Internet. It is
   the mechanism used by {{Glossary("Browser","browsers")}} to retrieve any published resource on the Web.</p>
 
-<h3 id="What_is_a_domain_name"><a href="/en-US/docs/Learn/Common_questions/What_is_a_domain_name">What is a domain
-    name?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">What is a URL?</a></strong></p>
+
+<h3 id="What_is_a_domain_name">What is a domain
+    name?</h3>
 
 <p>Domain names are a key component of the Internet infrastructure. They provide a human-readable address for any Web
   server available on the Internet.</p>
 
-<h3 id="What_is_a_Web_server"><a href="/en-US/docs/Learn/Common_questions/What_is_a_web_server">What is a Web
-    server?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_a_domain_name">What is a domain
+  name?</a></strong></p>
+
+<h3 id="What_is_a_Web_server">What is a Web
+    server?</h3>
 
 <p>The term "Web server" can refer to the hardware or software that serves websites to clients across the Web — or both
   of them working together. In this article we go over how Web servers work, and why they're important.</p>
-
+<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_a_web_server">What is a Web
+  server?</a></strong></p>
 
 <h2 id="Tools_and_setup">Tools and setup</h2>
 
 <p>Questions related to the tools/software you can use to build websites.</p>
 
-<h3 id="What_software_do_I_need_to_build_a_website"><a
-    href="/en-US/docs/Learn/Common_questions/What_software_do_I_need">What software do I need to build a website?</a>
+<h3 id="What_software_do_I_need_to_build_a_website">What software do I need to build a website?
 </h3>
 
 <p>In this article we explain which software components you need to edit, upload, or view a website.</p>
 
-<h3 id="How_much_does_it_cost_to_do_something_on_the_Web"><a
-    href="/en-US/docs/Learn/Common_questions/How_much_does_it_cost">How much does it cost to do something on the
-    Web?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/What_software_do_I_need">What software do I need to build a website?</a></strong></p>
+
+<h3 id="How_much_does_it_cost_to_do_something_on_the_Web">How much does it cost to do something on the
+    Web?</h3>
 
 <p>When you're launching a website, you may spend nothing or your costs may go through the roof. In this article we
   discuss how much everything costs and what you get for what you pay (or don't pay).</p>
 
-<h3 id="What_text_editors_are_available"><a href="/en-US/docs/Learn/Common_questions/Available_text_editors">What text
-    editors are available?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/How_much_does_it_cost">How much does it cost to do something on the
+  Web?</a></strong></p>
+
+<h3 id="What_text_editors_are_available">What text
+    editors are available?</h3>
 
 <p>In this article we highlight some things to think about when choosing and installing a text editor for Web
   development.</p>
 
-<h3 id="What_are_browser_developer_tools"><a
-    href="/en-US/docs/Learn/Common_questions/What_are_browser_developer_tools">What are browser developer tools?</a>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/Available_text_editors">What text
+  editors are available?</a></strong></p>
+
+<h3 id="What_are_browser_developer_tools">What are browser developer tools?
 </h3>
 
 <p>Every browser features a set of devtools for debugging HTML, CSS, and other Web code. This article explains how to
   use the basic functions of your browser's devtools.</p>
 
-<h3 id="How_do_you_make_sure_your_website_works_properly"><a
-    href="/en-US/docs/Learn/Common_questions/Checking_that_your_web_site_is_working_properly">How do you make sure your
-    website works properly?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/What_are_browser_developer_tools">What are browser developer tools?</a></strong></p>
+
+<h3 id="How_do_you_make_sure_your_website_works_properly">How do you make sure your
+    website works properly?</h3>
 
 <p>So you've published your website online — very good! But are you sure it works properly? This article provides some
   basic troubleshooting steps.</p>
 
-<h3 id="How_do_you_set_up_a_local_testing_server"><a
-    href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server">How do you set up a local testing
-    server?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/Checking_that_your_web_site_is_working_properly">How do you make sure your
+  website works properly?</a></strong></p>
 
+<h3 id="How_do_you_set_up_a_local_testing_server">How do you set up a local testing
+    server?</h3>
 
 <p>This article explains how to set up a simple local testing server on your machine, and the basics of how to use it.
 </p>
 
-<h3 id="How_do_you_upload_files_to_a_Web_server"><a
-    href="/en-US/docs/Learn/Common_questions/Upload_files_to_a_web_server">How do you upload files to a Web server?</a>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server">How do you set up a local testing
+  server?</a></strong></p>
+
+<h3 id="How_do_you_upload_files_to_a_Web_server">How do you upload files to a Web server?
 </h3>
 
 <p>This article shows how to publish your site online with <a class="glossaryLink" href="/en-US/docs/Glossary/FTP"
     title="FTP: FTP (File Transfer Protocol) is the standard network protocol for transferring files from one host to another over the Internet through TCP.">FTP</a>
   tools — one of the most common ways to get a website online so others can access it from their computers.</p>
 
-<h3 id="How_do_I_use_GitHub_Pages"><a href="/en-US/docs/Learn/Common_questions/Using_GitHub_Pages">How do I use GitHub
-    Pages?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/Upload_files_to_a_web_server">How do you upload files to a Web server?</a></strong></p>
+
+<h3 id="How_do_I_use_GitHub_Pages">How do I use GitHub
+    Pages?</h3>
 
 <p>This article provides a basic guide to publishing content using GitHub's gh-pages feature.</p>
 
-<h3 id="How_do_you_host_your_website_on_Google_App_Engine"><a
-    href="/en-US/docs/Learn/Common_questions/How_do_you_host_your_website_on_Google_App_Engine">How do you host your website
-    on Google App Engine?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/Using_Github_pages">How do I use GitHub
+  Pages?</a></strong></p>
+
+<h3 id="How_do_you_host_your_website_on_Google_App_Engine">How do you host your website
+    on Google App Engine?</h3>
 
 <p>Looking for a place to host your website? Here's a step-by-step guide to hosting your website on Google App Engine.
 </p>
 
-<h3 id="What_tools_are_available_to_debug_and_improve_website_performance"><a href="/en-US/docs/Tools/Performance">What
-    tools are available to debug and improve website performance?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/How_do_you_host_your_website_on_Google_App_Engine">How do you host your website
+  on Google App Engine?</a></strong></p>
+
+<h3 id="What_tools_are_available_to_debug_and_improve_website_performance">What
+    tools are available to debug and improve website performance?</h3>
 
 <p>This set of articles shows you how to use the Developer Tools in Firefox to debug and improve performance of your
   website, using the tools to check memory usage, the JavaScript call tree, the number of DOM nodes being rendered, and
   more.</p>
 
+<p><strong><a href="/en-US/docs/Tools/Performance">What
+  tools are available to debug and improve website performance?</a></strong></p>
 
 <h2 id="Design_and_accessibility">Design and accessibility</h2>
 
 <p>This section lists questions related to aesthetics, page structure, accessibility techniques, etc.</p>
 
-<h3 id="How_do_I_start_to_design_my_website"><a href="/en-US/docs/Learn/Common_questions/Thinking_before_coding">How do
-    I start to design my website?</a></h3>
+<h3 id="How_do_I_start_to_design_my_website">How do
+    I start to design my website?</h3>
 
 <p>This article covers the all-important first step of every project: define what you want to accomplish with it.</p>
 
-<h3 id="What_do_common_Web_layouts_contain"><a href="/en-US/docs/Learn/Common_questions/Common_web_layouts">What do
-    common Web layouts contain?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/Thinking_before_coding">How do
+  I start to design my website?</a></strong></p>
+
+<h3 id="What_do_common_Web_layouts_contain">What do
+    common Web layouts contain?</h3>
 
 <p>When designing pages for your website, it's good to have an idea of the most common layouts. This article runs
   through some typical Web layouts, looking at the parts that make up each one.</p>
 
-<h3 id="What_is_accessibility"><a href="/en-US/docs/Learn/Common_questions/What_is_accessibility">What is
-    accessibility?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/Common_web_layouts">What do
+  common Web layouts contain?</a></strong></p>
+
+<h3 id="What_is_accessibility">What is
+    accessibility?</h3>
 
 <p>This article introduces the basic concepts behind Web accessibility.</p>
 
-<h3 id="How_can_we_design_for_all_types_of_users"><a
-    href="/en-US/docs/Learn/Common_questions/Design_for_all_types_of_users">How can we design for all types of
-    users?</a></h3>
+<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_accessibility">What is
+  accessibility?</a></strong></p>
+
+<h3 id="How_can_we_design_for_all_types_of_users">How can we design for all types of
+    users?</h3>
 
 <p>This article provides basic techniques to help you design websites for any kind of user — quick accessibility wins,
   and other such things.</p>
 
-<h3 id="What_HTML_features_promote_accessibility"><a
-    href="/en-US/docs/Learn/Common_questions/HTML_features_for_accessibility">What HTML features promote
-    accessibility?</a></h3>
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/Design_for_all_types_of_users">How can we design for all types of
+  users?</a></strong></p>
+
+<h3 id="What_HTML_features_promote_accessibility">What HTML features promote
+    accessibility?</h3>
 
 <p>This article describes specific features of HTML that can be used to make a webpage more accessible to people with
   different disabilities.</p>
+
+<p><strong><a
+  href="/en-US/docs/Learn/Common_questions/HTML_features_for_accessibility">What HTML features promote
+  accessibility?</a></strong></p>
 
 <h2 id="HTML_CSS_and_JavaScript_questions">HTML, CSS and JavaScript questions</h2>
 

--- a/files/en-us/learn/common_questions/index.html
+++ b/files/en-us/learn/common_questions/index.html
@@ -15,206 +15,142 @@ tags:
     href="/en-US/docs/Learn/HTML">HTML</a> or <a href="/en-US/docs/Learn/CSS">CSS</a> learning articles.) These articles
   are designed to work on their own.</p>
 
-<h2 id="How_the_Web_works">How the Web works</h2>
+<h2 id="How_the_Web_works">How the web works</h2>
 
-<p>This section covers Web mechanics —questions relating to general knowledge of the Web ecosystem and how it works.</p>
+<p>This section covers web mechanics —questions relating to general knowledge of the web ecosystem and how it works.</p>
 
-<h3 id="How_does_the_Internet_work">How does the Internet work?</h3>
-
-<p>The <strong>Internet</strong> is the backbone of the Web, the technical infrastructure that makes the Web possible.
-  At its most basic, the Internet is a massive network of computers communicating with each other. This article
-  discusses how it works, in broad terms.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/How_does_the_Internet_work">How does the Internet work?</a></strong></p>
-
-<h3 id="What_is_the_difference_between_webpage_website_Web_server_and_search_engine">What is the difference between
-    webpage, website, Web server, and search engine?</h3>
-
-<p>In this article we describe various Web-related concepts: webpages, websites, Web servers, and search engines. These
-  terms are often a source of confusion for newcomers to the Web, or are used incorrectly. Let's discover what they
-  actually mean!</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/Pages_sites_servers_and_search_engines">What is the difference between
-  webpage, website, Web server, and search engine?</a></strong></p>
-
-<h3 id="What_are_hyperlinks">What are hyperlinks?
-</h3>
-
-<p>In this article, we'll go over what hyperlinks are and why they matter.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/What_are_hyperlinks">What are hyperlinks?</a></strong></p>
-
-<h3 id="What_is_a_URL">What is a URL?</h3>
-
-<p>With {{Glossary("Hypertext")}} and {{Glossary("HTTP")}}, URL is a key concept when it comes to the Internet. It is
-  the mechanism used by {{Glossary("Browser","browsers")}} to retrieve any published resource on the Web.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">What is a URL?</a></strong></p>
-
-<h3 id="What_is_a_domain_name">What is a domain
-    name?</h3>
-
-<p>Domain names are a key component of the Internet infrastructure. They provide a human-readable address for any Web
-  server available on the Internet.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_a_domain_name">What is a domain
-  name?</a></strong></p>
-
-<h3 id="What_is_a_Web_server">What is a Web
-    server?</h3>
-
-<p>The term "Web server" can refer to the hardware or software that serves websites to clients across the Web — or both
-  of them working together. In this article we go over how Web servers work, and why they're important.</p>
-<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_a_web_server">What is a Web
-  server?</a></strong></p>
+<dl>
+  <dt><a href="/en-US/docs/Learn/Common_questions/How_does_the_Internet_work">How does the Internet work?</a></dt>
+  <dd>
+    <p>The <strong>Internet</strong> is the backbone of the web, the technical infrastructure that makes the web possible.
+      At its most basic, the Internet is a massive network of computers communicating with each other. This article
+      discusses how it works, in broad terms.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/Pages_sites_servers_and_search_engines">What is the difference between
+    webpage, website, web server, and search engine?</a></dt>
+  <dd>
+    <p>In this article we describe various web-related concepts: webpages, websites, web servers, and search engines. These
+      terms are often a source of confusion for newcomers to the web, or are used incorrectly. Let's discover what they
+      actually mean!</p>
+  </dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/What_are_hyperlinks">What are hyperlinks?</a></dt>
+  <dd><p>In this article, we'll go over what hyperlinks are and why they matter.</p></dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">What is a URL?</a></dt>
+  <dd><p>With {{Glossary("Hypertext")}} and {{Glossary("HTTP")}}, URL is a key concept when it comes to the Internet. It is
+    the mechanism used by {{Glossary("Browser","browsers")}} to retrieve any published resource on the web.</p></dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/What_is_a_domain_name">What is a domain name?</a></dt>
+  <dd><p>Domain names are a key component of the Internet infrastructure. They provide a human-readable address for any web
+    server available on the Internet.</p></dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/What_is_a_web_server">What is a web server?</a></dt>
+  <dd><p>The term "web server" can refer to the hardware or software that serves websites to clients across the web — or both
+    of them working together. In this article we go over how web servers work, and why they're important.</p></dd>
+</dl>
 
 <h2 id="Tools_and_setup">Tools and setup</h2>
 
 <p>Questions related to the tools/software you can use to build websites.</p>
 
-<h3 id="What_software_do_I_need_to_build_a_website">What software do I need to build a website?
-</h3>
-
-<p>In this article we explain which software components you need to edit, upload, or view a website.</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/What_software_do_I_need">What software do I need to build a website?</a></strong></p>
-
-<h3 id="How_much_does_it_cost_to_do_something_on_the_Web">How much does it cost to do something on the
-    Web?</h3>
-
-<p>When you're launching a website, you may spend nothing or your costs may go through the roof. In this article we
-  discuss how much everything costs and what you get for what you pay (or don't pay).</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/How_much_does_it_cost">How much does it cost to do something on the
-  Web?</a></strong></p>
-
-<h3 id="What_text_editors_are_available">What text
-    editors are available?</h3>
-
-<p>In this article we highlight some things to think about when choosing and installing a text editor for Web
-  development.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/Available_text_editors">What text
-  editors are available?</a></strong></p>
-
-<h3 id="What_are_browser_developer_tools">What are browser developer tools?
-</h3>
-
-<p>Every browser features a set of devtools for debugging HTML, CSS, and other Web code. This article explains how to
-  use the basic functions of your browser's devtools.</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/What_are_browser_developer_tools">What are browser developer tools?</a></strong></p>
-
-<h3 id="How_do_you_make_sure_your_website_works_properly">How do you make sure your
-    website works properly?</h3>
-
-<p>So you've published your website online — very good! But are you sure it works properly? This article provides some
-  basic troubleshooting steps.</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/Checking_that_your_web_site_is_working_properly">How do you make sure your
-  website works properly?</a></strong></p>
-
-<h3 id="How_do_you_set_up_a_local_testing_server">How do you set up a local testing
-    server?</h3>
-
-<p>This article explains how to set up a simple local testing server on your machine, and the basics of how to use it.
-</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server">How do you set up a local testing
-  server?</a></strong></p>
-
-<h3 id="How_do_you_upload_files_to_a_Web_server">How do you upload files to a Web server?
-</h3>
-
-<p>This article shows how to publish your site online with <a class="glossaryLink" href="/en-US/docs/Glossary/FTP"
-    title="FTP: FTP (File Transfer Protocol) is the standard network protocol for transferring files from one host to another over the Internet through TCP.">FTP</a>
-  tools — one of the most common ways to get a website online so others can access it from their computers.</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/Upload_files_to_a_web_server">How do you upload files to a Web server?</a></strong></p>
-
-<h3 id="How_do_I_use_GitHub_Pages">How do I use GitHub
-    Pages?</h3>
-
-<p>This article provides a basic guide to publishing content using GitHub's gh-pages feature.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/Using_Github_pages">How do I use GitHub
-  Pages?</a></strong></p>
-
-<h3 id="How_do_you_host_your_website_on_Google_App_Engine">How do you host your website
-    on Google App Engine?</h3>
-
-<p>Looking for a place to host your website? Here's a step-by-step guide to hosting your website on Google App Engine.
-</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/How_do_you_host_your_website_on_Google_App_Engine">How do you host your website
-  on Google App Engine?</a></strong></p>
-
-<h3 id="What_tools_are_available_to_debug_and_improve_website_performance">What
-    tools are available to debug and improve website performance?</h3>
-
-<p>This set of articles shows you how to use the Developer Tools in Firefox to debug and improve performance of your
-  website, using the tools to check memory usage, the JavaScript call tree, the number of DOM nodes being rendered, and
-  more.</p>
-
-<p><strong><a href="/en-US/docs/Tools/Performance">What
-  tools are available to debug and improve website performance?</a></strong></p>
+<dl>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/What_software_do_I_need">What software do I need to build a website?</a></dt>
+  <dd>
+    <p>In this article we explain which software components you need to edit, upload, or view a website.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/How_much_does_it_cost">How much does it cost to do something on the
+    web?</a></dt>
+  <dd>
+    <p>When you're launching a website, you may spend nothing or your costs may go through the roof. In this article we
+    discuss how much everything costs and what you get for what you pay (or don't pay).</p>
+  </dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/Available_text_editors">What text editors are available?</a></dt>
+  <dd>
+    <p>In this article we highlight some things to think about when choosing and installing a text editor for web
+      development.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/What_are_browser_developer_tools">What are browser developer tools?</a></dt>
+  <dd>
+    <p>Every browser features a set of devtools for debugging HTML, CSS, and other web code. This article explains how to
+    use the basic functions of your browser's devtools.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/Checking_that_your_web_site_is_working_properly">How do you make sure your
+    website works properly?</a></dt>
+  <dd><p>So you've published your website online — very good! But are you sure it works properly? This article provides some
+    basic troubleshooting steps.</p></dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server">How do you set up a local testing
+    server?</a></dt>
+  <dd>
+    <p>This article explains how to set up a simple local testing server on your machine, and the basics of how to use it.
+  </p>
+</dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/Upload_files_to_a_web_server">How do you upload files to a web server?</a></dt>
+  <dd>
+    <p>This article shows how to publish your site online with <a class="glossaryLink" href="/en-US/docs/Glossary/FTP"
+      title="FTP: FTP (File Transfer Protocol) is the standard network protocol for transferring files from one host to another over the Internet through TCP.">FTP</a>
+    tools — one of the most common ways to get a website online so others can access it from their computers.</p>
+  </dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/Using_Github_pages">How do I use GitHub
+    Pages?</a></dt>
+  <dd>
+    <p>This article provides a basic guide to publishing content using GitHub's gh-pages feature.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/How_do_you_host_your_website_on_Google_App_Engine">How do you host your website
+    on Google App Engine?</a></dt>
+  <dd>
+    <p>Looking for a place to host your website? Here's a step-by-step guide to hosting your website on Google App Engine.
+    </p>
+  </dd>
+  <dt><a href="/en-US/docs/Tools/Performance">What
+    tools are available to debug and improve website performance?</a></dt>
+  <dd>
+    <p>This set of articles shows you how to use the Developer Tools in Firefox to debug and improve performance of your
+    website, using the tools to check memory usage, the JavaScript call tree, the number of DOM nodes being rendered, and
+    more.</p>
+  </dd>
+</dl>
 
 <h2 id="Design_and_accessibility">Design and accessibility</h2>
 
 <p>This section lists questions related to aesthetics, page structure, accessibility techniques, etc.</p>
 
-<h3 id="How_do_I_start_to_design_my_website">How do
-    I start to design my website?</h3>
-
-<p>This article covers the all-important first step of every project: define what you want to accomplish with it.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/Thinking_before_coding">How do
-  I start to design my website?</a></strong></p>
-
-<h3 id="What_do_common_Web_layouts_contain">What do
-    common Web layouts contain?</h3>
-
-<p>When designing pages for your website, it's good to have an idea of the most common layouts. This article runs
-  through some typical Web layouts, looking at the parts that make up each one.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/Common_web_layouts">What do
-  common Web layouts contain?</a></strong></p>
-
-<h3 id="What_is_accessibility">What is
-    accessibility?</h3>
-
-<p>This article introduces the basic concepts behind Web accessibility.</p>
-
-<p><strong><a href="/en-US/docs/Learn/Common_questions/What_is_accessibility">What is
-  accessibility?</a></strong></p>
-
-<h3 id="How_can_we_design_for_all_types_of_users">How can we design for all types of
-    users?</h3>
-
-<p>This article provides basic techniques to help you design websites for any kind of user — quick accessibility wins,
-  and other such things.</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/Design_for_all_types_of_users">How can we design for all types of
-  users?</a></strong></p>
-
-<h3 id="What_HTML_features_promote_accessibility">What HTML features promote
-    accessibility?</h3>
-
-<p>This article describes specific features of HTML that can be used to make a webpage more accessible to people with
-  different disabilities.</p>
-
-<p><strong><a
-  href="/en-US/docs/Learn/Common_questions/HTML_features_for_accessibility">What HTML features promote
-  accessibility?</a></strong></p>
+<dl>
+  <dt><a href="/en-US/docs/Learn/Common_questions/Thinking_before_coding">How do
+    I start to design my website?</a></dt>
+  <dd>
+    <p>This article covers the all-important first step of every project: define what you want to accomplish with it.</p>
+  </dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/Common_web_layouts">What do
+    common web layouts contain?</a></dt>
+  <dd>
+    <p>When designing pages for your website, it's good to have an idea of the most common layouts. This article runs
+      through some typical web layouts, looking at the parts that make up each one.</p>
+  </dd>
+  <dt><a href="/en-US/docs/Learn/Common_questions/What_is_accessibility">What is
+    accessibility?</a></dt>
+  <dd>
+    <p>This article introduces the basic concepts behind web accessibility.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/Design_for_all_types_of_users">How can we design for all types of
+    users?</a></dt>
+  <dd>
+    <p>This article provides basic techniques to help you design websites for any kind of user — quick accessibility wins,
+      and other such things.</p>
+  </dd>
+  <dt><a
+    href="/en-US/docs/Learn/Common_questions/HTML_features_for_accessibility">What HTML features promote
+    accessibility?</a></dt>
+  <dd>
+    <p>This article describes specific features of HTML that can be used to make a webpage more accessible to people with
+      different disabilities.</p>
+  </dd>
+</dl>
 
 <h2 id="HTML_CSS_and_JavaScript_questions">HTML, CSS and JavaScript questions</h2>
 


### PR DESCRIPTION
Fixes #1130

The links contained in headings were being overwritten by whatever creates permalinks. I'll raise a separate issue for that. I've moved the links out of the headings. They weren't very obviously links as part of the heading anyway so perhaps this is a better approach.