### PR TITLE
Fix CSP trusted domain(s) example

### DIFF
--- a/files/en-us/web/http/csp/index.html
+++ b/files/en-us/web/http/csp/index.html
@@ -118,7 +118,7 @@ tags:
   subdomains (it doesn't have to be the same domain that the CSP is set on.)</p>
 
 <pre
-  class="brush: html notranslate">Content-Security-Policy: default-src 'self' *.trusted.com</pre>
+  class="brush: html notranslate">Content-Security-Policy: default-src 'self' trusted.com *.trusted.com</pre>
 
 <h3 id="Example_3">Example 3</h3>
 


### PR DESCRIPTION
`Content-Security-Policy: default-src 'self' *.trusted.com` only allows
content from _subdomains_ of trusted.com. This was addressed in the W3C
spec with bug report https://github.com/w3c/webappsec-csp/issues/241 and
associated pull request https://github.com/w3c/webappsec-csp/pull/251 .
Update the code sample to include the root domain as well.

Fixes #1364