### PR TITLE
Remove {{Obsolete_header}} from Kitchensink

### DIFF
--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -297,8 +297,6 @@ rect2.bind("EnterFrame", function () {
 
 <h3 id="Obsolete_CSSOM_interfaces">Obsolete CSSOM interfaces {{Obsolete_Inline}}</h3>
 
-<p>{{Obsolete_Header}}</p>
-
 <p>{{InheritanceDiagram}}</p>
 
 <div>{{EmbedGHLiveSample("web-tech-games/index.html", '100%', 820)}}</div>
@@ -365,7 +363,7 @@ rect2.bind("EnterFrame", function () {
 </dl>
 
 {{Non-standard_Header}}
-{{Obsolete_Header}}
+{{SeeCompatTable}}
 {{Deprecated_Header}}
 
 <p>Small change</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -363,7 +363,6 @@ rect2.bind("EnterFrame", function () {
 </dl>
 
 {{Non-standard_Header}}
-{{SeeCompatTable}}
 {{Deprecated_Header}}
 
 <p>Small change</p>


### PR DESCRIPTION
This commit removes the last instances of {{Obsolete_header}} from EN-US content.