### PR TITLE
Clarify Promise.race rejection example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
@@ -147,7 +147,7 @@ Promise.race([p3, p4])
 .then(function(value) {
   console.log(value); // "three"
   // p3 is faster, so it fulfills
-}, function(reason) {
+}, function(error) {
   // Not called
 });
 


### PR DESCRIPTION
Just wanted to clarify the intention of the second parameter to Promise.race’s rejection examples. 

The variable name “error” is clearer than “result” for a variable of type Error or undefined. 