### PR TITLE
Adds httpsOnlyMode description to privacy.network page

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
@@ -37,8 +37,13 @@ tags:
  </dd>
  <dt><code>httpsOnlyMode</code></dt>
 <dd>
-  This setting allows your extension to determine if a user has enabled
-  <a href="https://support.mozilla.org/kb/https-only-prefs"> HTTPS-Only mode</a>. This property is read-only on all platforms. 
+  <p>This setting allows your extension to determine if a user has enabled
+  <a href="https://support.mozilla.org/kb/https-only-prefs"> HTTPS-Only mode</a>. This property is read-only on all platforms. Its underlying value is a string that may take one of three values:</p>
+  <ul>
+    <li><code>"always"</code>: HTTPS-Only mode is on.</li>
+    <li><code>"never"</code>: HTTPS-Only mode is off.</li>
+    <li><code>"private_browsing"</code>: HTTPS-Only mode is on in private browsing windows only.</li>
+  </ul>
 </dd>
 </dl>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
@@ -35,6 +35,11 @@ tags:
   <li><code>proxy_only</code> (only connections using TURN on a TCP connection through a proxy are allowed)</li>
  </ul>
  </dd>
+ <dt><code>httpsOnlyMode</code></dt>
+<dd>
+  This setting allows your extension to determine if a user has enabled
+  <a href="https://support.mozilla.org/kb/https-only-prefs"> HTTPS-Only mode</a>. This property is read-only on all platforms. 
+</dd>
 </dl>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>


### PR DESCRIPTION
Partial fix for #289. Updates https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy/network to add info about httpsOnlyMode. 

@Rob--W, I saw other descriptions on this page with sentences like "A types.BrowserSetting object whose underlying value is a string." Could you provide those details for httspOnlyMode, and also any other details we want to include? 