### PR TITLE
Update File System Access API Documentation

### DIFF
--- a/files/en-us/web/api/file_system_access_api/index.html
+++ b/files/en-us/web/api/file_system_access_api/index.html
@@ -22,11 +22,11 @@ tags:
 
 <p>Most of the interaction with files and directories is accomplished through handles. A parent {{domxref('FileSystemHandle')}} class helps define two child classes: {{domxref('FileSystemFileHandle')}} and {{domxref('FileSystemDirectoryHandle')}}, for files and directories respectively.</p>
 
-<p>These handles represent the file or directory on the user's system. You must first gain access to them by showing the user a file or directory picker. The methods which allow this are {{domxref('window.showOpenFilePicker')}} and {{domxref('window.showDirectoryPicker')}}. Once these are called the file picker presents itself and the user selects either a file or directory. Once this happens successfully a handle is returned. You can also gain access to file handles via the {{domxref('DataTransferItem.getAsFileSystemHandle()')}} method of the {{domxref('HTML Drag and Drop API')}}.</p>
+<p>These handles represent the file or directory on the user's system. You must first gain access to them by showing the user a file or directory picker. The methods which allow this are {{domxref('window.showOpenFilePicker')}} and {{domxref('window.showDirectoryPicker')}}. Once these are called, the file picker presents itself and the user selects either a file or directory. Once this happens successfully, a handle is returned. You can also gain access to file handles via the {{domxref('DataTransferItem.getAsFileSystemHandle()')}} method of the {{domxref('HTML Drag and Drop API')}}.</p>
 
-<p>The handle provides its own functionality and there are a few differences depending on whether a file or directory was selected (see the below <a href="#interfaces">interfaces</a> section for specific details). You then can access file data, or information (including children) of the directory selected.</p>
+<p>The handle provides its own functionality and there are a few differences depending on whether a file or directory was selected (see the <a href="#interfaces">interfaces</a> section for specific details). You then can access file data, or information (including children) of the directory selected.</p>
 
-<p>There is also save functionality, using the {{domxref('FilesystemWritableFileStream')}} interface. Once the data you'd like to save is in a format of {{domxref('Blob')}}, {{domxref('USVString')}} or {{jsxref('ArrayBuffer', 'buffer')}}, you can open a stream and save the data to a file. This can be the existing file or a new file.</p>
+<p>There is also “save” functionality, using the {{domxref('FilesystemWritableFileStream')}} interface. Once the data you'd like to save is in a format of {{domxref('Blob')}}, {{domxref('USVString')}} or {{jsxref('ArrayBuffer', 'buffer')}}, you can open a stream and save the data to a file. This can be the existing file or a new file.</p>
 
 <p>This API opens up potential functionality the web has been lacking. Still, security has been of utmost concern when designing the API, and access to file/directory data is disallowed unless the user specifically permits it.</p>
 
@@ -126,7 +126,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
 
 <h3 id="Writing_to_files">Writing to files</h3>
 
-<p>The below asynchronous function opens the save file picker, which returns a {{domxref('FileSystemFileHandle')}} once a file is selected. A writable stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}} method.</p>
+<p>The following asynchronous function opens the save file picker, which returns a {{domxref('FileSystemFileHandle')}} once a file is selected. A writable stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}} method.</p>
 
 <p>A user defined {{domxref('Blob')}} is then written to the stream which is subsequently closed.</p>
 

--- a/files/en-us/web/api/file_system_access_api/index.html
+++ b/files/en-us/web/api/file_system_access_api/index.html
@@ -18,19 +18,17 @@ tags:
 
 <h2 id="Concepts_and_Usage">Concepts and Usage</h2>
 
-<p>The API allows interaction with files on a users local device. These don't have to be files directly stored on the device, they can be files accessed through cloud storage software. Core functionality includes reading files, writing or saving files, as well as access to directory structure.</p>
+<p>This API allows interaction with files on a user's local device, or on a user-accessible network file system. Core functionality of this API includes reading files, writing or saving files, and access to directory structure.</p>
 
-<p>It expands the current file capabilities of a browser and can enable developers to create software to open and save files. Software such as IDE's, photo or video editors and text editors, to name but a few.</p>
+<p>Most of the interaction with files and directories is accomplished through handles. A parent {{domxref('FileSystemHandle')}} class helps define two child classes: {{domxref('FileSystemFileHandle')}} and {{domxref('FileSystemDirectoryHandle')}}, for files and directories respectively.</p>
 
