### PR TITLE
Removing empty notes

### DIFF
--- a/files/en-us/web/api/window/name/index.html
+++ b/files/en-us/web/api/window/name/index.html
@@ -57,8 +57,6 @@ window.name = <var>string</var>;
 &lt;a href="url2" target="other-tab"&gt;This link will be opened in the other tab.&lt;/a&gt;
 </pre>
 
-<div class="notecard note"></div>
-
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">

--- a/files/en-us/web/css/conic-gradient()/index.html
+++ b/files/en-us/web/css/conic-gradient()/index.html
@@ -20,8 +20,6 @@ tags:
 
 <div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
-<div class="notecard note"></div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="language-css notranslate" id="css">/* A conic gradient rotated 45 degrees,

--- a/files/en-us/web/javascript/reference/operators/this/index.html
+++ b/files/en-us/web/javascript/reference/operators/this/index.html
@@ -518,8 +518,6 @@ for (var i = 0; i &lt; elements.length; i++) {
 
 <h3 id="this_in_classes">this in classes</h3>
 
-<div class="notecard note"></div>
-
 <p>Just like with regular functions, the value of <code>this</code> within methods depends
   on how they are called. Sometimes it is useful to override this behavior so that
   <code>this</code> within classes always refers to the class instance. To achieve this,

--- a/files/en-us/web/security/mixed_content/index.html
+++ b/files/en-us/web/security/mixed_content/index.html
@@ -18,8 +18,6 @@ tags:
 
 <p>Mixed passive/display content is content served over HTTP that is included in an HTTPS webpage, but that cannot alter other portions of the webpage. For example, an attacker could replace an image served over HTTP with an inappropriate image or message to the user. The attacker could also infer information about the user's activities by watching which images are served to the user; often images are only served on a specific page within a website. If the attacker observes HTTP requests to certain images, they could determine which webpage the user is visiting.</p>
 
-<div class="notecard note"></div>
-
 <h4 id="Passive_content_list">Passive content list</h4>
 
 <p>This section lists all types of HTTP requests which are considered passive content:</p>


### PR DESCRIPTION
I walked across an empty ~land, I knew the pathway like the back of my hand ♫~ note right after https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#this_in_classes and I decided to check if there were some others.

Here's my attempt to removing such empty notes.