### PR TITLE
Fix link to ResizeObserverEntry.borderBoxSize spec

### DIFF
--- a/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
@@ -73,8 +73,7 @@ resizeObserver.observe(document.querySelector('div'));</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Resize
-        Observer','#dom-resizeobserverentry-borderboxsize','target')}}</td>
+      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-borderboxsize','borderBoxSize')}}</td>
       <td>{{Spec2('Resize Observer')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
@@ -83,8 +83,7 @@ resizeObserver.observe(document.querySelector('div'));</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Resize
-        Observer','#dom-resizeobserverentry-contentboxsize','target')}}</td>
+      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-contentboxsize','contentBoxSize')}}</td>
       <td>{{Spec2('Resize Observer')}}</td>
       <td>Initial definition.</td>
     </tr>


### PR DESCRIPTION
I noticed this minor problem in the course of triaging https://github.com/mdn/browser-compat-data/issues/8730.