-<p>Most of the interaction with files and directories is accomplished through handles. A parent {{domxref('FileSystemHandle')}} class helps define two child classes: {{domxref('FileSystemFileHandle')}} and {{domxref('FileSystemDirectoryHandle')}}, depending if you want to work with files or directories respectively.</p>
+<p>These handles represent the file or directory on the user's system. You must first gain access to them by showing the user a file or directory picker. The methods which allow this are {{domxref('window.showOpenFilePicker')}} and {{domxref('window.showDirectoryPicker')}}. Once these are called the file picker presents itself and the user selects either a file or directory. Once this happens successfully a handle is returned. You can also gain access to file handles via the {{domxref('DataTransferItem.getAsFileSystemHandle()')}} method of the {{domxref('HTML Drag and Drop API')}}.</p>
 
-<p>These handles represent the file or directory on the users system. You gain access to them by showing the user a file or directory picker. The methods which allow this are {{domxref('window.showOpenFilePicker')}} and {{domxref('window.showDirectoryPicker')}}. Once these are called the picker presents itself and the user selects either a file or directory. Once this happens successfully a handle is returned. You can also gain access to file handles via the {{domxref('DataTransferItem.getAsFileSystemHandle()')}} method of the {{domxref('HTML Drag and Drop API')}}.</p>
+<p>The handle provides its own functionality and there are a few differences depending on whether a file or directory was selected (see the below <a href="#interfaces">interfaces</a> section for specific details). You then can access file data, or information (including children) of the directory selected.</p>
 
-<p>The handle provides it's own functionality and there are a few differences depending on whether a file or directory was selected (see the below <a href="#interfaces">interfaces</a> section for specific details). For the main part you gain access to the file data, or information (including children) of the directory selected.</p>
+<p>There is also save functionality, using the {{domxref('FilesystemWritableFileStream')}} interface. Once the data you'd like to save is in a format of {{domxref('Blob')}}, {{domxref('USVString')}} or {{jsxref('ArrayBuffer', 'buffer')}}, you can open a stream and save the data to a file. This can be the existing file or a new file.</p>
 
-<p>There is also save functionality, which is where the {{domxref('FilesystemWritableFileStream')}} interface comes in. Once the data you'd like to save is in a format of {{domxref('Blob')}}, {{domxref('USVString')}} or {{jsxref('ArrayBuffer', 'buffer')}}, you can open a stream and save the data to a file. That can be the existing file or a new file.</p>
-
-<p>Primarily this API opens up functionality the web has been lacking. Security has been of upmost consideration when designing the API and access to file/directory data is not allowed unless the user specifically permits it.</p>
+<p>This API opens up potential functionality the web has been lacking. Still, security has been of utmost concern when designing the API, and access to file/directory data is disallowed unless the user specifically permits it.</p>
 
 <h2 id="Interfaces">Interfaces</h2>
 
@@ -47,7 +45,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Accessing_files.">Accessing files.</h3>
+<h3 id="Accessing_files">Accessing files</h3>
 
 <p>The below code allows the user to choose a file from the file picker and then tests to see whether the handle returned is a file or directory</p>
 
@@ -60,7 +58,7 @@ async function getFile() {
 
   if (fileHandle.type === 'file') {
     // run file code
-  } else if (fileHandle.type === 'directory')
+  } else if (fileHandle.type === 'directory') {
     // run directory code
   }
 
@@ -90,9 +88,9 @@ async function getTheFile() {
   const fileData = await fileHandle.getFile();
 }</pre>
 
-<h3 id="Accessing_directories.">Accessing directories.</h3>
+<h3 id="Accessing_directories">Accessing directories</h3>
 
-<p>The following example returns a directory handle with the specified name, if the directory does not exist it is created.</p>
+<p>The following example returns a directory handle with the specified name. If the directory does not exist, it is created.</p>
 
 <pre class="brush: js notranslate">const dirName = 'directoryToGetName';
 
@@ -126,9 +124,9 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
 }
 </pre>
 
-<h3 id="Writing_to_files.">Writing to files.</h3>
+<h3 id="Writing_to_files">Writing to files</h3>
 
-<p>This asynchronous function opens the save file picker, which returns a {{domxref('FileSystemFileHandle')}} once a file is selected. From which a writable stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}} method.</p>
+<p>The below asynchronous function opens the save file picker, which returns a {{domxref('FileSystemFileHandle')}} once a file is selected. A writable stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}} method.</p>
 
 <p>A user defined {{domxref('Blob')}} is then written to the stream which is subsequently closed.</p>
 


### PR DESCRIPTION
- Fix typos in code examples
- Remove redundant language from API overview
- Fix misformatted header names