### PR TITLE
replace /en/ for /en-US/docs/ in Web/CSS

### DIFF
--- a/files/en-us/web/css/@charset/index.html
+++ b/files/en-us/web/css/@charset/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{ CSSRef }}</div>
 
-<p>The <strong><code>@charset</code></strong> <a href="/en/CSS">CSS</a> <a href="/en/CSS/At-rule" title="At-rule">at-rule</a> specifies the character encoding used in the style sheet. It must be the first element in the style sheet and not be preceded by any character; as it is not a <a href="/en/CSS/Syntax#nested_statements">nested statement</a>, it cannot be used inside <a href="/en/CSS/At-rule#Conditional_Group_Rules">conditional group at-rules</a>. If several <code>@charset</code> at-rules are defined, only the first one is used, and it cannot be used inside a <code>style</code> attribute on an HTML element or inside the {{ HTMLElement("style") }} element where the character set of the HTML page is relevant.</p>
+<p>The <strong><code>@charset</code></strong> <a href="/en-US/docs/CSS">CSS</a> <a href="/en-US/docs/CSS/At-rule" title="At-rule">at-rule</a> specifies the character encoding used in the style sheet. It must be the first element in the style sheet and not be preceded by any character; as it is not a <a href="/en-US/docs/CSS/Syntax#nested_statements">nested statement</a>, it cannot be used inside <a href="/en-US/docs/CSS/At-rule#Conditional_Group_Rules">conditional group at-rules</a>. If several <code>@charset</code> at-rules are defined, only the first one is used, and it cannot be used inside a <code>style</code> attribute on an HTML element or inside the {{ HTMLElement("style") }} element where the character set of the HTML page is relevant.</p>
 
 <pre class="brush: css no-line-numbers notranslate">@charset "utf-8";</pre>
 

--- a/files/en-us/web/css/@viewport/index.html
+++ b/files/en-us/web/css/@viewport/index.html
@@ -18,7 +18,7 @@ tags:
 <p><strong>Note</strong>: See <a href="https://github.com/w3c/csswg-drafts/issues/4766">https://github.com/w3c/csswg-drafts/issues/4766</a> for discussion around @viewport's removal from the standards track.</p>
 </div>
 
-<p>The <strong><code>@viewport</code></strong> <a href="/en/CSS">CSS</a> <a href="/en/CSS/At-rule">at-rule</a> lets you configure the {{glossary("viewport")}} through which the document is viewed. It's primarily used for mobile devices, but is also used by desktop browsers that support features like "snap to edge" (such as Microsoft Edge).</p>
+<p>The <strong><code>@viewport</code></strong> <a href="/en-US/docs/CSS">CSS</a> <a href="/en-US/docs/CSS/At-rule">at-rule</a> lets you configure the {{glossary("viewport")}} through which the document is viewed. It's primarily used for mobile devices, but is also used by desktop browsers that support features like "snap to edge" (such as Microsoft Edge).</p>
 
 <p>Lengths specified as percentages are calculated relative to the <strong>initial viewport</strong>, which is the viewport before any user agent or authored styles have had an opportunity to adjust the viewport. This is typically based on the size of the window on desktop browsers that aren't in full screen mode.</p>
 

--- a/files/en-us/web/css/_colon_scope/index.html
+++ b/files/en-us/web/css/_colon_scope/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>:scope</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en/CSS/Pseudo-classes">pseudo-class</a> represents elements that are a reference point for selectors to match against.</p>
+<p>The <strong><code>:scope</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/CSS/Pseudo-classes">pseudo-class</a> represents elements that are a reference point for selectors to match against.</p>
 
 <pre class="brush: css notranslate">/* Selects a scoped element */
 :scope {

--- a/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.html
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-cancel-button/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{CSSRef}}{{Non-standard_header}}</div>
 
-<p>The <strong><code>::-webkit-search-cancel-button</code></strong> CSS <a href="/en/CSS/Pseudo-elements">pseudo-element</a> represents a button (the "cancel button") at the edge of an {{HTMLElement("input")}} of <code>type="search"</code> which clears away the current value of the {{HTMLElement("input")}} element. This button and pseudo-element are non-standard, supported only in WebKit and Blink, hence the vendor prefix. The clear button is only shown on non-empty search {{HTMLElement("input")}} elements.</p>
+<p>The <strong><code>::-webkit-search-cancel-button</code></strong> CSS <a href="/en-US/docs/CSS/Pseudo-elements">pseudo-element</a> represents a button (the "cancel button") at the edge of an {{HTMLElement("input")}} of <code>type="search"</code> which clears away the current value of the {{HTMLElement("input")}} element. This button and pseudo-element are non-standard, supported only in WebKit and Blink, hence the vendor prefix. The clear button is only shown on non-empty search {{HTMLElement("input")}} elements.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/_doublecolon_-webkit-search-results-button/index.html
+++ b/files/en-us/web/css/_doublecolon_-webkit-search-results-button/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{CSSRef}}{{Non-standard_header}}</p>
 
