### PR TITLE
Make the PWA code more modern and readable

### DIFF
--- a/files/en-us/web/progressive_web_apps/app_structure/index.html
+++ b/files/en-us/web/progressive_web_apps/app_structure/index.html
@@ -120,61 +120,61 @@ tags:
 
 <p>The app.js file does a few things we will look into closely in the next articles. First of all it generates the content based on this template:</p>
 
-<pre class="brush: js">var template = "&lt;article&gt;\n\
-    &lt;img src='data/img/SLUG.jpg' alt='NAME'&gt;\n\
-    &lt;h3&gt;#POS. NAME&lt;/h3&gt;\n\
-    &lt;ul&gt;\n\
-    &lt;li&gt;&lt;span&gt;Author:&lt;/span&gt; &lt;strong&gt;AUTHOR&lt;/strong&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;Twitter:&lt;/span&gt; &lt;a href='https://twitter.com/TWITTER'&gt;@TWITTER&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;Website:&lt;/span&gt; &lt;a href='http://WEBSITE/'&gt;WEBSITE&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;GitHub:&lt;/span&gt; &lt;a href='https://GITHUB'&gt;GITHUB&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;More:&lt;/span&gt; &lt;a href='http://js13kgames.com/entries/SLUG'&gt;js13kgames.com/entries/SLUG&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;/ul&gt;\n\
-&lt;/article&gt;";
-var content = '';
-for(var i=0; i&lt;games.length; i++) {
-    var entry = template.replace(/POS/g,(i+1))
-        .replace(/SLUG/g,games[i].slug)
-        .replace(/NAME/g,games[i].name)
-        .replace(/AUTHOR/g,games[i].author)
-        .replace(/TWITTER/g,games[i].twitter)
-        .replace(/WEBSITE/g,games[i].website)
-        .replace(/GITHUB/g,games[i].github);
-    entry = entry.replace('&lt;a href=\'http:///\'&gt;&lt;/a&gt;','-');
-    content += entry;
-};
+<pre class="brush: js">const template = `&lt;article&gt;
+  &lt;img src='data/img/placeholder.png' data-src='data/img/SLUG.jpg' alt='NAME'&gt;
+  &lt;h3&gt;#POS. NAME&lt;/h3&gt;
+  &lt;ul&gt;
+  &lt;li&gt;&lt;span&gt;Author:&lt;/span&gt; &lt;strong&gt;AUTHOR&lt;/strong&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;Twitter:&lt;/span&gt; &lt;a href='https://twitter.com/TWITTER'&gt;@TWITTER&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;Website:&lt;/span&gt; &lt;a href='http://WEBSITE/'&gt;WEBSITE&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;GitHub:&lt;/span&gt; &lt;a href='https://GITHUB'&gt;GITHUB&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;More:&lt;/span&gt; &lt;a href='http://js13kgames.com/entries/SLUG'&gt;js13kgames.com/entries/SLUG&lt;/a&gt;&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/article&gt;`;
+let content = '';
+for (let i = 0; i &lt; games.length; i++) {
+  let entry = template.replace(/POS/g, (i + 1))
+    .replace(/SLUG/g, games[i].slug)
+    .replace(/NAME/g, games[i].name)
+    .replace(/AUTHOR/g, games[i].author)
+    .replace(/TWITTER/g, games[i].twitter)
+    .replace(/WEBSITE/g, games[i].website)
+    .replace(/GITHUB/g, games[i].github);
+  entry = entry.replace('&lt;a href=\'http:///\'&gt;&lt;/a&gt;', '-');
+  content += entry;
+}
 document.getElementById('content').innerHTML = content;</pre>
 
 <p>Next, it registers a service worker:</p>
 
 <pre class="brush: js">if('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/pwa-examples/js13kpwa/sw.js');
+  navigator.serviceWorker.register('/pwa-examples/js13kpwa/sw.js');
 };</pre>
 
 <p>The next code block requests permission for notifications when a button is clicked:</p>
 
