### PR TITLE
Portal element

### DIFF
--- a/files/en-us/web/html/element/portal/index.html
+++ b/files/en-us/web/html/element/portal/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{HTMLRef}}</div>
 
-<p><span class="seoSummary">The <strong>HTML Portal element (<code>&lt;portal&gt;</code>)</strong> allows for a {{Glossary("portal browsing context")}}, embedding another HTML page into the current one.</span></p>
+<p><span class="seoSummary">The <strong>HTML Portal element (<code>&lt;portal&gt;</code>)</strong> enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages.</span></p>
 
 <p>A <code>&lt;portal&gt;</code> is similar to an <code>&lt;iframe&gt;</code>. An <code>&lt;iframe&gt;</code> allows a separate {{Glossary("browsing context")}} to be embedded. However, the embedded content of a <code>&lt;portal&gt;</code> is more limited than that of an <code>&lt;iframe&gt;</code>. It cannot be interacted with, and therefore is not suitable for embedding widgets into a document. Instead, the <code>&lt;portal&gt;</code> acts as a preview of the content of another page. It can be navigated into therefore allowing for seamless transition to the embedded content.</p>
 

--- a/files/en-us/web/html/element/portal/index.html
+++ b/files/en-us/web/html/element/portal/index.html
@@ -1,0 +1,84 @@
+---
+title: '<portal>: The Portal element'
+slug: Web/HTML/Element/portal
+tags:
+  - Content
+  - Element
+  - Embedded content
+  - Embedding
+  - HTML
+  - HTML embedded content
+  - Reference
+  - Web
+  - Portal
+---
+<div>{{HTMLRef}}</div>
+
+<p><span class="seoSummary">The <strong>HTML Portal element (<code>&lt;portal&gt;</code>)</strong> allows for a {{Glossary("portal browsing context")}}, embedding another HTML page into the current one.</span></p>
+
+<p>A <code>&lt;portal&gt;</code> is similar to an <code>&lt;iframe&gt;</code>. An <code>&lt;iframe&gt;</code> allows a separate {{Glossary("browsing context")}} to be embedded. However, the embedded content of a <code>&lt;portal&gt;</code> is more limited than that of an <code>&lt;iframe&gt;</code>. It cannot be interacted with, and therefore is not suitable for embedding widgets into a document. Instead, the <code>&lt;portal&gt;</code> acts as a preview of the content of another page. It can be navigated into therefore allowing for seamless transition to the embedded content.</p>
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Implicit ARIA role</th>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></td>
+    </tr>
+    <tr>
+      <th scope="row">DOM interface</th>
+      <td>{{domxref("HTMLPortalElement")}}</td>
+     </tr>
+  </tbody>
+</table>
+   
+<h2 id="Attributes">Attributes</h2>
+
+<p>This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
+
+<dl>
+  <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
+  <dd>Sets the <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy">referrer policy</a> to use when requesting the page at the URL given as the value of the <code>src</code> attribute. 
+  </dd>
+  <dt id="attr-src">{{htmlattrdef("src")}}</dt>
+  <dd>The URL of the page to embed.</dd>
+</dl>
+
+<h2 id="Examples">Examples<h2>
+
+<h3>Basic example</h3>
+
+<p>The following example will embed the contents of <code>https://example.com</code> as a preview.</p>
+
+<pre class="brush:html">&lt;portal id="exampleportal" src="https://example.com/"&gt;&lt;/portal&gt;</pre>
+
+<h2 id="Accessibility_concerns">Accessibility concerns</h2>
+
+<p>The preview displayed by a <code>&lt;portal&gt;</code> is not interactive, therefore does not receive input events or focus. Therefore the embedded contents of the portal are not exposed as elements in the {{Glossary("accessibility tree")}}. The portal can be navigated to and activated like a button, the default behavior when clicking on the portal is to activate it.</p>
+
+<p>Portals are given a default label which is the title of the embedded page. If no title is present the visible text in the preview is concatenated to create a label. The {{htmlattrxref("aria-label")}} attribute can be used to override this.</p>
+
+<p>Portals used for prerendering only should be hidden with the hidden HTML attribute or the CSS {{cssxref("display")}} property with a value of <code>none</code>.</p>
+
+<p>When using animations during portal activation the {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}} <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features">media feature</a> should be respected.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+   <td>{{SpecName('Portals')}}</td>
+   <td>{{Spec2('Portals')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("html.elements.portal")}}</p>


### PR DESCRIPTION
Working on #1209 

This adds the new HTML `<portal>` element, in order that I can document the linked API.

The current spec is behind the explainer, so some of the detail here was taken from the new explainer document https://github.com/WICG/portals

Once I write the main Portals docs in the API reference this should link to that, I'm not sure it is useful putting a lot of examples on this page as the HTML element itself isn't especially useful.

I'll add BCD once I know we are happy to have BCD for these things in https://github.com/mdn/browser-compat-data/pull/8680

Reviewer @jpmedley 