-<p>The <strong><code>::-webkit-search-results-button</code></strong> CSS <a href="/en/CSS/Pseudo-elements">pseudo-element</a> represents a button (the "search results button") at the left edge of an {{HTMLElement("input")}} of <code>type="search"</code> which when clicked displays a menu which allows the user to choose from previous recent search queries. This button and pseudo-element are non-standard, supported only in WebKit and Blink, hence the vendor prefix. The search results button is only shown on search {{HTMLElement("input")}} elements that have a <a href="/en/docs/Web/HTML/Element/Input#attr-results"><code>results</code></a> attribute.</p>
+<p>The <strong><code>::-webkit-search-results-button</code></strong> CSS <a href="/en-US/docs/CSS/Pseudo-elements">pseudo-element</a> represents a button (the "search results button") at the left edge of an {{HTMLElement("input")}} of <code>type="search"</code> which when clicked displays a menu which allows the user to choose from previous recent search queries. This button and pseudo-element are non-standard, supported only in WebKit and Blink, hence the vendor prefix. The search results button is only shown on search {{HTMLElement("input")}} elements that have a <a href="/en-US/docs/Web/HTML/Element/Input#attr-results"><code>results</code></a> attribute.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/_doublecolon_grammar-error/index.html
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>::grammar-error</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en/CSS/Pseudo-elements">pseudo-element</a> represents a text segment which the {{glossary("user agent")}} has flagged as grammatically incorrect.</p>
+<p>The <strong><code>::grammar-error</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/CSS/Pseudo-elements">pseudo-element</a> represents a text segment which the {{glossary("user agent")}} has flagged as grammatically incorrect.</p>
 
 <h2 id="Allowable_properties">Allowable properties</h2>
 

