### PR TITLE
Fix spec macro in “TouchList: item()” doc

### DIFF
--- a/files/en-us/web/api/touchlist/item/index.html
+++ b/files/en-us/web/api/touchlist/item/index.html
@@ -75,8 +75,7 @@ target.addEventListener('touchstart', function(ev) {
       <td>Non-stable version.</td>
     </tr>
     <tr>
-      <td>{{SpecName('Touch
-        Events','#widl-TouchList-item-getter-Touch-unsigned-long-index')}}</td>
+      <td>{{SpecName('Touch Events','#widl-TouchList-item-getter-Touch-unsigned-long-index')}}</td>
       <td>{{Spec2('Touch Events')}}</td>
       <td>Initial definition.</td>
     </tr>


### PR DESCRIPTION
This change closes a linebreak in a SpecName macro call in the “TouchList: item()” article. Otherwise, without this change, the spec shows up in the spec table as a broken link with Unknown as its title.