### PR TITLE
Fix broken links in Browser Extensions “options_ui” doc

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
@@ -35,16 +35,16 @@ tags:
 	</tbody>
 </table>
 
-<p>Use the <code>options_ui</code> key to define an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Options_pages">options page</a> for your extension.</p>
+<p>Use the <code>options_ui</code> key to define an <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages">options page</a> for your extension.</p>
 
 <p>The options page contains settings for the extension. The user can access it from the browser's add-ons manager, and you can open it from within your extension using {{WebExtAPIRef("runtime.openOptionsPage()")}}.</p>
 
-<p>You specify <code>options_ui</code> as a path to an HTML file packaged with your extension. The HTML file can include CSS and JavaScript files, just like a normal web page. Unlike a normal page, though, the JavaScript can use all the <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API">WebExtension APIs</a> that the extension has <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permissions</a> for. However, it runs in a different scope than your background scripts.</p>
+<p>You specify <code>options_ui</code> as a path to an HTML file packaged with your extension. The HTML file can include CSS and JavaScript files, just like a normal web page. Unlike a normal page, though, the JavaScript can use all the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API">WebExtension APIs</a> that the extension has <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permissions</a> for. However, it runs in a different scope than your background scripts.</p>
 
 <p>If you want to <strong>share</strong> data or functions between the JavaScript on your <strong>options page</strong> and your <strong>background script(s)</strong>, you can do so directly by obtaining a reference to the <a href="/en-US/docs/Web/API/Window">Window</a> of your background scripts by using {{WebExtAPIRef("extension.getBackgroundPage()")}}, or a reference to the {{domxref("Window")}} of any of the pages running within your extension with {{WebExtAPIRef("extension.getViews()")}}. Alternately, you can communicate between the JavaScript for your options page and your background script(s) using {{WebExtAPIRef("runtime.sendMessage()")}}, {{WebExtAPIRef("runtime.onMessage")}}, or {{WebExtAPIRef("runtime.connect()")}}.<br>
-The latter (or {{WebExtAPIRef("runtime.Port")}} equivalents) can also be used to share options between your <a href="/en-US/Add-ons/WebExtensions/Background_scripts">background script(s)</a> and your <strong><a href="/en-US/Add-ons/WebExtensions/Content_scripts">content script(s).</a></strong></p>
+The latter (or {{WebExtAPIRef("runtime.Port")}} equivalents) can also be used to share options between your <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts">background script(s)</a> and your <strong><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts">content script(s).</a></strong></p>
 
-<p>In general, you will want to store options changed on option pages using the {{WebExtAPIRef("storage", "storage API", "", "true")}} to either {{WebExtAPIRef("storage.sync()")}} (if you want the settings synchronized across all instances of that browser that the user is logged into), or {{WebExtAPIRef("storage.local()")}} (if the settings are local to the current machine/profile). If you do so and your <a href="/en-US/Add-ons/WebExtensions/Background_scripts">background script(s)</a> (or <a href="/en-US/docs/">content script(s)</a>) need to know about the change, your script(s) might choose to add a listener to {{WebExtAPIRef("storage.onChanged")}}.</p>
+<p>In general, you will want to store options changed on option pages using the {{WebExtAPIRef("storage", "storage API", "", "true")}} to either {{WebExtAPIRef("storage.sync()")}} (if you want the settings synchronized across all instances of that browser that the user is logged into), or {{WebExtAPIRef("storage.local()")}} (if the settings are local to the current machine/profile). If you do so and your <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts">background script(s)</a> (or <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts">content script(s)</a>) need to know about the change, your script(s) might choose to add a listener to {{WebExtAPIRef("storage.onChanged")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -68,7 +68,7 @@ The latter (or {{WebExtAPIRef("runtime.Port")}} equivalents) can also be used 
 
 			<p>Use this to include a stylesheet in your page that will make it look consistent with the browser's UI and with other extensions that use the <code>browser_style</code> property. Although it defaults to <code>true</code>, it's recommended that you include this property.</p>
 
-			<p>In Firefox, the stylesheet can be seen at <code>chrome://browser/content/extension.css</code>, or <code>chrome://browser/content/extension-mac.css</code> on macOS. When setting dimensions, be aware that this style sheet currently sets <code>box-sizing: border-box</code> (see <a href="https://developer.mozilla.org/docs/Web/CSS/box-sizing">box-sizing</a>).</p>
+			<p>In Firefox, the stylesheet can be seen at <code>chrome://browser/content/extension.css</code>, or <code>chrome://browser/content/extension-mac.css</code> on macOS. When setting dimensions, be aware that this style sheet currently sets <code>box-sizing: border-box</code> (see <a href="/en-US/docs/Web/CSS/box-sizing">box-sizing</a>).</p>
 
 			<p>The <a class="external external-icon" href="http://design.firefox.com/photon/">Firefox Style Guide</a> describes the classes you can apply to elements in the popup in order to get particular styles.</p>
 			</td>


### PR DESCRIPTION
While reading the doc,  found a URL was pointing to wrong location, fixed it 🚀