### PR TITLE
fix: use promise result instead of promise itself

### DIFF
--- a/files/en-us/webassembly/rust_to_wasm/index.html
+++ b/files/en-us/webassembly/rust_to_wasm/index.html
@@ -260,8 +260,7 @@ module.exports = {
 
 <p>Finally, create the <code>index.js</code> referenced in the HTML file and give it these contents:</p>
 
-<pre class="brush: js notranslate">const js = import("./node_modules/hello-wasm/hello_wasm.js");
-js.then(() =&gt; {
+<pre class="brush: js notranslate">import("./node_modules/hello-wasm/hello_wasm.js").then((js) =&gt; {
   js.greet("WebAssembly");
 });</pre>
 


### PR DESCRIPTION
The previous code incorrectly called the `greet` function on the JS Promise. The
fix correctly resolves the promise and calls the `greet` function on the result.

Incorrect:
```
// `js` is the promise, not the result of the promise
const js = import("./node_modules/hello-wasm/hello_wasm.js");
js.then(() => {
  js.greet("WebAssembly"); // Method `greet` not found on `js`
});
```

Correct (fix):
```
// `js` contains result of the promise
import("./node_modules/hello-wasm/hello_wasm.js").then((js) => {
  js.greet("WebAssembly");
});
```