### PR TITLE
Mark HTMLMediaElement: mozGetMetadata() deprecated

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.html
+++ b/files/en-us/web/api/htmlmediaelement/index.html
@@ -174,7 +174,7 @@ tags:
  <dd>[enter description]</dd>
  <dt>{{domxref("HTMLMediaElement.mozCaptureStreamUntilEnded()")}} {{non-standard_inline}}</dt>
  <dd>[enter description]</dd>
- <dt>{{domxref("HTMLMediaElement.mozGetMetadata()")}} {{non-standard_inline}}</dt>
+ <dt>{{domxref("HTMLMediaElement.mozGetMetadata()")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>Returns {{jsxref('Object')}}, which contains properties that represent metadata from the playing media resource as <code>{key: value}</code> pairs. A separate copy of the data is returned each time the method is called. This method must be called after the <a href="/en-US/docs/Web/Events/loadedmetadata">loadedmetadata</a> event fires.</dd>
  <dt>{{domxref("HTMLMediaElement.mozLoadFrom()")}} {{non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>This method, available only in Mozilla's implementation, loads data from another media element. This works similarly to <code>load()</code> except that instead of running the normal resource selection algorithm, the source is set to the <code>other</code> element's <code>currentSrc</code>. This is optimized so this element gets access to all of the <code>other</code> element's cached and buffered data; in fact, the two elements share downloaded data, so data downloaded by either element is available to both.</dd>


### PR DESCRIPTION
This method was never standardized and Gecko's media team have plans to remove it (per https://bugzilla.mozilla.org/show_bug.cgi?id=1336402). Mark it as deprecated to signal more strongly that it should not be used and will be removed.