### PR TITLE
Remove HTMLVersionInline

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_article_role/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_article_role/index.html
@@ -10,7 +10,7 @@ tags:
 
 <p>Articles can be nested; for example, a web log entry on a site that accepts user-submitted comments could represent the comments as articles nested within the article for the web log entry.</p>
 
-<p>The ARIA article role is similar to the {{ HTMLVersionInline("5") }} <a href="/en/HTML/Element/article">article</a> element; however the <a href="/en/HTML/Element/article">article</a> element should still be given the ARIA role of article, since not all assistive technologies support HTML5 yet.</p>
+<p>The ARIA article role is similar to the <a href="/en-us/docs/Web/HTML/Element/article"><code>&lt;article&gt;</code></a> element; however the <a href="/en/HTML/Element/article">article</a> element should still be given the ARIA role of article, since not all assistive technologies support HTML5 yet.</p>
 
 <h3 id="Possible_effects_on_user_agents_and_assistive_technology">Possible effects on user agents and assistive technology </h3>
 

--- a/files/en-us/web/api/htmlbuttonelement/index.html
+++ b/files/en-us/web/api/htmlbuttonelement/index.html
@@ -43,13 +43,13 @@ tags:
  <dt>{{domxref("HTMLButtonElement.menu")}} {{experimental_inline}}</dt>
  <dd>Is a {{domxref("HTMLMenuElement")}} representing the menu element to be displayed if the button is clicked and is of <code>type="menu"</code>.</dd>
  <dt>{{domxref("HTMLButtonElement.name")}}</dt>
- <dd>Is a {{domxref("DOMString")}} representing the name of the object when submitted with a form. {{HTMLVersionInline(5)}} If specified, it must not be the empty string.</dd>
+ <dd>Is a {{domxref("DOMString")}} representing the name of the object when submitted with a form. If specified, it must not be the empty string.</dd>
  <dt>{{domxref("HTMLButtonElement.tabIndex")}}</dt>
  <dd>Is a <code>long</code> that represents this element's position in the tabbing order.</dd>
  <dt>{{domxref("HTMLButtonElement.type")}}</dt>
  <dd>Is a {{domxref("DOMString")}} indicating the behavior of the button. This is an enumerated attribute with the following possible values:
  <ul>
-  <li><code>submit</code>: The button submits the form. This is the default value if the attribute is not specified, {{HTMLVersionInline(5)}} or if it is dynamically changed to an empty or invalid value.</li>
+  <li><code>submit</code>: The button submits the form. This is the default value if the attribute is not specified, or if it is dynamically changed to an empty or invalid value.</li>
   <li><code>reset</code>: The button resets the form.</li>
   <li><code>button</code>: The button does nothing.</li>
   <li><code>menu</code>: The button displays a menu. {{experimental_inline}}</li>

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -196,7 +196,7 @@ tags:
   <tr>
    <td><code>readOnly</code></td>
    <td><em><code>boolean</code>:</em><strong> Returns / Sets</strong> the element's {{ htmlattrxref("readonly", "input") }} attribute, indicating that the user cannot modify the value of the control.<br>
-    {{HTMLVersionInline(5)}}This is ignored if the value of the {{htmlattrxref("type","input")}} attribute is <code>hidden</code>, <code>range</code>, <code>color</code>, <code>checkbox</code>, <code>radio</code>, <code>file</code>, or a button type.</td>
+    This is ignored if the value of the {{htmlattrxref("type","input")}} attribute is <code>hidden</code>, <code>range</code>, <code>color</code>, <code>checkbox</code>, <code>radio</code>, <code>file</code>, or a button type.</td>
   </tr>
   <tr>
    <td><code>selectionStart</code></td>

--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -27,7 +27,7 @@ tags:
 <p>This element's attributes include the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
 <dl>
- <dt id="download">{{HTMLAttrDef("download")}}{{HTMLVersionInline(5)}}</dt>
+ <dt id="download">{{HTMLAttrDef("download")}}</dt>
  <dd>Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:</dd>
  <dd>
  <ul>

