### PR TITLE
Fix dead link in HTMLMediaElement: initialTime doc

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/initialtime/index.html
+++ b/files/en-us/web/api/htmlmediaelement/initialtime/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{deprecated_header}}{{APIRef("HTML DOM")}}</div>
 
-<p>The <strong><code>HTMLMediaElement.initialTime</code></strong> is the initial playback position in seconds. This property is obsolete, you can use a <a href="https://developer.mozilla.org/de/docs/Web/HTML/Using_HTML5_audio_and_video#Specifying_playback_range">Media Fragments URI</a> in the {{domxref("HTMLMediaElement.src")}} attribute instead.</p>
+<p>The <strong><code>HTMLMediaElement.initialTime</code></strong> is the initial playback position in seconds. This property is obsolete, you can use a <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery#specifying_playback_range">Media Fragments URI</a> in the {{domxref("HTMLMediaElement.src")}} attribute instead.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/htmlmediaelement/initialtime/index.html
+++ b/files/en-us/web/api/htmlmediaelement/initialtime/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{deprecated_header}}{{APIRef("HTML DOM")}}</div>
 
-<p>The <strong><code>HTMLMediaElement.initialTime</code></strong> is the initial playback position in seconds. This property is obsolete, you can use a <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery#specifying_playback_range">Media Fragments URI</a> in the {{domxref("HTMLMediaElement.src")}} attribute instead.</p>
+<p>The <strong><code>HTMLMediaElement.initialTime</code></strong> is the initial playback position in seconds. This property is obsolete, you can use a <a href="/en-US/docs/Web/Guide/Audio_and_video_delivery#specifying_playback_range">Media Fragments URI</a> in the {{domxref("HTMLMediaElement.src")}} attribute instead.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
The current link leads to a 404, simply changing the `/de/` part to `/en-US/` leads yet to an other wrong page, this is the correct one.