### PR TITLE
Replace stale webcomponents.org link

### DIFF
--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -209,7 +209,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="https://www.webcomponents.org/">webcomponents.org</a> — site featuring web components examples, tutorials, and other information.</li>
+ <li><a href="https://open-wc.org/">Open Web Components</a> — Guides, tools and libraries for developing web components.</li>
  <li><a href="https://www.dataformsjs.com/">DataFormsJS</a> — Open source web components library — Set of Web Components that can be used to build Single Page Apps (SPA), Display JSON data from API’s and Web Services, and bind data to different elements on screen. All Web Components are plain JavaScript and require no build process.</li>
  <li><a href="https://fast.design/" rel="noopener">FAST</a> is a web component library built by Microsoft which offers several packages to leverage depending on your project needs. <a href="https://github.com/microsoft/fast/tree/master/packages/web-components/fast-element" rel="noopener">Fast Element</a> is a lightweight means to easily build performant, memory-efficient, standards-compliant Web Components. <a href="https://github.com/microsoft/fast/tree/master/packages/web-components/fast-foundation" rel="noopener">Fast Foundation</a> is a library of Web Component classes, templates, and other utilities built on fast-element intended to be composed into registered Web Components.</li>
  <li><a href="https://github.com/hybridsjs/hybrids">Hybrids</a> — Open source web components library, which favors plain objects and pure functions over <code>class</code> and <code>this</code> syntax. It provides a simple and functional API for creating custom elements.</li>


### PR DESCRIPTION
The link to webcomponents.org is unhelpful because that site has fallen into disrepair.

#931 