### PR TITLE
Fix: amend that `URL` can be passed to `fetch`

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -57,6 +57,7 @@ tags:
         fetch. Some browsers accept the <code>blob:</code> and <code>data:</code> schemes.
       </li>
       <li>A {{domxref("Request")}} object.</li>
+      <li>A {{domxref("URL")}} object.</li>
     </ul>
   </dd>
   <dt><code><var>init</var></code> {{optional_inline}}</dt>

--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -57,7 +57,7 @@ tags:
         fetch. Some browsers accept the <code>blob:</code> and <code>data:</code> schemes.
       </li>
       <li>A {{domxref("Request")}} object.</li>
-      <li>A {{domxref("URL")}} object.</li>
+      <li>A {{domxref("URL")}} object, or any other object with a <a href="https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers">stringifier</a> that provides the URL for the resource you want to fetch.</li>
     </ul>
   </dd>
   <dt><code><var>init</var></code> {{optional_inline}}</dt>


### PR DESCRIPTION
Based on the current `resource` list I implemented some code which assumed that a `fetch` could only be passed a `Request` object or a string. My code ended up being buggy because of usages of some sites' usage of `fetch`, where a `URL` instance is passed.

This change mentions the possibility of a `URL` instance being passed as `resource` parameter to `fetch`.

Admittedly I did not research whether that's defined in the standard, just a real-world implementation detail. I also don't know whether it works because `fetch` calls `.toString()` or accesses `.href` on the `URL` instance. Based on the lack of knowledge on my side, I kept it short to not misinform. I'd still have found the mention helpful.

Maybe someone else can fill in the details of how / why that works.