### PR TITLE
Fix description/code mismatch in TypedArray.prototype.every()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.html
@@ -82,7 +82,7 @@ tags:
 <h3 id="Testing_size_of_all_typed_array_elements">Testing size of all typed array elements
 </h3>
 
-<p>The following example tests whether all elements in the typed array are bigger than 10.
+<p>The following example tests whether all elements in the typed array are bigger than 9.
 </p>
 
 <pre class="brush: js notranslate">function isBigEnough(element, index, array) {


### PR DESCRIPTION
Doc says greater than 10 But the condition is >=10
Doc must say greater than 9 (which is >=10)

This change will allow the code to match, and fewer changes will be needed on this page.