### PR TITLE
Change default referrerpolicy for HTMLIframeElement

### DIFF
--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
@@ -27,8 +27,8 @@ tags:
   <dt>no-referrer</dt>
   <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer
     information is sent along with requests.</dd>
-  <dt>no-referrer-when-downgrade (default)</dt>
-  <dd>This is the user agent's default behavior if no policy is specified. The URL is sent
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent
     as a referrer when the protocol security level stays the same (HTTP→HTTP,
     HTTPS→HTTPS), but isn't sent to a less secure destination (HTTPS→HTTP).</dd>
   <dt>origin</dt>
@@ -46,8 +46,8 @@ tags:
   <dd>Only send the origin of the document as the referrer when the protocol security
     level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination
     (HTTPS→HTTP).</dd>
-  <dt>strict-origin-when-cross-origin</dt>
-  <dd>Send a full URL when performing a same-origin request, only send the origin when the
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the
     protocol security level stays the same (HTTPS→HTTPS), and send no header to a less
     secure destination (HTTPS→HTTP).</dd>
   <dt>unsafe-url</dt>


### PR DESCRIPTION
I'm working on `HTMLPortalElement` and while looking up the referrerpolicy details noticed this has changed in the spec with regards to the default, so this is an update to the details on the attribute for `HTMLIframeElement`.

- Spec: https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-strict-origin-when-cross-origin
- Change implemented in Chrome: https://www.chromestatus.com/feature/6251880185331712

I've updated this here as I had the page open anyway, I'll raise an issue to check elsewhere this might need updating.