### PR TITLE
Adding Interface HTMLPortalElement plus subpages.

### DIFF
--- a/files/en-us/web/api/htmlportalelement/activate/index.html
+++ b/files/en-us/web/api/htmlportalelement/activate/index.html
@@ -1,0 +1,79 @@
+---
+title: HTMLPortalElement.activate()
+slug: Web/API/HTMLPortalElement/activate
+tags:
+  - API
+  - HTML DOM
+  - HTMLPortalElement
+  - Portals 
+  - Method
+  - Reference
+---
+
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p class="summary">The <strong><code>activate()</code></strong> method of the {{domxref("HTMLPortalElement")}} interface returns a {{jsxref('Promise')}} that resolves when the activation completes.</p>
+
+<p>Calling <code>activate()</code> causes the embedding window to navigate to the content already loaded into the portal.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>promise</var> = <var>HTMLPortalElement</var>.activate(<var>portalActivateOptions</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+    <dt>portalActivateOptions {{Optional_Inline}}</dt>
+    <dd>An optional {{jsxref("array")}} of {{domxref("Transferable")}} objects.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref('Promise')}}.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+    <dt>InvalidStateError</dt>
+    <dd>Thrown if the {{Glossary("browsing context")}} of the document hosting the portal is null.</dd>
+    <dt>InvalidStateError</dt>
+    <dd>Thrown if the document hosting the portal has a portal state other than 'none'. This prevents portals being embedded in portals.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The promise returned by <code>activate()</code> will not be resolved until navigation to the URL example.com will be successful. Once the response arrives then the promise will fulfill and activation has completed.</p>
+
+<pre class="brush: js">const portal = document.createElement("portal");
+portal.src = "https://example.com";
+document.body.append(portal);
+portal.activate();</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName('Portals', "#dom-htmlportalelement-activate", "HTMLPortalElement.activate")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement.activate")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>

--- a/files/en-us/web/api/htmlportalelement/index.html
+++ b/files/en-us/web/api/htmlportalelement/index.html
@@ -1,0 +1,80 @@
+---
+title: HTMLPortalElement
+slug: Web/API/HTMLPortalElement
+tags:
+  - API
+  - HTML DOM
+  - Portals
+  - Interface
+  - Reference
+---
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p class="summary">The <strong><code>HTMLPortalElement</code></strong> interface of the {{domxref('HTML DOM API','','',' ')}} represents the {{htmlelement("portal")}} HTML element, providing the properties and methods used to manipulate a portal.</p>
+
+<p>{{InheritanceDiagram(600,120)}}</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>This interface also inherits properties from {{domxref("HTMLElement")}}</em>.</p>
+
+<dl>
+  <dt>{{domxref('HTMLPortalElement.referrerPolicy')}}</dt>
+  <dd>A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "portal")}} HTML attribute indicating which referrer policy to use when fetching the linked resource.</dd>
+  <dt>{{domxref('HTMLPortalElement.src')}}</dt>
+  <dd>A {{domxref("USVString")}} that reflects the {{htmlattrxref("src", "portal")}} HTML attribute, containing the address of the content to be embedded.</dd>
+</dl>
+
+<h3 id="Event_handlers">Event handlers</h3>
+
+<dl>
+  <dt>{{domxref('HTMLPortalElement.onmessage')}}</dt>
+  <dd>Fired when a message is received by the object, and no exception is thrown.</dd>
+  <dt>{{domxref('HTMLPortalElement.onmessageerror')}}</dt>
+  <dd>Fired when a message is received by the object, but an exception is thrown.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>This interface also inherits methods from {{domxref("HTMLElement")}}</em>.</p>
+
+<dl>
+  <dt>{{domxref('HTMLPortalElement.activate()')}}</dt>
+  <dd>Returns a {{jsxref('Promise')}} that resolves when the activation completes.</dd>
+  <dt>{{domxref('HTMLPortalElement.postMessage()')}}</dt>
+  <dd>Sends a message to the portaled page, which can consist of any JavaScript object. Returns {{jsxref("undefined")}}.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>For usage examples of Portals see <a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a>.</p>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName('Portals', "#htmlportalelement", "HTMLPortalElement")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>

