### PR TITLE
Fixing two statements with undefined variables in an example for async_await

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/async_await/index.html
+++ b/files/en-us/learn/javascript/asynchronous/async_await/index.html
@@ -304,9 +304,9 @@ displayContent()
 <p>Async/await makes your code look synchronous, and in a way it makes it behave more synchronously. The <code>await</code> keyword blocks execution of all the code that follows it until the promise fulfills, exactly as it would with a synchronous operation. It does allow other tasks to continue to run in the meantime, but the awaited code is blocked.</p>
 
 <pre class="brush: js notranslate">async function makeResult(items) {
- let newArr;
+ let newArr = [];
  for(let i=0; i &lt; items.length; i++) {
-  newArr[i].push('word_'+i);
+  newArr.push('word_'+i);
  }
  return newArr;
 }


### PR DESCRIPTION
Fixes #1202 
- `newArr` is undefined in the example for async_away.
- `newArr[i]` is also undefined in 309.