### PR TITLE
[ReadableStream] `getIterator()` is no longer in the spec

### DIFF
--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -37,8 +37,6 @@ tags:
 <dl>
 	<dt>{{domxref("ReadableStream.cancel()")}}</dt>
 	<dd>Cancels the stream, signaling a loss of interest in the stream by a consumer. The supplied reason argument will be given to the underlying source, which may or may not use it.</dd>
-	<dt>{{domxref("ReadableStream.getIterator()")}}</dt>
-	<dd>Creates a ReadableStream async iterator instance and locks the stream to it. While the stream is locked, no other reader can be acquired until this one is released.</dd>
 	<dt>{{domxref("ReadableStream.getReader()")}}</dt>
 	<dd>Creates a reader and locks the stream to it. While the stream is locked, no other reader can be acquired until this one is released.</dd>
 	<dt>{{domxref("ReadableStream.pipeThrough()")}}</dt>


### PR DESCRIPTION
Iteration happens directly on the stream now ([spec](https://streams.spec.whatwg.org/#rs-asynciterator)).