### PR TITLE
Update array sort api docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
@@ -82,8 +82,8 @@ tags:
     behavior <a
       href="https://www.ecma-international.org/ecma-262/10.0/index.html#sec-intro">in
       2019</a>, thus, older browsers may not respect this.</li>
-  <li>If <code>compareFunction(a, b)</code> returns greater than 0, sort <code>b</code> to
-    an index lower than <code>a</code> (i.e. <code>b</code> comes first).</li>
+  <li>If <code>compareFunction(a, b)</code> returns greater than 0, leave <code>a</code> and
+    <code>b</code> unchanged.</li>
   <li><code>compareFunction(a, b)</code> must always return the same value when given a
     specific pair of elements <code>a</code> and <code>b</code> as its two arguments. If
     inconsistent results are returned, then the sort order is undefined.</li>


### PR DESCRIPTION
If compareFunction sort when returns less than 0, sort will not work if returns greater than 0.
Here is a case:
```
[5, 3, 4, 7, 2, 10].sort((a, b) => {
  console.log(a,b)
  return a - b
})

// console, do sort or not
3 5  <0 do
4 3  >0 not
4 5  <0 do
4 3  >0 not
7 4  >0 not
7 5  >0 not
2 5  <0 do
2 4  <0 do
2 3  <0 do
10 4 >0 not
10 7 >0 not
[2, 3, 4, 5, 7, 10]
```