--- a/files/en-us/web/api/htmlportalelement/onmessage/index.html
+++ b/files/en-us/web/api/htmlportalelement/onmessage/index.html
@@ -1,0 +1,46 @@
+---
+title: HTMLPortalElement.onmessage
+slug: Web/API/HTMLPortalElement/onmessage
+tags:
+  - API
+  - HTML DOM
+  - Portals
+  - Event Handler
+  - Reference
+---
+<p class="summary">The <strong><code>onmessage</code></strong> EventHandler of the {{domxref("HTMLPortalElement")}} interface is an <a href="/en-US/docs/Web/Guide/Events/Event_handlers">Event Handler</a>, that is a function to be called when a message is received.</p>
+
+<p>The event fires when the embedding page sends a message to the portaled content, and no exception is thrown.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">HTMLPortalElement.onmessage = <var>function() { ... };</var></pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName('Portals', "#dom-htmlportalelement-onmessage", "HTMLPortalElement.onmessage")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement.onmessage")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>

--- a/files/en-us/web/api/htmlportalelement/onmessageerror/index.html
+++ b/files/en-us/web/api/htmlportalelement/onmessageerror/index.html
@@ -1,0 +1,47 @@
+---
+title: HTMLPortalElement.onmessageerror
+slug: Web/API/HTMLPortalElement/onmessageerror
+tags:
+  - API
+  - HTML DOM
+  - Portals 
+  - Event Handler 
+  - Reference
+---
+
+<p class="summary">The <strong><code>onmessageerror</code></strong> EventHandler of the {{domxref("HTMLPortalElement")}} interface is an<a href="/en-US/docs/Web/Guide/Events/Event_handlers">Event Handler</a>, that is a function to be called when a message is received.</p>
+
+<p>The event fires when the embedding page sends a message to the portaled content, and an exception is thrown.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">HTMLPortalElement.onmessageerror = <var>function() { ... };</var></pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName('Portals', "#dom-htmlportalelement-onmessageerror", "HTMLPortalElement.onmessageerror")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement.onmessageerror")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>

