### PR TITLE
CSS declaration and declaration block

### DIFF
--- a/files/en-us/web/api/css_object_model/css_declaration/index.html
+++ b/files/en-us/web/api/css_object_model/css_declaration/index.html
@@ -1,0 +1,53 @@
+---
+title: CSS Declaration
+slug: Web/API/CSS_Object_Model/CSS_Declaration
+tags:
+  - CSS
+  - CSS Object Model
+  - CSS Declaration
+  - Reference
+---
+<div>{{ APIRef("CSSOM") }}</div>
+
+<p class="summary">A <strong>CSS declaration</strong> is an abstract concept not exposed as an object in the DOM. It represents a CSS property and value pairing.</p>
+
+<p>A CSS declaration has the following associated properties:</p>
+
+<dl>
+  <dt>property name</dt>
+  <dd>The property name of the declaration, for example {{cssxref("background-color")}}.</dd>
+  <dt>value</dt>
+  <dd>The value of the declaration as a list of component values.</dd>
+  <dt>important flag</dt>
+  <dd>Either set or unset.</dd>
+  <dt>case-sensitive flag</dt>
+  <dd>Set if the property name is defined to be case-sensitive according to the specification, otherwise unset.</dd>
+</dl>
+
+<h2 id="Basic_example">Basic example</h2>
+
+<p>The following example shows a CSS rule with a <a href="/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block">CSS declaration block</a> for the {{htmlelement("Heading_elements","&lt;h1&gt;")}} element. The CSS declaration block is the lines between the curly braces, it contains two CSS declarations. One for {{cssxref("font-style")}} and another for {{cssxref("color")}}.</p>
+
+<pre class="brush: css">h1 {
+  font-style: italic;
+  color: rebeccapurple;
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+    <td>{{SpecName('CSSOM', '#css-declarations', 'CSS Declarations')}}</td>
+    <td>{{Spec2('CSSOM')}}</td>
+    <td></td>
+  </tr>
+ </tbody>
+</table>

--- a/files/en-us/web/api/css_object_model/css_declaration_block/index.html
+++ b/files/en-us/web/api/css_object_model/css_declaration_block/index.html
@@ -1,0 +1,66 @@
+---
+title: CSS Declaration Block
+slug: Web/API/CSS_Object_Model/CSS_Declaration_Block
+tags:
+  - CSS
+  - CSS Object Model
+  - CSS Declaration Block
+  - CSS Declarations
+  - Reference
+---
+<div>{{ APIRef("CSSOM") }}</div>
+
+<p class="summary">A <strong>CSS declaration block</strong> is an ordered collection of CSS properties and values. It is represented in the DOM as a {{domxref("CSSStyleDeclaration")}}.</p>
+
+<p>Each property and value pairing is known as a <a href="/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration">CSS declaration</a>. The CSS declaration block has the following associated properties:</p>
+
+<dl>
+  <dt>computed flag</dt>
+  <dd>Set if the {{domxref("CSSStyleDeclaration")}} object is a computed rather than specified style. Unset by default.</dd>
+  <dt>declarations</dt>
+  <dd>The <a href="/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration">CSS declarations</a> associated with this object.</dd>
+  <dt>parent CSS rule</dt>
+  <dd>The {{domxref("CSSRule")}} that the CSS declaration block is associated with, otherwise null. </dd>
+  <dt>owner node</dt>
+  <dd>The {{domxref("element")}} that the CSS declaration block is associated with, otherwise null.</dd>
+  <dt>updating flag</dt>
+  <dd>Set when the CSS declaration block is updating the owner node's {{htmlattrxref("style")}} attribute.</dd>
+</dl>
+
+<p>When a {{domxref("CSSStyleDeclaration")}} is returned by a <a href="/en-US/docs/Web/API/CSS_Object_Model">CSS Object Model (CSSOM)</a> interface these properties are set to appropriate values as defined by the specification.</p>
+
+<h2 id="Basic_example">Basic example</h2>
+
+<p>The following example shows a CSS rule with a declaration block for the {{htmlelement("Heading_elements","&lt;h1&gt;")}} element. The CSS declaration block is the lines between the curly braces.</p>
+
+<pre class="brush: css; highlight[2,5]">h1 {
+  margin: 0 auto;
+  font-family: "Helvetica Neue", "Arial", sans-serif;
+  font-style: italic;
+  color: rebeccapurple;
+}</pre>
+
+<p>We can return a {{domxref("CSSStyleDeclaration")}} representing this CSS declaration block using {{domxref("CSSStyleRule.style")}}.</p>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+let rule = myRules[0]; // a CSSStyleRule 
+console.log(rule.style); // a CSSStyleDeclaration object </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+    <td>{{SpecName('CSSOM', '#css-declaration-blocks', 'CSS Declaration Blocks')}}</td>
+    <td>{{Spec2('CSSOM')}}</td>
+    <td></td>
+  </tr>
+ </tbody>
+</table>


### PR DESCRIPTION
Fixes #1104 

Adding some documentation for [CSS Declarations](https://drafts.csswg.org/cssom-1/#css-declarations) and [CSS Declaration Blocks](https://drafts.csswg.org/cssom-1/#css-declaration-blocks). These are represented through CSSStyleDeclaration in the CSS OM, but are referred to throughout the CSS OM APIs.

Notes for @jpmedley who is reviewing this: 

- I spoke to Chris in terms of where to put these, and we came up with placing them under the CSS Object Model landing page. From a writing stylesheets point of view, these things are mentioned in https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax however the information in these descriptions isn't especially useful to a CSS author.
- The properties listed aren't properties in the way that interfaces have properties. These are somewhat more abstract, so I didn't put them under a Properties heading as we would with an interface, but see what you think.
- Once these are merged I'll go round all the other interfaces and link them up. 