### PR TITLE
Removed "let" from "let badString = string;"

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/strings/index.html
@@ -50,12 +50,12 @@ tags:
 string;</pre>
   Just like we did with numbers, we are declaring a variable, initializing it with a string value, and then returning the value. The only difference here is that when writing a string, you need to surround the value with quotes.</li>
  <li>If you don't do this, or miss one of the quotes, you'll get an error. Try entering the following lines:
-  <pre class="brush: js example-bad">let badString = This is a test;
-let badString = 'This is a test;
-let badString = This is a test';</pre>
+  <pre class="brush: js example-bad">let badString1 = This is a test;
+let badString2 = 'This is a test;
+let badString3 = This is a test';</pre>
   These lines don't work because any text without quotes around it is assumed to be a variable name, property name, a reserved word, or similar. If the browser can't find it, then an error is raised (e.g. "missing; before statement"). If the browser can see where a string starts, but can't find the end of the string, as indicated by the 2nd quote, it complains with an error (with "unterminated string literal"). If your program is raising such errors, then go back and check all your strings to make sure you have no missing quote marks.</li>
  <li>The following will work if you previously defined the variable <code>string</code> — try it now:
-  <pre class="brush: js">badString = string;
+  <pre class="brush: js">let badString = string;
 badString;</pre>
   <code>badString</code> is now set to have the same value as <code>string</code>.</li>
 </ol>
@@ -87,7 +87,7 @@ dblSgl;</pre>
 
 <p>To fix our previous problem code line, we need to escape the problem quote mark. Escaping characters means that we do something to them to make sure they are recognized as text, not part of the code. In JavaScript, we do this by putting a backslash just before the character. Try this:</p>
 
-<pre class="brush: js">let bigmouth = 'I\'ve got no right to take my place...';
+<pre class="brush: js">bigmouth = 'I\'ve got no right to take my place...';
 bigmouth;</pre>
 
 <p>This works fine. You can escape other characters in the same way, e.g. <code>\"</code>,  and there are some special codes besides. See <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Escape_notation">Escape notation</a> for more details.</p>

--- a/files/en-us/learn/javascript/first_steps/strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/strings/index.html
@@ -55,7 +55,7 @@ let badString = 'This is a test;
 let badString = This is a test';</pre>
   These lines don't work because any text without quotes around it is assumed to be a variable name, property name, a reserved word, or similar. If the browser can't find it, then an error is raised (e.g. "missing; before statement"). If the browser can see where a string starts, but can't find the end of the string, as indicated by the 2nd quote, it complains with an error (with "unterminated string literal"). If your program is raising such errors, then go back and check all your strings to make sure you have no missing quote marks.</li>
  <li>The following will work if you previously defined the variable <code>string</code> — try it now:
-  <pre class="brush: js">let badString = string;
+  <pre class="brush: js">badString = string;
 badString;</pre>
   <code>badString</code> is now set to have the same value as <code>string</code>.</li>
 </ol>


### PR DESCRIPTION
let creates error message: Uncaught SyntaxError: redeclaration of let badString