### PR TITLE
[ReadableStream()] `underlyingSource` is optional

### DIFF
--- a/files/en-us/web/api/readablestream/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/readablestream/index.html
@@ -20,7 +20,7 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt>underlyingSource</dt>
+  <dt>underlyingSource {{optional_inline}}</dt>
   <dd>An object containing methods and properties that define how the constructed stream
     instance will behave. <code>underlyingSource</code> can contain the following:
     <dl>


### PR DESCRIPTION
See [spec](https://streams.spec.whatwg.org/#dom-readablestream-readablestream-underlyingsource-strategy-underlyingsource).