### PR TITLE
Changed link for "URL scheme"

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.html
@@ -63,7 +63,7 @@ Content-Security-Policy: default-src &lt;source&gt; &lt;source&gt;;
 
 <dl>
  <dt>&lt;host-source&gt;</dt>
- <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/URIs_and_URLs">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
+ <dd>Internet hosts by name or IP address, as well as an optional <a href="/en-US/docs/Learn/Common_questions/What_is_a_URL">URL scheme</a> and/or port number. The site's address may include an optional leading wildcard (the asterisk character, <code>'*'</code>), and you may use a wildcard (again, <code>'*'</code>) as the port number, indicating that all legal ports are valid for the source.<br>
  Examples:
  <ul>
   <li><code>http://*.example.com</code>: Matches all attempts to load from any subdomain of example.com using the <code>http:</code> URL scheme.</li>


### PR DESCRIPTION
Removed reference to archived doc "https://developer.mozilla.org/en-US/docs/Archive/Mozilla/URIs_and_URLs", changed to "https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL". Actual link leads to a "Page not found" (see issue #1431)