### PR TITLE
Fix links on Resource Timing API

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/index.html
@@ -108,6 +108,6 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/Web/API/Resource_Timing">Resource Timing (Overview)</a></li>
- <li><a href="/Web/API/Resource_Timing_API/Using_the_Resource_Timing_API">Using the Resource Timing API</a></li>
+ <li><a href="/en-US/docs/Web/API/Resource_Timing">Resource Timing (Overview)</a></li>
+ <li><a href="/en-US/docs/Web/API/Resource_Timing_API/Using_the_Resource_Timing_API">Using the Resource Timing API</a></li>
 </ul>


### PR DESCRIPTION
👋 Hey folks!

The links referring to Resource Timing API is broken. I'm not sure if I can just hardcode the locale like this, but I can't seem to find references to other locales in my quick 5 minute skim, so apologies if I got this wrong.