### PR TITLE
[WritableStream()] `underlyingSink` is optional

### DIFF
--- a/files/en-us/web/api/writablestream/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/writablestream/index.html
@@ -22,7 +22,7 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt>underlyingSink</dt>
+  <dt>underlyingSink {{optional_inline}}</dt>
   <dd>An object containing methods and properties that define how the constructed stream
     instance will behave. <code>underlyingSink</code> can contain the following:
     <dl>


### PR DESCRIPTION
See [spec](https://streams.spec.whatwg.org/#dom-writablestream-writablestream-underlyingsink-strategy-underlyingsink).