--- a/files/en-us/web/css/_doublecolon_marker/index.html
+++ b/files/en-us/web/css/_doublecolon_marker/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>::marker</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en/CSS/Pseudo-elements">pseudo-element</a> selects the marker box of a list item, which typically contains a bullet or number.</span> It works on any element or pseudo-element set to <code><a href="/en-US/docs/Web/CSS/display">display: list-item</a></code>, such as the {{HTMLElement("li")}} and {{HTMLElement("summary")}} elements.</p>
+<p><span class="seoSummary">The <strong><code>::marker</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/CSS/Pseudo-elements">pseudo-element</a> selects the marker box of a list item, which typically contains a bullet or number.</span> It works on any element or pseudo-element set to <code><a href="/en-US/docs/Web/CSS/display">display: list-item</a></code>, such as the {{HTMLElement("li")}} and {{HTMLElement("summary")}} elements.</p>
 
 <pre class="brush: css no-line-numbers notranslate">::marker {
   color: blue;

--- a/files/en-us/web/css/_doublecolon_spelling-error/index.html
+++ b/files/en-us/web/css/_doublecolon_spelling-error/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>::spelling-error</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en/CSS/Pseudo-elements">pseudo-element</a> represents a text segment which the {{glossary("user agent")}} has flagged as incorrectly spelled.</p>
+<p>The <strong><code>::spelling-error</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/CSS/Pseudo-elements">pseudo-element</a> represents a text segment which the {{glossary("user agent")}} has flagged as incorrectly spelled.</p>
 
 <h2 id="Allowable_properties">Allowable properties</h2>
 

--- a/files/en-us/web/css/animation-fill-mode/index.html
+++ b/files/en-us/web/css/animation-fill-mode/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-fill-mode</code></strong> <a href="/en/CSS">CSS</a> property sets how a CSS animation applies styles to its target before and after its execution.</p>
+<p>The <strong><code>animation-fill-mode</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets how a CSS animation applies styles to its target before and after its execution.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/animation-fill-mode.html")}}</div>
 
@@ -152,7 +152,7 @@ animation-fill-mode: both, forwards, none;
 
 <p>{{EmbedLiveSample('Examples',700,300)}}</p>
 
-<p>See <a href="/en/CSS/CSS_animations">CSS animations</a> for more examples.</p>
+<p>See <a href="/en-US/docs/CSS/CSS_animations">CSS animations</a> for more examples.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/animation-iteration-count/index.html
+++ b/files/en-us/web/css/animation-iteration-count/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>animation-iteration-count</code></strong> <a href="/en/CSS">CSS</a> property sets the number of times an animation sequence should be played before stopping.</p>
+<p>The <strong><code>animation-iteration-count</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets the number of times an animation sequence should be played before stopping.</p>
 
 <p>If multiple values are specified, each time the animation is played the next value in the list is used, cycling back to the first value after the last one is used.</p>
 

--- a/files/en-us/web/css/border-style/index.html
+++ b/files/en-us/web/css/border-style/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>border-style</code></strong> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand</a> <a href="/en/CSS">CSS</a> property sets the line style for all four sides of an element's border.</span></p>
+<p><span class="seoSummary">The <strong><code>border-style</code></strong> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand</a> <a href="/en-US/docs/CSS">CSS</a> property sets the line style for all four sides of an element's border.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/css/border-style.html")}}</div>
 

--- a/files/en-us/web/css/caption-side/index.html
+++ b/files/en-us/web/css/caption-side/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>caption-side</code></strong> <a href="/en/CSS">CSS</a> property puts the content of a table's {{HTMLElement("caption")}} on the specified side. The values are relative to the {{cssxref('writing-mode')}} of the table.</p>
+<p>The <strong><code>caption-side</code></strong> <a href="/en-US/docs/CSS">CSS</a> property puts the content of a table's {{HTMLElement("caption")}} on the specified side. The values are relative to the {{cssxref('writing-mode')}} of the table.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/caption-side.html")}}</div>
 

--- a/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.html
+++ b/files/en-us/web/css/css_box_model/introduction_to_the_css_box_model/index.html
@@ -29,7 +29,7 @@ tags:
 
 <p id="margin-area">The <strong>margin area</strong>, bounded by the margin edge, extends the border area to include an empty area used to separate the element from its neighbors. Its dimensions are the <em>margin-box width</em> and the <em>margin-box height</em>.</p>
 
-<p>The size of the margin area is determined by the {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, {{cssxref("margin-left")}}, and shorthand {{cssxref("margin")}} properties. When <a href="/en/CSS/margin_collapsing">margin collapsing</a> occurs, the margin area is not clearly defined since margins are shared between boxes.</p>
+<p>The size of the margin area is determined by the {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, {{cssxref("margin-left")}}, and shorthand {{cssxref("margin")}} properties. When <a href="/en-US/docs/CSS/margin_collapsing">margin collapsing</a> occurs, the margin area is not clearly defined since margins are shared between boxes.</p>
 
 <p>Finally, note that for non-replaced inline elements, the amount of space taken up (the contribution to the height of the line) is determined by the {{cssxref('line-height')}} property, even though the borders and padding are still displayed around the content.</p>
 

--- a/files/en-us/web/css/flex-wrap/index.html
+++ b/files/en-us/web/css/flex-wrap/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/flex-wrap.html")}}</div>
 
-<p>See <a href="/en/CSS/Using_CSS_flexible_boxes">Using CSS flexible boxes</a> for more properties and information.</p>
+<p>See <a href="/en-US/docs/CSS/Using_CSS_flexible_boxes">Using CSS flexible boxes</a> for more properties and information.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/font-smooth/index.html
+++ b/files/en-us/web/css/font-smooth/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{ CSSRef }} {{ Non-standard_header }}</div>
 
-<p>The <strong><code>font-smooth</code></strong> <a href="/en/CSS">CSS</a> property controls the application of anti-aliasing when fonts are rendered.</p>
+<p>The <strong><code>font-smooth</code></strong> <a href="/en-US/docs/CSS">CSS</a> property controls the application of anti-aliasing when fonts are rendered.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/list_of_proprietary_css_features/index.html
+++ b/files/en-us/web/css/list_of_proprietary_css_features/index.html
@@ -23,7 +23,7 @@ tags:
 </ul>
 </div>
 
-<p>This list includes proprietary extensions to CSS in different browser engines which are not experimental implementations of features being standardized (see <a href="/en/CSS/Draft_Implementations_of_CSS_Features">Draft Implementations of CSS Features</a> for a list of these).</p>
+<p>This list includes proprietary extensions to CSS in different browser engines which are not experimental implementations of features being standardized (see <a href="/en-US/docs/CSS/Draft_Implementations_of_CSS_Features">Draft Implementations of CSS Features</a> for a list of these).</p>
 
 <h2 id="Gecko">Gecko</h2>
 

--- a/files/en-us/web/css/shape/index.html
+++ b/files/en-us/web/css/shape/index.html
@@ -82,5 +82,5 @@ tags:
 
 <ul>
 	<li>Related CSS property: {{ cssxref("clip") }}</li>
-	<li>The <code><a href="/en/CSS/-moz-image-rect">-moz-image-rect()</a></code> function has similar coordinate values to <code>rect()</code>.</li>
+	<li>The <code><a href="/en-US/docs/CSS/-moz-image-rect">-moz-image-rect()</a></code> function has similar coordinate values to <code>rect()</code>.</li>
 </ul>

--- a/files/en-us/web/css/transition/index.html
+++ b/files/en-us/web/css/transition/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>transition</code></strong> <a href="/en/CSS">CSS </a>property is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> for {{ cssxref("transition-property") }}, {{ cssxref("transition-duration") }}, {{ cssxref("transition-timing-function") }}, and {{ cssxref("transition-delay") }}.</p>
+<p>The <strong><code>transition</code></strong> <a href="/en-US/docs/CSS">CSS </a>property is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> for {{ cssxref("transition-property") }}, {{ cssxref("transition-duration") }}, {{ cssxref("transition-timing-function") }}, and {{ cssxref("transition-delay") }}.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/transition.html")}}</div>
 


### PR DESCRIPTION
This is done by automation. Limited to the en-us/web/css tree.