### PR TITLE
Typo fix

### DIFF
--- a/files/en-us/web/api/event/composed/index.html
+++ b/files/en-us/web/api/event/composed/index.html
@@ -37,7 +37,7 @@ tags:
 <p>All UA-dispatched UI events are composed (click/touch/mouseover/copy/paste, etc.). Most
   other types of events are not composed, and so will return <code>false</code>. For
   example, this includes synthetic events that are created without their
-  <code>composed</code> option wil set to <code>true</code>.</p>
+  <code>composed</code> option set to <code>true</code>.</p>
 
 <p>Propagation only occurs if the {{domxref("Event.bubbles", "bubbles")}} property is also
   <code>true</code>. However, capturing only composed events are also handled at host as


### PR DESCRIPTION
`without their composed option wil set to true.` has been changed into `without their composed option set to true.`.
`wil` has been removed.