### PR TITLE
Clarified XMLHttpRequestEventTarget.onerror usage

### DIFF
--- a/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
@@ -15,8 +15,8 @@ tags:
 	called when an {{domxref("XMLHttpRequest")}} transaction fails due to an error.</p>
 
 <p>It's important to note that this is only called if there's an error at the 
-  <em>network</em> level. If the error only exists on the <em>application</em> level, 
-  e.g. an HTTP error code is sent, this method will not be called.</p>
+  <em>network</em> level. If the error only exists at the <em>application</em> level 
+  (e.g. an HTTP error code is sent), this method will not be called.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
@@ -14,6 +14,10 @@ tags:
 <p>The <strong><code>XMLHttpRequestEventTarget.onerror</code></strong> is the function
 	called when an {{domxref("XMLHttpRequest")}} transaction fails due to an error.</p>
 
+<p>It's important to note that this is only called if there's an error at the 
+  <em>network</em> level. If the error only exists on the <em>application</em> level, 
+  e.g. an HTTP error code is sent, this method will not be called.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre


### PR DESCRIPTION
Clarified that the event `onerror` is only called when _network_ level errors happen, not _application_ level. The verbiage could be confusing for people not familiar with how `onerror` works.

I think this is an important clarification that needs to be added since people who may be newer to JavaScript might see `onerror` and think that will be the event that gets called if their application receives a 4xx or 5xx status error code. I am embarrassed to say, but I spent longer than I care to admit before I knew this was the case. I would like to make sure nobody else has to go through a similar issue, which is why I proposed this edit.

https://stackoverflow.com/a/10584491 for credit to who clarified this for me.