### PR TITLE
Fix "Window features" anchor

### DIFF
--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -47,8 +47,9 @@ tags:
   <dd>A {{domxref("DOMString")}} containing a comma-separated list of window features
     given with their corresponding values in the form "name=value". These features include
     options such as the window's default size and position, whether or not to include
-    toolbar, and so forth. There must be no whitespace in the string. See {{anch("Window
-    features")}} below for documentation of each of the features that can be specified.
+    toolbar, and so forth. There must be no whitespace in the string. See
+    {{anch("Window features")}} below for documentation of each of the features that can
+    be specified.
   </dd>
 </dl>
 


### PR DESCRIPTION
The line break causes the anchor to have four underscores rather than just one, which results in a broken link.