### PR TITLE
Fix wrong info about ACAO header allowing a list

### DIFF
--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.html
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.html
@@ -23,17 +23,13 @@ tags:
 
 <h2 id="What_went_wrong">What went wrong?</h2>
 
-<p>In other words, the origin making the request does not match any of the origins
-  permitted by the  {{HTTPHeader("Access-Control-Allow-Origin")}} header.</p>
-
-<p>This error can also occur if the response includes more than one
+<p>The origin making the request does not match the origin permitted by the {{HTTPHeader("Access-Control-Allow-Origin")}} header. This error can also occur if the response includes more than one
   <code>Access-Control-Allow-Origin</code> header.</p>
 
 <p>If the service your code is accessing using a CORS request is under your control, make
   sure that it's configured to include your origin in its
   <code>Access-Control-Allow-Origin</code> header, and that only one such header is
-  included in responses. The header itself accepts a comma-delineated list of origins, so
-  adding a new origin is not difficult.</p>
+  included in responses, and that it includes only a single origin.</p>
 
 <p>For example, in Apache, add a line such as the following to the server's configuration
   (within the appropriate <code>&lt;Directory&gt;</code>, <code>&lt;Location&gt;</code>,
@@ -42,11 +38,11 @@ tags:
   and <code>apache.conf</code> are common names for these), or in an
   <code>.htaccess</code> file.</p>
 
-<pre>Header set Access-Control-Allow-Origin '<em>origin-list</em>'</pre>
+<pre>Header set Access-Control-Allow-Origin '<em>origin</em>'</pre>
 
 <p>For Nginx, the command to set up this header is:</p>
 
-<pre>add_header 'Access-Control-Allow-Origin' '<em>origin-list</em>'</pre>
+<pre>add_header 'Access-Control-Allow-Origin' '<em>origin</em>'</pre>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
The value of the Access-Control-Allow-Origin response header must either be the `*` wildcard, or a single origin. It can’t be a list of origins.