### PR TITLE
Hyperlink the word “stringifier” throughout

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/index.html
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/index.html
@@ -112,7 +112,7 @@ tags:
  <li>We document methods defined on the <u>prototype</u> of an object implementing this interface (instance methods), and methods defined on the actual class itself (static methods). On the rare occasions that they both exist on the same interface, you should list them in separate sections on the page (Static methods/Instance methods). Usually only instance methods exist, in which case you can put these under the title "Methods".</li>
  <li>We do not document inherited properties and methods of the interface: they are listed on the respective parent interface. We do hint at their existence though.</li>
  <li>We do document properties and methods defined in mixins, though we use the mixin name as interface name. (This is not optimal as the mixin name will not appear in the console, but it prevents the duplication of documentation. We may revisit this in the future.)</li>
- <li>Special methods like the stringifier (<code>toString()</code>) and the jsonizer (<code>toJSON()</code>) are also listed if they do exist.</li>
+ <li>Special methods like the <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> (<code>toString()</code>) and the jsonizer (<code>toJSON()</code>) are also listed if they do exist.</li>
  <li>Named constructors (like <code>Image()</code>  for {{domxref("HTMLImageElement")}} ) are also listed, if relevant.</li>
 </ul>
 </div>

--- a/files/en-us/web/api/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
-<p><span class="seoSummary">The <strong><code>CSSKeywordValue</code></strong> interface of the <a href="/docs/Web/API/CSS_Typed_Object_Model_API">CSS Typed Object Model API</a> creates an object to represent CSS keywords and other identifiers. </span> The interface instance name is a stringifier meaning that when used anywhere a string is expected it will return the value of <code>CSSKeyword.value</code>.</p>
+<p><span class="seoSummary">The <strong><code>CSSKeywordValue</code></strong> interface of the <a href="/docs/Web/API/CSS_Typed_Object_Model_API">CSS Typed Object Model API</a> creates an object to represent CSS keywords and other identifiers. </span> The interface instance name is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> meaning that when used anywhere a string is expected it will return the value of <code>CSSKeyword.value</code>.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
-<p class="summary">The <strong><code>toString()</code></strong> method of the {{domxref("CSSTransformComponent")}} interface is a stringifier returning a <a href="/en-US/docs/Web/CSS/CSS_Transforms">CSS Transforms</a> function.</p>
+<p class="summary">The <strong><code>toString()</code></strong> method of the {{domxref("CSSTransformComponent")}} interface is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> returning a <a href="/en-US/docs/Web/CSS/CSS_Transforms">CSS Transforms</a> function.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/domtokenlist/index.html
+++ b/files/en-us/web/api/domtokenlist/index.html
@@ -18,7 +18,7 @@ tags:
  <dt>{{domxref("DOMTokenList.length")}} {{ReadOnlyInline}}</dt>
  <dd>Is an <code>integer</code> representing the number of objects stored in the object.</dd>
  <dt>{{domxref("DOMTokenList.value")}}</dt>
- <dd>A stringifier property that returns the value of the list as a {{domxref("DOMString")}}.</dd>
+ <dd>A <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> property that returns the value of the list as a {{domxref("DOMString")}}.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/domtokenlist/value/index.html
+++ b/files/en-us/web/api/domtokenlist/value/index.html
@@ -12,7 +12,7 @@ tags:
 <p>{{APIRef("DOM")}}</p>
 
 <p>The <code><strong>value</strong></code> property of the {{domxref("DOMTokenList")}}
-  interface is a stringifier that returns the value of the list as a
+  interface is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns the value of the list as a
   {{domxref("DOMString")}}, or clears and sets the list to the given value.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/htmlhyperlinkelementutils/href/index.html
+++ b/files/en-us/web/api/htmlhyperlinkelementutils/href/index.html
@@ -13,7 +13,7 @@ tags:
 <p>{{ApiRef("URL API")}}</p>
 
 <p>The <strong><code>HTMLHyperlinkElementUtils.href</code></strong> property is a
-  stringifier that returns a {{domxref("USVString")}} containing the whole URL, and allows
+  <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("USVString")}} containing the whole URL, and allows
   the href to be updated.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/htmlhyperlinkelementutils/index.html
