### PR TITLE
CSS translate property is no longer experimental

### DIFF
--- a/files/en-us/web/css/translate/index.html
+++ b/files/en-us/web/css/translate/index.html
@@ -4,7 +4,6 @@ slug: Web/CSS/translate
 tags:
   - CSS
   - CSS Property
-  - Experimental
   - Reference
   - Transforms
   - 'recipe:css-property'


### PR DESCRIPTION
The `translate` property was marked as experimental, but `rotate` and `scale` were not.
Remove the header metadata that was causing the little conical flask / experimental icon
to appear.