### PR TITLE
Rename example var names to be consistent

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/entries/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate"><var>array</var>.entries()</pre>
+<pre class="brush: js notranslate"><var>arr</var>.entries()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate"><var>arrName</var>.pop()</pre>
+<pre class="brush: js notranslate"><var>arr</var>.pop()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
@@ -62,7 +62,7 @@ tags:
 <p>The call to the reduceRight <code><var>callback</var></code> would look something like
   this:</p>
 
-<pre class="brush: js notranslate">array.reduceRight(function(accumulator, currentValue, index, array) {
+<pre class="brush: js notranslate">arr.reduceRight(function(accumulator, currentValue, index, array) {
   // ...
 });
 </pre>

--- a/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
@@ -23,7 +23,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate"><var>a</var>.reverse()</pre>
+<pre class="brush: js notranslate"><var>arr</var>.reverse()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate">let <var>arrDeletedItems</var> = <var>array</var>.splice(<var>start</var>[, <var>deleteCount</var>[, <var>item1</var>[, <var>item2</var>[, ...]]]])
+<pre class="brush: js notranslate">let <var>arrDeletedItems</var> = <var>arr</var>.splice(<var>start</var>[, <var>deleteCount</var>[, <var>item1</var>[, <var>item2</var>[, ...]]]])
 </pre>
 
 <h3 id="Parameters">Parameters</h3>


### PR DESCRIPTION
In other docs locations, the example array variable name is arr

Examples:

- https://github.com/mdn/content/blob/705c2c07254f06c9f63cac7bf3e35a3a44644ac9/files/en-us/web/javascript/reference/global_objects/array/slice/index.html#L27
- https://github.com/mdn/content/blob/705c2c07254f06c9f63cac7bf3e35a3a44644ac9/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.html#L23
- https://github.com/mdn/content/blob/705c2c07254f06c9f63cac7bf3e35a3a44644ac9/files/en-us/web/javascript/reference/global_objects/array/shift/index.html#L27