### PR TITLE
Fix code typo in “WebSocket: close event” doc

### DIFF
--- a/files/en-us/web/api/websocket/close_event/index.html
+++ b/files/en-us/web/api/websocket/close_event/index.html
@@ -39,7 +39,7 @@ tags:
 
 <pre class="brush: js">exampleSocket.addEventListener('close', (event) =&gt; {
   console.log('The connection has been closed successfully.');
-)};</pre>
+});</pre>
 
 <p>You can perform the same actions using the event handler property, like this:</p>
 


### PR DESCRIPTION
Swapped parenthesis and bracket for function

Before:
```
exampleSocket.addEventListener('close', (event) => {
  console.log('The connection has been closed successfully.');
)};
```

After:
```
exampleSocket.addEventListener('close', (event) => {
  console.log('The connection has been closed successfully.');
});
```