### PR TITLE
Add hint for where console log level settings might exist in console.debug

### DIFF
--- a/files/en-us/web/api/console/debug/index.html
+++ b/files/en-us/web/api/console/debug/index.html
@@ -19,7 +19,8 @@ tags:
 <p><span class="seoSummary">The {{domxref("console")}} method
     <strong><code>debug()</code></strong> outputs a message to the web console at the
     "debug" log level. The message is only displayed to the user if the console is
-    configured to display debug output.</span></p>
+    configured to display debug output. In most cases, the log level is configured within
+    the console UI. This log level might correspond to the `Debug` or `Verbose` log level</span></p>
 
 <p>{{AvailableInWorkers}}</p>
 


### PR DESCRIPTION
I found the message around "if the console is configured to display debug output" to not be very helpful since I had no idea where the configuration *was*. While this would vary by situation, we can at least give a hint that most people (using devtools in their browser) will be able to use