### PR TITLE
Consistently bold "Iterator" in Map API docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.html
@@ -247,7 +247,7 @@ console.log(contacts.size) // 1
   <dd>Returns a new Iterator object that contains the <strong>values</strong> for each
     element in the <code>Map</code> object in insertion order.</dd>
   <dt>{{jsxref("Map.prototype.entries()")}}</dt>
-  <dd>Returns a new <strong>Iterator</strong> object that contains <strong>an array of
+  <dd>Returns a new Iterator object that contains <strong>an array of
       <code>[<var>key</var>, <var>value</var>]</code></strong> for each element in the
     <code>Map</code> object in insertion order.</dd>
   <dt>{{jsxref("Map.forEach", "Map.prototype.forEach(<var>callbackFn</var>[,


### PR DESCRIPTION
It seemed odd that "Iterator" was bolded only for the `.entries()` method of the `Map` API docs. At first glance I though this was juxtaposed to other methods. This PR makes the bolding consistent with the rest of the document.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#iteration_methods

<img width="680" alt="Screen Shot 2021-01-19 at 8 14 01 PM" src="https://user-images.githubusercontent.com/2488926/105126206-18575100-5a93-11eb-87ec-ed7fcf976acf.png">
