### PR TITLE
Fixed 'Bugzilla component' hyperlink format

### DIFF
--- a/files/en-us/mozilla/developer_guide/introduction/index.html
+++ b/files/en-us/mozilla/developer_guide/introduction/index.html
@@ -101,7 +101,7 @@ tags:
 
 <ul>
  <li><a class="link-https" href="https://bugzilla.mozilla.org/query.cgi">Search Bugzilla</a> for relevant keywords. See pages on <a href="/en-US/docs/Mozilla/Bugzilla">Bugzilla </a>and <a href="/en-US/docs/Mozilla/QA/Searching_Bugzilla">Searching Bugzilla </a>for further help</li>
- <li>Learn the B<a class="link-https" href="https://bugzilla.mozilla.org/describecomponents.cgi">ugzilla component</a>, with which your pet peeve is implemented, using the components list. Browse this component on Bugzilla for related bugs</li>
+ <li>Learn the <a class="link-https" href="https://bugzilla.mozilla.org/describecomponents.cgi">Bugzilla component</a>, with which your pet peeve is implemented, using the components list. Browse this component on Bugzilla for related bugs</li>
  <li>Ask in our Matrix channels : <a href="https://chat.mozilla.org/#/room/#introduction:mozilla.org">#introduction:mozilla.org</a> or <a href="https://chat.mozilla.org/#/room/#developers:mozilla.org">#developers:mozilla.org</a></li>
 </ul>
 


### PR DESCRIPTION
The 'B' in 'Bugzilla component' was added inside the anchor tag