### PR TITLE
removed class notranslate

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -216,7 +216,7 @@ tags:
 
 <p>Use two spaces per tab in all code examples. Indent the code cleanly, with open-brace ("<code>{</code>") characters on the same line as the statement that opens the block. For example:</p>
 
-<pre >if (condition) {
+<pre class="brush: js ">if (condition) {
   /* handle the condition */
 } else {
   /* handle the "else" case */
@@ -225,7 +225,7 @@ tags:
 
 <p>Long lines shouldn't be allowed to stretch off horizontally to the extent that they require horizontal scrolling to read. Instead, break long lines at natural breaking points. Some examples follow:</p>
 
-<pre >if (class.CONDITION || class.OTHER_CONDITION || class.SOME_OTHER_CONDITION
+<pre class="brush: js">if (class.CONDITION || class.OTHER_CONDITION || class.SOME_OTHER_CONDITION
        || class.YET_ANOTHER_CONDITION ) {
   /* something */
 }

--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -216,7 +216,7 @@ tags:
 
 <p>Use two spaces per tab in all code examples. Indent the code cleanly, with open-brace ("<code>{</code>") characters on the same line as the statement that opens the block. For example:</p>
 
-<pre class="brush: js notranslate">if (condition) {
+<pre >if (condition) {
   /* handle the condition */
 } else {
   /* handle the "else" case */
@@ -225,7 +225,7 @@ tags:
 
 <p>Long lines shouldn't be allowed to stretch off horizontally to the extent that they require horizontal scrolling to read. Instead, break long lines at natural breaking points. Some examples follow:</p>
 
-<pre class="brush: js notranslate">if (class.CONDITION || class.OTHER_CONDITION || class.SOME_OTHER_CONDITION
+<pre >if (class.CONDITION || class.OTHER_CONDITION || class.SOME_OTHER_CONDITION
        || class.YET_ANOTHER_CONDITION ) {
   /* something */
 }


### PR DESCRIPTION
Removed 2 'notranslate' classes in '<pre>' elements. Did my first contribution.
File path:   content/files/en-us/mdn/guidelines/writing_style_guide/index.html