### PR TITLE
Re-add the grid- prefix for old gap properties

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -415,7 +415,7 @@ tags:
 </pre>
 
 <div class="note">
-<p><strong>Note:</strong> When grid first shipped in browsers the {{cssxref("column-gap")}}, {{cssxref("row-gap")}} and {{cssxref("gap")}} were prefixed with the <code>grid-</code> prefix as {{cssxref("column-gap")}}, {{cssxref("row-gap")}} and {{cssxref("gap")}} respectively.<br>
+<p><strong>Note:</strong> When grid first shipped in browsers the {{cssxref("column-gap")}}, {{cssxref("row-gap")}} and {{cssxref("gap")}} were prefixed with the <code>grid-</code> prefix as {{cssxref("grid-column-gap")}}, {{cssxref("grid-row-gap")}} and {{cssxref("grid-gap")}} respectively.<br>
  <br>
  Browsers are updating to remove this prefix, however the prefixed versions will be maintained as aliases making them safe to use. </p>
 </div>


### PR DESCRIPTION
I noticed this [was changed a few weeks ago,](https://github.com/mdn/content/commit/dc0aaed30a20dc3806d7f1c0d82e98b3ee932af0#diff-43cc2bfc2278b8ed8aa5a424706610aeee424bd81f5c595917ec2b523256ccdc) but as I'm reading this guide for the first time I found it confusing to not show the old gap property names as they were (with the prefix). 

This change re adds the prefix to make the last part of the sentence:

> as `column-gap`, `row-gap` and `gap` respectively.

change into this:

> as `grid-column-gap`, `grid-row-gap` and `grid-gap` respectively.

so that it makes more sense to new readers (like me!).