--- a/files/en-us/web/api/htmlportalelement/postmessage/index.html
+++ b/files/en-us/web/api/htmlportalelement/postmessage/index.html
@@ -1,0 +1,89 @@
+---
+title: HTMLPortalElement.postMessage()
+slug: Web/API/HTMLPortalElement/postMessage
+tags:
+  - API
+  - HTML DOM
+  - HTMLPortalElement
+  - Portals 
+  - Method
+  - Reference
+---
+
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p class="summary">The <strong><code>postMessage()</code></strong> method of the {{domxref("HTMLPortalElement")}} interface enables messaging between the page embedding the {{htmlelement("portal")}} element and the page which is in the portal.</p>
+
+<p>All pages will have a <code>window.portalHost</code> property. This property is non-null if the page is in a portal.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox"><var>HTMLPortalElement</var>.postMessage(<var>message</var>,<var>postMessageOptions</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+    <dt>message</dt>
+    <dd>The message to be passed. This may be any value or JavaScript object.</dd>
+    <dt>postMessageOptions {{Optional_Inline}}</dt>
+    <dd>An optional {{jsxref("array")}} of {{domxref("Transferable")}} objects.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>{{jsxref('undefined')}}</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+    <dt>InvalidStateError</dt>
+    <dd>Thrown if the portal does not have a browsing context.</dd>
+</dl>
+
+<div class="notecard note">
+    <p>Note: The <code>postMessage()</code> method only functions if the <code>portalHost</code> and portaled content are same origin, in order to prevent cross-site tracking. If the portaled content is cross-origin no <code>message</code> events will be sent to <code>window.portalHost</code> and <code>window.portalHost.postMessage()</code> will not deliver any message.</p>
+</div>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <a href="https://github.com/WICG/portals/tree/master/demos/portal-embed-demo">Portal Embed Demo</a> attached to the specification uses <code>postMessage</code> to pass information about the play state of the embedded content to the portal.</p>
+
+<pre class="brush:js">play.addEventListener('click', (evt) => {
+  const isPlaying = play.getAttribute('playing');
+  if (isPlaying === 'true') {
+    this.portal.postMessage({ control: 'pause' }, this.src.origin);
+    play.setAttribute('playing', false);
+  } else {
+    this.portal.postMessage({ control: 'play' }, this.src.origin);
+    play.setAttribute('playing', true);
+  }
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName('Portals', "#dom-htmlportalelement-postmessage", "HTMLPortalElement.postMessage")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement.postMessage")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>

--- a/files/en-us/web/api/htmlportalelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlportalelement/referrerpolicy/index.html
@@ -1,0 +1,79 @@
+---
+title: HTMLPortalElement.referrerPolicy
+slug: Web/API/HTMLPortalElement/referrerPolicy
+tags:
+  - API
+  - HTML DOM
+  - HTMLPortalElement
+  - Portals 
+  - Property
+  - Reference
+---
+
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p class="summary">The <strong><code>referrerPolicy</code></strong> property of the {{domxref("HTMLPortalElement")}} interface reflects the {{htmlattrxref("referrerPolicy", "portal")}} HTML attribute.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>referrerPolicy</var> = <var>HTMLPortalElement</var>.referrerPolicy;
+<var>HTMLPortalElement</var>.referrerPolicy = <var>referrerPolicy</var>;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "portal")}} HTML attribute indicating which referrer policy to use when fetching the linked resource. This is limited to one of the following values:</p>
+
+<dl>
+  <dt>no-referrer</dt>
+  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer information is sent along with requests.</dd>
+  <dt>no-referrer-when-downgrade</dt>
+  <dd>The URL is sent as a referrer when the protocol security level stays the same (HTTP→HTTP, HTTPS→HTTPS), but isn't sent to a less secure destination (HTTPS→HTTP).</dd>
+  <dt>origin</dt>
+  <dd>Only send the origin of the document as the referrer in all cases. The document <code>https://example.com/page.html</code> will send the referrer <code>https://example.com/</code>.</dd>
+  <dt>origin-when-cross-origin</dt>
+  <dd>Send a full URL when performing a same-origin request, but only send the origin of the document for other cases.</dd>
+  <dt>same-origin</dt>
+  <dd>A referrer will be sent for <a href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but cross-origin requests will contain no referrer information.</dd>
+  <dt>strict-origin</dt>
+  <dd>Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</dd>
+  <dt>strict-origin-when-cross-origin (default)</dt>
+  <dd>This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).</dd>
+  <dt>unsafe-url</dt>
+  <dd>Send a full URL when performing a same-origin or cross-origin request.
+  <div class="note">This policy will leak origins and paths from TLS-protected resources to insecure origins. Carefully consider the impact of this setting.</div>
+  </dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush:js">const portal = document.createElement('portal');
+portal.src = "https://example.com";
+portal.referrerPolicy = 'no-referrer' // Do not send a referrer header</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+    </tr>
+    <tr>
+    <td>{{SpecName('Portals', "#dom-htmlportalelement-referrerpolicy", "HTMLPortalElement.referrerPolicy")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement.referrerPolicy")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>

--- a/files/en-us/web/api/htmlportalelement/src/index.html
+++ b/files/en-us/web/api/htmlportalelement/src/index.html
@@ -1,0 +1,57 @@
+---
+title: HTMLPortalElement.src
+slug: Web/API/HTMLPortalElement/src
+tags:
+  - API
+  - HTML DOM
+  - HTMLPortalElement
+  - Portals 
+  - Property
+  - Reference
+---
+
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p class="summary">The <strong><code>src</code></strong> property of the {{domxref("HTMLPortalElement")}} interface reflects the {{htmlattrxref("src", "portal")}} HTML attribute. This contains the address of the content to be embedded.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>src</var> = <var>HTMLPortalElement</var>.src;
+<var>HTMLPortalElement</var>.src = <var>src</var></pre>
+
+<h3>Value</h3>
+<p>A {{domxref("USVString")}} which is a valid, non-empty URL.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush:js">const portal = document.createElement('portal');
+portal.src = 'https://example.com' // The page to navigate to</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName('Portals', "#dom-htmlportalelement-src", "HTMLPortalElement.src")}}</td>
+    <td>{{Spec2('Portals')}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.HTMLPortalElement.src")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+    <li><a href="https://web.dev/hands-on-portals/">Hands-on with Portals</a></li>
+</ul>


### PR DESCRIPTION
Reviewer @jpmedley 

Here is a pass at HTMLPortalElement, as mentioned there are a few complexities with this.

- The [spec](https://wicg.github.io/portals/) is behind the [explainer](https://github.com/WICG/portals#readme) so I've been working between the two to figure out what needs to be documented.
- We are missing BCD awaiting your thoughts on https://github.com/mdn/browser-compat-data/pull/8680
- As mentioned in my earlier email I think there are bits that need adding elsewhere. Glossary entries for things like Portal Browsing Context, which is a new thing. An addition to window `window.portalHost`.

Have a look, there are other Interfaces for Portals to document. Once we are happy with this one and any additions we need to make elsewhere for it to make sense, I'll do the others.