### PR TITLE
Update documentation on Firefox's state size limit

### DIFF
--- a/files/en-us/web/api/history/pushstate/index.html
+++ b/files/en-us/web/api/history/pushstate/index.html
@@ -36,7 +36,7 @@ tags:
     <code>state</code> object.</dd>
   <dd>The <code>state</code> object can be anything that can be serialized. Because
     Firefox saves <code>state</code> objects to the user's disk so they can be restored
-    after the user restarts the browser, we impose a size limit of 640k characters on the
+    after the user restarts the browser, we impose a size limit of 2 MiB on the
     serialized representation of a <code>state</code> object. If you pass a
     <code>state</code> object whose serialized representation is larger than this
     to <code>pushState()</code>, the method will throw an exception. If you need more


### PR DESCRIPTION
Per https://searchfox.org/mozilla-central/rev/d1e33e3e11f559952d7d80e722d26a6cf5dd80ac/docshell/base/nsDocShell.cpp#11230