+++ b/files/en-us/web/api/htmlhyperlinkelementutils/index.html
@@ -21,7 +21,7 @@ tags:
 
 <dl>
  <dt>{{domxref("HTMLHyperlinkElementUtils.href")}}</dt>
- <dd>This a stringifier property that returns a {{domxref("USVString")}} containing the whole URL, and allows the href to be updated.</dd>
+ <dd>This a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a>property that returns a {{domxref("USVString")}} containing the whole URL, and allows the href to be updated.</dd>
  <dt>{{domxref("HTMLHyperlinkElementUtils.protocol")}}</dt>
  <dd>This is a {{domxref("USVString")}} containing the protocol scheme of the URL, including the final <code>':'</code>.</dd>
  <dt>{{domxref("HTMLHyperlinkElementUtils.host")}}</dt>

--- a/files/en-us/web/api/htmlhyperlinkelementutils/tostring/index.html
+++ b/files/en-us/web/api/htmlhyperlinkelementutils/tostring/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{ApiRef("URL API")}}</p>
 
-<p>The <strong><code>HTMLHyperlinkElementUtils.toString()</code></strong> stringifier
+<p>The <strong><code>HTMLHyperlinkElementUtils.toString()</code></strong> <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a>
   method returns a {{domxref("USVString")}} containing the whole URL. It is a read-only
   version of {{domxref("HTMLHyperlinkElementUtils.href")}}.</p>
 

--- a/files/en-us/web/api/location/href/index.html
+++ b/files/en-us/web/api/location/href/index.html
@@ -10,7 +10,7 @@ tags:
 <p>{{ApiRef("Location")}}</p>
 
 <p>The <strong><code>href</code></strong> property of the {{domxref("Location")}}
-  interface is a stringifier that returns a {{domxref("USVString")}} containing the whole
+  interface is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("USVString")}} containing the whole
   URL, and allows the href to be updated.</p>
 
 <p>Setting the value of <code>href</code> <em>navigates</em> to the provided URL. If you

--- a/files/en-us/web/api/location/index.html
+++ b/files/en-us/web/api/location/index.html
@@ -64,7 +64,7 @@ body {display:table-cell; text-align:center; vertical-align:middle; font-family:
  <dt>{{domxref("Location.ancestorOrigins")}}</dt>
  <dd>Is a static {{domxref("DOMStringList")}} containing, in reverse order, the origins of all ancestor browsing contexts of the document associated with the given <code>Location</code> object.</dd>
  <dt>{{domxref("Location.href")}}</dt>
- <dd>Is a stringifier that returns a {{domxref("USVString")}} containing the entire URL. If changed, the associated document navigates to the new page. It can be set from a different origin than the associated document.</dd>
+ <dd>Is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("USVString")}} containing the entire URL. If changed, the associated document navigates to the new page. It can be set from a different origin than the associated document.</dd>
  <dt>{{domxref("Location.protocol")}}</dt>
  <dd>Is a {{domxref("USVString")}} containing the protocol scheme of the URL, including the final <code>':'</code>.</dd>
  <dt>{{domxref("Location.host")}}</dt>

--- a/files/en-us/web/api/location/tostring/index.html
+++ b/files/en-us/web/api/location/tostring/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{ApiRef("Location")}}</p>
 
-<p>The <strong><code>toString()</code></strong> stringifier method of the
+<p>The <strong><code>toString()</code></strong> <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> method of the
   {{domxref("Location")}} interface returns a {{domxref("USVString")}} containing the
   whole URL. It is a read-only version of {{domxref("Location.href")}}.</p>
 

--- a/files/en-us/web/api/medialist/index.html
+++ b/files/en-us/web/api/medialist/index.html
@@ -20,7 +20,7 @@ tags:
 
 <dl>
  <dt>{{domxref("MediaList.mediaText")}}</dt>
- <dd>A stringifier that returns a {{domxref("DOMString")}} representing the <code>MediaList</code> as text, and also allows you to set a new <code>MediaList</code>.</dd>
+ <dd>A <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("DOMString")}} representing the <code>MediaList</code> as text, and also allows you to set a new <code>MediaList</code>.</dd>
  <dt>{{domxref("MediaList.length")}} {{readonlyInline}}</dt>
  <dd>Returns the number of media queries in the <code>MediaList</code>.</dd>
 </dl>

