### PR TITLE
Add missing end brace in MediaMetadata code example

### DIFF
--- a/files/en-us/web/api/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/index.html
@@ -52,7 +52,8 @@ tags:
       <span class="punctuation token">{</span> src<span class="punctuation token">:</span> <span class="string token">'https://dummyimage.com/384x384'</span><span class="punctuation token">,</span> sizes<span class="punctuation token">:</span> <span class="string token">'384x384'</span><span class="punctuation token">,</span> type<span class="punctuation token">:</span> <span class="string token">'image/png'</span> <span class="punctuation token">}</span><span class="punctuation token">,</span>
       <span class="punctuation token">{</span> src<span class="punctuation token">:</span> <span class="string token">'https://dummyimage.com/512x512'</span><span class="punctuation token">,</span> sizes<span class="punctuation token">:</span> <span class="string token">'512x512'</span><span class="punctuation token">,</span> type<span class="punctuation token">:</span> <span class="string token">'image/png'</span> <span class="punctuation token">}</span><span class="punctuation token">,</span>
     <span class="punctuation token">]</span>
-  <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code></pre>
+  <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+  <span class="punctuation token">}</span></code></pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/index.html
@@ -53,7 +53,7 @@ tags:
       <span class="punctuation token">{</span> src<span class="punctuation token">:</span> <span class="string token">'https://dummyimage.com/512x512'</span><span class="punctuation token">,</span> sizes<span class="punctuation token">:</span> <span class="string token">'512x512'</span><span class="punctuation token">,</span> type<span class="punctuation token">:</span> <span class="string token">'image/png'</span> <span class="punctuation token">}</span><span class="punctuation token">,</span>
     <span class="punctuation token">]</span>
   <span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-  <span class="punctuation token">}</span></code></pre>
+<span class="punctuation token">}</span></code></pre>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fix for Issue #1274 

Added Curly Bracket at the end of the example code for 
Folder: en-us/web/api/mediametadata
MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/MediaMetadata
GitHub URL: https://github.com/mdn/content/blob/master/files/en-us/web/api/mediametadata/index.html