-<pre class="brush: js">var button = document.getElementById("notifications");
-button.addEventListener('click', function(e) {
-    Notification.requestPermission().then(function(result) {
-        if(result === 'granted') {
-            randomNotification();
-        }
-    });
+<pre class="brush: js">const button = document.getElementById('notifications');
+button.addEventListener('click', () =&gt; {
+  Notification.requestPermission().then((result) =&gt; {
+    if (result === 'granted') {
+      randomNotification();
+    }
+  });
 });</pre>
 
 <p>The last block creates notifications that display a randomly-selected item from the games list:</p>
 
 <pre class="brush: js">function randomNotification() {
-    var randomItem = Math.floor(Math.random()*games.length);
-    var notifTitle = games[randomItem].name;
-    var notifBody = 'Created by '+games[randomItem].author+'.';
-    var notifImg = 'data/img/'+games[randomItem].slug+'.jpg';
-    var options = {
-        body: notifBody,
-        icon: notifImg
-    }
-    var notif = new Notification(notifTitle, options);
-    setTimeout(randomNotification, 30000);
+  const randomItem = Math.floor(Math.random() * games.length);
+  const notifTitle = games[randomItem].name;
+  const notifBody = `Created by ${games[randomItem].author}.`;
+  const notifImg = `data/img/${games[randomItem].slug}.jpg`;
+  const options = {
+    body: notifBody,
+    icon: notifImg,
+  };
+  new Notification(notifTitle, options);
+  setTimeout(randomNotification, 30000);
 }</pre>
 
 <h3 id="The_service_worker">The service worker</h3>
@@ -185,8 +185,8 @@ button.addEventListener('click', function(e) {
 
 <p>Next, it creates a list of all the files to be cached, both from the app shell and the content:</p>
 
-<pre class="brush: js">var cacheName = 'js13kPWA-v1';
-var appShellFiles = [
+<pre class="brush: js">const cacheName = 'js13kPWA-v1';
+const appShellFiles = [
   '/pwa-examples/js13kpwa/',
   '/pwa-examples/js13kpwa/index.html',
   '/pwa-examples/js13kpwa/app.js',
@@ -204,41 +204,38 @@ var appShellFiles = [
   '/pwa-examples/js13kpwa/icons/icon-168.png',
   '/pwa-examples/js13kpwa/icons/icon-192.png',
   '/pwa-examples/js13kpwa/icons/icon-256.png',
-  '/pwa-examples/js13kpwa/icons/icon-512.png'
+  '/pwa-examples/js13kpwa/icons/icon-512.png',
 ];
-var gamesImages = [];
-for(var i=0; i&lt;games.length; i++) {
-  gamesImages.push('data/img/'+games[i].slug+'.jpg');
+const gamesImages = [];
+for (let i = 0; i &lt; games.length; i++) {
+  gamesImages.push(`data/img/${games[i].slug}.jpg`);
 }
-var contentToCache = appShellFiles.concat(gamesImages);</pre>
+const contentToCache = appShellFiles.concat(gamesImages);</pre>
 
 <p>The next block installs the service worker, which then actually caches all the files contained in the above list:</p>
 
-<pre class="brush: js">self.addEventListener('install', function(e) {
+<pre class="brush: js">self.addEventListener('install', (e) =&gt; {
   console.log('[Service Worker] Install');
-  e.waitUntil(
-    caches.open(cacheName).then(function(cache) {
-      console.log('[Service Worker] Caching all: app shell and content');
-      return cache.addAll(contentToCache);
-    })
-  );
+  e.waitUntil((async () =&gt; {
+    const cache = await caches.open(cacheName);
+    console.log('[Service Worker] Caching all: app shell and content');
+    await cache.addAll(contentToCache);
+  })());
 });</pre>
 
 <p>Last of all, the service worker fetches content from the cache if it is available there, providing offline functionality:</p>
 
-<pre class="brush: js">self.addEventListener('fetch', function(e) {
-  e.respondWith(
-    caches.match(e.request).then(function(r) {
-      console.log('[Service Worker] Fetching resource: '+e.request.url);
-      return r || fetch(e.request).then(function(response) {
-        return caches.open(cacheName).then(function(cache) {
-          console.log('[Service Worker] Caching new resource: '+e.request.url);
-          cache.put(e.request, response.clone());
-          return response;
-        });
-      });
-    })
-  );
+<pre class="brush: js">self.addEventListener('fetch', (e) =&gt; {
+  e.respondWith((async () =&gt; {
+    const r = await caches.match(e.request);
+    console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
+    if (r) return r;
+    const response = await fetch(e.request);
+    const cache = await caches.open(cacheName);
+    console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
+    cache.put(e.request, response.clone());
+    return response;
+  })());
 });</pre>
 
 <h3 id="The_JavaScript_data">The JavaScript data</h3>
@@ -246,31 +243,31 @@ var contentToCache = appShellFiles.concat(gamesImages);</pre>
 <p>The games data is present in the data folder in a form of a JavaScript object (<a href="https://github.com/mdn/pwa-examples/blob/master/js13kpwa/data/games.js">games.js</a>):</p>
 
 <pre class="brush: js">var games = [
-    {
-        slug: 'lost-in-cyberspace',
-        name: 'Lost in Cyberspace',
-        author: 'Zosia and Bartek',
-        twitter: 'bartaz',
-        website: '',
-        github: 'github.com/bartaz/lost-in-cyberspace'
-    },
-    {
-        slug: 'vernissage',
-        name: 'Vernissage',
-        author: 'Platane',
-        twitter: 'platane_',
-        website: 'github.com/Platane',
-        github: 'github.com/Platane/js13k-2017'
-    },
-// ...
-    {
-        slug: 'emma-3d',
-        name: 'Emma-3D',
-        author: 'Prateek Roushan',
-        twitter: '',
-        website: '',
-        github: 'github.com/coderprateek/Emma-3D'
-    }
+  {
+    slug: 'lost-in-cyberspace',
+    name: 'Lost in Cyberspace',
+    author: 'Zosia and Bartek',
+    twitter: 'bartaz',
+    website: '',
+    github: 'github.com/bartaz/lost-in-cyberspace'
+  },
+  {
+    slug: 'vernissage',
+    name: 'Vernissage',
+    author: 'Platane',
+    twitter: 'platane_',
+    website: 'github.com/Platane',
+    github: 'github.com/Platane/js13k-2017'
+  },
+  // ...
+  {
+    slug: 'emma-3d',
+    name: 'Emma-3D',
+    author: 'Prateek Roushan',
+    twitter: '',
+    website: '',
+    github: 'github.com/coderprateek/Emma-3D'
+  }
 ];</pre>
 
 <p>Every entry has its own image in the data/img folder. This is our content, loaded into the content section with JavaScript.</p>

--- a/files/en-us/web/progressive_web_apps/app_structure/index.html
+++ b/files/en-us/web/progressive_web_apps/app_structure/index.html
@@ -229,7 +229,7 @@ const contentToCache = appShellFiles.concat(gamesImages);</pre>
   e.respondWith((async () =&gt; {
     const r = await caches.match(e.request);
     console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
-    if (r) return r;
+    if (r) { return r; }
     const response = await fetch(e.request);
     const cache = await caches.open(cacheName);
     console.log(`[Service Worker] Caching new resource: ${e.request.url}`);

--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -90,7 +90,7 @@ const appShellFiles = [
 <p>Next, the links to images to be loaded along with the content from the data/games.js file are generated in the second array. After that, both arrays are merged using the {{jsxref("Array.prototype.concat()")}} function.</p>
 
 <pre class="brush: js">const gamesImages = [];
-for (let i = 0; i < games.length; i++) {
+for (let i = 0; i &lt; games.length; i++) {
   gamesImages.push(`data/img/${games[i].slug}.jpg`);
 }
 const contentToCache = appShellFiles.concat(gamesImages);</pre>

--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -164,7 +164,6 @@ const contentToCache = appShellFiles.concat(gamesImages);</pre>
 // ...
 
 self.addEventListener('install', (e) =&gt; {
-  console.log('[Service Worker] Install');
   e.waitUntil((async () =&gt; {
     const cache = await caches.open(cacheName);
     await cache.addAll(contentToCache);

--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -136,7 +136,7 @@ const contentToCache = appShellFiles.concat(gamesImages);</pre>
   e.respondWith((async () =&gt; {
     const r = await caches.match(e.request);
     console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
-    if (r) return r;
+    if (r) { return r; }
     const response = await fetch(e.request);
     const cache = await caches.open(cacheName);
     console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
@@ -181,7 +181,7 @@ self.addEventListener('install', (e) =&gt; {
   e.waitUntil((async () =&gt; {
     const keyList = await caches.keys();
     await Promise.all(keyList.map((key) =&gt; {
-      if (key === cacheName) return;
+      if (key === cacheName) { return; }
       await caches.delete(key);
     }))
   })());

--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -44,7 +44,7 @@ tags:
 <p><strong>NOTE</strong> : We're using the <a href="http://es6-features.org/">es6</a> <strong>arrow functions</strong> syntax in the Service Worker Implementation</p>
 
 <pre class="brush: js">if('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('./pwa-examples/js13kpwa/sw.js');
+  navigator.serviceWorker.register('./pwa-examples/js13kpwa/sw.js');
 };</pre>
 
 <p>If the service worker API is supported in the browser, it is registered against the site using the {{domxref("ServiceWorkerContainer.register()")}} method. Its contents reside in the sw.js file, and can be executed after the registration is successful. It's the only piece of Service Worker code that sits inside the app.js file; everything else that is Service Worker-specific is written in the sw.js file itself.</p>
@@ -58,15 +58,15 @@ tags:
 <p>The API allows us to add event listeners for key events we are interested in — the first one is the <code>install</code> event:</p>
 
 <pre class="brush: js">self.addEventListener('install', (e) =&gt; {
-    console.log('[Service Worker] Install');
+  console.log('[Service Worker] Install');
 });</pre>
 
 <p>In the <code>install</code> listener, we can initialize the cache and add files to it for offline use. Our js13kPWA app does exactly that.</p>
 
 <p>First, a variable for storing the cache name is created, and the app shell files are listed in one array.</p>
 
-<pre class="brush: js">var cacheName = 'js13kPWA-v1';
-var appShellFiles = [
+<pre class="brush: js">const cacheName = 'js13kPWA-v1';
+const appShellFiles = [
   '/pwa-examples/js13kpwa/',
   '/pwa-examples/js13kpwa/index.html',
   '/pwa-examples/js13kpwa/app.js',
@@ -89,22 +89,21 @@ var appShellFiles = [
 
 <p>Next, the links to images to be loaded along with the content from the data/games.js file are generated in the second array. After that, both arrays are merged using the {{jsxref("Array.prototype.concat()")}} function.</p>
 
-<pre class="brush: js">var gamesImages = [];
-for(var i=0; i&lt;games.length; i++) {
-  gamesImages.push('data/img/'+games[i].slug+'.jpg');
+<pre class="brush: js">const gamesImages = [];
+for (let i = 0; i < games.length; i++) {
+  gamesImages.push(`data/img/${games[i].slug}.jpg`);
 }
-var contentToCache = appShellFiles.concat(gamesImages);</pre>
+const contentToCache = appShellFiles.concat(gamesImages);</pre>
 
 <p>Then we can manage the <code>install</code> event itself:</p>
 
 <pre class="brush: js">self.addEventListener('install', (e) =&gt; {
   console.log('[Service Worker] Install');
-  e.waitUntil(
-    caches.open(cacheName).then((cache) =&gt; {
-          console.log('[Service Worker] Caching all: app shell and content');
-      return cache.addAll(contentToCache);
-    })
-  );
+  e.waitUntil((async () =&gt; {
+    const cache = await caches.open(cacheName);
+    console.log('[Service Worker] Caching all: app shell and content');
+    await cache.addAll(contentToCache);
+  })());
 });</pre>
 
 <p>There are two things that need an explanation here: what {{domxref("ExtendableEvent.waitUntil")}} does, and what the {{domxref("Cache","caches")}} object is.</p>
@@ -126,7 +125,7 @@ var contentToCache = appShellFiles.concat(gamesImages);</pre>
 <p>We also have a <code>fetch</code> event at our disposal, which fires every time an HTTP request is fired off from our app. This is very useful, as it allows us to intercept requests and respond to them with custom responses. Here is a simple usage example:</p>
 
 <pre class="brush: js">self.addEventListener('fetch', (e) =&gt; {
-    console.log('[Service Worker] Fetched resource '+e.request.url);
+  console.log(`[Service Worker] Fetched resource ${e.request.url}`);
 });</pre>
 
 <p>The response can be anything we want: the requested file, its cached copy, or a piece of JavaScript code that will do something specific — the possibilities are endless.</p>
@@ -134,18 +133,16 @@ var contentToCache = appShellFiles.concat(gamesImages);</pre>
 <p>In our example app, we serve content from the cache instead of the network as long as the resource is actually in the cache. We do this whether the app is online or offline. If the file is not in the cache, the app adds it there first before then serving it:</p>
 
 <pre class="brush: js">self.addEventListener('fetch', (e) =&gt; {
-  e.respondWith(
-    caches.match(e.request).then((r) =&gt; {
-          console.log('[Service Worker] Fetching resource: '+e.request.url);
-      return r || fetch(e.request).then((response) =&gt; {
-                return caches.open(cacheName).then((cache) =&gt; {
-          console.log('[Service Worker] Caching new resource: '+e.request.url);
-          cache.put(e.request, response.clone());
-          return response;
-        });
-      });
-    })
-  );
+  e.respondWith((async () =&gt; {
+    const r = await caches.match(e.request);
+    console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
+    if (r) return r;
+    const response = await fetch(e.request);
+    const cache = await caches.open(cacheName);
+    console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
+    cache.put(e.request, response.clone());
+    return response;
+  })());
 });</pre>
 
 <p>Here, we respond to the fetch event with a function that tries to find the resource in the cache and return the response if it's there. If not, we use another fetch request to fetch it from the network, then store the response in the cache so it will be available there next time it is requested.</p>
@@ -167,11 +164,11 @@ var contentToCache = appShellFiles.concat(gamesImages);</pre>
 // ...
 
 self.addEventListener('install', (e) =&gt; {
-  e.waitUntil(
-    caches.open('js13kPWA-v2').then((cache) =&gt; {
-      return cache.addAll(contentToCache);
-    })
-  );
+  console.log('[Service Worker] Install');
+  e.waitUntil((async () =&gt; {
+    const cache = await caches.open(cacheName);
+    await cache.addAll(contentToCache);
+  })());
 });</pre>
 
 <p>A new service worker is installed in the background, and the previous one (v1) works correctly up until there are no pages using it — the new Service Worker is then activated and takes over management of the page from the old one.</p>
@@ -181,15 +178,13 @@ self.addEventListener('install', (e) =&gt; {
 <p>Remember the <code>activate</code> event we skipped? It can be used to clear out the old cache we don't need anymore:</p>
 
 <pre class="brush: js">self.addEventListener('activate', (e) =&gt; {
-  e.waitUntil(
-    caches.keys().then((keyList) =&gt; {
-          return Promise.all(keyList.map((key) =&gt; {
-        if(key !== cacheName) {
-          return caches.delete(key);
-        }
-      }));
-    })
-  );
+  e.waitUntil((async () =&gt; {
+    const keyList = await caches.keys();
+    await Promise.all(keyList.map((key) =&gt; {
+      if (key === cacheName) return;
+      await caches.delete(key);
+    }))
+  })());
 });</pre>
 
 <p>This ensures we have only the files we need in the cache, so we don't leave any garbage behind; the <a href="/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria">available cache space in the browser is limited</a>, so it is a good idea to clean up after ourselves.</p>

--- a/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.html
+++ b/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.html
@@ -27,14 +27,14 @@ tags:
 
 <p>To show a notification, we have to request permission to do so first. Instead of showing the notification immediately though, best practice dictates that we should show the popup when the user requests it by clicking on a button:</p>
 
-<pre class="brush: js">var button = document.getElementById("notifications");
-button.addEventListener('click', function(e) {
-    Notification.requestPermission().then(function(result) {
-        if(result === 'granted') {
-            randomNotification();
-        }
-    });
-});</pre>
+<pre class="brush: js">const button = document.getElementById('notifications');
+button.addEventListener('click', () =&gt; {
+  Notification.requestPermission().then((result) =&gt; {
+    if (result === 'granted') {
+      randomNotification();
+    }
+  });
+})</pre>
 
 <p>This shows a popup using the operating system’s own notifications service:</p>
 
@@ -49,16 +49,16 @@ button.addEventListener('click', function(e) {
 <p>The example app creates a notification out of the available data — a game is picked at random, and the chosen one feeds the notification with the content: it sets the game's name as the title, mentioning the author in the body, and showing the image as an icon:</p>
 
 <pre class="brush: js">function randomNotification() {
-    var randomItem = Math.floor(Math.random()*games.length);
-    var notifTitle = games[randomItem].name;
-    var notifBody = 'Created by '+games[randomItem].author+'.';
-    var notifImg = 'data/img/'+games[randomItem].slug+'.jpg';
-    var options = {
-        body: notifBody,
-        icon: notifImg
-    }
-    var notif = new Notification(notifTitle, options);
-    setTimeout(randomNotification, 30000);
+  const randomItem = Math.floor(Math.random() * games.length);
+  const notifTitle = games[randomItem].name;
+  const notifBody = `Created by ${games[randomItem].author}.`;
+  const notifImg = `data/img/${games[randomItem].slug}.jpg`;
+  const options = {
+    body: notifBody,
+    icon: notifImg,
+  };
+  new Notification(notifTitle, options);
+  setTimeout(randomNotification, 30000);
 }</pre>
 
 <p>A new random notification is created every 30 seconds until it becomes too annoying and is disabled by the user. (For a real app, the notifications should be much less frequent, and more useful.) The advantage of the Notifications API is that it uses the operating system's notification functionality. This means that notifications can be displayed to the user even when they are not looking at the web app, and the notifications look similar to ones displayed by native apps.</p>
@@ -71,7 +71,7 @@ button.addEventListener('click', function(e) {
 
 <p>As mentioned before, to be able to receive push messages, you have to have a service worker, the basics of which are already explained in the <a href="/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers">Making PWAs work offline with Service workers</a> article. Inside the service worker, a push service subscription mechanism is created.</p>
 
-<pre class="brush: js">registration.pushManager.getSubscription() .then( /* ... */ );</pre>
+<pre class="brush: js">registration.pushManager.getSubscription().then( /* ... */ );</pre>
 
 <p>Once the user is subscribed, they can receive push notifications from the server.</p>
 
@@ -79,7 +79,7 @@ button.addEventListener('click', function(e) {
 
 <p>To receive push messages, we can listen to the {{event("push")}} event in the Service Worker file:</p>
 
-<pre class="brush: js">self.addEventListener('push', function(e) { /* ... */ });</pre>
+<pre class="brush: js">self.addEventListener('push', (e) =&gt; { /* ... */ });</pre>
 
 <p>The data can be retrieved and then shown as a notification to the user immediately. This, for example, can be used to remind the user about something, or let them know about new content being available in the app.</p>
 
@@ -102,22 +102,22 @@ button.addEventListener('click', function(e) {
 <p>The <code>index.js</code> file starts by registering the service worker:</p>
 
 <pre class="brush: js">navigator.serviceWorker.register('service-worker.js')
-.then(function(registration) {
-  return registration.pushManager.getSubscription()
-  .then(async function(subscription) {
-      // registration part
-  });
-})
-.then(function(subscription) {
+  .then((registration) =&gt; {
+    return registration.pushManager.getSubscription()
+      .then(async (subscription) =&gt; {
+        // registration part
+      });
+  })
+  .then((subscription) =&gt; {
     // subscription part
-});</pre>
+  });</pre>
 
 <p>It is a little bit more complicated than the service worker we saw in the <a href="https://mdn.github.io/pwa-examples/js13kpwa/">js13kPWA demo</a>. In this particular case, after registering, we use the registration object to subscribe, and then use the resulting subscription object to complete the whole process.</p>
 
 <p>In the registration part, the code looks like this:</p>
 
 <pre class="brush: js">if(subscription) {
-    return subscription;
+  return subscription;
 }</pre>
 
 <p>If the user has already subscribed, we then return the subscription object and move to the subscription part. If not, we initialize a new subscription:</p>
@@ -131,41 +131,41 @@ const convertedVapidKey = urlBase64ToUint8Array(vapidPublicKey);</pre>
 <p>The app can now use the {{domxref("PushManager")}} to subscribe the new user. There are two options passed to the {{domxref("PushManager.subscribe()")}} method — the first is <code>userVisibleOnly: true</code>, which means all the notifications sent to the user will be visible to them, and the second one is the <code>applicationServerKey</code>, which contains our successfully acquired and converted VAPID key.</p>
 
 <pre class="brush: js">return registration.pushManager.subscribe({
-    userVisibleOnly: true,
-    applicationServerKey: convertedVapidKey
+  userVisibleOnly: true,
+  applicationServerKey: convertedVapidKey
 });</pre>
 
 <p>Now let's move to the subscription part — the app first sends the subscription details as JSON to the server using Fetch.</p>
 
 <pre class="brush: js">fetch('./register', {
-    method: 'post',
-    headers: {
-        'Content-type': 'application/json'
-    },
-    body: JSON.stringify({
-        subscription: subscription
-    }),
+  method: 'post',
+  headers: {
+    'Content-type': 'application/json'
+  },
+  body: JSON.stringify({
+    subscription: subscription
+  }),
 });</pre>
 
 <p>Then the {{domxref("onclick","GlobalEventHandlers.onclick")}} function on the <em>Subscribe</em> button is defined:</p>
 
 <pre class="brush: js">document.getElementById('doIt').onclick = function() {
-    const payload = document.getElementById('notification-payload').value;
-    const delay = document.getElementById('notification-delay').value;
-    const ttl = document.getElementById('notification-ttl').value;
+  const payload = document.getElementById('notification-payload').value;
+  const delay = document.getElementById('notification-delay').value;
+  const ttl = document.getElementById('notification-ttl').value;
 
-    fetch('./sendNotification', {
-        method: 'post',
-        headers: {
-            'Content-type': 'application/json'
-        },
-        body: JSON.stringify({
-            subscription: subscription,
-            payload: payload,
-            delay: delay,
-            ttl: ttl,
-        }),
-    });
+  fetch('./sendNotification', {
+    method: 'post',
+    headers: {
+      'Content-type': 'application/json'
+    },
+    body: JSON.stringify({
+      subscription: subscription,
+      payload: payload,
+      delay: delay,
+      ttl: ttl,
+    }),
+  });
 };</pre>
 
 <p>When the button is clicked, <code>fetch</code> asks the server to send the notification with the given parameters: <code>payload</code> is the text that to be shown in the notification, <code>delay</code> defines a delay in seconds until the notification will be shown, and <code>ttl</code> is the time-to-live setting that keeps the notification available on the server for a specified amount of time, also defined in seconds.</p>
@@ -231,12 +231,12 @@ webPush.setVapidDetails(
 <p>The last file we will look at is the service worker:</p>
 
 <pre class="brush: js">self.addEventListener('push', function(event) {
-    const payload = event.data ? event.data.text() : 'no payload';
-    event.waitUntil(
-        self.registration.showNotification('ServiceWorker Cookbook', {
-            body: payload,
-        })
-    );
+  const payload = event.data ? event.data.text() : 'no payload';
+  event.waitUntil(
+    self.registration.showNotification('ServiceWorker Cookbook', {
+        body: payload,
+    })
+  );
 });</pre>
 
 <p>All it does is add a listener for the {{event("push")}} event, create the payload variable consisting of the text taken from the data (or create a string to use if data is empty), and then wait until the notification is shown to the user.</p>

--- a/files/en-us/web/progressive_web_apps/structural_overview/index.html
+++ b/files/en-us/web/progressive_web_apps/structural_overview/index.html
@@ -260,7 +260,7 @@ const contentToCache = appShellFiles.concat(gamesImages);</pre>
   e.respondWith((async () =&gt; {
     const r = await caches.match(e.request);
     console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
-    if (r) return r;
+    if (r) { return r; }
     const response = await fetch(e.request);
     const cache = await caches.open(cacheName);
     console.log(`[Service Worker] Caching new resource: ${e.request.url}`);

--- a/files/en-us/web/progressive_web_apps/structural_overview/index.html
+++ b/files/en-us/web/progressive_web_apps/structural_overview/index.html
@@ -151,68 +151,62 @@ tags:
 
 <p>The first thing it does is to generate the app's displayed content using the following template:</p>
 
-<pre class="brush: js">var template = "&lt;article&gt;\n\
-    &lt;img src='data/img/SLUG.jpg' alt='NAME'&gt;\n\
-    &lt;h3&gt;#POS. NAME&lt;/h3&gt;\n\
-    &lt;ul&gt;\n\
-    &lt;li&gt;&lt;span&gt;Author:&lt;/span&gt; &lt;strong&gt;AUTHOR&lt;/strong&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;Twitter:&lt;/span&gt; &lt;a href='https://twitter.com/TWITTER'&gt;
-        @TWITTER&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;Website:&lt;/span&gt; &lt;a href='http://WEBSITE/'&gt;WEBSITE&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;GitHub:&lt;/span&gt; &lt;a href='https://GITHUB'&gt;GITHUB&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;li&gt;&lt;span&gt;More:&lt;/span&gt; &lt;a href='http://js13kgames.com/entries/SLUG'&gt;
-        js13kgames.com/entries/SLUG&lt;/a&gt;&lt;/li&gt;\n\
-    &lt;/ul&gt;\n\
-&lt;/article&gt;";
-var content = '';
-for(var i=0; i&lt;games.length; i++) {
-    var entry = template.replace(/POS/g,(i+1))
-        .replace(/SLUG/g,games[i].slug)
-        .replace(/NAME/g,games[i].name)
-        .replace(/AUTHOR/g,games[i].author)
-        .replace(/TWITTER/g,games[i].twitter)
-        .replace(/WEBSITE/g,games[i].website)
-        .replace(/GITHUB/g,games[i].github);
-    entry = entry.replace('&lt;a href=\'http:///\'&gt;&lt;/a&gt;','-');
-    content += entry;
-};
-document.getElementById('content').innerHTML = content;
-</pre>
+<pre class="brush: js">const template = `&lt;article&gt;
+  &lt;img src='data/img/placeholder.png' data-src='data/img/SLUG.jpg' alt='NAME'&gt;
+  &lt;h3&gt;#POS. NAME&lt;/h3&gt;
+  &lt;ul&gt;
+  &lt;li&gt;&lt;span&gt;Author:&lt;/span&gt; &lt;strong&gt;AUTHOR&lt;/strong&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;Twitter:&lt;/span&gt; &lt;a href='https://twitter.com/TWITTER'&gt;@TWITTER&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;Website:&lt;/span&gt; &lt;a href='http://WEBSITE/'&gt;WEBSITE&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;GitHub:&lt;/span&gt; &lt;a href='https://GITHUB'&gt;GITHUB&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;span&gt;More:&lt;/span&gt; &lt;a href='http://js13kgames.com/entries/SLUG'&gt;js13kgames.com/entries/SLUG&lt;/a&gt;&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/article&gt;`;
+let content = '';
+for (let i = 0; i &lt; games.length; i++) {
+  let entry = template.replace(/POS/g, (i + 1))
+    .replace(/SLUG/g, games[i].slug)
+    .replace(/NAME/g, games[i].name)
+    .replace(/AUTHOR/g, games[i].author)
+    .replace(/TWITTER/g, games[i].twitter)
+    .replace(/WEBSITE/g, games[i].website)
+    .replace(/GITHUB/g, games[i].github);
+  entry = entry.replace('&lt;a href=\'http:///\'&gt;&lt;/a&gt;', '-');
+  content += entry;
+}
+document.getElementById('content').innerHTML = content;</pre>
 
 <p>Then it registers a <a href="/en-US/docs/Web/API/Service_Worker_API">service worker</a>:</p>
 
 <pre class="brush: js">if ("serviceWorker" in navigator) {
   navigator.serviceWorker.register("/pwa-examples/js13kpwa/sw.js");
-}
-</pre>
+}</pre>
 
 <p>After that, the app adds a handler for clicks on a button whose ID is <code>notifications</code>; this handler requests permission to send notifications to the user, then generates and sends a random notification.</p>
 
-<pre class="brush: js">var button = document.getElementById("notifications");
-button.addEventListener('click', function(e) {
-  Notification.requestPermission().then(function(result) {
-    if (result === 'granted') {
-      randomNotification();
-    }
-  });
-});
-</pre>
+<pre class="brush: js">const button = document.getElementById('notifications');
+button.addEventListener('click', () =&gt; {
+    Notification.requestPermission().then((result) =&gt; {
+        if (result === 'granted') {
+            randomNotification();
+        }
+    });
+});</pre>
 
 <p>The <code>randomNotification()</code> function follows, rounding out the last of the code in the file:</p>
 
 <pre class="brush: js">function randomNotification() {
-  var randomItem = Math.floor(Math.random()*games.length);
-  var notifTitle = games[randomItem].name;
-  var notifBody = 'Created by '+games[randomItem].author+'.';
-  var notifImg = 'data/img/'+games[randomItem].slug+'.jpg';
-  var options = {
-     body: notifBody,
-     icon: notifImg
-  }
-  var notif = new Notification(notifTitle, options);
-  setTimeout(randomNotification, 30000);
-}
-</pre>
+  const randomItem = Math.floor(Math.random() * games.length);
+  const notifTitle = games[randomItem].name;
+  const notifBody = `Created by ${games[randomItem].author}.`;
+  const notifImg = `data/img/${games[randomItem].slug}.jpg`;
+  const options = {
+    body: notifBody,
+    icon: notifImg,
+  };
+  new Notification(notifTitle, options);
+  setTimeout(randomNotification, 30000);
+}</pre>
 
 <h3 id="The_service_worker">The service worker</h3>
 
@@ -222,102 +216,95 @@ button.addEventListener('click', function(e) {
 
 <p>Then it creates a list of all the files that the service worker needs to cache. This list includes both app shell and content files:</p>
 
-<pre class="brush: js">var cacheName = 'js13kPWA-v1';
-var appShellFiles = [
-  '/pwa-examples/js13kpwa/',
-  '/pwa-examples/js13kpwa/index.html',
-  '/pwa-examples/js13kpwa/app.js',
-  '/pwa-examples/js13kpwa/style.css',
-  '/pwa-examples/js13kpwa/fonts/graduate.eot',
-  '/pwa-examples/js13kpwa/fonts/graduate.ttf',
-  '/pwa-examples/js13kpwa/fonts/graduate.woff',
-  '/pwa-examples/js13kpwa/favicon.ico',
-  '/pwa-examples/js13kpwa/img/js13kgames.png',
-  '/pwa-examples/js13kpwa/img/bg.png',
-  '/pwa-examples/js13kpwa/icons/icon-32.png',
-  '/pwa-examples/js13kpwa/icons/icon-64.png',
-  '/pwa-examples/js13kpwa/icons/icon-96.png',
-  '/pwa-examples/js13kpwa/icons/icon-128.png',
-  '/pwa-examples/js13kpwa/icons/icon-168.png',
-  '/pwa-examples/js13kpwa/icons/icon-192.png',
-  '/pwa-examples/js13kpwa/icons/icon-256.png',
-  '/pwa-examples/js13kpwa/icons/icon-512.png'
+<pre class="brush: js">const cacheName = 'js13kPWA-v1';
+const appShellFiles = [
+    '/pwa-examples/js13kpwa/',
+    '/pwa-examples/js13kpwa/index.html',
+    '/pwa-examples/js13kpwa/app.js',
+    '/pwa-examples/js13kpwa/style.css',
+    '/pwa-examples/js13kpwa/fonts/graduate.eot',
+    '/pwa-examples/js13kpwa/fonts/graduate.ttf',
+    '/pwa-examples/js13kpwa/fonts/graduate.woff',
+    '/pwa-examples/js13kpwa/favicon.ico',
+    '/pwa-examples/js13kpwa/img/js13kgames.png',
+    '/pwa-examples/js13kpwa/img/bg.png',
+    '/pwa-examples/js13kpwa/icons/icon-32.png',
+    '/pwa-examples/js13kpwa/icons/icon-64.png',
+    '/pwa-examples/js13kpwa/icons/icon-96.png',
+    '/pwa-examples/js13kpwa/icons/icon-128.png',
+    '/pwa-examples/js13kpwa/icons/icon-168.png',
+    '/pwa-examples/js13kpwa/icons/icon-192.png',
+    '/pwa-examples/js13kpwa/icons/icon-256.png',
+    '/pwa-examples/js13kpwa/icons/icon-512.png',
 ];
-var gamesImages = [];
-for(var i=0; i&lt;games.length; i++) {
-  gamesImages.push('data/img/'+games[i].slug+'.jpg');
+const gamesImages = [];
+for (let i = 0; i &lt; games.length; i++) {
+    gamesImages.push(`data/img/${games[i].slug}.jpg`);
 }
-var contentToCache = appShellFiles.concat(gamesImages);
-</pre>
+const contentToCache = appShellFiles.concat(gamesImages);</pre>
 
 <p>With the file list prepared, it's time to install the service worker itself. The service worker will actually handle caching all the listed files.</p>
 
-<pre class="brush: js">self.addEventListener('install', function(e) {
-  console.log('[Service Worker] Install');
-  e.waitUntil(
-    caches.open(cacheName).then(function(cache) {
-      console.log('[Service Worker] Caching all: app shell and content');
-      return cache.addAll(contentToCache);
-    })
-  );
-});
-</pre>
+<pre class="brush: js">self.addEventListener('install', (e) =&gt; {
+  console.log('[Service Worker] Install');
+  e.waitUntil((async () =&gt; {
+    const cache = await caches.open(cacheName);
+    console.log('[Service Worker] Caching all: app shell and content');
+    await cache.addAll(contentToCache);
+  })());
+});</pre>
 
 <p>With that done, we implement the service worker's <a href="/en-US/docs/Web/API/FetchEvent">fetch event</a> handler; its job is to return the contents of the specified file, either from the cache or by loading it over the network (caching it upon doing so):</p>
 
-<pre class="brush: js">self.addEventListener('fetch', function(e) {
-  e.respondWith(
-    caches.match(e.request).then(function(r) {
-      console.log('[Service Worker] Fetching resource: '+e.request.url);
-      return r || fetch(e.request).then(function(response) {
-        return caches.open(cacheName).then(function(cache) {
-          console.log('[Service Worker] Caching new resource: '+e.request.url);
-          cache.put(e.request, response.clone());
-          return response;
-        });
-      });
-    })
-  );
-});
-</pre>
+<pre class="brush: js">self.addEventListener('fetch', (e) =&gt; {
+  e.respondWith((async () =&gt; {
+    const r = await caches.match(e.request);
+    console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
+    if (r) return r;
+    const response = await fetch(e.request);
+    const cache = await caches.open(cacheName);
+    console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
+    cache.put(e.request, response.clone());
+    return response;
+  })());
+});</pre>
 
 <h3 id="Auxiliary_JavaScript_file_games.js">Auxiliary JavaScript file: games.js</h3>
 
 <p>The games data for this app example is provided in a JavaScript source file called <code>games.js</code>. Other apps might use JSON or other formats for this data.</p>
 
 <pre class="brush: js">var games = [
-    {
-        slug: 'lost-in-cyberspace',
-        name: 'Lost in Cyberspace',
-        author: 'Zosia and Bartek',
-        twitter: 'bartaz',
-        website: '',
-        github: 'github.com/bartaz/lost-in-cyberspace'
-    },
-    {
-        slug: 'vernissage',
-        name: 'Vernissage',
-        author: 'Platane',
-        twitter: 'platane_',
-        website: 'github.com/Platane',
-        github: 'github.com/Platane/js13k-2017'
-    },
-// ...
-    {
-        slug: 'emma-3d',
-        name: 'Emma-3D',
-        author: 'Prateek Roushan',
-        twitter: '',
-        website: '',
-        github: 'github.com/coderprateek/Emma-3D'
-    }
-];
-</pre>
+  {
+    slug: 'lost-in-cyberspace',
+    name: 'Lost in Cyberspace',
+    author: 'Zosia and Bartek',
+    twitter: 'bartaz',
+    website: '',
+    github: 'github.com/bartaz/lost-in-cyberspace'
+  },
+  {
+    slug: 'vernissage',
+    name: 'Vernissage',
+    author: 'Platane',
+    twitter: 'platane_',
+    website: 'github.com/Platane',
+    github: 'github.com/Platane/js13k-2017'
+  },
+  // ...
+  {
+    slug: 'emma-3d',
+    name: 'Emma-3D',
+    author: 'Prateek Roushan',
+    twitter: '',
+    website: '',
+    github: 'github.com/coderprateek/Emma-3D'
+  }
+];</pre>
 
 <p>Each entry in the array <code>games</code> describes a specific game, and has a corresponding image file in the <code>data/img/</code> directory. This is the content we'll load into the <code>content</code> section of the page using JavaScript code.</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a></li>
+    <li><a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a></li>
 </ul>


### PR DESCRIPTION
https://github.com/mdn/pwa-examples/pull/15 has just been merged: it updates the js13kgames example web app, used in the PWA guides, so that

- it uses modern syntax (fat arrows instead of functions, consts and lets over vars, ...)
- it fixes lint issues (variables not used, non-uniform indentation, ...)
- it is more readable, mainly through the rewrite of chained promises into async/await

This PR updates the MDN guides that reference these example app with the new code, in other words the code has already been reviewed, this PR only copy-pasted it at the right places and excaped the `<` and `>`