### PR TITLE
Add ES 11th edition spec to JS “Language resources” doc

### DIFF
--- a/files/en-us/web/javascript/language_resources/index.html
+++ b/files/en-us/web/javascript/language_resources/index.html
@@ -22,6 +22,14 @@ tags:
   <tr>
    <th colspan="4">Current editions</th>
   </tr>
+   <tr>
+   <td>ECMA-262 11<sup>th</sup> Edition</td>
+   <td>
+    <p><a href="https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf">PDF</a>, <a href="https://ecma-international.org/ecma-262/11.0/index.html">HTML</a>, <a href="https://tc39.github.io/ecma262/">Working draft</a>, <a href="https://github.com/tc39/ecma262">repository</a></p>
+   </td>
+   <td>2020</td>
+   <td>ECMAScript 2020 Language Specification</td>
+  </tr>
   <tr>
    <td>ECMA-262 10<sup>th</sup> Edition</td>
    <td>


### PR DESCRIPTION
added table row with 11th edition