### PR TITLE
chore: Put build output in local build folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true node node_modules/@mdn/yari/server",
     "filecheck": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/filecheck/cli.js --cwd=$(pwd)",
     "content": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/tool/cli.js",
-    "build": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/build/cli.js"
+    "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build node node_modules/@mdn/yari/build/cli.js"
   },
   "dependencies": {
     "@mdn/yari": "0.2.18",


### PR DESCRIPTION
Currently generates inside "node_modules" with get's reset after yarn installs
The `build` folder is already in `.gitignore`