### PR TITLE
Add NSS 3.61 release notes

### DIFF
--- a/files/en-us/mozilla/projects/nss/nss_3.61_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.61_release_notes/index.html
@@ -4,7 +4,7 @@ slug: Mozilla/Projects/NSS/NSS_3.61_release_notes
 ---
 <h2 id="Introduction">Introduction</h2>
 
-<p>The NSS team has released Network Security Services (NSS) 3.61 on <strong>22 January 2021</strong>, which is a minor release.</p>
+<p>The NSS team released Network Security Services (NSS) 3.61 on <strong>22 January 2021</strong>, which is a minor release.</p>
 
 
 <h2 id="Distribution_Information">Distribution Information</h2>
@@ -36,8 +36,8 @@ slug: Mozilla/Projects/NSS/NSS_3.61_release_notes
 
 <h2 id="Compatibility">Compatibility</h2>
 
-<p>NSS 3.61 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.61 shared libraries without recompiling or relinking. Furthermore, applications that restrict their use of NSS APIs to the functions listed in NSS Public Functions will remain compatible with future versions of the NSS shared libraries.</p>
+<p>NSS 3.61 shared libraries are backwards-compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.61 shared libraries without recompiling or relinking. Furthermore, applications that restrict their use of NSS APIs to the functions listed in NSS Public Functions will remain compatible with future versions of the NSS shared libraries.</p>
 
 <h2 id="Feedback">Feedback</h2>
 
-<p>Bugs discovered should be reported by filing a bug report with<a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS"> bugzilla.mozilla.org</a> (product NSS).</p>
+<p>Bugs discovered should be reported by filing a bug report on <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS">bugzilla.mozilla.org</a> (product NSS).</p>

--- a/files/en-us/mozilla/projects/nss/nss_3.61_release_notes/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_3.61_release_notes/index.html
@@ -1,0 +1,43 @@
+---
+title: NSS 3.61 release notes
+slug: Mozilla/Projects/NSS/NSS_3.61_release_notes
+---
+<h2 id="Introduction">Introduction</h2>
+
+<p>The NSS team has released Network Security Services (NSS) 3.61 on <strong>22 January 2021</strong>, which is a minor release.</p>
+
+
+<h2 id="Distribution_Information">Distribution Information</h2>
+
+<p>The HG tag is NSS_3_61_RTM. NSS 3.61 requires NSPR 4.29 or newer.</p>
+
+<p>NSS 3.61 source distributions are available on ftp.mozilla.org for secure HTTPS download:</p>
+
+<ul>
+ <li>Source tarballs:<br>
+  <a href="https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_61_RTM/src/">https://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/NSS_3_61_RTM/src/</a></li>
+</ul>
+
+<p>Other releases are available <a href="/en-US/docs/Mozilla/Projects/NSS/NSS_Releases">in NSS Releases</a>.</p>
+
+<h2 id="Bugs_fixed_in_NSS_3.61">Bugs fixed in NSS 3.61</h2>
+
+<ul>
+  <li>Bug 1682071 - Fix issue with IKE Quick mode deriving incorrect key values under certain conditions.</li>
+  <li>Bug 1684300 - Fix default PBE iteration count when NSS is compiled with NSS_DISABLE_DBM.</li>
+  <li>Bug 1651411 - Improve constant-timeness in RSA operations.</li>
+  <li>Bug 1677207 - Upgrade Google Test version to latest release.</li>
+  <li>Bug 1654332 - Add aarch64-make target to nss-try.</li>
+</ul>
+
+<p>This Bugzilla query returns all the bugs fixed in NSS 3.61:</p>
+
+<p><a class="external" href="https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&amp;classification=Components&amp;query_format=advanced&amp;product=NSS&amp;target_milestone=3.61" rel="noopener">https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&amp;classification=Components&amp;query_format=advanced&amp;product=NSS&amp;target_milestone=3.61</a></p>
+
+<h2 id="Compatibility">Compatibility</h2>
+
+<p>NSS 3.61 shared libraries are backward compatible with all older NSS 3.x shared libraries. A program linked with older NSS 3.x shared libraries will work with NSS 3.61 shared libraries without recompiling or relinking. Furthermore, applications that restrict their use of NSS APIs to the functions listed in NSS Public Functions will remain compatible with future versions of the NSS shared libraries.</p>
+
+<h2 id="Feedback">Feedback</h2>
+
+<p>Bugs discovered should be reported by filing a bug report with<a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS"> bugzilla.mozilla.org</a> (product NSS).</p>

--- a/files/en-us/mozilla/projects/nss/nss_releases/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_releases/index.html
@@ -10,13 +10,14 @@ tags:
   - Release Notes
   - Security
 ---
-<p>The current <strong>Stable</strong> release of NSS is 3.60.1, which was released on <strong>4 January 2021</strong>. (<a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.60.1_release_notes">NSS 3.60.1 release notes</a>)</p>
+<p>The current <strong>Stable</strong> release of NSS is 3.61, which was released on <strong>22 January 2021</strong>. (<a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.61_release_notes">NSS 3.61 release notes</a>)</p>
 
 <p>The current <strong>ESR</strong> releases of NSS are 3.44.4 (<a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.44.4_release_notes">NSS 3.44.4 release notes</a>), intended for Firefox ESR 68, which was released on <strong>19 May 2020</strong>, and  3.53.1 <a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.53.1_release_notes">(NSS 3.53.1 release notes)</a>, intended for Firefox ESR 78, which was released on <strong>16 June 2020</strong>.</p>
 
 <h2 id="Past_releases">Past releases</h2>
 
 <ul>
+ <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.60.1_release_notes">NSS 3.60.1 release notes</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.60_release_notes">NSS 3.60 release notes</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.59.1_release_notes">NSS 3.59.1 release notes</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/NSS_3.59_release_notes">NSS 3.59 release notes</a></li>


### PR DESCRIPTION
While we actively pursue moving NSS project information and release notes off of MDN, we have another release that should be captured in the meantime.