### PR TITLE
adding SVG review team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,11 @@
 /files/en-us/web/javascript/    @mdn/yari-content-javascript
 
 # ----------------------------------------------------------------------------
+# ENGLISH SVG CONTENT OWNER(S)
+# ----------------------------------------------------------------------------
+/files/en-us/web/svg/    @mdn/yari-content-svg
+
+# ----------------------------------------------------------------------------
 # CONTROL FILES OWNER(S)
 # ----------------------------------------------------------------------------
 # These should be the last matches in this file, since any pull request that


### PR DESCRIPTION
I've gotten agreement from one of our community members to review SVG-related PRs, so I've created a yari-content-svg team, added him to it, and added it to the CODEOWNERS file. 

Does this look OK?