### PR TITLE
TextDecoderStream

### DIFF
--- a/files/en-us/web/api/encoding_api/encodings/index.html
+++ b/files/en-us/web/api/encoding_api/encodings/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>The constructors for {{domxref("TextDecoder")}} and {{domxref("TextDecoderStream")}} can be passed an optional <code>label</code>, representing the encoding to be used. The default is <code>UTF-8</code>.</p>
 
-<p>The following table details all encoding names and labels that User Agents must support, as defined in the Encoding Spec. THese are generally applicable anywhere character encodings are used.</p> 
+<p>The following table lists all encoding names and labels that user agents must support, as defined in the Encoding Spec. These are generally applicable anywhere character encodings are used.</p> 
 
 <table class="standard-table">
     <thead>

--- a/files/en-us/web/api/encoding_api/encodings/index.html
+++ b/files/en-us/web/api/encoding_api/encodings/index.html
@@ -1,0 +1,305 @@
+---
+title: Encoding API Encodings
+slug: Web/API/Encoding_API/Encodings
+tags:
+  - API
+  - Encoding
+  - Overview
+  - Reference
+---
+<p>{{DefaultAPISidebar("Encoding API")}}</p>
+
+<p>The constructors for {{domxref("TextDecoder")}} and {{domxref("TextDecoderStream")}} can be passed an optional <code>label</code>, representing the encoding to be used. The default is <code>UTF-8</code>.</p>
+
+<p>The following table details all encoding names and labels that User Agents must support, as defined in the Encoding Spec. THese are generally applicable anywhere character encodings are used.</p> 
+
+<table class="standard-table">
+    <thead>
+      <tr>
+        <th scope="col">Label</th>
+        <th scope="col">Encoding</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>"<code>unicode-1-1-utf-8</code>", "<code>utf-8</code>", "<code>utf8</code>"
+        </td>
+        <td><code>'utf-8'</code></td>
+      </tr>
+      <tr>
+        <td>"<code>866</code>", "<code>cp866</code>", "<code>csibm866</code>",
+          "<code>ibm866</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'Code_page_866', "'ibm866'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatin2</code>", "<code>iso-8859-2</code>",
+          "<code>iso-ir-101</code>", "<code>iso8859-2</code>", "<code>iso88592</code>",
+          "<code>iso_8859-2</code>", "<code>iso_8859-2:1987</code>", "<code>l2</code>",
+          "<code>latin2</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-2', "'iso-8859-2'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatin3</code>", "<code>iso-8859-3</code>",
+          "<code>iso-ir-109</code>", "<code>iso8859-3</code>", "<code>iso88593</code>",
+          "<code>iso_8859-3</code>", "<code>iso_8859-3:1988</code>", "<code>l3</code>",
+          "<code>latin3</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-3', "'iso-8859-3'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatin4</code>", "<code>iso-8859-4</code>",
+          "<code>iso-ir-110</code>", "<code>iso8859-4</code>", "<code>iso88594</code>",
+          "<code>iso_8859-4</code>", "<code>iso_8859-4:1988</code>", "<code>l4</code>",
+          "<code>latin4</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-4', "'iso-8859-4'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatincyrillic</code>", "<code>cyrillic</code>",
+          "<code>iso-8859-5</code>", "<code>iso-ir-144</code>", "<code>iso88595</code>",
+          "<code>iso_8859-5</code>", "<code>iso_8859-5:1988</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-5', "'iso-8859-5'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>arabic</code>", "<code>asmo-708</code>", "<code>csiso88596e</code>",
+          "<code>csiso88596i</code>", "<code>csisolatinarabic</code>",
+          "<code>ecma-114</code>", "<code>iso-8859-6</code>",
+          "<code>iso-8859-6-e</code>", "<code>iso-8859-6-i</code>",
+          "<code>iso-ir-127</code>", "<code>iso8859-6</code>", "<code>iso88596</code>",
+          "<code>iso_8859-6</code>", "<code>iso_8859-6:1987</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-6', "'iso-8859-6'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatingreek</code>", "<code>ecma-118</code>",
+          "<code>elot_928</code>", "<code>greek</code>", "<code>greek8</code>",
+          "<code>iso-8859-7</code>", "<code>iso-ir-126</code>",
+          "<code>iso8859-7</code>", "<code>iso88597</code>", "<code>iso_8859-7</code>",
+          "<code>iso_8859-7:1987</code>", "<code>sun_eu_greek</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-7', "'iso-8859-7'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csiso88598e</code>", "<code>csisolatinhebrew</code>",
+          "<code>hebrew</code>", "<code>iso-8859-8</code>", "<code>iso-8859-8-e</code>",
+          "<code>iso-ir-138</code>", "<code>iso8859-8</code>", "<code>iso88598</code>",
+          "<code>iso_8859-8</code>", "<code>iso_8859-8:1988</code>",
+          "<code>visual</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-8', "'iso-8859-8'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csiso88598i</code>", "<code>iso-8859-8-i</code>",
+          "<code>logical</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO-8859-8-I', "'iso-8859-8i'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatin6</code>", "<code>iso-8859-10</code>",
+          "<code>iso-ir-157</code>", "<code>iso8859-10</code>",
+          "<code>iso885910</code>", "<code>l6</code>", "<code>latin6</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-10', "'iso-8859-10'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>iso-8859-13</code>", "<code>iso8859-13</code>",
+          "<code>iso885913</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-13', "'iso-8859-13'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>iso-8859-14</code>", "<code>iso8859-14</code>",
+          "<code>iso885914</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-14', "'iso-8859-14'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csisolatin9</code>", "<code>iso-8859-15</code>",
+          "<code>iso8859-15</code>", "<code>iso885915</code>", "<code>l9</code>",
+          "<code>latin9</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-15', "'iso-8859-15'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>iso-8859-16</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-16', "'iso-8859-16'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cskoi8r</code>", "<code>koi</code>", "<code>koi8</code>",
+          "<code>koi8-r</code>", "<code>koi8_r</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'KOI8-R', "'koi8-r'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>koi8-u</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'KOI8-U', "'koi8-u'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>csmacintosh</code>", "<code>mac</code>", "<code>macintosh</code>",
+          "<code>x-mac-roman</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'Mac OS Roman', "'macintosh'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>dos-874</code>", "<code>iso-8859-11</code>",
+          "<code>iso8859-11</code>", "<code>iso885911</code>", "<code>tis-620</code>",
+          "<code>windows-874</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'Windows-874', "'windows-874'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>cp1250</code>", "<code>windows-1250</code>", "<code>x-cp1250</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1250', "'windows-1250'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1251</code>", "<code>windows-1251</code>", "<code>x-cp1251</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1251', "'windows-1251'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>ansi_x3.4-1968</code>", "<code>ascii</code>", "<code>cp1252</code>",
+          "<code>cp819</code>", "<code>csisolatin1</code>", "<code>ibm819</code>",
+          "<code>iso-8859-1</code>", "<code>iso-ir-100</code>",
+          "<code>iso8859-1</code>", "<code>iso88591</code>", "<code>iso_8859-1</code>",
+          "<code>iso_8859-1:1987</code>", "<code>l1</code>", "<code>latin1</code>",
+          "<code>us-ascii</code>", "<code>windows-1252</code>", "<code>x-cp1252</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1252', "'windows-1252'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1253</code>", "<code>windows-1253</code>", "<code>x-cp1253</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1253', "'windows-1253'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1254</code>", "<code>csisolatin5</code>",
+          "<code>iso-8859-9</code>", "<code>iso-ir-148</code>",
+          "<code>iso8859-9</code>", "<code>iso88599</code>", "<code>iso_8859-9</code>",
+          "<code>iso_8859-9:1989</code>", "<code>l5</code>", "<code>latin5</code>",
+          "<code>windows-1254</code>", "<code>x-cp1254</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1254', "'windows-1254'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1255</code>", "<code>windows-1255</code>", "<code>x-cp1255</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1255', "'windows-1255'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1256</code>", "<code>windows-1256</code>", "<code>x-cp1256</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1256', "'windows-1256'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1257</code>", "<code>windows-1257</code>", "<code>x-cp1257</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1257', "'windows-1257'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>cp1258</code>", "<code>windows-1258</code>", "<code>x-cp1258</code>"
+        </td>
+        <td><code>{{interwiki('wikipedia', 'Windows-1258', "'windows-1258'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>x-mac-cyrillic</code>", "<code>x-mac-ukrainian</code>"</td>
+        <td>
+          <code>{{interwiki('wikipedia', 'Macintosh Cyrillic encoding', "'x-mac-cyrillic'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>chinese</code>", "<code>csgb2312</code>",
+          "<code>csiso58gb231280</code>", "<code>gb2312</code>", "<code>gb_2312</code>",
+          "<code>gb_2312-80</code>", "<code>gbk</code>", "<code>iso-ir-58</code>",
+          "<code>x-gbk</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'GBK', "'gbk'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>gb18030</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'GB_18030', "'gb18030'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>hz-gb-2312</code>"</td>
+        <td>
+          <code>{{interwiki('wikipedia', 'HZ_(character_encoding)', "'hz-gb-2312'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>big5</code>", "<code>big5-hkscs</code>", "<code>cn-big5</code>",
+          "<code>csbig5</code>", "<code>x-x-big5</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'Big5', "'big5'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>cseucpkdfmtjapanese</code>", "<code>euc-jp</code>",
+          "<code>x-euc-jp</code>"</td>
+        <td>
+          <code>{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-JP', "'euc-jp'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <p>"<code>csiso2022jp</code>", "<code>iso-2022-jp</code>"</p>
+
+          <div class="note">
+            <p><strong>Note</strong>: Firefox used to accept <code>iso-2022-jp-2</code>
+              sequences silently when an <code>iso-2022-jp</code> decoder was
+              instantiated, however this was removed in version 56 to simplify the API,
+              as no other browsers support it and no pages seem to use it.</p>
+          </div>
+        </td>
+        <td>
+          <code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-JP', "'iso-2022-jp'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csshiftjis</code>", "<code>ms_kanji</code>",
+          "<code>shift-jis</code>", "<code>shift_jis</code>", "<code>sjis</code>",
+          "<code>windows-31j</code>", "<code>x-sjis</code>"</td>
+        <td><code>{{interwiki('wikipedia', 'Shift JIS', "'shift-jis'")}}</code></td>
+      </tr>
+      <tr>
+        <td>"<code>cseuckr</code>", "<code>csksc56011987</code>", "<code>euc-kr</code>",
+          "<code>iso-ir-149</code>", "<code>korean</code>",
+          "<code>ks_c_5601-1987</code>", "<code>ks_c_5601-1989</code>",
+          "<code>ksc5601</code>", "<code>ksc_5601</code>", "<code>windows-949</code>"
+        </td>
+        <td>
+          <code>{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-KR', "'euc-kr'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>csiso2022kr</code>", "<code>iso-2022-kr</code>"</td>
+        <td>
+          <code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-KR', "'iso-2022-kr'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>utf-16be</code>"</td>
+        <td>
+          <code>{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16be'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>utf-16</code>", "<code>utf-16le</code>"</td>
+        <td>
+          <code>{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16le'")}}</code>
+        </td>
+      </tr>
+      <tr>
+        <td>"<code>x-user-defined</code>"</td>
+        <td><code>'x-user-defined'</code></td>
+      </tr>
+      <tr>
+        <td>"<code>iso-2022-cn</code>", "<code>iso-2022-cn-ext</code>"</td>
+        <td><code>'replacement'</code></td>
+      </tr>
+    </tbody>
+  </table>

--- a/files/en-us/web/api/encoding_api/encodings/index.html
+++ b/files/en-us/web/api/encoding_api/encodings/index.html
@@ -251,7 +251,7 @@ tags:
           <div class="note">
             <p><strong>Note</strong>: Firefox used to accept <code>iso-2022-jp-2</code>
               sequences silently when an <code>iso-2022-jp</code> decoder was
-              instantiated, however this was removed in version 56 to simplify the API,
+              instantiated; however this was removed in version 56 to simplify the API,
               as no other browsers support it and no pages seem to use it.</p>
           </div>
         </td>

--- a/files/en-us/web/api/textdecoder/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.html
@@ -29,7 +29,7 @@ tags:
 <dl>
   <dt><code>utfLabel</code>{{Optional_Inline}}</dt>
   <dd>Is a {{DOMxRef("DOMString")}}, defaulting to <code>"utf-8"</code>, containing the
-    <em>label</em> of the encoder.  This may be <a href="/en-US/docs/Web/API/Encoding_API/Encodings">any valid label</a>
+    <em>label</em> of the encoder.  This may be <a href="/en-US/docs/Web/API/Encoding_API/Encodings">any valid label</a>.
   </dd>
   <dt><code>options</code>{{Optional_Inline}}</dt>
   <dd>Is a <code>TextDecoderOptions</code> dictionary with the property:

--- a/files/en-us/web/api/textdecoder/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.html
@@ -2,12 +2,12 @@
 title: TextDecoder()
 slug: Web/API/TextDecoder/TextDecoder
 tags:
-- API
-- Constructor
-- Encoding
-- Experimental
-- Reference
-- TextDecoder
+  - API
+  - Constructor
+  - Encoding
+  - Experimental
+  - Reference
+  - TextDecoder
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -29,303 +29,13 @@ tags:
 <dl>
   <dt><code>utfLabel</code>{{Optional_Inline}}</dt>
   <dd>Is a {{DOMxRef("DOMString")}}, defaulting to <code>"utf-8"</code>, containing the
-    <em>label</em> of the encoder. Each label is associated with a specific encoding type:
-    <table class="standard-table">
-      <thead>
-        <tr>
-          <th scope="col">Possible values of <code>utfLabel</code></th>
-          <th scope="col">Encoding</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>"<code>unicode-1-1-utf-8</code>", "<code>utf-8</code>", "<code>utf8</code>"
-          </td>
-          <td><code>'utf-8'</code></td>
-        </tr>
-        <tr>
-          <td>"<code>866</code>", "<code>cp866</code>", "<code>csibm866</code>",
-            "<code>ibm866</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'Code_page_866', "'ibm866'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatin2</code>", "<code>iso-8859-2</code>",
-            "<code>iso-ir-101</code>", "<code>iso8859-2</code>", "<code>iso88592</code>",
-            "<code>iso_8859-2</code>", "<code>iso_8859-2:1987</code>", "<code>l2</code>",
-            "<code>latin2</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-2', "'iso-8859-2'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatin3</code>", "<code>iso-8859-3</code>",
-            "<code>iso-ir-109</code>", "<code>iso8859-3</code>", "<code>iso88593</code>",
-            "<code>iso_8859-3</code>", "<code>iso_8859-3:1988</code>", "<code>l3</code>",
-            "<code>latin3</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-3', "'iso-8859-3'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatin4</code>", "<code>iso-8859-4</code>",
-            "<code>iso-ir-110</code>", "<code>iso8859-4</code>", "<code>iso88594</code>",
-            "<code>iso_8859-4</code>", "<code>iso_8859-4:1988</code>", "<code>l4</code>",
-            "<code>latin4</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-4', "'iso-8859-4'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatincyrillic</code>", "<code>cyrillic</code>",
-            "<code>iso-8859-5</code>", "<code>iso-ir-144</code>", "<code>iso88595</code>",
-            "<code>iso_8859-5</code>", "<code>iso_8859-5:1988</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-5', "'iso-8859-5'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>arabic</code>", "<code>asmo-708</code>", "<code>csiso88596e</code>",
-            "<code>csiso88596i</code>", "<code>csisolatinarabic</code>",
-            "<code>ecma-114</code>", "<code>iso-8859-6</code>",
-            "<code>iso-8859-6-e</code>", "<code>iso-8859-6-i</code>",
-            "<code>iso-ir-127</code>", "<code>iso8859-6</code>", "<code>iso88596</code>",
-            "<code>iso_8859-6</code>", "<code>iso_8859-6:1987</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-6', "'iso-8859-6'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatingreek</code>", "<code>ecma-118</code>",
-            "<code>elot_928</code>", "<code>greek</code>", "<code>greek8</code>",
-            "<code>iso-8859-7</code>", "<code>iso-ir-126</code>",
-            "<code>iso8859-7</code>", "<code>iso88597</code>", "<code>iso_8859-7</code>",
-            "<code>iso_8859-7:1987</code>", "<code>sun_eu_greek</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-7', "'iso-8859-7'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csiso88598e</code>", "<code>csisolatinhebrew</code>",
-            "<code>hebrew</code>", "<code>iso-8859-8</code>", "<code>iso-8859-8-e</code>",
-            "<code>iso-ir-138</code>", "<code>iso8859-8</code>", "<code>iso88598</code>",
-            "<code>iso_8859-8</code>", "<code>iso_8859-8:1988</code>",
-            "<code>visual</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-8', "'iso-8859-8'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csiso88598i</code>", "<code>iso-8859-8-i</code>",
-            "<code>logical</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO-8859-8-I', "'iso-8859-8i'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatin6</code>", "<code>iso-8859-10</code>",
-            "<code>iso-ir-157</code>", "<code>iso8859-10</code>",
-            "<code>iso885910</code>", "<code>l6</code>", "<code>latin6</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-10', "'iso-8859-10'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>iso-8859-13</code>", "<code>iso8859-13</code>",
-            "<code>iso885913</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-13', "'iso-8859-13'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>iso-8859-14</code>", "<code>iso8859-14</code>",
-            "<code>iso885914</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-14', "'iso-8859-14'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csisolatin9</code>", "<code>iso-8859-15</code>",
-            "<code>iso8859-15</code>", "<code>iso885915</code>", "<code>l9</code>",
-            "<code>latin9</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-15', "'iso-8859-15'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>iso-8859-16</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'ISO/IEC_8859-16', "'iso-8859-16'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cskoi8r</code>", "<code>koi</code>", "<code>koi8</code>",
-            "<code>koi8-r</code>", "<code>koi8_r</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'KOI8-R', "'koi8-r'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>koi8-u</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'KOI8-U', "'koi8-u'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>csmacintosh</code>", "<code>mac</code>", "<code>macintosh</code>",
-            "<code>x-mac-roman</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'Mac OS Roman', "'macintosh'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>dos-874</code>", "<code>iso-8859-11</code>",
-            "<code>iso8859-11</code>", "<code>iso885911</code>", "<code>tis-620</code>",
-            "<code>windows-874</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'Windows-874', "'windows-874'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>cp1250</code>", "<code>windows-1250</code>", "<code>x-cp1250</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1250', "'windows-1250'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1251</code>", "<code>windows-1251</code>", "<code>x-cp1251</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1251', "'windows-1251'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>ansi_x3.4-1968</code>", "<code>ascii</code>", "<code>cp1252</code>",
-            "<code>cp819</code>", "<code>csisolatin1</code>", "<code>ibm819</code>",
-            "<code>iso-8859-1</code>", "<code>iso-ir-100</code>",
-            "<code>iso8859-1</code>", "<code>iso88591</code>", "<code>iso_8859-1</code>",
-            "<code>iso_8859-1:1987</code>", "<code>l1</code>", "<code>latin1</code>",
-            "<code>us-ascii</code>", "<code>windows-1252</code>", "<code>x-cp1252</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1252', "'windows-1252'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1253</code>", "<code>windows-1253</code>", "<code>x-cp1253</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1253', "'windows-1253'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1254</code>", "<code>csisolatin5</code>",
-            "<code>iso-8859-9</code>", "<code>iso-ir-148</code>",
-            "<code>iso8859-9</code>", "<code>iso88599</code>", "<code>iso_8859-9</code>",
-            "<code>iso_8859-9:1989</code>", "<code>l5</code>", "<code>latin5</code>",
-            "<code>windows-1254</code>", "<code>x-cp1254</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1254', "'windows-1254'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1255</code>", "<code>windows-1255</code>", "<code>x-cp1255</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1255', "'windows-1255'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1256</code>", "<code>windows-1256</code>", "<code>x-cp1256</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1256', "'windows-1256'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1257</code>", "<code>windows-1257</code>", "<code>x-cp1257</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1257', "'windows-1257'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>cp1258</code>", "<code>windows-1258</code>", "<code>x-cp1258</code>"
-          </td>
-          <td><code>{{interwiki('wikipedia', 'Windows-1258', "'windows-1258'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>x-mac-cyrillic</code>", "<code>x-mac-ukrainian</code>"</td>
-          <td>
-            <code>{{interwiki('wikipedia', 'Macintosh Cyrillic encoding', "'x-mac-cyrillic'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>chinese</code>", "<code>csgb2312</code>",
-            "<code>csiso58gb231280</code>", "<code>gb2312</code>", "<code>gb_2312</code>",
-            "<code>gb_2312-80</code>", "<code>gbk</code>", "<code>iso-ir-58</code>",
-            "<code>x-gbk</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'GBK', "'gbk'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>gb18030</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'GB_18030', "'gb18030'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>hz-gb-2312</code>"</td>
-          <td>
-            <code>{{interwiki('wikipedia', 'HZ_(character_encoding)', "'hz-gb-2312'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>big5</code>", "<code>big5-hkscs</code>", "<code>cn-big5</code>",
-            "<code>csbig5</code>", "<code>x-x-big5</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'Big5', "'big5'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>cseucpkdfmtjapanese</code>", "<code>euc-jp</code>",
-            "<code>x-euc-jp</code>"</td>
-          <td>
-            <code>{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-JP', "'euc-jp'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <p>"<code>csiso2022jp</code>", "<code>iso-2022-jp</code>"</p>
-
-            <div class="note">
-              <p><strong>Note</strong>: Firefox used to accept <code>iso-2022-jp-2</code>
-                sequences silently when an <code>iso-2022-jp</code> decoder was
-                instantiated, however this was removed in version 56 to simplify the API,
-                as no other browsers support it and no pages seem to use it.</p>
-            </div>
-          </td>
-          <td>
-            <code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-JP', "'iso-2022-jp'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csshiftjis</code>", "<code>ms_kanji</code>",
-            "<code>shift-jis</code>", "<code>shift_jis</code>", "<code>sjis</code>",
-            "<code>windows-31j</code>", "<code>x-sjis</code>"</td>
-          <td><code>{{interwiki('wikipedia', 'Shift JIS', "'shift-jis'")}}</code></td>
-        </tr>
-        <tr>
-          <td>"<code>cseuckr</code>", "<code>csksc56011987</code>", "<code>euc-kr</code>",
-            "<code>iso-ir-149</code>", "<code>korean</code>",
-            "<code>ks_c_5601-1987</code>", "<code>ks_c_5601-1989</code>",
-            "<code>ksc5601</code>", "<code>ksc_5601</code>", "<code>windows-949</code>"
-          </td>
-          <td>
-            <code>{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-KR', "'euc-kr'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>csiso2022kr</code>", "<code>iso-2022-kr</code>"</td>
-          <td>
-            <code>{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-KR', "'iso-2022-kr'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>utf-16be</code>"</td>
-          <td>
-            <code>{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16be'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>utf-16</code>", "<code>utf-16le</code>"</td>
-          <td>
-            <code>{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16le'")}}</code>
-          </td>
-        </tr>
-        <tr>
-          <td>"<code>x-user-defined</code>"</td>
-          <td><code>'x-user-defined'</code></td>
-        </tr>
-        <tr>
-          <td>"<code>iso-2022-cn</code>", "<code>iso-2022-cn-ext</code>"</td>
-          <td><code>'replacement'</code></td>
-        </tr>
-      </tbody>
-    </table>
+    <em>label</em> of the encoder.  This may be <a href="/en-US/docs/Web/API/Encoding_API/Encodings">any valid label</a>
   </dd>
   <dt><code>options</code>{{Optional_Inline}}</dt>
   <dd>Is a <code>TextDecoderOptions</code> dictionary with the property:
     <dl>
       <dt><code>fatal</code></dt>
-      <dd>A <a href="/en-US/docs/Web/API/Boolean"
+      <dd>A <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean"
           title="The Boolean object is an object wrapper for a boolean value."><code>Boolean</code></a>
         flag indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a
         {{DOMxRef("DOMException")}} with the <code>"EncodingError"</code> value when an
@@ -337,10 +47,10 @@ tags:
 <h2 id="Example">Example</h2>
 
 <pre
-  class="brush: js"><code class="language-js">var textDecoder1 = new TextDecoder("iso-8859-2");
+  class="brush: js">var textDecoder1 = new TextDecoder(&quot;iso-8859-2&quot;);
 var textDecoder2 = new TextDecoder();
-var textDecoder3 = new TextDecoder("csiso2022kr", {fatal: true}); // Allows EncodingError exception to be thrown.
-var textDecoder4 = new TextDecoder("iso-2022-cn"); // Throw a TypeError exception.</code></pre>
+var textDecoder3 = new TextDecoder(&quot;csiso2022kr&quot;, {fatal: true}); // Allows EncodingError exception to be thrown.
+var textDecoder4 = new TextDecoder(&quot;iso-2022-cn&quot;); // Throw a TypeError exception.</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.html
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.html
@@ -10,9 +10,7 @@ tags:
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a
-  {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the
-  specific encoder.</p>
+<p class="summary">The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the specific encoder.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.html
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.html
@@ -1,0 +1,53 @@
+---
+title: TextDecoderStream.encoding
+slug: Web/API/TextDecoderStream/encoding
+tags:
+  - API
+  - Property
+  - Reference
+  - encoding
+  - TextDecoderStream
+---
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>encoding</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a
+  {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the
+  specific encoder.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>encoding</var> = <var>TextDecoderStream</var>.encoding;</pre>
+
+<h3>Value</h3>
+<p>A {{DOMxRef("DOMString")}}, ASCII lowercased.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Returning the value of <code>encoding</code> from a <code>TextDecoderStream</code>.</p>
+
+<pre class="brush:js">stream = new TextDecoderStream();
+console.log(stream.encoding); // returns the default "utf-8"</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName("Encoding", "#dom-textdecoder-encoding", "TextDecoderStream.encoding")}}</td>
+    <td>{{Spec2("Encoding")}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream.encoding")}}</p>

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -19,7 +19,7 @@ tags:
 <pre class="syntaxbox">var <var>fatal</var> = <var>TextDecoderStream</var>.fatal;</pre>
 
 <h3>Value</h3>
-<p>A {{jsxref("boolean")}} which will return <code>true</code> if the error mode is set to <code>fatal</code>, otherwise it returns <code>false</code>.</p>
+<p>A {{jsxref("boolean")}} which will return <code>true</code> if the error mode is set to <code>fatal</code>. Otherwise it returns <code>false</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p class="summary">The <strong><code>fatal</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref("boolean")}} indicating if the error mode of the <code>TextDecoderStream</code> object is set to <code>fatal</code>.</p>
 
-<p>The two possible values of error mode are <code>fatal</code> or <code>replacement</code>, the default being <code>replacement</code>.</p>
+<p>The two possible values of error mode are <code>fatal</code> or <code>replacement</code>, the default being <code>replacement</code> which pushes a replacement character <code>U+FFFD</code> (�) to the output.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -1,0 +1,50 @@
+---
+title: TextDecoderStream.fatal
+slug: Web/API/TextDecoderStream/fatal
+tags:
+  - API
+  - Property
+  - Reference
+  - fatal
+  - TextDecoderStream
+---
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>fatal</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref("boolean")}} indicating if the error mode of the <code>TextDecoderStream</code> object is set to <code>fatal</code>.</p>
+
+<p>The two possible values of error mode are <code>fatal</code> or <code>replacement</code>, the default being <code>replacement</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>fatal</var> = <var>TextDecoderStream</var>.fatal;</pre>
+
+<h3>Value</h3>
+<p>A {{jsxref("boolean")}} which will return <code>true</code> if the error mode is set to <code>fatal</code>, otherwise it returns <code>false</code>.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush:js">stream = new TextDecoderStream();
+console.log(stream.fatal); // returns false</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+     <td>{{SpecName("Encoding", "#dom-textdecoder-fatal", "TextDecoderStream.fatal")}}</td>
+     <td>{{Spec2("Encoding")}}</td>
+     <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream.fatal")}}</p>

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.html
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.html
@@ -1,0 +1,48 @@
+---
+title: TextDecoderStream.ignoreBOM
+slug: Web/API/TextDecoderStream/ignoreBOM
+tags:
+  - API
+  - Property
+  - Reference
+  - ignoreBOM
+  - TextDecoderStream
+---
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>ignoreBOM</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{jsxref("boolean")}} indicating if the byte order mark (BOM) is to be ignored.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>ignoreBOM</var> = <var>TextDecoderStream</var>.ignoreBOM;</pre>
+
+<h3>Value</h3>
+<p>A {{jsxref("boolean")}}, initially <code>false</code> </p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush:js">stream = new TextDecoderStream();
+console.log(stream.ignoreBOM); // returns false</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName("Encoding", "#textdecoder-ignore-bom-flag", "TextDecoderStream.ignoreBOM")}}</td>
+    <td>{{Spec2("Encoding")}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream.ignoreBOM")}}</p>

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.html
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.html
@@ -3,6 +3,7 @@ title: TextDecoderStream.ignoreBOM
 slug: Web/API/TextDecoderStream/ignoreBOM
 tags:
   - API
+  - Encoding API
   - Property
   - Reference
   - ignoreBOM

--- a/files/en-us/web/api/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
-<p class="summary">The <strong><code>TextDecoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} is used to convert a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextDecoder")}}.</p>
+<p class="summary">The <strong><code>TextDecoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} converts a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextDecoder")}}.</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/index.html
@@ -1,0 +1,72 @@
+---
+title: TextDecoderStream
+slug: Web/API/TextDecoderStream
+tags:
+  - API
+  - Interface
+  - Reference
+  - TextDecoderStream
+---
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>TextDecoderStream</code></strong> interface of the {{domxref('Encoding API','','',' ')}} is used to convert a stream of strings into bytes in the UTF-8 encoding. It is the streaming equivalent of {{domxref("TextDecoder")}}.</p>
+
+<h2 id="Constructor">Constructor</h2>
+
+<dl>
+  <dt>{{domxref("TextDecoderStream.TextDecoderStream()")}}</dt>
+  <dd>Creates a new <code>TextDecoderStream</code> object.</dd>
+</dl>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+  <dt>{{DOMxRef("TextDecoderStream.encoding")}}{{ReadOnlyInline}}</dt>
+  <dd>An encoding.</dd>
+  <dt>{{DOMxRef("TextDecoderStream.fatal")}}{{ReadOnlyInline}}</dt>
+  <dd>A {{jsxref("boolean")}} indicating if the error mode is fatal.</dd>
+  <dt>{{DOMxRef("TextDecoderStream.ignoreBOM")}}{{ReadOnlyInline}}</dt>
+  <dd>A {{jsxref("boolean")}} indicating whether the byte order mark is ignored.</dd>
+  <dt>{{DOMxRef("TextDecoderStream.readable")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the {{domxref("ReadableStream")}} instance controlled by this object.</dd>
+  <dt>{{DOMxRef("TextDecoderStream.writable")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the {{domxref("WritableStream")}} instance controlled by this object.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<ul>
+  <li><a href="https://streams.spec.whatwg.org/demos/">Examples of streaming structured data and HTML</a></li>
+  <li><a href="https://glitch.com/~fetch-request-stream">An example of fetch request streams which uses <code>TextDecoderStream</code></a>.</li>
+</ul>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName("Encoding", "#interface-TextDecoderStream", "TextDecoderStream")}}</td>
+    <td>{{Spec2("Encoding")}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("TextEncoderStream")}}</li>
+  <li><a href="/en-US/docs/Web/API/Streams_API/Concepts">Streams API Concepts</a></li>
+  <li><a href="https://deanhume.com/experimenting-with-the-streams-api/">Experimenting with the Streams API</a></li>
+</ul>

--- a/files/en-us/web/api/textdecoderstream/readable/index.html
+++ b/files/en-us/web/api/textdecoderstream/readable/index.html
@@ -1,0 +1,50 @@
+---
+title: TextDecoderStream.readable
+slug: Web/API/TextDecoderStream/readable
+tags:
+  - API
+  - Property
+  - Reference
+  - readable
+  - TextDecoderStream
+---
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>readable</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("ReadableStream")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>readable</var> = <var>TextDecoderStream</var>.readable;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("ReadableStream")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Returning a {{domxref("ReadableStream")}} from a <code>TextDecoderStream</code>.</p>
+
+<pre class="brush:js">stream = new TextDecoderStream();
+console.log(stream.readable); //a ReadableStream</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName("Streams", "#dom-generictransformstream-readable", "readable")}}</td>
+    <td>{{Spec2("Streams")}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream.readable")}}</p>

--- a/files/en-us/web/api/textdecoderstream/readable/index.html
+++ b/files/en-us/web/api/textdecoderstream/readable/index.html
@@ -21,7 +21,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>Returning a {{domxref("ReadableStream")}} from a <code>TextDecoderStream</code>.</p>
+<p>This example shows how to return a {{domxref("ReadableStream")}} from a <code>TextDecoderStream</code>.</p>
 
 <pre class="brush:js">stream = new TextDecoderStream();
 console.log(stream.readable); //a ReadableStream</pre>

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -22,7 +22,7 @@ tags:
   <dt>label</dt>
   <dd>A {{domxref("DOMString")}} defaulting to <code>utf-8</code>. This may be <a href="/en-US/docs/Web/API/Encoding_API/Encodings">any valid label</a>.</dd>
   <dt><code>options</code>{{optional_inline}}</dt>
-  <dd>Is a <code>TextDecoderOptions</code> dictionary with the property:
+  <dd>A <code>TextDecoderOptions</code> dictionary with the property:
   <dl>
     <dt><code>fatal</code></dt>
     <dd>A {{domxref("boolean")}} indicating the error mode. If true then a {{domxref("DOMException")}} will be thrown if the decoder encounters an error. Defaults to <code>false</code>.</dd>

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -1,0 +1,60 @@
+---
+title: TextDecoderStream.TextDecoderStream()
+slug: Web/API/TextDecoderStream/TextDecoderStream
+tags:
+  - API
+  - Constructor
+  - Reference
+  - TextDecoderStream
+---
+
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>TextDecoderStream()</code></strong> constructor creates a new {{domxref("TextDecoderStream")}} object which is used to convert a stream of text in a binary encoding into strings.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>TextDecoderStream</var> = new TextDecoderStream(<var>label</var>,<var>options</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt>label</dt>
+  <dd>A {{domxref("DOMString")}} defaulting to <code>utf-8</code>. This may be <a href="/en-US/docs/Web/API/Encoding_API/Encodings">any valid label</a>.</dd>
+  <dt><code>options</code>{{optional_inline}}</dt>
+  <dd>Is a <code>TextDecoderOptions</code> dictionary with the property:
+  <dl>
+    <dt><code>fatal</code></dt>
+    <dd>A {{domxref("boolean")}} indicating the error mode. If true then a {{domxref("DOMException")}} will be thrown if the decoder encounters an error. Defaults to <code>false</code>.</dd>
+  </dl>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example demonstrates how to decode binary data retrieved from a {{jsxref("fetch")}}. THe data will be intepreted as UTF-8, as no <code>label</code> has been passed.</p>
+
+<pre class="brush: js">const response = await fetch("https://example.com");
+const stream = response.body.pipeThrough(new TextDecoderStream());</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName("Encoding", "#dom-textdecoderstream", "TextDecoderStream()")}}</td>
+    <td>{{Spec2("Encoding")}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream.TextDecoderStream")}}</p>

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example demonstrates how to decode binary data retrieved from a {{jsxref("fetch")}}. THe data will be intepreted as UTF-8, as no <code>label</code> has been passed.</p>
+<p>The following example demonstrates how to decode binary data retrieved from a {{jsxref("fetch")}} call. The data will be interpreted as UTF-8, as no <code>label</code> has been passed.</p>
 
 <pre class="brush: js">const response = await fetch("https://example.com");
 const stream = response.body.pipeThrough(new TextDecoderStream());</pre>

--- a/files/en-us/web/api/textdecoderstream/writable/index.html
+++ b/files/en-us/web/api/textdecoderstream/writable/index.html
@@ -1,0 +1,51 @@
+---
+title: TextDecoderStream.writable
+slug: Web/API/TextDecoderStream/writable
+tags:
+  - API
+  - Property
+  - Reference
+  - writable
+  - TextDecoderStream
+---
+<p>{{APIRef("Encoding API")}}</p>
+
+<p class="summary">The <strong><code>writable</code></strong> read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{domxref("WritableStream")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>writable</var> = <var>TextDecoderStream</var>.writable;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("WritableStream")}}.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Returning a {{domxref("WritableStream")}} from a <code>TextDecoderStream</code>.</p>
+
+<pre class="brush:js">stream = new TextDecoderStream();
+console.log(stream.writeable); //a WritableStream</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+    <td>{{SpecName("Streams", "#dom-generictransformstream-writable", "writable")}}</td>
+    <td>{{Spec2("Streams")}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TextDecoderStream.writable")}}</p>


### PR DESCRIPTION
Adds the `TextDecoderStream` API.

Discussed in Matrix where to put the table of encodings, used by both this API and `TextDecoder`. As it is specified in the Encoding Standard we decided to place it under the Encoding API.

The only update to `TextEncoder` was to move that table from the constructor and link to it, and deal with the fixable flaws on that constructor page while I was at it.

Reviewer: @jpmedley 