--- a/files/en-us/web/api/medialist/mediatext/index.html
+++ b/files/en-us/web/api/medialist/mediatext/index.html
@@ -12,7 +12,7 @@ tags:
 <div>{{APIRef("CSSOM")}}</div>
 
 <p>The <code><strong>mediaText</strong></code> property of the {{domxref("MediaList")}}
-  interface is a stringifier that returns a {{domxref("DOMString")}} representing the
+  interface is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("DOMString")}} representing the
   <code>MediaList</code> as text, and also allows you to set a new <code>MediaList</code>.
 </p>
 

--- a/files/en-us/web/api/range/tostring/index.html
+++ b/files/en-us/web/api/range/tostring/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{ApiRef("DOM")}}</div>
 
-<p>The <strong><code>Range.toString()</code></strong> method is a stringifier returning
+<p>The <strong><code>Range.toString()</code></strong> method is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> returning
   the text of the {{domxref("Range")}}.</p>
 
 <p>Alerting the contents of a {{domxref("Range")}} makes an implicit

--- a/files/en-us/web/api/url/index.html
+++ b/files/en-us/web/api/url/index.html
@@ -42,7 +42,7 @@ tags:
  <dt>{{domxref("URL.hostname", "hostname")}}</dt>
  <dd>A {{domxref("USVString")}} containing the domain of the URL.</dd>
  <dt>{{domxref("URL.href", "href")}}</dt>
- <dd>A stringifier that returns a {{domxref("USVString")}} containing the whole URL.</dd>
+ <dd>A <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("USVString")}} containing the whole URL.</dd>
  <dt>{{domxref("URL.origin", "origin")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("USVString")}} containing the origin of the URL, that is its scheme, its domain and its port.</dd>
  <dt>{{domxref("URL.password", "password")}}</dt>

--- a/files/en-us/web/api/url/tostring/index.html
+++ b/files/en-us/web/api/url/tostring/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{ApiRef("URL API")}}</div>
 
-<p>The <strong><code>URL.toString()</code></strong> stringifier method returns a
+<p>The <strong><code>URL.toString()</code></strong> <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> method returns a
   {{domxref("USVString")}} containing the whole URL. It is effectively a read-only version
   of {{domxref("URL.href")}}.</p>
 

--- a/files/en-us/web/api/urlutilsreadonly/href/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/href/index.html
@@ -13,7 +13,7 @@ tags:
 <p>{{ApiRef("URL API")}}{{SeeCompatTable}}</p>
 
 <p>The <code><strong>URLUtilsReadOnly</strong></code><strong><code>.href</code></strong>
-  read-only property is a stringifier that returns a {{domxref("DOMString")}} containing
+  read-only property is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("DOMString")}} containing
   the whole URL.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/urlutilsreadonly/tostring/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/tostring/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>The
   <code><strong>URLUtilsReadOnly</strong></code><strong><code>.toString()</code></strong>
-  stringifier method returns a {{domxref("DOMString")}} containing the whole URL. It is a
+  <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> method returns a {{domxref("DOMString")}} containing the whole URL. It is a
   synonym for {{domxref("URLUtilsReadOnly.href")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/workerlocation/index.html
+++ b/files/en-us/web/api/workerlocation/index.html
@@ -17,7 +17,7 @@ tags:
 
 <dl>
  <dt>{{domxref("URLUtilsReadOnly.href")}} {{readOnlyInline}}</dt>
- <dd>Is a stringifier that returns a {{domxref("DOMString")}} containing the whole URL of the script executed in the {{domxref("Worker")}}.</dd>
+ <dd>Is a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers">stringifier</a> that returns a {{domxref("DOMString")}} containing the whole URL of the script executed in the {{domxref("Worker")}}.</dd>
  <dt>{{domxref("URLUtilsReadOnly.protocol")}} {{readOnlyInline}}</dt>
  <dd>Is a {{domxref("DOMString")}} containing the protocol scheme of the URL of the script executed in the {{domxref("Worker")}}, including the final <code>':'</code>.</dd>
  <dt>{{domxref("URLUtilsReadOnly.host")}} {{readOnlyInline}}</dt>


### PR DESCRIPTION
This change hyperlinks the word “stringifier” to https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#Stringifiers in a number of MDN articles where the word occurs.