### PR TITLE
Fix typo in Escaping special characters

### DIFF
--- a/files/en-us/web/api/document/queryselector/index.html
+++ b/files/en-us/web/api/document/queryselector/index.html
@@ -95,7 +95,7 @@ tags:
   document.querySelector('#foo\\\\bar'); // Match the first div
 
   document.querySelector('#foo:bar');    // Does not match anything
-  document.querySelector('#foo\\:bar');  // Match the second div
+  document.querySelector('#foo\:bar');  // Match the second div
 &lt;/script&gt;</pre>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
'foo\\:bar' must be used to find 'foo:bar'.