### PR TITLE
Fix spec macro in “HTMLMediaElement: seekable” doc

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/seekable/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seekable/index.html
@@ -61,8 +61,7 @@ for (let count = 0; count &lt; timeRangesObject.length; count ++) {
       <td>Initial definition.</td>
     </tr>
     <tr>
-      <td>{{SpecName('Media Source
-        Extensions','#htmlmediaelement-extensions','HTMLMediaElement extensions, like for
+      <td>{{SpecName('Media Source Extensions','#htmlmediaelement-extensions','HTMLMediaElement extensions, like for
         seekable')}}</td>
       <td>{{Spec2('Media Source Extensions')}}</td>
       <td>Specifies a new algorithm for returning the seekable time range of a media


### PR DESCRIPTION
This change closes a linebreak in a SpecName macro call in the “HTMLMediaElement.seekable” article. Otherwise, without this change, the spec shows up in the spec table as a broken link with Unknown as the spec title.