### PR TITLE
Update "Using HTML sections and outlines"

### DIFF
--- a/files/en-us/web/guide/html/using_html_sections_and_outlines/index.html
+++ b/files/en-us/web/guide/html/using_html_sections_and_outlines/index.html
@@ -95,7 +95,7 @@ tags:
 
 <h3 id="Nav_Element">Nav Element</h3>
 
-<p>The <code>&lt;nav&gt;</code> element indicates a navigation block and is mainly used for sections that consists of major navigation blocks.</p>
+<p>The <code>&lt;nav&gt;</code> element indicates a navigation block and is mainly used for sections that consist of major navigation blocks.</p>
 
 <pre>&lt;nav&gt;
   &lt;ul&gt;
@@ -124,7 +124,7 @@ tags:
 
 <h4 id="Collection_of_Links">Collection of Links</h4>
 
-<p>The <code>&lt;nav&gt;</code> element is intended to be used to mark a section with navigation links. Not all collections of links on a page need to be in a <code>&lt;nav&gt;</code> element.</p>
+<p>The <code>&lt;nav&gt;</code> element is intended to be used to mark up the page's <em>primary</em> navigation, for example, a navigation menu or a search box. For other collections of links, such as social media profiles or related links, the <code>&lt;aside&gt;</code> or <code>&lt;section&lt;</code> element may be more suitable.</p>
 
 <h4 id="HTML_Elements_in_&lt;nav&gt;">HTML Elements in &lt;nav&gt;</h4>
 

--- a/files/en-us/web/guide/html/using_html_sections_and_outlines/index.html
+++ b/files/en-us/web/guide/html/using_html_sections_and_outlines/index.html
@@ -95,7 +95,7 @@ tags:
 
 <h3 id="Nav_Element">Nav Element</h3>
 
-<p>The <code>&lt;nav&gt;</code> element indicates a navigation block and should be used for major navigational menus.</p>
+<p>The <code>&lt;nav&gt;</code> element indicates a navigation block and is mainly used for sections that consists of major navigation blocks.</p>
 
 <pre>&lt;nav&gt;
   &lt;ul&gt;
@@ -106,7 +106,7 @@ tags:
 
 <h4 id="Nesting_Menus">Nesting Menus</h4>
 
-<p>You do not nest <code>&lt;nav&gt;</code> elements. The <code>&lt;nav&gt;</code> can contain both primary and secondary menus.</p>
+<p>You don't have to nest <code>&lt;nav&gt;</code> elements. The <code>&lt;nav&gt;</code> can contain both primary and secondary menus.</p>
 
 <pre>&lt;nav&gt;
   &lt;ul&gt;
@@ -124,7 +124,7 @@ tags:
 
 <h4 id="Collection_of_Links">Collection of Links</h4>
 
-<p>Use the <code>&lt;nav&gt;</code> element only for site navigation menus. Collections of links such as social media profiles or a blogroll should not be wrapped in the <code>&lt;nav&gt;</code> element.</p>
+<p>The <code>&lt;nav&gt;</code> element is intended to be used to mark a section with navigation links. Not all collections of links on a page need to be in a <code>&lt;nav&gt;</code> element.</p>
 
 <h4 id="HTML_Elements_in_&lt;nav&gt;">HTML Elements in &lt;nav&gt;</h4>
 

--- a/files/en-us/web/guide/html/using_html_sections_and_outlines/index.html
+++ b/files/en-us/web/guide/html/using_html_sections_and_outlines/index.html
@@ -95,7 +95,7 @@ tags:
 
 <h3 id="Nav_Element">Nav Element</h3>
 
-<p>The <code>&lt;nav&gt;</code> element indicates a navigation block and is mainly used for sections that consist of major navigation blocks.</p>
+<p>The <code>&lt;nav&gt;</code> element indicates a navigation block and should be used to mark up a document's primary navigation functionality.</p>
 
 <pre>&lt;nav&gt;
   &lt;ul&gt;
@@ -106,7 +106,7 @@ tags:
 
 <h4 id="Nesting_Menus">Nesting Menus</h4>
 
-<p>You don't have to nest <code>&lt;nav&gt;</code> elements. The <code>&lt;nav&gt;</code> can contain both primary and secondary menus.</p>
+<p>You shouldn't nest multiple <code>&lt;nav&gt;</code> elements. A single <code>&lt;nav&gt;</code> can contain multiple levels of menu hierarchy, or related navigation features.</p>
 
 <pre>&lt;nav&gt;
   &lt;ul&gt;
@@ -124,7 +124,7 @@ tags:
 
 <h4 id="Collection_of_Links">Collection of Links</h4>
 
-<p>The <code>&lt;nav&gt;</code> element is intended to be used to mark up the page's <em>primary</em> navigation, for example, a navigation menu or a search box. For other collections of links, such as social media profiles or related links, the <code>&lt;aside&gt;</code> or <code>&lt;section&lt;</code> element may be more suitable.</p>
+<p>The <code>&lt;nav&gt;</code> element should be used to mark up the page's <em>primary</em> navigation, for example, a navigation menu or a search box. For other collections of links — such as social media profiles or related links — a <code>&lt;aside&gt;</code> or <code>&lt;section&gt;</code> element may be more suitable.</p>
 
 <h4 id="HTML_Elements_in_&lt;nav&gt;">HTML Elements in &lt;nav&gt;</h4>
 


### PR DESCRIPTION
https://github.com/mdn/content/issues/1303

Both the living standard and the W3C standard don't say "should be" nor "shouldn't be" for `<nav>`'s usage. So I've modified it so that it doesn't use these expressions for things that are not prohibited by the Living Standard.