### PR TITLE
Broken link on ARIA Overview page

### DIFF
--- a/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.html
+++ b/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.html
@@ -168,7 +168,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en/ARIA">ARIA</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA">ARIA</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets">Writing Keyboard-navigable JavaScript widgets</a></li>
  <li><a class="external" href="https://www.w3.org/TR/wai-aria-1.1/">WAI-ARIA Specification</a></li>
  <li><a class="external" href="https://www.w3.org/TR/wai-aria-practices/">WAI-ARIA Authoring Practices</a></li>


### PR DESCRIPTION
Update "ARIA" link to point to a page named ARIA, it seems to be what was intended based on the context