### PR TITLE
Update known bugs section for Marionette in Firefox 84.

### DIFF
--- a/files/en-us/mozilla/firefox/releases/84/index.html
+++ b/files/en-us/mozilla/firefox/releases/84/index.html
@@ -91,10 +91,7 @@ tags:
 <h4 id="WebDriver_known_bugs">Known bugs</h4>
 
 <ul>
-  <li>After page navigations accessing a previously retrieved element might not
-  always raise a "stale element" error, but could also lead to a "no such element"
-  error. To prevent that set the <code>marionette.actors.enabled</code> preference
-  to <code>false</code> ({{bug(1684827)}}).
+  <li>After page navigation, accessing a previously-retrieved element might not always raise a "stale element" error, and can also lead to a "no such element" error. To prevent this, set the <code>marionette.actors.enabled</code> preference to <code>false</code> ({{bug(1684827)}}).
 </ul>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>

--- a/files/en-us/mozilla/firefox/releases/84/index.html
+++ b/files/en-us/mozilla/firefox/releases/84/index.html
@@ -88,6 +88,15 @@ tags:
  <li>Fixed a hang for <code>WebDriver:Back</code> encountered when the currently-selected <code><a href="/en-US/docs/Web/HTML/Element/iframe">&lt;iframe&gt;</a></code> gets unloaded ({{bug(1672758)}}).</li>
 </ul>
 
+<h4 id="WebDriver_known_bugs">Known bugs</h4>
+
+<ul>
+  <li>After page navigations accessing a previously retrieved element might not
+  always raise a "stale element" error, but could also lead to a "no such element"
+  error. To prevent that set the <code>marionette.actors.enabled</code> preference
+  to <code>false</code> ({{bug(1684827)}}).
+</ul>
+
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
 <ul>


### PR DESCRIPTION
Based on the [known bug in Firefox 84](https://bugzilla.mozilla.org/show_bug.cgi?id=1684827) we have to make sure to list this regression on the release page.