### PR TITLE
Trim and clarify  multi-criteria case for switch

### DIFF
--- a/files/en-us/web/javascript/reference/statements/switch/index.html
+++ b/files/en-us/web/javascript/reference/statements/switch/index.html
@@ -173,11 +173,7 @@ switch (foo) {
 
 <h3 id="Methods_for_multi-criteria_case">Methods for multi-criteria <code>case</code></h3>
 
-<p>Source for this technique is here:</p>
-
-<p><a
-    href="http://stackoverflow.com/questions/13207927/switch-statement-multiple-cases-in-javascript">Switch
-    statement multiple cases in JavaScript (Stack Overflow)</a></p>
+<p>This technique is also commonly called fall-through.</p>
 
 <h4 id="Multi-case_single_operation">Multi-<code>case</code> : single operation</h4>
 


### PR DESCRIPTION
The link to the SO article and claiming that that is the source of this technique is misleading - this techniques exists in many languages that predate JS and is not some obscure hack, but is a basic function of the language.

Also included is the statement that this is also called "fall-through", a term that is used without explanation a few lines above in a comment in the sample code.

This was discussed briefly in #1142