### PR TITLE
feat(firefox-85): add `<link rel="preload">` to the Fx85 dev notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/85/index.html
+++ b/files/en-us/mozilla/firefox/releases/85/index.html
@@ -20,7 +20,7 @@ tags:
 <h3 id="HTML">HTML</h3>
 
 <ul>
-  <li>The <a href="/en-US/docs/Web/HTML/Link_types/preload"><code>&lt;link rel="preload"&gt;</code></a> is now enabled. ({{bug(1222633)}}).</li>
+  <li>The <a href="/en-US/docs/Web/HTML/Link_types/preload"><code>&lt;link rel="preload"&gt;</code></a> is now enabled. ({{bug(1626997)}}).</li>
 </ul>
 
 <h4 id="Removals_2">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/85/index.html
+++ b/files/en-us/mozilla/firefox/releases/85/index.html
@@ -19,6 +19,10 @@ tags:
 
 <h3 id="HTML">HTML</h3>
 
+<ul>
+  <li>The <a href="/en-US/docs/Web/HTML/Link_types/preload"><code>&lt;link rel="preload"&gt;</code></a> is now enabled. ({{bug(1222633)}}).</li>
+</ul>
+
 <h4 id="Removals_2">Removals</h4>
 
 <ul>


### PR DESCRIPTION
it's enabled by default in 85 on all channels.
https://hg.mozilla.org/releases/mozilla-beta/rev/c46b088d9a1d