--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -55,7 +55,7 @@ tags:
 <p>This element's attributes include the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
 <dl>
- <dt>{{htmlattrdef("autofocus")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("autofocus")}}</dt>
  <dd>This Boolean attribute specifies that the button should have input <a href="/en-US/docs/Web/API/HTMLOrForeignElement/focus">focus</a> when the page loads. <strong>Only one element in a document can have this attribute.</strong></dd>
  <dt>{{htmlattrdef("autocomplete")}} {{non-standard_inline}}</dt>
  <dd>This attribute on a {{HTMLElement("button")}} is nonstandard and Firefox-specific. Unlike other browsers, <a href="https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing">Firefox persists the dynamic disabled state</a> of a {{HTMLElement("button")}} across page loads. Setting <code>autocomplete="off"</code> on the button disables this feature; see {{bug(654072)}}.</dd>
@@ -65,12 +65,12 @@ tags:
 
  <p>Firefox, unlike other browsers, <a href="https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing">persists the dynamic disabled state</a> of a {{HTMLElement("button")}} across page loads. Use the {{htmlattrxref("autocomplete","button")}} attribute to control this feature.</p>
  </dd>
- <dt>{{htmlattrdef("form")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("form")}}</dt>
  <dd>The {{HTMLElement("form")}} element to associate the button with (its <em>form owner</em>). The value of this attribute must be the <code>id</code> of a <code>&lt;form&gt;</code> in the same document. (If this attribute is not set, the <code>&lt;button&gt;</code> is associated with its ancestor <code>&lt;form&gt;</code> element, if any.)</dd>
  <dd>This attribute lets you associate <code>&lt;button&gt;</code> elements to <code>&lt;form&gt;</code>s anywhere in the document, not just inside a <code>&lt;form&gt;</code>. It can also override an ancestor <code>&lt;form&gt;</code> element.</dd>
- <dt>{{htmlattrdef("formaction")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("formaction")}}</dt>
  <dd>The URL that processes the information submitted by the button. Overrides the {{htmlattrxref("action","form")}} attribute of the button's form owner. Does nothing if there is no form owner.</dd>
- <dt>{{htmlattrdef("formenctype")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("formenctype")}}</dt>
  <dd>If the button is a submit button (it's inside/associated with a <code>&lt;form&gt;</code> and doesn't have <code>type="button"</code>), specifies how to encode the form data that is submitted. Possible values:
  <ul>
   <li><code>application/x-www-form-urlencoded</code>: The default if the attribute is not used.</li>
@@ -80,7 +80,7 @@ tags:
 
  <p>If this attribute is specified, it overrides the {{htmlattrxref("enctype","form")}} attribute of the button's form owner.</p>
  </dd>
- <dt>{{htmlattrdef("formmethod")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("formmethod")}}</dt>
  <dd>If the button is a submit button (it's inside/associated with a <code>&lt;form&gt;</code> and doesn't have <code>type="button"</code>), this attribute specifies the <a href="/en-US/docs/Web/HTTP/Methods">HTTP method</a> used to submit the form. Possible values:
  <ul>
   <li><code>post</code>: The data from the form are included in the body of the HTTP request when sent to the server. Use when the form contains information that shouldn’t be public, like login credentials.</li>
@@ -89,10 +89,10 @@ tags:
 
  <p>If specified, this attribute overrides the {{htmlattrxref("method","form")}} attribute of the button's form owner.</p>
  </dd>
- <dt>{{htmlattrdef("formnovalidate")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("formnovalidate")}}</dt>
  <dd>If the button is a submit button, this Boolean attribute specifies that the form is not to be <a href="/en-US/docs/Learn/Forms/Form_validation">validated</a> when it is submitted. If this attribute is specified, it overrides the {{htmlattrxref("novalidate","form")}} attribute of the button's form owner.</dd>
  <dd>This attribute is also available on <code><a href="/en-US/docs/Web/HTML/Element/input/image">&lt;input type="image"&gt;</a></code> and <code><a href="/en-US/docs/Web/HTML/Element/input/submit">&lt;input type="submit"&gt;</a></code> elements.</dd>
