### PR TITLE
Change casing of IDs in “Iteration protocol” doc

### DIFF
--- a/files/en-us/web/javascript/reference/iteration_protocols/index.html
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p>There are two protocols: The <a href="#the_iterable_protocol">iterable protocol</a> and the <a href="#the_iterator_protocol">iterator protocol</a>.</p>
 
-<h2 id="The_iterable_protocol">The iterable protocol</h2>
+<h2 id="the_iterable_protocol">The iterable protocol</h2>
 
 <p><strong>The iterable protocol</strong> allows JavaScript objects to define or customize their iteration behavior, such as what values are looped over in a {{jsxref("Statements/for...of", "for...of")}} construct. Some built-in types are <a href="#built-in_iterables">built-in iterables</a> with a default iteration behavior, such as {{jsxref("Array")}} or {{jsxref("Map")}}, while other types (such as {{jsxref("Object")}}) are not.</p>
 
@@ -43,7 +43,7 @@ tags:
 
 <p>This function can be an ordinary function, or it can be a generator function, so that when invoked, an iterator object is returned. Inside of this generator function, each entry can be provided by using <code>yield</code>.</p>
 
-<h2 id="The_iterator_protocol">The iterator protocol</h2>
+<h2 id="the_iterator_protocol">The iterator protocol</h2>
 
 <p><strong>The iterator protocol</strong> defines a standard way to produce a sequence of values (either finite or infinite), and potentially a return value when all values have been generated.</p>
 


### PR DESCRIPTION
I saw other places of the MDN docs that the `id` should be all lower cases... and if not changed here, then even the links within this page won't link to them.