### PR TITLE
Fix "Reasons for delays longer than specified" link

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/settimeout/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/settimeout/index.html
@@ -44,7 +44,7 @@ var <var>timeoutID</var> = <var>scope</var>.setTimeout(<var>code</var>[, <var>de
     the specified function or code is executed. If this parameter is omitted, a value of 0
     is used, meaning execute "immediately", or more accurately, the next event cycle. Note
     that in either case, the actual delay may be longer than intended; see
-    {{anch("Reasons for delays longer than specified")} below.</dd>
+    {{anch("Reasons for delays longer than specified")}} below.</dd>
   <dt><code><var>arg1</var>, ..., <var>argN</var></code> {{optional_inline}}</dt>
   <dd>Additional arguments which are passed through to the function specified by
     <code><var>function</var></code>.</dd>

--- a/files/en-us/web/api/windoworworkerglobalscope/settimeout/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/settimeout/index.html
@@ -43,8 +43,8 @@ var <var>timeoutID</var> = <var>scope</var>.setTimeout(<var>code</var>[, <var>de
   <dd>The time, in milliseconds (thousandths of a second), the timer should wait before
     the specified function or code is executed. If this parameter is omitted, a value of 0
     is used, meaning execute "immediately", or more accurately, the next event cycle. Note
-    that in either case, the actual delay may be longer than intended; see {{anch("Reasons
-    for delays longer than specified")}} below.</dd>
+    that in either case, the actual delay may be longer than intended; see
+    {{anch("Reasons for delays longer than specified")} below.</dd>
   <dt><code><var>arg1</var>, ..., <var>argN</var></code> {{optional_inline}}</dt>
   <dd>Additional arguments which are passed through to the function specified by
     <code><var>function</var></code>.</dd>


### PR DESCRIPTION
Extra whitespace was breaking the "Reasons for delays longer than specified" link in the [delay parameter description](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#parameters) causing it to link to `#reasons____for_delays_longer_than_specified` rather than `#reasons_for_delays_longer_than_specified`.