- <dt>{{htmlattrdef("formtarget")}} {{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("formtarget")}}</dt>
  <dd>If the button is a submit button, this attribute is a author-defined name or standardized, underscore-prefixed keyword indicating where to display the response from submitting the form. This is the <code>name</code> of, or keyword for, a <em>browsing context</em> (a tab, window, or {{HTMLElement("iframe")}}). If this attribute is specified, it overrides the {{htmlattrxref("target", "form")}} attribute of the button's form owner. The following keywords have special meanings:
  <ul>
   <li><code>_self</code>: Load the response into the same browsing context as the current one. This is the default if the attribute is not specified.</li>

--- a/files/en-us/web/html/element/input/image/index.html
+++ b/files/en-us/web/html/element/input/image/index.html
@@ -237,9 +237,9 @@ tags:
 <p><code>&lt;input type="image"&gt;</code> elements — like regular <a href="/en-US/docs/Web/HTML/Element/input/submit">submit buttons</a> — can accept a number of attributes that override the default form behavior:</p>
 
 <dl>
- <dt>{{htmlattrdef("formaction")}} {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("formaction")}}</dt>
  <dd>The URI of a program that processes the information submitted by the input element; overrides the {{htmlattrxref("action","form")}} attribute of the element's form owner.</dd>
- <dt>{{htmlattrdef("formenctype")}} {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("formenctype")}}</dt>
  <dd>Specifies the type of content that is used to submit the form to the server. Possible values are:
  <ul>
   <li><code>application/x-www-form-urlencoded</code>: The default value if the attribute is not specified.</li>
@@ -248,7 +248,7 @@ tags:
 
  <p>If this attribute is specified, it overrides the {{htmlattrxref("enctype","form")}} attribute of the element's form owner.</p>
  </dd>
- <dt>{{htmlattrdef("formmethod")}} {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("formmethod")}}</dt>
  <dd>Specifies the HTTP method that the browser uses to submit the form. Possible values are:
  <ul>
   <li><code>post</code>: The data from the form is included in the body of the form and is sent to the server.</li>
@@ -257,9 +257,9 @@ tags:
 
  <p>If specified, this attribute overrides the {{htmlattrxref("method","form")}} attribute of the element's form owner.</p>
  </dd>
- <dt>{{htmlattrdef("formnovalidate")}} {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("formnovalidate")}}</dt>
  <dd>A Boolean attribute specifying that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the {{htmlattrxref("novalidate","form")}} attribute of the element's form owner.</dd>
- <dt>{{htmlattrdef("formtarget")}} {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("formtarget")}}</dt>
  <dd>A name or keyword indicating where to display the response that is received after submitting the form. This is a name of, or keyword for, a <em>browsing context</em> (for example, tab, window, or inline frame). If this attribute is specified, it overrides the {{htmlattrxref("target", "form")}} attribute of the element's form owner. The following keywords have special meanings:
  <ul>
   <li>_<code>self</code>: Load the response into the same browsing context as the current one. This value is the default if the attribute is not specified.</li>

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -39,7 +39,6 @@ tags:
    <th>Type</th>
    <th>Description</th>
    <th>Basic Examples</th>
-   <th>Spec</th>
   </tr>
  </thead>
  <tbody>
