### PR TITLE
Style adjustments for the `offsetContainer`

### DIFF
--- a/files/en-us/web/api/element/scrollheight/index.html
+++ b/files/en-us/web/api/element/scrollheight/index.html
@@ -40,7 +40,7 @@ tags:
 <h2 id="Example">Example</h2>
 
 <div id="offsetContainer"
-  style="margin: 0px 40px 50px;background-color: rgb(255, 255, 204);border: 4px dashed black;color: black;position: relative;display: inline-block;min-width: 300px;">
+  style="margin: 30px 10px 50px;background-color: rgb(255, 255, 204);border: 4px dashed black;color: black;position: relative;display: inline-block;min-width: 270px;">
   <div id="idDiv"
     style="margin: 24px auto;border: 24px black solid;padding: 0px 15px;width: 220px;height: 120px;overflow: auto;background-color: white;font-size: 13px!important;font-family: Arial, sans-serif;">
     <p id="PaddingTopLabel"


### PR DESCRIPTION
I've finally got a chance to test this page on the mobile.
`offsetContainer` looked a bit offset, so I've made a few changes to make it look better on mobile.

**BEFORE THE CHANGE**

![image](https://user-images.githubusercontent.com/7681999/105501819-5c359a80-5ccd-11eb-8cfa-55372c26c2ba.png)




**AFTER THE CHANGE**

![image](https://user-images.githubusercontent.com/7681999/105501930-838c6780-5ccd-11eb-83cf-37e1622dd21b.png)
 