### PR TITLE
fix: update reference to elements considered form controls

### DIFF
--- a/files/en-us/web/api/htmlformelement/elements/index.html
+++ b/files/en-us/web/api/htmlformelement/elements/index.html
@@ -47,8 +47,7 @@ tags:
   in the form by following a preorder, depth-first traversal of the tree. This is called
   <strong>tree order</strong>.</p>
 
-<p>{{page("/en-US/docs/Web/API/HTMLFormElement", "Elements that are considered form
-  controls")}}</p>
+<p>{{page("/en-US/docs/Web/API/HTMLFormElement", "Elements that are considered form controls")}}</p>
 
 <h2 id="Example">Example</h2>
 


### PR DESCRIPTION
Removes line break so content is displayed inline correctly.