### PR TITLE
cssFloat

### DIFF
--- a/files/en-us/web/api/cssstyledeclaration/cssfloat/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/cssfloat/index.html
@@ -1,0 +1,60 @@
+---
+title: CSSStyleDeclaration.cssFloat
+slug: Web/API/CSSStyleDeclaration/cssFloat
+tags:
+  - API
+  - CSSOM
+  - CSSStyleDeclaration
+  - Reference
+---
+<div>{{APIRef("CSSOM")}}</div>
+
+<p><span class="seoSummary">The <code><strong>cssFloat</strong></code> property of the {{domxref("CSSStyleDeclaration")}} interface returns the result of invoking {{DOMxRef("CSSStyleDeclaration.getPropertyValue()")}} with <code>float</code> as an argument.</span></p>
+<p>When setting, it invokes {{DOMxRef("CSSStyleDeclaration.setProperty()")}} with <code>float</code> as the first argument, and the given value as the second argument. The given value must be a valid value for the {{cssxref("float")}} property.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">var <var>float</var> = <var>CSSStyleDeclaration</var>.cssFloat();
+<var>CSSStyleDeclaration</var>.cssFloat = <var>"right"</var></pre>
+
+<h3>Value</h3>
+<p>A {{domxref('CSSOMString')}}.</p>
+
+<h2 id="Example">Example</h2>
+
+<p>In the below example, the stylesheet contains a single rule for <code>.box</code>, which has the {{cssxref("float")}} property with a value of <code>left</code>. This value will be returned by <code>cssFloat</code>. We then set the value to "right" using <code>cssFloat</code>, and return the new value.</p>
+
+<pre class="brush: css">.box {
+  float: left;
+  inline-size: 300px;
+}
+</pre>
+
+<pre class="brush: js">let myRules = document.styleSheets[0].cssRules;
+let rule = myRules[0];
+console.log(rule.style.cssFloat); // "left"
+rule.style.cssFloat = "right";
+console.log(rule.style.cssFloat); //right</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName("CSSOM", "#dom-cssstyledeclaration-cssfloat", "CSSStyleDeclaration.cssFloat")}}</td>
+   <td>{{Spec2("CSSOM")}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.CSSStyleDeclaration.cssFloat")}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/index.html
@@ -15,7 +15,7 @@ tags:
 <p>A <code>CSSStyleDeclaration</code> object can be exposed using three different APIs:</p>
 
 <ul>
- <li>Via {{DOMxRef("HTMLElement.style")}}, which deals with the inline styles of a single element (e.g., <code>&lt;div style="..."&gt;</code>).</li>
+ <li>Via {{DOMxRef("ElementCSSInlineStyle.style")}}, which deals with the inline styles of a single element (e.g., <code>&lt;div style="..."&gt;</code>).</li>
  <li>Via the {{DOMxRef("CSSStyleSheet")}} API. For example, <code>document.styleSheets[0].cssRules[0].style</code> returns a <code>CSSStyleDeclaration</code> object on the first CSS rule in the document's first stylesheet.</li>
  <li>Via {{DOMxRef("Window.getComputedStyle()")}}, which exposes the <code>CSSStyleDeclaration</code> object as a <strong>read-only</strong> interface.</li>
 </ul>
@@ -34,7 +34,7 @@ tags:
 <h3 id="CSS_Properties">CSS Properties</h3>
 
 <dl>
- <dt>{{DOMxRef("CSSStyleDeclaration.named_properties", "CSSStyleDeclaration.cssFloat")}}</dt>
+ <dt>{{DOMxRef("CSSStyleDeclaration.cssFloat", "CSSStyleDeclaration.cssFloat")}}</dt>
  <dd>Special alias for the {{CSSxRef("float")}} CSS property.</dd>
  <dt>{{DOMxRef("CSSStyleDeclaration.named_properties", '<code>CSSStyleDeclaration</code> named properties', "", 1)}}</dt>
  <dd>Dashed and camel-cased attributes for all supported CSS properties.</dd>


### PR DESCRIPTION
Wrapping up my work on https://github.com/mdn/content/issues/344 this is the missing page for `cssFloat`.

Fixes: #796 

Spec: https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-cssfloat

Reviewer: @jpmedley 