### PR TITLE
Fix Stringifiers link in “info in a WebIDL file”

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
@@ -1,6 +1,7 @@
 ---
 title: Information contained in a WebIDL file
-slug: MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
+slug: >-
+  MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
 tags:
   - Howto
   - MDN Meta
@@ -234,10 +235,10 @@ interface SpeechSynthesis {
 
 <p>It is uncommon to have getters throwing exceptions, though it happens in a few cases. In this case the <code>[GetterThrows]</code> annotation is used. Here also, the Syntax section of the property page <em>must</em> have an Exceptions subsection.</p>
 
-<pre class="brush: js notranslate"><code id="line-16">partial interface Blob {</code><code id="line-17">
-</code><code id="line-18">  <strong>[GetterThrows]</strong>
-</code><code id="line-19">  readonly attribute <span class="k">unsigned</span> <span class="k">long</span> <span class="k">long</span> size;
-};</code>
+<pre class="brush: js notranslate">partial interface Blob {
+  [GetterThrows]
+  readonly attribute unsigned long long size;
+};
 </pre>
 
 <h3 id="Not_throwing_exceptions">Not throwing exceptions</h3>
@@ -246,12 +247,12 @@ interface SpeechSynthesis {
 
 <p>Mostly for compatibility purpose, this behavior is sometimes annoying. To prevent this by creating a no-op setter (that is by silently ignoring any attempt to set the property to a new value), the <code>[LenientSetter]</code> annotation can be used.</p>
 
-<pre class="brush: js notranslate"><code id="line-223">partial interface Document {</code><code id="line-225">
-</code><code id="line-226"><strong>  [LenientSetter]</strong>
-</code><code id="line-227">  readonly attribute boolean fullscreen;</code><code id="line-229">
-</code><code id="line-230"><strong>  [LenientSetter]</strong>
-</code><code id="line-231">  readonly attribute boolean fullscreenEnabled;
-};</code>
+<pre class="brush: js notranslate">partial interface Document {
+  [LenientSetter]
+  readonly attribute boolean fullscreen;
+  [LenientSetter]
+  readonly attribute boolean fullscreenEnabled;
+};
 </pre>
 
 <p>In these cases, an extra sentence is added to the description of the property. E.g</p>
@@ -386,7 +387,7 @@ interface SpeechSynthesis {
 
 <h3 id="toString_and_toJSON">toString() and toJSON()</h3>
 
-<p>A stringifier specifies how an object based on an interface is resolved in contexts expecting a string. (See <a href="Stringifiers">stringifiers</a>.) Additionally, the keyword is mapped to <code>toString()</code> and defined as:</p>
+<p>A stringifier specifies how an object based on an interface is resolved in contexts expecting a string. (See the <a href="#Stringifiers">Stringifiers</a> section.) Additionally, the keyword is mapped to <code>toString()</code> and defined as:</p>
 
 <pre class="brush: js notranslate"><strong>stringifier;</strong></pre>
 


### PR DESCRIPTION
This change also fixes some some “HTML in `<pre>`” flaws.