### PR TITLE
[WritableStreamDefaultWriter/write] write() method, not property

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.html
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{APIRef("Streams")}}{{SeeCompatTable}}</p>
 
-<p>The <strong><code>write()</code></strong> property of the
+<p>The <strong><code>write()</code></strong> method of the
   {{domxref("WritableStreamDefaultWriter")}} interface writes a passed chunk of data to a
   {{domxref("WritableStream")}} and its underlying sink, then returns a
   {{jsxref("Promise")}} that resolves to indicate the success or failure of the write


### PR DESCRIPTION
The `WritableStreamDefaultWriter`'s `write()` is a method, not a property.