### PR TITLE
Adding at() docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -99,8 +99,8 @@ console.log(item2); // Logs: 'orange'
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('Array','#TBD','at')}}</td>
-   <td>{{Spec2('Array')}}</td>
+   <td>{{SpecName('ESDraft','#sec-array.prototype.at','Array.prototype.at')}}</td>
+   <td>{{Spec2('ESDraft')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>
@@ -110,7 +110,7 @@ console.log(item2); // Logs: 'orange'
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.Array.prototype.at")}}</p>
+<p>{{Compat("javascript.builtins.Array.at")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -66,27 +66,27 @@ for (let C of [Array, String, Uint8Array]) {
 
 <h2 id="Examples">Examples</h2>
 
-<h3>Return the last value of an array.</h3>
+<h3>Return the last value of an array</h3>
 
 <p>The following example provides a function which returns the last element found in a specified array.</p>
 
 <pre class="brush: js notranslate">
-  // Our array with items
-  const cart = ['apple', 'banana', 'pear'];
+// Our array with items
+const cart = ['apple', 'banana', 'pear'];
 
-  // A function which returns the last item of a given array
-  function returnLast(arr) {
-    return arr.at(-1);
-  }
+// A function which returns the last item of a given array
+function returnLast(arr) {
+  return arr.at(-1);
+}
 
-  // Get the last item of our array 'cart'
-  const item1 = returnLast(cart);
-  console.log(item1); // Logs: 'pear'
+// Get the last item of our array 'cart'
+const item1 = returnLast(cart);
+console.log(item1); // Logs: 'pear'
 
-  // Add an item to our 'cart' array
-  cart.push('orange');
-  const item2 = returnLast(cart);
-  console.log(item2); // Logs: 'orange'
+// Add an item to our 'cart' array
+cart.push('orange');
+const item2 = returnLast(cart);
+console.log(item2); // Logs: 'orange'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -13,15 +13,12 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for negative integers which count back from the last item.</p>
+<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.</p>
+
+<!-- changed -->
+<p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{domxref('Array.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-at.html")}}</div>
-
-<ul>
-  <li>If you need to find an element based on a provided testing function, use {{jsxref("Array.prototype.find()", "find()")}}.</li>
-  <li>If you need to find if a value <strong>exists</strong> in an array, use {{jsxref("Array.prototype.includes()")}}.</li>
-  <li>If you need the <strong>index</strong> of an element in the array, use {{jsxref("Array.indexOf", "indexOf()")}}.</li>
-</ul>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -38,31 +35,6 @@ tags:
 
 <p>The element in the array matching the given index. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
 
-
-<h2 id="Polyfill">Polyfill</h2>
-
-<p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>Array.prototype.at</code> with the following snippet:</p>
-
-<pre class="brush: js notranslate">
-function at(n) {
-	// ToInteger() abstract op
-	n = Math.trunc(n) || 0;
-	// Allow negative indexing from the end
-	if(n < 0) n += this.length;
-	// OOB access is guaranteed to return undefined
-	if(n < 0 || n >= this.length) return undefined;
-	// Otherwise, this is just normal property access
-	return this[n];
-}
-
-// Other TypedArray constructors omitted for brevity.
-for (let C of [Array, String, Uint8Array]) {
-    Object.defineProperty(C.prototype, "at",
-                        { value: at,
-                          writable: true,
-                          enumerable: false,
-                          configurable: true });
-}</pre>
 
 <h2 id="Examples">Examples</h2>
 
@@ -89,21 +61,39 @@ const item2 = returnLast(cart);
 console.log(item2); // Logs: 'orange'
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
+<h3>Comparing methods</h3>
+
+<p>Here we compare different ways to select the penultimate (last but one) item of an {{domxref('Array')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
+
+<pre class="brush: js notranslate">
+// Our array with items
+const colors = ['red', 'green', 'blue'];
+
+// Using length property
+const lengthWay = colors[colors.length-2];
+console.log(lengthWay); // Logs: 'green'
+
+// Using slice() method. Note an array is returned
+const sliceWay = colors.slice(-2, -1);
+console.log(sliceWay[0]); // Logs: 'green'
+
+// Using at() method
+const atWay = colors.at(-2);
+console.log(atWay); // Logs: 'green'
+</pre>
+
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft','#sec-array.prototype.at','Array.prototype.at')}}</td>
-   <td>{{Spec2('ESDraft')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('Relative Indexing Method', '#sec-array-prototype-additions', 'Relative Indexing Method')}}</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -115,6 +105,7 @@ console.log(item2); // Logs: 'orange'
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="https://github.com/tc39/proposal-relative-indexing-method#polyfill">A polyfill for the at() method</a>.</li>
   <li>{{jsxref("Array.prototype.find()")}} – return a value based on a given test.</li>
   <li>{{jsxref("Array.prototype.includes()")}} – test whether a value exists in the array.</li>
   <li>{{jsxref("Array.prototype.indexOf()")}} – return the index of a given element.</li>

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -25,7 +25,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>item</var> = arr.at(index)</pre>
+<pre class="syntaxbox notranslate">arr.at(index)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -62,7 +62,7 @@ console.log(item2); // Logs: 'orange'
 
 <h3>Comparing methods</h3>
 
-<p>Here we compare different ways to select the penultimate (last but one) item of an {{domxref('Array')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
+<p>Here we compare different ways to select the penultimate (last but one) item of an {{jsxref('Array')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
 
 <pre class="brush: js notranslate">
 // Our array with items

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.</p>
 
-<p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{domxref('Array.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
+<p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{jsxref('Array.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-at.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -1,0 +1,122 @@
+---
+title: Array.prototype.at()
+slug: Web/JavaScript/Reference/Global_Objects/Array/at
+tags:
+  - Array
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
+  - polyfill
+  - at
+  - Experimental
+---
+<div>{{JSRef}}</div>
+
+<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for negative integers which count back from the last item.</p>
+
+<div>{{EmbedInteractiveExample("pages/js/array-at.html","shorter")}}</div>
+
+<ul>
+  <li>If you need to find an element based on a provided testing function, use {{jsxref("Array.prototype.find()", "find()")}}.</li>
+  <li>If you need to find if a value <strong>exists</strong> in an array, use {{jsxref("Array.prototype.includes()")}}.</li>
+  <li>If you need the <strong>index</strong> of an element in the array, use {{jsxref("Array.indexOf", "indexOf()")}}.</li>
+</ul>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>item</var> = arr.at(index)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>index</code></dt>
+  <dd>The index (position) of the array element to be returned. Supports relative indexing from the end of the array when passed a negative index. i.e. If a negative number is used the element returned will be found by counting back from the end of the array.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The element in the array matching the given index. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
+
+
+<h2 id="Polyfill">Polyfill</h2>
+
+<p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>Array.prototype.at</code> with the following snippet:</p>
+
+<pre class="brush: js notranslate">
+function at(n) {
+	// ToInteger() abstract op
+	n = Math.trunc(n) || 0;
+	// Allow negative indexing from the end
+	if(n < 0) n += this.length;
+	// OOB access is guaranteed to return undefined
+	if(n < 0 || n >= this.length) return undefined;
+	// Otherwise, this is just normal property access
+	return this[n];
+}
+
+// Other TypedArray constructors omitted for brevity.
+for (let C of [Array, String, Uint8Array]) {
+    Object.defineProperty(C.prototype, "at",
+                        { value: at,
+                          writable: true,
+                          enumerable: false,
+                          configurable: true });
+}</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Return the last value of an array.</h3>
+
+<p>The following example provides a function which returns the last element found in a specified array.</p>
+
+<pre class="brush: js notranslate">
+  // Our array with items
+  const cart = ['apple', 'banana', 'pear'];
+
+  // A function which returns the last item of a given array
+  function returnLast(arr) {
+    return arr.at(-1);
+  }
+
+  // Get the last item of our array 'cart'
+  const item1 = returnLast(cart);
+  console.log(item1); // Logs: 'pear'
+
+  // Add an item to our 'cart' array
+  cart.push('orange');
+  const item2 = returnLast(cart);
+  console.log(item2); // Logs: 'orange'
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('Array','#TBD','at')}}</td>
+   <td>{{Spec2('Array')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.Array.prototype.at")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{jsxref("Array.prototype.find()")}} – return a value based on a given test.</li>
+  <li>{{jsxref("Array.prototype.includes()")}} – test whether a value exists in the array.</li>
+  <li>{{jsxref("Array.prototype.indexOf()")}} – return the index of a given element.</li>
+</ul>
+

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -15,7 +15,6 @@ tags:
 
 <p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.</p>
 
-<!-- changed -->
 <p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{domxref('Array.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-at.html")}}</div>

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for negative integers which count back from the last item.</p>
 
-<div>{{EmbedInteractiveExample("pages/js/array-at.html","shorter")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/array-at.html")}}</div>
 
 <ul>
   <li>If you need to find an element based on a provided testing function, use {{jsxref("Array.prototype.find()", "find()")}}.</li>

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -31,7 +31,7 @@ tags:
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>The index (position) of the array element to be returned. Supports relative indexing from the end of the array when passed a negative index. i.e. If a negative number is used the element returned will be found by counting back from the end of the array.</dd>
+  <dd>The index (position) of the array element to be returned. Supports relative indexing from the end of the array when passed a negative index; i.e. if a negative number is used, the element returned will be found by counting back from the end of the array.</dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>
@@ -119,4 +119,3 @@ for (let C of [Array, String, Uint8Array]) {
   <li>{{jsxref("Array.prototype.includes()")}} – test whether a value exists in the array.</li>
   <li>{{jsxref("Array.prototype.indexOf()")}} – return the index of a given element.</li>
 </ul>
-

--- a/files/en-us/web/javascript/reference/global_objects/array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.html
@@ -279,6 +279,8 @@ const myArray = myRe.exec('cdbBdbsbz')
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
+ <dt>{{jsxref("Array.prototype.at()")}}{{Experimental_Inline}}</dt>
+ <dd>Returns the array item at the given index. Accepts negative integers which count back from the last item.</dd>
  <dt>{{jsxref("Array.prototype.concat()")}}</dt>
  <dd>Returns a new array that is this array joined with other array(s) and/or value(s).</dd>
  <dt>{{jsxref("Array.prototype.copyWithin()")}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.html
@@ -280,7 +280,7 @@ const myArray = myRe.exec('cdbBdbsbz')
 
 <dl>
  <dt>{{jsxref("Array.prototype.at()")}}{{Experimental_Inline}}</dt>
- <dd>Returns the array item at the given index. Accepts negative integers which count back from the last item.</dd>
+ <dd>Returns the array item at the given index. Accepts negative integers, which count back from the last item.</dd>
  <dt>{{jsxref("Array.prototype.concat()")}}</dt>
  <dd>Returns a new array that is this array joined with other array(s) and/or value(s).</dd>
  <dt>{{jsxref("Array.prototype.copyWithin()")}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -60,7 +60,7 @@ for (let C of [Array, String, Uint8Array]) {
 
 <h2 id="Examples">Examples</h2>
 
-<h3>Return the last character of a string.</h3>
+<h3>Return the last character of a string</h3>
 
 <p>The following example provides a function which returns the last character found in a specified string.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -33,7 +33,6 @@ tags:
 
 <p>A {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified position. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
 
-
 <h2 id="Polyfill">Polyfill</h2>
 
 <p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>String.prototype.at</code> with the following snippet:</p>
@@ -66,21 +65,20 @@ for (let C of [Array, String, Uint8Array]) {
 <p>The following example provides a function which returns the last character found in a specified string.</p>
 
 <pre class="brush: js notranslate">
-  // A function which returns the last character of a given string
-  function returnLast(arr) {
-    return arr.at(-1);
-  }
+// A function which returns the last character of a given string
+function returnLast(arr) {
+  return arr.at(-1);
+}
 
-  let invoiceRef = 'myinvoice01';
+let invoiceRef = 'myinvoice01';
 
-	console.log( returnLast(invoiceRef) );
-	// Logs: '1'
+console.log( returnLast(invoiceRef) );
+// Logs: '1'
 
-	invoiceRef = 'myinvoice02';
+invoiceRef = 'myinvoice02';
 
-	console.log( returnLast(invoiceRef) );
-	// Logs: '2'
-
+console.log( returnLast(invoiceRef) );
+// Logs: '2'
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -1,0 +1,118 @@
+---
+title: String.prototype.at()
+slug: Web/JavaScript/Reference/Global_Objects/String/at
+tags:
+  - String
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
+  - polyfill
+  - at
+  - Experimental
+---
+<div>{{JSRef}}</div>
+
+<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns a new {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified offset. This method allows for negative integers which count back from the last string character.</p>
+
+<div>{{EmbedInteractiveExample("pages/js/string-at.html","shorter")}}</div>
+
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">let <var>character</var> = string.at(index)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>index</code></dt>
+  <dd>The index (position) of the string character to be returned. Supports relative indexing from the end of the string when passed a negative index. i.e. If a negative number is used the character returned will be found by counting back from the end of the string.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified position. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
+
+
+<h2 id="Polyfill">Polyfill</h2>
+
+<p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>String.prototype.at</code> with the following snippet:</p>
+
+<pre class="brush: js notranslate">
+function at(n) {
+	// ToInteger() abstract op
+	n = Math.trunc(n) || 0;
+	// Allow negative indexing from the end
+	if(n < 0) n += this.length;
+	// OOB access is guaranteed to return undefined
+	if(n < 0 || n >= this.length) return undefined;
+	// Otherwise, this is just normal property access
+	return this[n];
+}
+
+// Other TypedArray constructors omitted for brevity.
+for (let C of [Array, String, Uint8Array]) {
+    Object.defineProperty(C.prototype, "at",
+                        { value: at,
+                          writable: true,
+                          enumerable: false,
+                          configurable: true });
+}</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Return the last character of a string.</h3>
+
+<p>The following example provides a function which returns the last character found in a specified string.</p>
+
+<pre class="brush: js notranslate">
+  // A function which returns the last character of a given string
+  function returnLast(arr) {
+    return arr.at(-1);
+  }
+
+  let invoiceRef = 'myinvoice01';
+
+	console.log( returnLast(invoiceRef) );
+	// Logs: '1'
+
+	invoiceRef = 'myinvoice02';
+
+	console.log( returnLast(invoiceRef) );
+	// Logs: '2'
+
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('String','#TBD','at')}}</td>
+   <td>{{Spec2('String')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.String.prototype.at")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{jsxref("String.prototype.indexOf()")}}</li>
+  <li>{{jsxref("String.prototype.lastIndexOf()")}}</li>
+  <li>{{jsxref("String.prototype.charCodeAt()")}}</li>
+  <li>{{jsxref("String.prototype.codePointAt()")}}</li>
+  <li>{{jsxref("String.prototype.split()")}}</li>
+</ul>
+

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -26,7 +26,7 @@ tags:
 
 <dl>
   <dt><code>index</code></dt>
-  <dd>The index (position) of the string character to be returned. Supports relative indexing from the end of the string when passed a negative index. i.e. If a negative number is used the character returned will be found by counting back from the end of the string.</dd>
+  <dd>The index (position) of the string character to be returned. Supports relative indexing from the end of the string when passed a negative index; i.e. if a negative number is used, the character returned will be found by counting back from the end of the string.</dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>
@@ -115,4 +115,3 @@ for (let C of [Array, String, Uint8Array]) {
   <li>{{jsxref("String.prototype.codePointAt()")}}</li>
   <li>{{jsxref("String.prototype.split()")}}</li>
 </ul>
-

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -91,8 +91,8 @@ console.log( returnLast(invoiceRef) );
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('String','#TBD','at')}}</td>
-   <td>{{Spec2('String')}}</td>
+   <td>{{SpecName('ESDraft','#sec-string.prototype.at','String.prototype.at')}}</td>
+   <td>{{Spec2('ESDraft')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>
@@ -102,7 +102,7 @@ console.log( returnLast(invoiceRef) );
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.String.prototype.at")}}</p>
+<p>{{Compat("javascript.builtins.String.at")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns a new {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified offset. This method allows for negative integers which count back from the last string character.</p>
+<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns a new {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified offset. This method allows for positive and negative integers. Negative integers count back from the last string character.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/string-at.html","shorter")}}</div>
 
@@ -32,31 +32,6 @@ tags:
 <h3 id="Returns">Return value</h3>
 
 <p>A {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified position. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
-
-<h2 id="Polyfill">Polyfill</h2>
-
-<p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>String.prototype.at</code> with the following snippet:</p>
-
-<pre class="brush: js notranslate">
-function at(n) {
-	// ToInteger() abstract op
-	n = Math.trunc(n) || 0;
-	// Allow negative indexing from the end
-	if(n < 0) n += this.length;
-	// OOB access is guaranteed to return undefined
-	if(n < 0 || n >= this.length) return undefined;
-	// Otherwise, this is just normal property access
-	return this[n];
-}
-
-// Other TypedArray constructors omitted for brevity.
-for (let C of [Array, String, Uint8Array]) {
-    Object.defineProperty(C.prototype, "at",
-                        { value: at,
-                          writable: true,
-                          enumerable: false,
-                          configurable: true });
-}</pre>
 
 <h2 id="Examples">Examples</h2>
 
@@ -81,21 +56,39 @@ console.log( returnLast(invoiceRef) );
 // Logs: '2'
 </pre>
 
+<h3>Comparing methods</h3>
+
+<p>Here we compare different ways to select the penultimate (last but one) character of a {{domxref('String')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
+
+<pre class="brush: js notranslate">
+const myString = 'Every green bus drives fast.';
+
+// Using length property and charAt() method
+const lengthWay = myString.charAt(myString.length-2);
+console.log(lengthWay); // Logs: 't'
+
+// Using slice() method
+const sliceWay = myString.slice(-2, -1);
+console.log(sliceWay); // Logs: 't'
+
+// Using at() method
+const atWay = myString.at(-2);
+console.log(atWay); // Logs: 't'
+</pre>
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft','#sec-string.prototype.at','String.prototype.at')}}</td>
-   <td>{{Spec2('ESDraft')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('Relative Indexing Method', '#sec-string-prototype-additions', 'Relative Indexing Method')}}</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -107,6 +100,7 @@ console.log( returnLast(invoiceRef) );
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="https://github.com/tc39/proposal-relative-indexing-method#polyfill">A polyfill for the at() method</a>.</li>
   <li>{{jsxref("String.prototype.indexOf()")}}</li>
   <li>{{jsxref("String.prototype.lastIndexOf()")}}</li>
   <li>{{jsxref("String.prototype.charCodeAt()")}}</li>

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns a new {{jsxref('String')}} consisting of the single UTF-16 code unit located at the specified offset. This method allows for positive and negative integers. Negative integers count back from the last string character.</p>
 
-<div>{{EmbedInteractiveExample("pages/js/string-at.html","shorter")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/string-at.html")}}</div>
 
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -58,7 +58,7 @@ console.log( returnLast(invoiceRef) );
 
 <h3>Comparing methods</h3>
 
-<p>Here we compare different ways to select the penultimate (last but one) character of a {{domxref('String')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
+<p>Here we compare different ways to select the penultimate (last but one) character of a {{jsxref('String')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
 
 <pre class="brush: js notranslate">
 const myString = 'Every green bus drives fast.';

--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -282,6 +282,8 @@ otherwise my code is unreadable."
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
+ <dt>{{jsxref("String.prototype.at()", "String.prototype.at(<var>index</var>)")}}{{Experimental_Inline}}</dt>
+ <dd>Returns the character (exactly one UTF-16 code unit) at the specified <code><var>index</var></code>. Accepts negative integers, which count back from the last string character.</dd>
   <dt>{{jsxref("String.prototype.charAt()", "String.prototype.charAt(<var>index</var>)")}}
   </dt>
   <dd>Returns the character (exactly one UTF-16 code unit) at the specified

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.</p>
 
-<p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{domxref('TypedArray.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
+<p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{jsxref('TypedArray.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-at.html","shorter")}}</div>
 
@@ -104,4 +104,3 @@ console.log(atWay); // Logs: 11
   <li>{{jsxref("TypedArray.prototype.includes()")}} – test whether a value exists in the array.</li>
   <li>{{jsxref("TypedArray.prototype.indexOf()")}} – return the index of a given element.</li>
 </ul>
-

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -87,8 +87,8 @@ console.log(lastItem); // Logs: 18
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('TypedArray','#TBD','at')}}</td>
-   <td>{{Spec2('TypedArray')}}</td>
+   <td>{{SpecName('ESDraft','#sec-%typedarray%.prototype.at','TypedArray.prototype.at')}}</td>
+   <td>{{Spec2('ESDraft')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>
@@ -98,7 +98,7 @@ console.log(lastItem); // Logs: 18
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.TypedArray.prototype.at")}}</p>
+<p>{{Compat("javascript.builtins.TypedArray.at")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -14,7 +14,9 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index. This method allows for negative integers which count back from the last item.</p>
+<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index, allowing for positive and negative integers. Negative integers count back from the last item in the array.</p>
+
+<p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{domxref('TypedArray.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-at.html","shorter")}}</div>
 
@@ -34,31 +36,6 @@ tags:
 <p>The element in the array matching the given index. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
 
 
-<h2 id="Polyfill">Polyfill</h2>
-
-<p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>Array.prototype.at</code> with the following snippet:</p>
-
-<pre class="brush: js notranslate">
-function at(n) {
-	// ToInteger() abstract op
-	n = Math.trunc(n) || 0;
-	// Allow negative indexing from the end
-	if(n < 0) n += this.length;
-	// OOB access is guaranteed to return undefined
-	if(n < 0 || n >= this.length) return undefined;
-	// Otherwise, this is just normal property access
-	return this[n];
-}
-
-// Other TypedArray constructors omitted for brevity.
-for (let C of [Array, String, Uint8Array]) {
-    Object.defineProperty(C.prototype, "at",
-                        { value: at,
-                          writable: true,
-                          enumerable: false,
-                          configurable: true });
-}</pre>
-
 <h2 id="Examples">Examples</h2>
 
 <h3>Return the last value of a typed array</h3>
@@ -77,21 +54,40 @@ const lastItem = returnLast(uint8);
 console.log(lastItem); // Logs: 18
 </pre>
 
+<h3>Comparing methods</h3>
+
+<p>Here we compare different ways to select the penultimate (last but one) item of a {{domxref('TypedArray')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
+
+<pre class="brush: js notranslate">
+// Our typed array with values
+const uint8 = new Uint8Array([1, 2, 4, 7, 11, 18]);
+
+// Using length property
+const lengthWay = uint8[uint8.length-2];
+console.log(lengthWay); // Logs: 11
+
+// Using slice() method. Note an array is returned
+const sliceWay = uint8.slice(-2, -1);
+console.log(sliceWay[0]); // Logs: 11
+
+// Using at() method
+const atWay = uint8.at(-2);
+console.log(atWay); // Logs: 11
+</pre>
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft','#sec-%typedarray%.prototype.at','TypedArray.prototype.at')}}</td>
-   <td>{{Spec2('ESDraft')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('Relative Indexing Method', '#sec-%typedarray.prototype%-additions', 'Relative Indexing Method')}}</td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -103,6 +99,7 @@ console.log(lastItem); // Logs: 18
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="https://github.com/tc39/proposal-relative-indexing-method#polyfill">A polyfill for the at() method</a>.</li>
   <li>{{jsxref("TypedArray.prototype.find()")}} – return a value based on a given test.</li>
   <li>{{jsxref("TypedArray.prototype.includes()")}} – test whether a value exists in the array.</li>
   <li>{{jsxref("TypedArray.prototype.indexOf()")}} – return the index of a given element.</li>

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -18,7 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-at.html","shorter")}}</div>
 
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox notranslate">var <var>item</var> = typedArr.at(index)</pre>
@@ -62,21 +61,20 @@ for (let C of [Array, String, Uint8Array]) {
 
 <h2 id="Examples">Examples</h2>
 
-<h3>Return the last value of a typed array.</h3>
+<h3>Return the last value of a typed array</h3>
 
 <p>The following example provides a function which returns the last element found in a specified array.</p>
 
 <pre class="brush: js notranslate">
-  const uint8 = new Uint8Array([1, 2, 4, 7, 11, 18]);
+const uint8 = new Uint8Array([1, 2, 4, 7, 11, 18]);
 
-  // A function which returns the last item of a given array
-  function returnLast(arr) {
-    return arr.at(-1);
-  }
+// A function which returns the last item of a given array
+function returnLast(arr) {
+  return arr.at(-1);
+}
 
-  const lastItem = returnLast(uint8);
-  console.log(lastItem); // Logs: 18
-
+const lastItem = returnLast(uint8);
+console.log(lastItem); // Logs: 18
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>This is not to suggest there is anything wrong with using the square bracket notation. For example <code>array[0]</code> would return the first item. However instead of using {{jsxref('TypedArray.prototype.length','array.length')}} for latter items; e.g. <code>array[array.length-1]</code> for the last item, you can call <code>array.at(-1)</code>. <a href="#Examples">(See the examples below)</a></p>
 
-<div>{{EmbedInteractiveExample("pages/js/typedarray-at.html","shorter")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/typedarray-at.html")}}</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -56,7 +56,7 @@ console.log(lastItem); // Logs: 18
 
 <h3>Comparing methods</h3>
 
-<p>Here we compare different ways to select the penultimate (last but one) item of a {{domxref('TypedArray')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
+<p>Here we compare different ways to select the penultimate (last but one) item of a {{jsxref('TypedArray')}}. Whilst all below methods are valid, it highlights the succinctness and readability of the <code>at()</code> method.</p>
 
 <pre class="brush: js notranslate">
 // Our typed array with values

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -1,0 +1,112 @@
+---
+title: TypedArray.prototype.at()
+slug: Web/JavaScript/Reference/Global_Objects/TypedArray/at
+tags:
+  - TypedArray
+  - TypedArrays
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
+  - polyfill
+  - at
+  - Experimental
+---
+<div>{{JSRef}}</div>
+
+<p class="summary">The <strong><code>at()</code></strong> method takes an integer value and returns the item at that index. This method allows for negative integers which count back from the last item.</p>
+
+<div>{{EmbedInteractiveExample("pages/js/typedarray-at.html","shorter")}}</div>
+
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>item</var> = typedArr.at(index)</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>index</code></dt>
+  <dd>The index (position) of the array element to be returned. Supports relative indexing from the end of the array when passed a negative index. i.e. If a negative number is used the element returned will be found by counting back from the end of the array.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The element in the array matching the given index. Returns {{jsxref('undefined')}} if the given index can not be found.</p>
+
+
+<h2 id="Polyfill">Polyfill</h2>
+
+<p>This method may not be available in all JavaScript implementations yet. However you can polyfill <code>Array.prototype.at</code> with the following snippet:</p>
+
+<pre class="brush: js notranslate">
+function at(n) {
+	// ToInteger() abstract op
+	n = Math.trunc(n) || 0;
+	// Allow negative indexing from the end
+	if(n < 0) n += this.length;
+	// OOB access is guaranteed to return undefined
+	if(n < 0 || n >= this.length) return undefined;
+	// Otherwise, this is just normal property access
+	return this[n];
+}
+
+// Other TypedArray constructors omitted for brevity.
+for (let C of [Array, String, Uint8Array]) {
+    Object.defineProperty(C.prototype, "at",
+                        { value: at,
+                          writable: true,
+                          enumerable: false,
+                          configurable: true });
+}</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Return the last value of a typed array.</h3>
+
+<p>The following example provides a function which returns the last element found in a specified array.</p>
+
+<pre class="brush: js notranslate">
+  const uint8 = new Uint8Array([1, 2, 4, 7, 11, 18]);
+
+  // A function which returns the last item of a given array
+  function returnLast(arr) {
+    return arr.at(-1);
+  }
+
+  const lastItem = returnLast(uint8);
+  console.log(lastItem); // Logs: 18
+
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('TypedArray','#TBD','at')}}</td>
+   <td>{{Spec2('TypedArray')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TypedArray.prototype.at")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{jsxref("TypedArray.prototype.find()")}} – return a value based on a given test.</li>
+  <li>{{jsxref("TypedArray.prototype.includes()")}} – test whether a value exists in the array.</li>
+  <li>{{jsxref("TypedArray.prototype.indexOf()")}} – return the index of a given element.</li>
+</ul>
+

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.html
@@ -254,7 +254,7 @@ new <var>TypedArray</var>(<var>buffer</var> [, <var>byteOffset</var> [, <var>len
 
 <dl>
   <dt>{{jsxref("TypedArray.prototype.at()")}}</dt>
-  <dd>Takes an integer value and returns the item at that index. This method allows for negative integers which count back from the last item.</dd>
+  <dd>Takes an integer value and returns the item at that index. This method allows for negative integers, which count back from the last item.</dd>
   <dt>{{jsxref("TypedArray.prototype.copyWithin()")}}</dt>
   <dd>Copies a sequence of array elements within the array. See also
     {{jsxref("Array.prototype.copyWithin()")}}.</dd>

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.html
@@ -253,6 +253,8 @@ new <var>TypedArray</var>(<var>buffer</var> [, <var>byteOffset</var> [, <var>len
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
+  <dt>{{jsxref("TypedArray.prototype.at()")}}</dt>
+  <dd>Takes an integer value and returns the item at that index. This method allows for negative integers which count back from the last item.</dd>
   <dt>{{jsxref("TypedArray.prototype.copyWithin()")}}</dt>
   <dd>Copies a sequence of array elements within the array. See also
     {{jsxref("Array.prototype.copyWithin()")}}.</dd>


### PR DESCRIPTION
Adding array.at(), string.at() and typedarray.at() pages.

Looking at a review as these are actually my first js ref docs... some notes:

* Live samples won't work until this pr is merged https://github.com/mdn/interactive-examples/pull/1753/files (not sure why tests are failing)
* Note BCD data is not yet in
* Not sure what to reference in the way of spec which is here https://tc39.es/proposal-relative-indexing-method/

tl:dr; please review but don't merge until I've resolved above :) @chrisdavidmills 