### PR TITLE
Allow geolocation in Geolocation doc live sample

### DIFF
--- a/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.html
+++ b/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.html
@@ -166,4 +166,4 @@ document.querySelector('#find-me').addEventListener('click', geoFindMe);
 
 <h3 id="Result">Result</h3>
 
-<p>{{EmbedLiveSample('Examples', 350, 150)}}</p>
+<p>{{EmbedLiveSample('Examples', 350, 150, "", "", "", "geolocation")}}</p>


### PR DESCRIPTION
This change adds a 7th argument to the EmbedLiveSample call in the Web/API/Geolocation_API/Using_the_Geolocation_API article, with the value `geolocation`, to allow the generated cross-origin iframe to have Geolocation API access. That change also makes the live sample in the Web/API/Geolocation_API article work too — because that article transcludes the live sample from the Using_the_Geolocation_API article

Otherwise, without this change, both live sample fails (silently) in Chrome — and in Firefox too, in my testing at least — because the default in those browsers for any cross-origin iframe is to (silently) disallow geolocation.

Fixes https://github.com/mdn/content/issues/1254