@@ -50,7 +49,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="button" name="button" /&gt;</pre>
     {{EmbedLiveSample("examplebutton",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/checkbox", "checkbox")}}</td>
@@ -59,7 +57,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="checkbox" name="checkbox"/&gt;</pre>
     {{EmbedLiveSample("examplecheckbox",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/color", "color")}}</td>
@@ -68,7 +65,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="color" name="color"/&gt;</pre>
     {{EmbedLiveSample("examplecolor",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/date", "date")}}</td>
@@ -77,7 +73,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="date" name="date"/&gt;</pre>
     {{EmbedLiveSample("exampledate",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/datetime-local", "datetime-local")}}</td>
@@ -86,7 +81,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="datetime-local" name="datetime-local"/&gt;</pre>
     {{EmbedLiveSample("exampledtl",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/email", "email")}}</td>
@@ -95,7 +89,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="email" name="email"/&gt;</pre>
     {{EmbedLiveSample("exampleemail",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/file", "file")}}</td>
@@ -104,13 +97,11 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="file" accept="image/*, text/*" name="file"/&gt;</pre>
     {{EmbedLiveSample("examplefile",'100%',55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/hidden", "hidden")}}</td>
    <td>A control that is not displayed but whose value is submitted to the server. There is an example in the next column, but it's hidden!</td>
    <td><input id="userId" name="userId" type="hidden" value="abc123"></td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/image", "image")}}</td>
@@ -119,7 +110,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="image" name="image" src="" alt="image input"/&gt;</pre>
     {{EmbedLiveSample("exampleimage",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/month", "month")}}</td>
@@ -128,7 +118,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="month" name="month"/&gt;</pre>
     {{EmbedLiveSample("examplemonth",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/number", "number")}}</td>
@@ -137,7 +126,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="number" name="number"/&gt;</pre>
     {{EmbedLiveSample("examplenumber",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/password", "password")}}</td>
@@ -146,7 +134,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="password" name="password"/&gt;</pre>
     {{EmbedLiveSample("examplepassword",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/radio", "radio")}}</td>
@@ -155,7 +142,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="radio" name="radio"/&gt;</pre>
     {{EmbedLiveSample("exampleradio",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/range", "range")}}</td>
@@ -164,7 +150,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="range" name="range" min="0" max="25"/&gt;</pre>
     {{EmbedLiveSample("examplerange",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/reset", "reset")}}</td>
@@ -173,7 +158,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="reset" name="reset"/&gt;</pre>
     {{EmbedLiveSample("examplereset",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/search", "search")}}</td>
@@ -182,7 +166,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="search" name="search"/&gt;</pre>
     {{EmbedLiveSample("examplesearch",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/submit", "submit")}}</td>
@@ -191,7 +174,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="submit" name="submit"/&gt;</pre>
     {{EmbedLiveSample("examplesubmit",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/tel", "tel")}}</td>
@@ -200,7 +182,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="tel" name="tel"/&gt;</pre>
     {{EmbedLiveSample("exampletel",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/text", "text")}}</td>
@@ -209,7 +190,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="text" name="text"/&gt;</pre>
     {{EmbedLiveSample("exampletext",200,55,"","", "nobutton")}}</td>
-   <td></td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/time", "time")}}</td>
@@ -218,7 +198,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input  type="time" name="time"/&gt;</pre>
     {{EmbedLiveSample("exampletime",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/url", "url")}}</td>
@@ -227,7 +206,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="url" name="url"/&gt;</pre>
     {{EmbedLiveSample("exampleurl",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <td>{{HTMLElement("input/week", "week")}}</td>
@@ -236,7 +214,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="week" name="week"/&gt;</pre>
     {{EmbedLiveSample("exampleweek",200,55,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
   <tr>
    <th colspan="4">Obsolete values</th>
@@ -248,7 +225,6 @@ tags:
     <pre class="brush: html hidden notranslate">
 &lt;input type="datetime" name="datetime"/&gt;</pre>
     {{EmbedLiveSample("exampledatetime",200,75,"","", "nobutton")}}</td>
-   <td>{{HTMLVersionInline("5")}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/element/object/index.html
+++ b/files/en-us/web/html/element/object/index.html
@@ -54,33 +54,33 @@ tags:
 <p>This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
 <dl>
- <dt>{{HTMLAttrDef("archive")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("archive")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>A space-separated list of URIs for archives of resources for the object.</dd>
  <dt>{{HTMLAttrDef("border")}}{{Deprecated_Inline("HTML4.01")}}{{Obsolete_Inline("HTML5")}}</dt>
  <dd>The width of a border around the control, in pixels.</dd>
- <dt>{{HTMLAttrDef("classid")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("classid")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>The URI of the object's implementation. It can be used together with, or in place of, the <strong>data</strong> attribute.</dd>
- <dt>{{HTMLAttrDef("codebase")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("codebase")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>The base path used to resolve relative URIs specified by <strong>classid</strong>, <strong>data</strong>, or <strong>archive</strong>. If not specified, the default is the base URI of the current document.</dd>
- <dt>{{HTMLAttrDef("codetype")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("codetype")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>The content type of the data specified by <strong>classid</strong>.</dd>
  <dt>{{HTMLAttrDef("data")}}</dt>
  <dd>The address of the resource as a valid URL. At least one of <strong>data</strong> and <strong>type</strong> must be defined.</dd>
- <dt>{{HTMLAttrDef("declare")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("declare")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent <code>&lt;object&gt;</code> element. In HTML5, repeat the &lt;object&gt; element completely each time that the resource is reused.</dd>
- <dt>{{HTMLAttrDef("form")}}{{HTMLVersionInline(5)}}</dt>
+ <dt>{{HTMLAttrDef("form")}}</dt>
  <dd>The form element, if any, that the object element is associated with (its <em>form owner</em>). The value of the attribute must be an ID of a {{HTMLElement("form")}} element in the same document.</dd>
  <dt>{{HTMLAttrDef("height")}}</dt>
  <dd>The height of the displayed resource, in <a href="https://drafts.csswg.org/css-values/#px">CSS pixels</a>. -- (Absolute values only. <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes">NO percentages</a>)</dd>
  <dt>{{HTMLAttrDef("name")}}</dt>
  <dd>The name of valid browsing context (HTML5), or the name of the control (HTML 4).</dd>
- <dt>{{HTMLAttrDef("standby")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("standby")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>A message that the browser can show while loading the object's implementation and data.</dd>
- <dt>{{HTMLAttrDef("tabindex")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}</dt>
+ <dt>{{HTMLAttrDef("tabindex")}} {{Obsolete_Inline("HTML5")}}</dt>
  <dd>The position of the element in the tabbing navigation order for the current document.</dd>
  <dt>{{HTMLAttrDef("type")}}</dt>
  <dd>The <a href="/en-US/docs/Glossary/MIME_type">content type</a> of the resource specified by <strong>data</strong>. At least one of <strong>data</strong> and <strong>type</strong> must be defined.</dd>
- <dt>{{HTMLAttrDef("typemustmatch")}}{{HTMLVersionInline(5)}}</dt>
+ <dt>{{HTMLAttrDef("typemustmatch")}}</dt>
  <dd>This Boolean attribute indicates if the <strong>type</strong> attribute and the actual <a href="/en-US/docs/Glossary/MIME_type">content type</a> of the resource must match to be used.</dd>
  <dt>{{HTMLAttrDef("usemap")}}</dt>
  <dd>A hash-name reference to a {{HTMLElement("map")}} element; that is a '#' followed by the value of a {{htmlattrxref("name", "map")}} of a map element.</dd>

--- a/files/en-us/web/html/element/script/index.html
+++ b/files/en-us/web/html/element/script/index.html
@@ -56,7 +56,7 @@ tags:
 <p>This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
 
 <dl>
- <dt>{{htmlattrdef("async")}}{{HTMLVersionInline(5)}}</dt>
+ <dt>{{htmlattrdef("async")}}</dt>
  <dd>
  <p>For classic scripts, if the <code>async</code> attribute is present, then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available.</p>
 

--- a/files/en-us/web/html/element/tfoot/index.html
+++ b/files/en-us/web/html/element/tfoot/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <th scope="row">Permitted parents</th>
    <td>A {{HTMLElement("table")}} element. The {{HTMLElement("tfoot")}} must appear after any {{HTMLElement("caption")}}, {{HTMLElement("colgroup")}}, {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, or {{HTMLElement("tr")}} element. Note that this is the requirement as of HTML5.<br>
-    {{HTMLVersionInline("4")}} The {{HTMLElement("tfoot")}} element cannot be placed after any {{HTMLElement("tbody")}} and {{HTMLElement("tr")}} element. Note that this directly contradicts the above normative requirement from HTML5.</td>
+    In HTML4, the {{HTMLElement("tfoot")}} element cannot be placed after any {{HTMLElement("tbody")}} and {{HTMLElement("tr")}} element. Note that this directly contradicts the above normative requirement from HTML5.</td>
   </tr>
   <tr>
    <th scope="row">Implicit ARIA role</th>

--- a/files/en-us/web/html/element/thead/index.html
+++ b/files/en-us/web/html/element/thead/index.html
@@ -57,7 +57,7 @@ tags:
 <h3 id="Deprecated_attributes">Deprecated attributes</h3>
 
 <dl>
- <dt>{{htmlattrdef("align")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("align")}} {{obsolete_inline}}</dt>
  <dd>This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:
  <ul>
   <li><code>left</code>, aligning the content to the left of the cell</li>
@@ -134,15 +134,15 @@ tags:
 
  <div class="note"><strong>Usage note:</strong> Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: the {{HTMLElement("thead")}} element should be styled using <a href="/en-US/docs/Web/CSS">CSS</a>. To give a similar effect to the <strong>bgcolor</strong> attribute, use the <a href="/en-US/docs/Web/CSS">CSS</a> property {{cssxref("background-color")}}, on the relevant {{HTMLElement("td")}} or {{HTMLElement("th")}} elements.</div>
  </dd>
- <dt>{{htmlattrdef("char")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("char")}} {{obsolete_inline}}</dt>
  <dd>This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If {{htmlattrxref("align", "thead")}} is not set to <code>char</code>, this attribute is ignored.
  <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the {{htmlattrxref("char", "thead")}}, in CSS3, you can use the character set using the {{htmlattrxref("char", "thead")}} attribute as the value of the {{cssxref("text-align")}} property {{unimplemented_inline}}.</div>
  </dd>
- <dt>{{htmlattrdef("charoff")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("charoff")}} {{obsolete_inline}}</dt>
  <dd>This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the <strong>char</strong> attribute.
  <div class="note"><strong>Note:</strong> Do not use this attribute as it is obsolete (and not supported) in the latest standard.</div>
  </dd>
- <dt>{{htmlattrdef("valign")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}</dt>
+ <dt>{{htmlattrdef("valign")}} {{obsolete_inline}}</dt>
  <dd>This attribute specifies the vertical alignment of the text within each row of cells of the table header. Possible values for this attribute are:
  <ul>
   <li><code>baseline</code>, which will put the text as close to the bottom of the cell as it is possible, but align it on the <a class="external" href="https://en.wikipedia.org/wiki/Baseline_%28typography%29">baseline</a> of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as <code>bottom</code>.</li>

--- a/files/en-us/web/progressive_web_apps/responsive/media_types/index.html
+++ b/files/en-us/web/progressive_web_apps/responsive/media_types/index.html
@@ -27,7 +27,8 @@ tags:
 
 <p>A document on a website has a navigation area that contains the primary site menu.</p>
 
-<p>In the markup language, the navigation area's parent element has the <strong>id</strong> <code>nav-area</code>. (In {{HTMLVersionInline(5)}}, this can be marked up with the {{HTMLElement("nav")}} element instead of {{HTMLElement("div")}} with an <strong>id</strong> attribute.)</p>
+<p>In the markup language, the navigation area's parent element has the <strong>id</strong> <code>nav-area</code>.
+(This can also be marked up with the {{HTMLElement("nav")}} element instead of {{HTMLElement("div")}} with an <strong>id</strong> attribute.)</p>
 
 <p>When printing the document, the navigation area has no purpose. This CSS (below) removes the navigation area when printing the document:</p>
 


### PR DESCRIPTION
This is a macro that can go away imo. HTML5 is not new anymore and these banners add no real benefit. 
(Usually the compat table should be consulted rather than the spec level anyways)

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes for an example of how it shows up currently.