### PR TITLE
"Strict mode": Rewrite paragraph about duplicate property names

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.html
+++ b/files/en-us/web/javascript/reference/strict_mode/index.html
@@ -142,7 +142,7 @@ false.true = '';         // TypeError
 
 })();</pre>
 
-<p>In ECMAScript 5 strict mode code, duplicate property names were considered a {{jsxref("SyntaxError")}}. With the introduction of <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer">computed property names</a> making duplication possible at runtime, ECMAScript 2015 has removed this restriction.</p>
+<p>In ECMAScript 5 strict-mode code, duplicate property names were considered a {{jsxref("SyntaxError")}}. With the introduction of <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer">computed property names</a>, making duplication possible at runtime, ECMAScript 2015 removed that restriction.</p>
 
 <pre class="brush: js notranslate">'use strict';
 var o = { p: 1, p: 2 }; // syntax error prior to ECMAScript 2015 

--- a/files/en-us/web/javascript/reference/strict_mode/index.html
+++ b/files/en-us/web/javascript/reference/strict_mode/index.html
@@ -108,17 +108,7 @@ fixed.newProp = 'ohai'; // throws a TypeError
 delete Object.prototype; // throws a TypeError
 </pre>
 
-<p>Fourth, strict mode prior to Gecko 34 requires that all properties named in an object literal be unique. The normal code may duplicate property names, with the last one determining the property's value. But since only the last one does anything, the duplication is a vector for bugs, if the code is modified to change the property value other than by changing the last instance. Duplicate property names are a syntax error in strict mode:</p>
-
-<div class="note">
-<p>This is no longer the case in ECMAScript 2015 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1041128">bug 1041128</a>).</p>
-</div>
-
-<pre class="brush: js notranslate">'use strict';
-var o = { p: 1, p: 2 }; // !!! syntax error
-</pre>
-
-<p>Fifth, strict mode requires that function parameter names be unique. In normal code the last duplicated argument hides previous identically-named arguments. Those previous arguments remain available through <code>arguments[i]</code>, so they're not completely inaccessible. Still, this hiding makes little sense and is probably undesirable (it might hide a typo, for example), so in strict mode duplicate argument names are a syntax error:</p>
+<p>Fourth, strict mode requires that function parameter names be unique. In normal code the last duplicated argument hides previous identically-named arguments. Those previous arguments remain available through <code>arguments[i]</code>, so they're not completely inaccessible. Still, this hiding makes little sense and is probably undesirable (it might hide a typo, for example), so in strict mode duplicate argument names are a syntax error:</p>
 
 <pre class="brush: js notranslate">function sum(a, a, c) { // !!! syntax error
   'use strict';
@@ -126,7 +116,7 @@ var o = { p: 1, p: 2 }; // !!! syntax error
 }
 </pre>
 
-<p>Sixth, a strict mode in ECMAScript 5 forbids octal syntax. The octal syntax isn't part of ECMAScript 5, but it's supported in all browsers by prefixing the octal number with a zero: <code>0644 === 420</code> and <code>"\045" === "%"</code>. In ECMAScript 2015 Octal number is supported by prefixing a number with "<code>0o</code>". i.e. </p>
+<p>Fifth, a strict mode in ECMAScript 5 forbids octal syntax. The octal syntax isn't part of ECMAScript 5, but it's supported in all browsers by prefixing the octal number with a zero: <code>0644 === 420</code> and <code>"\045" === "%"</code>. In ECMAScript 2015 Octal number is supported by prefixing a number with "<code>0o</code>". i.e. </p>
 
 <pre class="brush: js notranslate">var a = 0o10; // ES2015: Octal</pre>
 
@@ -141,7 +131,7 @@ var sumWithOctal = 0o10 + 8;
 console.log(sumWithOctal); // 16
 </pre>
 
-<p>Seventh, strict mode in ECMAScript 2015 forbids setting properties on <a href="/en-US/docs/Glossary/primitive">primitive</a> values. Without strict mode, setting properties is ignored (no-op), with strict mode, however, a {{jsxref("TypeError")}} is thrown.</p>
+<p>Sixth, strict mode in ECMAScript 2015 forbids setting properties on <a href="/en-US/docs/Glossary/primitive">primitive</a> values. Without strict mode, setting properties is ignored (no-op), with strict mode, however, a {{jsxref("TypeError")}} is thrown.</p>
 
 <pre class="brush: js notranslate">(function() {
 'use strict';
@@ -151,6 +141,12 @@ false.true = '';         // TypeError
 'with'.you = 'far away'; // TypeError
 
 })();</pre>
+
+<p>In ECMAScript 5 strict mode code, duplicate property names were considered a {{jsxref("SyntaxError")}}. With the introduction of <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer">computed property names</a> making duplication possible at runtime, ECMAScript 2015 has removed this restriction.</p>
+
+<pre class="brush: js notranslate">'use strict';
+var o = { p: 1, p: 2 }; // syntax error prior to ECMAScript 2015 
+</pre>
 
 <h3 id="Simplifying_variable_uses">Simplifying variable uses</h3>
 


### PR DESCRIPTION
Duplicate property names aren't an error in strict mode anymore, so I moved the content about it lower

Copied and modified some content from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer