### PR TITLE
console.exception does not exist in spec

### DIFF
--- a/files/en-us/web/api/console/error/index.html
+++ b/files/en-us/web/api/console/error/index.html
@@ -19,14 +19,7 @@ tags:
 
 <pre class="brush: js notranslate">console.error(<em>obj1</em> [, <em>obj2</em>, ..., <em>objN</em>]);
 console.error(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
-console.exception(<em>obj1</em> [, <em>obj2</em>, ..., <em>objN</em>]);
-console.exception(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 </pre>
-
-<div class="note">
-	<p><strong>Note:</strong> <code>console.exception()</code> is an alias for
-		<code>console.error()</code>; they are functionally identical.</p>
-</div>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -80,6 +73,6 @@ console.exception(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 	<li><a href="https://msdn.microsoft.com/library/gg589530">MSDN: Using the F12 Tools
 			Console to View Errors and Status</a></li>
 	<li><a
-			href="https://developers.google.com/chrome-developer-tools/docs/console#errors_and_warnings">Chrome
+			href="https://developers.google.com/web/tools/chrome-devtools/console/api#error">Chrome
 			Developer Tools: Using the Console</a></li>
 </ul>


### PR DESCRIPTION
It's also missing in Safari and Microsoft Edge.

Fixes #1447.