### PR TITLE
Document the serialization algorithm used by extensions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/index.html
@@ -46,7 +46,7 @@ setCookie<span class="punctuation token">.</span><span class="function token">th
 
 <p>Microsoft Edge uses the <code>browser</code> namespace, but doesn't yet support promise-based asynchronous APIs. In Edge, for the time being, asynchronous APIs must use callbacks.</p>
 
-<p>Not all browsers support all the APIs: for the details, see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs">Browser support for JavaScript APIs</a>.</p>
+<p>Not all browsers support all the APIs: for the details, see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs">Browser support for JavaScript APIs</a> and <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">Chrome incompatibilities</a>.</p>
 
 <h2 id="Examples">Examples </h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -88,12 +88,12 @@ browser.runtime.onMessage.hasListener(<var>listener</var>)
 
  <dl class="reference-values">
   <dt><code><var>message</var></code></dt>
-  <dd><code>object</code>. The message itself. This is a JSON-ifiable object.</dd>
+  <dd><code>object</code>. The message itself. This is a serializable object (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Data_cloning_algorithm">Data cloning algorithm</a>).</dd>
   <dt><code><var>sender</var></code></dt>
   <dd>A {{WebExtAPIRef('runtime.MessageSender')}} object representing the sender of the message.</dd>
   <dt><code><var>sendResponse</var></code></dt>
   <dd>
-  <p>A function to call, at most once, to send a response to the <code><var>message</var></code>. The function takes a single argument, which may be any JSON-ifiable object. This argument is passed back to the message sender.</p>
+  <p>A function to call, at most once, to send a response to the <code><var>message</var></code>. The function takes a single argument, which may be any serializable object (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Data_cloning_algorithm">Data cloning algorithm</a>). This argument is passed back to the message sender.</p>
 
   <p>If you have more than one <code>onMessage()</code> listener in the same document, then only one may send a response.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>One side initiates the connection, using a <code>connect()</code> API. This returns a <code>Port</code> object. The other side listens for connection attempts using an <code>onConnect</code> listener. This is passed a corresponding <code>Port</code> object.</p>
 
-<p>Once both sides have <code>Port</code> objects, they can exchange JSON messages using <code>Port.postMessage()</code> and <code>Port.onMessage</code>. When they are finished, either end can disconnect using <code>Port.disconnect()</code>, which will generate a <code>Port.onDisconnect</code> event at the other end, enabling the other end to do any cleanup required.</p>
+<p>Once both sides have <code>Port</code> objects, they can exchange messages using <code>Port.postMessage()</code> and <code>Port.onMessage</code>. When they are finished, either end can disconnect using <code>Port.disconnect()</code>, which will generate a <code>Port.onDisconnect</code> event at the other end, enabling the other end to do any cleanup required.</p>
 
 <p>You can use this pattern to communicate between:</p>
 
@@ -86,9 +86,9 @@ tags:
  <p>Note that in Google Chrome <code>port.error</code> is not supported: instead, use {{WebExtAPIRef("runtime.lastError")}} to get the error message.</p>
  </dd>
  <dt><code>onMessage</code></dt>
- <dd><code>object</code>. This contains the <code>addListener()</code> and <code>removeListener()</code> functions common to all events for extensions built using WebExtension APIs. Listener functions will be called when the other end has sent this port a message. The listener will be passed the JSON object that the other end sent.</dd>
+ <dd><code>object</code>. This contains the <code>addListener()</code> and <code>removeListener()</code> functions common to all events for extensions built using WebExtension APIs. Listener functions will be called when the other end has sent this port a message. The listener will be passed the value that the other end sent.</dd>
  <dt><code>postMessage</code></dt>
- <dd><code>function</code>. Send a message to the other end. This takes one argument, which is a JSON object representing the message to send. It will be delivered to any script listening to the port's <code>onMessage</code> event, or to the native application if this port is connected to a native application.</dd>
+ <dd><code>function</code>. Send a message to the other end. This takes one argument, which is a serializable value (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Data_cloning_algorithm">Data cloning algorithm</a>) representing the message to send. It will be delivered to any script listening to the port's <code>onMessage</code> event, or to the native application if this port is connected to a native application.</dd>
  <dt><code>sender</code>{{optional_inline}}</dt>
  <dd>{{WebExtAPIRef('runtime.MessageSender')}}. Contains information about the sender of the message. This property will only be present on ports passed to <code>onConnect</code>/<code>onConnectExternal</code> listeners.</dd>
 </dl>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -44,7 +44,7 @@ tags:
  <dd><code>string</code>. The ID of the extension to send the message to. Include this to send the message to a different extension. If the intended recipient has set an ID explicitly using the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications">applications</a> key in manifest.json, then <code>extensionId</code> should have that value. Otherwise it should have the ID that was generated for the intended recipient.</dd>
  <dd>If <code>extensionId</code> is omitted, the message will be sent to your own extension.</dd>
  <dt><code>message</code></dt>
- <dd><code>any</code>. An object that can be structured clone serialized.</dd>
+ <dd><code>any</code>. An object that can be structured clone serialized (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Data_cloning_algorithm">Data cloning algorithm</a>).</dd>
  <dt><code>options</code>{{optional_inline}}</dt>
  <dd><code>object</code>.
  <dl class="reference-values">
@@ -78,7 +78,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>. If the receiver sent a response, this will be fulfilled with the response as a JSON object. Otherwise it will be fulfilled with no arguments. If an error occurs while connecting to the extension, the promise will be rejected with an error message.</p>
+<p>A <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>. If the receiver sent a response, this will be fulfilled with the response. Otherwise it will be fulfilled with no arguments. If an error occurs while connecting to the extension, the promise will be rejected with an error message.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
@@ -120,7 +120,7 @@ tags:
 
 <p>Here the results array will contain the string "<code>my result</code>" as an element.</p>
 
-<p>The result values must be <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clonable</a>.</p>
+<p>The result values must be <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clonable</a> (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Data_cloning_algorithm">Data cloning algorithm</a>).</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> The last statement may be also a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>, but this feature is unsupported by <a href="https://github.com/mozilla/webextension-polyfill#tabsexecutescript">webextension-polyfill</a> library.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
@@ -39,7 +39,7 @@ tags:
  <dt><code><var>tabId</var></code></dt>
  <dd><code>integer</code>. ID of the tab whose content scripts we want to send a message to.</dd>
  <dt><code><var>message</var></code></dt>
- <dd><code>any</code>. An object that can be serialized to JSON.</dd>
+ <dd><code>any</code>. An object that can be serialized (see <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Data_cloning_algorithm">Data cloning algorithm</a>).</dd>
  <dt><code><var>options</var></code> {{optional_inline}}</dt>
  <dd><code>object</code>.</dd>
  <dd>
@@ -52,7 +52,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{jsxref("Promise")}} that will be fulfilled with the JSON response object sent by the handler of the message in the content script, or with no arguments if the content script did not send a response.</p>
+<p>A {{jsxref("Promise")}} that will be fulfilled with the response object sent by the handler of the message in the content script, or with no arguments if the content script did not send a response.</p>
 
 <p>If an error occurs while connecting to the specified tab or any other error occurs, the promise will be rejected with an error message.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
@@ -369,3 +369,18 @@ setCookie.then(logCookie, logError);</pre>
  <dt>In Chrome</dt>
  <dd>The app manifest is expected in a different place. See <a href="https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location">Native messaging host location</a> in the Chrome docs.</dd>
 </dl>
+
+<h2 id="Data_cloning_algorithm">Data cloning algorithm</h2>
+
+<p>Some extension APIs allow an extension to send data from one part of the extension to another, such as {{WebExtAPIRef("runtime.sendMessage()")}}, {{WebExtAPIRef("tabs.sendMessage()")}}, {{WebExtAPIRef("runtime.onMessage")}}, the <code>postMessage()</code> method of {{WebExtAPIRef("runtime.port")}}, and {{WebExtAPIRef("tabs.executeScript()")}}.</p>
+
+<dl>
+ <dt>In Firefox</dt>
+ <dd>The <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">Structured clone algorithm</a> is used.</dd>
+ <dt>In Chrome</dt>
+ <dd>The <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description">JSON serialization algorithm</a> is used. It may switch to structured cloning in the future (<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=248548">issue 248548</a>).</dd>
+</dl>
+
+<p>The Structured clone algorithm supports more types than the JSON serialization algorithm. A notable exception are (DOM) objects with a <code>toJSON</code> method. DOM objects are not cloneable nor JSON-serializable by default, but with a <code>toJSON()</code> method, these can be JSON-serialized (but still not cloned with the structured cloning algorithm). Examples of JSON-serializable objects that are not structured cloneable include instances of {{domxref("URL")}} and {{domxref("PerformanceEntry")}}.</p>
+
+<p>Extension that rely on the <code>toJSON()</code> method of the JSON serialization algorithm can use {{jsxref("JSON.stringify()")}} followed by {{jsxref("JSON.parse()")}} to ensure that a message can be exchanged, because a parsed JSON value is always structurally cloneable.</p>


### PR DESCRIPTION
The current documentation is inconsistent and does not always reflect the actual behavior. This update adds a new section about the data cloning algorithm to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities and updates several references to this new section in the appropriate locations (and rewords some phrases if needed).

Resolves https://bugzilla.mozilla.org/show_bug.cgi?id=1685688