### PR TITLE
Remove redundant IDBFactory spec link

### DIFF
--- a/files/en-us/web/api/idbfactory/index.html
+++ b/files/en-us/web/api/idbfactory/index.html
@@ -69,11 +69,6 @@ DBOpenRequest.onsuccess = function(event) {
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName("IndexedDB", "#idbfactory", "IDBFactory")}}</td>
-   <td>{{Spec2("IndexedDB")}}</td>
-   <td></td>
-  </tr>
-  <tr>
    <td>{{SpecName("IndexedDB 2", "#factory-interface", "IDBFactory")}}</td>
    <td>{{Spec2("IndexedDB 2")}}</td>
    <td></td>


### PR DESCRIPTION
Both links got the small text "The definition of 'IDBFactory' in that
specification." and lead to the same section. Keep the link to the
section heading as that keeps more useful context in view.