### PR TITLE
removing section fixing flaws

### DIFF
--- a/files/en-us/web/houdini/index.html
+++ b/files/en-us/web/houdini/index.html
@@ -13,9 +13,9 @@ tags:
 
 <h2 id="Advantages_of_Houdini">Advantages of Houdini</h2>
 
-<p>Houdini enables faster parse times than using JavaScript <code><a href="/en-US/docs/Web/API/HTMLElement/style">style</a></code> for style changes. Browsers parse the CSSOM — including layout, paint, and composite processes — before applying any style updates found in scripts. In addition, layout, paint, and composite processes are repeated for JavaScript style updates. Houdini code doesn't wait for that first rendering cycle to be complete. Rather, it is included in that first cycle — creating renderable, understandable styles. Houdini provides an object-based API for working with CSS values in JavaScript.</p>
+<p>Houdini enables faster parse times than using JavaScript <code><a href="/en-US/docs/Web/API/ElementCSSInlineStyle/style">style</a></code> for style changes. Browsers parse the CSSOM — including layout, paint, and composite processes — before applying any style updates found in scripts. In addition, layout, paint, and composite processes are repeated for JavaScript style updates. Houdini code doesn't wait for that first rendering cycle to be complete. Rather, it is included in that first cycle — creating renderable, understandable styles. Houdini provides an object-based API for working with CSS values in JavaScript.</p>
 
-<p>Houdini's CSS Typed OM is a CSS Object Model with types and methods, exposing values as JavaScript objects making for more intuitive CSS manipulation than previous string based <code><a href="/en-US/docs/Web/API/HTMLElement/style">HTMLElement.style</a></code> manipulations. Every element and style sheet rule has a style map which is accessible via its <code><a href="/en-US/docs/Web/API/StylePropertyMap">StylePropertyMap</a></code>.</p>
+<p>Houdini's CSS Typed OM is a CSS Object Model with types and methods, exposing values as JavaScript objects making for more intuitive CSS manipulation than previous string based <code><a href="/en-US/docs/Web/API/ElementCSSInlineStyle/style">HTMLElement.style</a></code> manipulations. Every element and style sheet rule has a style map which is accessible via its <code><a href="/en-US/docs/Web/API/StylePropertyMap">StylePropertyMap</a></code>.</p>
 
 <p>A feature of CSS Houdini is the <a href="/en-US/docs/Web/API/Worklet">Worklet</a>. With worklets, you can create modular CSS, requiring a single line of JavaScript to import configureable components: no pre-processors, post-processors or JavaScript frameworks needed.</p>
 
@@ -41,10 +41,6 @@ tags:
 <h2 class="Documentation" id="The_Houdini_APIs">The Houdini APIs</h2>
 
 <p>Below you can find links to the main reference pages covering the APIs that fall under the Houdini umbrella, along with links to guides to help you if you need guidance in learning how to use them.</p>
-
-<div class="hidden">
-<p>Start by reading <a href="/en-US/docs/Web/Houdini/learn">Houdini, an introduction</a> — this provides a brief history of Houdini and an overview of its many features.</p>
-</div>
 
 <dl>
  <dt>CSS Parser API</dt>
@@ -82,10 +78,9 @@ tags:
  </dd>
 </dl>
 
-<h2 id="Other_topics">Other topics</h2>
-
-<p>Related topics which may be of interest, since they can be used in tandem with Houdini APIs in interesting ways.</p>
+<h2 id="See_also">See also</h2>
 
 <ul>
- <li>Composite Scrolling and Animation</li>
+  <li>The <a href="https://houdini.how/">Worklet library</a> for examples and code.</li>
+  <li><a href="http://houdini.glitch.me/">Interactive introduction to Houdini</a></li>
 </ul>


### PR DESCRIPTION
Fixes #1409 

Looks like that section was added to link to a piece that was never written: https://github.com/mdn/sprints/issues/1390 so I removed it, also a hidden link to an introductory tutorial that was never written. If those things get written then we can add them back.

Related: do we want an intro tutorial? I could write such a thing cc: @chrisdavidmills 

I fixed a couple of links and also added a couple of resources in place of the removed section.