### PR TITLE
Adding elementtiming attribute

### DIFF
--- a/files/en-us/web/html/attributes/elementtiming/index.html
+++ b/files/en-us/web/html/attributes/elementtiming/index.html
@@ -1,0 +1,64 @@
+---
+title: 'HTML attribute: elementtiming'
+slug: Web/HTML/Attributes/elementtiming
+tags:
+  - Attribute
+  - Attributes
+  - HTML
+  - elementtiming
+  - Performance
+  - Reference
+---
+<p>{{HTMLSidebar}}</p>
+
+<p>The <strong><code>elementtiming</code></strong> attribute is used to indicate that an element is flagged for tracking by the {{domxref("Element Timing API")}}. This attribute may be applied to {{htmlelement("img")}}, {{SVGElement("image")}} elements inside an {{htmlelement("svg")}}, poster images of {{htmlelement("video")}} elements, elements which have a {{cssxref("background-image")}}, and elements containing text nodes, such as a {{htmlelement("p")}}.</p>
+
+<h2 id="Usage">Usage</h2>
+
+<p>The value given for <code>elementtiming</code> becomes an identifer for the observed element.</p>
+
+<pre class="brush: html">&lt;img alt="alt" src="img.jpg" elementtiming="label for element"&gt;</pre>
+
+<p>Good contenders for elements you might want to observe are:</p>
+<ul>
+  <li>The main image for an article.</li>
+  <li>A blog post title</li>
+  <li>Images in a carousel for a shopping site.</li>
+  <li>The poster image for the main video on a page.</li>
+</ul>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: html">&lt;img alt="Alt for a main blog post image" src="my-massive-image.jpg" elementtiming="Main image"&gt;
+
+&lt;p elementtiming="important-text"&gt;Some very important information.&lt;/p"&gt;
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('Element Timing', 'forms.html#attr-label-for', 'for as used with label')}}</td>
+   <td>{{Spec2('Element Timing')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("html.elements.attribute.elementtiming")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="https://web.dev/custom-metrics/">Custom metrics</a></li>
+</ul>


### PR DESCRIPTION
I'm working on the Element Timing API and this the HTML attribute for that API, missing bits (the API itself, BCD, spec) will be in other PRs.

Spec PR is: https://github.com/mdn/yari/pull/2723