### PR TITLE
[ReadableStream] `getIterator()` has been removed from the spec

### DIFF
--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -45,8 +45,6 @@ tags:
 	<dd>Pipes the current ReadableStream to a given {{domxref("WritableStream")}} and returns a promise that fulfills when the piping process completes successfully, or rejects if any errors were encountered.</dd>
 	<dt>{{domxref("ReadableStream.tee()")}}</dt>
 	<dd>The <code>tee</code> method <a href="https://streams.spec.whatwg.org/#tee-a-readable-stream" id="ref-for-tee-a-readable-stream②">tees</a> this readable stream, returning a two-element array containing the two resulting branches as new {{domxref("ReadableStream")}} instances. Each of those streams receives the same incoming data.</dd>
-	<dt>{{domxref("ReadableStream[@@asyncIterator]()")}}</dt>
-	<dd>Alias of <code>getIterator</code> method.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
Removing the alias, too.