### PR TITLE
Changing "fat line" to "thick line"

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.html
@@ -452,7 +452,7 @@ tags:
 
 <p>{{ EmbedLiveSample('Gutters') }}</p>
 
-<p>Any space used by gaps will be accounted for before space is assigned to the flexible length <code>fr</code> tracks, and gaps act for sizing purposes like a regular grid track, however you cannot place anything into a gap. In terms of line-based positioning, the gap acts like a fat line.</p>
+<p>Any space used by gaps will be accounted for before space is assigned to the flexible length <code>fr</code> tracks, and gaps act for sizing purposes like a regular grid track, however you cannot place anything into a gap. In terms of line-based positioning, the gap acts like a thick line.</p>
 
 <h2 id="Nesting_grids">Nesting grids</h2>
 


### PR DESCRIPTION
Calling it a "thick line" is nicer, and actually more precise.