### PR TITLE
Fix letter case in <h3> tag for 'Locale' page in Glossary

### DIFF
--- a/files/en-us/glossary/locale/index.html
+++ b/files/en-us/glossary/locale/index.html
@@ -12,7 +12,7 @@ tags:
 
 <h2 id="Learn_more">Learn more</h2>
 
-<h3 id="General_Knowledge">General Knowledge</h3>
+<h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
  <li>{{interwiki("wikipedia", "Locale", "Locale")}} on Wikipedia</li>


### PR DESCRIPTION
Fixes #1401 