### PR TITLE
scroll-snap-stop fixes

### DIFF
--- a/files/en-us/web/css/css_scroll_snap/index.html
+++ b/files/en-us/web/css/css_scroll_snap/index.html
@@ -12,17 +12,12 @@ tags:
 
 <p class="summary"><strong>CSS Scroll Snap</strong> is a module of CSS that introduces scroll snap positions, which enforce the scroll positions that a {{Glossary("scroll container")}}’s {{Glossary("scrollport")}} may end at after a scrolling operation has completed.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The previous version of this module was called Scroll Snap Points and has been deprecated. CSS Scroll Snap is the current implementation.</p>
-</div>
-
 <h2 id="Reference">Reference</h2>
 
 <h3 id="CSS_Properties_on_Containers">CSS Properties on Containers</h3>
 
 <ul>
 	<li>{{cssxref("scroll-snap-type")}}</li>
-	<li>{{cssxref("scroll-snap-stop")}}</li>
 	<li>{{cssxref("scroll-padding")}}</li>
 	<li>{{cssxref("scroll-padding-top")}}</li>
 	<li>{{cssxref("scroll-padding-right")}}</li>
@@ -51,13 +46,14 @@ tags:
 	<li>{{cssxref("scroll-margin-block")}}</li>
 	<li>{{cssxref("scroll-margin-block-start")}}</li>
 	<li>{{cssxref("scroll-margin-block-end")}}</li>
+	<li>{{cssxref("scroll-snap-stop")}}</li>
 </ul>
 
 <h2 id="Guides">Guides</h2>
 
 <ul>
 	<li><a href="/en-US/docs/Web/CSS/CSS_Scroll_Snap/Basic_concepts">Basic concepts of CSS Scroll Snap</a></li>
-	<li><a href="/en-US/docs/Web/CSS/CSS_Scroll_Snap/compat">Browser Compatibility and Scroll Snap</a></li>
+	<li><a href="/en-US/docs/Web/CSS/CSS_Scroll_Snap/Browser_compat">Browser Compatibility and Scroll Snap</a></li>
 </ul>
 
 <h2 id="Specifications">Specifications</h2>
@@ -81,4 +77,8 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The individual property pages detail the browser compatibility situation for Scroll Snap. <a href="/en-US/docs/Web/CSS/CSS_Scroll_Snap/compat">Read the guide to browser compatibility</a> for an overview of how to support both the old and new specification. </p>
+<p>The individual property pages detail browser compatibility information for each property.</p>
+
+<div class="note">
+  <p><strong>Note</strong>: The previous version of this module was called Scroll Snap Points and has been deprecated. CSS Scroll Snap is the current implementation. <a href="/en-US/docs/Web/CSS/CSS_Scroll_Snap/Browser_compat">Read the guide to browser compatibility</a> for an overview of how to support both the old and new specification. </p>
+</div>

--- a/files/en-us/web/css/scroll-snap-stop/index.html
+++ b/files/en-us/web/css/scroll-snap-stop/index.html
@@ -9,7 +9,7 @@ tags:
   - 'recipe:css-property'
   - scroll-snap-stop
 ---
-<div>{{CSSRef}}{{SeeCompatTable}}</div>
+<div>{{CSSRef}}</div>
 
 <p>The <strong><code>scroll-snap-stop</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines whether the scroll container is allowed to "pass over" possible snap positions.</p>
 


### PR DESCRIPTION
Fixes #1650 

`scroll-snap-stop` was in the wrong place in the listing, also tidied up a couple of things. Moved the note about the old Firefox spec to the bottom of the page.