### PR TITLE
Document HTMLElement.enterKeyHint

### DIFF
--- a/files/en-us/web/api/htmlelement/enterkeyhint/index.html
+++ b/files/en-us/web/api/htmlelement/enterkeyhint/index.html
@@ -1,6 +1,6 @@
 ---
-title: HTMLElement.enterkeyhint
-slug: Web/API/HTMLElement/enterkeyhint
+title: HTMLElement.enterKeyHint
+slug: Web/API/HTMLElement/enterKeyHint
 tags:
   - API
   - HTML DOM
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p>The <strong><code>enterkeyhint</code></strong> property is an enumerated property defining 
+<p>The <strong><code>enterKeyHint</code></strong> property is an enumerated property defining 
 what action label (or icon) to present for the enter key on virtual keyboards. <br>
 It reflects the <a href="/en-US/docs/Web/HTML/Global_attributes/enterkeyhint"><code>enterkeyhint</code></a>
 HTML global attribute and is an enumerated property only accepting the following values 
@@ -27,7 +27,7 @@ as a <a href="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a>:</p>
  <li><code>'send'</code> typically delivering the text to its target.	</li>
 </ul>
 
-<p>If no <code>enterkeyhint</code> value has been specified or if it was set to a different value than the allowed ones, it will return an empty string.</p>
+<p>If no <code>enterKeyHint</code> value has been specified or if it was set to a different value than the allowed ones, it will return an empty string.</p>
 
 <h2 id="Examples">Examples</h2>
 <p>Give a virtual keyboard a hint how to label the enter key (might render as <kbd>Send</kbd> and <kbd>Search</kbd>, depending on the OS or the user's language).</p>
@@ -35,8 +35,8 @@ as a <a href="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a>:</p>
 const send = document.getElementById('sendInput');
 const search = document.getElementById('searchInput');
 
-send.enterkeyhint = 'send';
-search.enterkeyhint = 'search';
+send.enterKeyHint = 'send';
+search.enterKeyHint = 'search';
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
@@ -49,14 +49,14 @@ search.enterkeyhint = 'search';
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-enterkeyhint', 'enterkeyhint')}}</td>
+   <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-enterkeyhint', 'enterKeyHint')}}</td>
   </tr>
  </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.HTMLElement.enterkeyhint")}}</p>
+<p>{{Compat("api.HTMLElement.enterKeyHint")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlelement/enterkeyhint/index.html
+++ b/files/en-us/web/api/htmlelement/enterkeyhint/index.html
@@ -14,7 +14,7 @@ tags:
 <p>The <strong><code>enterKeyHint</code></strong> property is an enumerated property defining 
 what action label (or icon) to present for the enter key on virtual keyboards. <br>
 It reflects the <a href="/en-US/docs/Web/HTML/Global_attributes/enterkeyhint"><code>enterkeyhint</code></a>
-HTML global attribute and is an enumerated property only accepting the following values 
+HTML global attribute and is an enumerated property, only accepting the following values 
 as a <a href="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a>:</p>
 
 <ul>

--- a/files/en-us/web/api/htmlelement/enterkeyhint/index.html
+++ b/files/en-us/web/api/htmlelement/enterkeyhint/index.html
@@ -1,0 +1,65 @@
+---
+title: HTMLElement.enterkeyhint
+slug: Web/API/HTMLElement/enterkeyhint
+tags:
+  - API
+  - HTML DOM
+  - HTMLElement
+  - Property
+  - Reference
+  - Keyboard
+---
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p>The <strong><code>enterkeyhint</code></strong> property is an enumerated property defining 
+what action label (or icon) to present for the enter key on virtual keyboards. <br>
+It reflects the <a href="/en-US/docs/Web/HTML/Global_attributes/enterkeyhint"><code>enterkeyhint</code></a>
+HTML global attribute and is an enumerated property only accepting the following values 
+as a <a href="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a>:</p>
+
+<ul>
+ <li><code>'enter'</code> typically indicating inserting a new line.</li>
+ <li><code>'done'</code> typically meaning there is nothing more to input and the input method editor (IME) will be closed.</li>
+ <li><code>'go'</code> typically meaning to take the user to the target of the text they typed.</li>
+ <li><code>'next'</code> typically taking the user to the next field that will accept text.	</li>
+ <li><code>'previous'</code> typically taking the user to the previous field that will accept text.	</li>
+ <li><code>'search'</code> typically taking the user to the results of searching for the text they have typed.</li>
+ <li><code>'send'</code> typically delivering the text to its target.	</li>
+</ul>
+
+<p>If no <code>enterkeyhint</code> value has been specified or if it was set to a different value than the allowed ones, it will return an empty string.</p>
+
+<h2 id="Examples">Examples</h2>
+<p>Give a virtual keyboard a hint how to label the enter key (might render as <kbd>Send</kbd> and <kbd>Search</kbd>, depending on the OS or the user's language).</p>
+<pre class="brush: js notranslate">
+const send = document.getElementById('sendInput');
+const search = document.getElementById('searchInput');
+
+send.enterkeyhint = 'send';
+search.enterkeyhint = 'search';
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('HTML WHATWG', 'interaction.html#dom-enterkeyhint', 'enterkeyhint')}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.HTMLElement.enterkeyhint")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="/en-US/docs/Web/HTML/Global_attributes/enterkeyhint"><code>enterkeyhint</code></a> HTML global attribute</li>
+</ul>

--- a/files/en-us/web/api/htmlelement/index.html
+++ b/files/en-us/web/api/htmlelement/index.html
@@ -36,6 +36,8 @@ tags:
  <dd>Is a {{DOMxRef("DOMString")}}, reflecting the <code>dir</code> global attribute, representing the directionality of the element. Possible values are <code>"ltr"</code>, <code>"rtl"</code>, and <code>"auto"</code>.</dd>
  <dt>{{DOMxRef("HTMLElement.draggable")}}</dt>
  <dd>Is a {{JSxRef("Boolean")}} indicating if the element can be dragged.</dd>
+ <dt>{{DOMxRef("HTMLElement.enterkeyhint")}}</dt>
+ <dd>Is a {{JSxRef("DOMString")}} defining what action label (or icon) to present for the enter key on virtual keyboards.</dd>
  <dt>{{DOMxRef("HTMLElement.hidden")}}</dt>
  <dd>Is a {{JSxRef("Boolean")}} indicating if the element is hidden or not.</dd>
  <dt>{{DOMxRef("HTMLElement.inert")}}</dt>


### PR DESCRIPTION
This is the API part of `enterkeyhint`. Following up from the HTML part in https://github.com/mdn/content/pull/1106.

Spec: https://html.spec.whatwg.org/multipage/interaction.html#dom-enterkeyhint

Why document this under `HTMLElement`? 
Well, the spec defines it under [`interface mixin ElementContentEditable`](https://html.spec.whatwg.org/multipage/interaction.html#elementcontenteditable) which [`HTMLElement` includes](https://html.spec.whatwg.org/multipage/dom.html#htmlelement). I don't think we want to document the `ElementContentEditable` mixin.