### PR TITLE
removing flag for clip, fixing links

### DIFF
--- a/files/en-us/web/css/overflow/index.html
+++ b/files/en-us/web/css/overflow/index.html
@@ -14,7 +14,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>overflow</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> sets the desired behavior for an element's overflow — i.e. when an element's content is too big to fit in its <a href="/en-US/docs/CSS/block_formatting_context">block formatting context</a> — in both directions.</span></p>
+<p><span class="seoSummary">The <strong><code>overflow</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> sets the desired behavior for an element's overflow — i.e. when an element's content is too big to fit in its <a href="/en-US/docs/Web/Guide/CSS/Block_formatting_context">block formatting context</a> — in both directions.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/css/overflow.html")}}</div>
 
@@ -52,7 +52,7 @@ overflow: unset;
  <dd>Content is not clipped and may be rendered outside the padding box.</dd>
  <dt><code>hidden</code></dt>
  <dd>Content is clipped if necessary to fit the padding box. No scrollbars are provided, and no support for allowing the user to scroll (such as by dragging or using a scroll wheel) is allowed. The content <em>can</em> be scrolled programmatically (for example, by setting the value of a property such as {{domxref("HTMLElement.offsetLeft", "offsetLeft")}}), so the element is still a scroll container.</dd>
- <dt><code>clip</code> {{experimental_inline}}</dt>
+ <dt><code>clip</code></dt>
  <dd>Like for <code>hidden</code>, the content is clipped to the element's padding box. The difference between <code>clip</code> and <code>hidden</code> is that the <code>clip</code> keyword also forbids all scrolling, including programmatic scrolling. The box is not a scroll container, and does not start a new formatting context. If you wish to start a new formatting context, you can use {{cssxref("display", "display: flow-root", "#flow-root")}} to do so.</dd>
  <dt><code>scroll</code></dt>
  <dd>Content is clipped if necessary to fit the padding box. Browsers always display scrollbars whether or not any content is actually clipped, preventing scrollbars from appearing or disappearing as content changes. Printers may still print overflowing content.</dd>
@@ -81,7 +81,7 @@ overflow: unset;
 
 <p>Overflow options include clipping, showing scrollbars, or displaying the content flowing out of its container into the surrounding area.</p>
 
-<p>Specifying a value other than <code>visible</code> (the default) creates a new <a href="/en-US/docs/CSS/block_formatting_context">block formatting context</a>. This is necessary for technical reasons — if a float intersected with the scrolling element it would forcibly rewrap the content after each scroll step, leading to a slow scrolling experience.</p>
+<p>Specifying a value other than <code>visible</code> (the default) creates a new <a href="/en-US/docs/Web/Guide/CSS/Block_formatting_context">block formatting context</a>. This is necessary for technical reasons — if a float intersected with the scrolling element it would forcibly rewrap the content after each scroll step, leading to a slow scrolling experience.</p>
 
 <p>In order for <code>overflow</code> to have an effect, the block-level container must have either a set height (<code>height</code> or <code>max-height</code>) or <code>white-space</code> set to <code>nowrap</code>.</p>
 


### PR DESCRIPTION
Removing the experimental flag from `overflow-clip` as it is shipping in Chrome 89, also fixed a couple of flaws while on the page.