### PR TITLE
MDN account → GitHub account in “Getting Started”

### DIFF
--- a/files/en-us/mdn/contribute/getting_started/index.html
+++ b/files/en-us/mdn/contribute/getting_started/index.html
@@ -21,20 +21,10 @@ tags:
 
 <p>Contributing is easy and safe. Even if you make a mistake, it's easily fixed. Even if you don't know exactly how things should look, or your grammar isn't all that good, don't worry about it! We have a team of people whose job it is to make sure that MDN's contents are as good as possible. Someone will be along to make sure your work is tidy and well-written. Share what you know and follow your strengths.</p>
 
-<h3 id="Step_1_Create_an_account_on_MDN">Step 1: Create an account on MDN</h3>
+<h3>Step 1: Create a GitHub account</h3>
 
-<p>To begin your contributions to MDN, you need to have an account on MDN. We presently allow authentication via <a href="https://www.google.com/account/about/">Google accounts</a> and <a href="https://github.com/join">GitHub accounts</a> — if you have one of these, you can use it to create an MDN account.</p>
+<p>To begin your contributions to MDN, you need to <a href="https://github.com/mdn/content/#setup">create a GitHub account</a>.</p>
 
-<p>To create an MDN account:</p>
-
-<ol>
- <li>If you are not signed in to MDN, you'll see a <em>Sign in</em> link at the top-right of any page. Select this link.</li>
- <li>You'll now be given two options, <em>Sign in the GitHub</em> and <em>Sign in with Google</em>. Choose the one that you want to authenticate with on MDN.</li>
- <li>You'll now be prompted to sign in to your chosen account / authenticate with it to continue on to MDN. Follow the on-screen instructions.</li>
- <li>When you come back to MDN, you'll be prompted to create a username and specify a few other credentials, and after that you'll be logged into MDN.</li>
-</ol>
-
-<p>In future if you want to log into MDN again you can just use the same authentication mechanism you used previously.</p>
 
 <h3 id="Step_2_Pick_a_task_to_complete">Step 2: Pick a task to complete</h3>
 


### PR DESCRIPTION
In MDN/Contribute/Getting_started, this change replaces guidance on creating an MDN account with a link to guidance on creating a GitHub account.