### PR TITLE
Update websocket/close doc to show all signatures

### DIFF
--- a/files/en-us/web/api/websocket/close/index.html
+++ b/files/en-us/web/api/websocket/close/index.html
@@ -17,7 +17,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate">WebSocket.close([code[, reason]]);</pre>
+<pre class="brush: js notranslate">WebSocket.close();</pre>
+<pre class="brush: js notranslate">WebSocket.close(code);</pre>
+<pre class="brush: js notranslate">WebSocket.close(reason);</pre>
+<pre class="brush: js notranslate">WebSocket.close(code, reason);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/websocket/close/index.html
+++ b/files/en-us/web/api/websocket/close/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate">WebSocket.close();</pre>
+<pre class="brush: js notranslate">WebSocket.close([code[, reason]]);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 


### PR DESCRIPTION
I added the same representation of parameters as shown in WebSocket's methods: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#methods