### PR TITLE
Add Content-Type warning to FormData docs

### DIFF
--- a/files/en-us/web/api/formdata/using_formdata_objects/index.html
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.html
@@ -116,6 +116,10 @@ form.addEventListener('submit', function(ev) {
 <p><strong>Note</strong>: If you pass in a reference to the form, the <a href="/en-US/docs/Web/HTTP/Methods">request method</a> specified in the form will be used over the method specified in the open() call.</p>
 </div>
 
+<div class="warning">
+<p><strong>Warning</strong>: When using FormData to submit POST requests using {{ domxref("XMLHttpRequest") }} or the {{ domxref("Fetch_API") }} with the <code>multipart/form-data</code> Content-Type (e.g. when uploading Files and Blobs to the server), <em>do not</em> explicitly set the <a href="/en-us/docs/Web/HTTP/Headers/Content-Type"><code>Content-Type</code></a> header on the request. Doing so will prevent the browser from being able to set the Content-Type header with the boundary expression it will use to delimit form fields in the request body.</p>
+</div>
+
 <p>You can also append a {{ domxref("File") }} or {{ domxref("Blob") }} directly to the {{ domxref("FormData") }} object, like this:</p>
 
 <pre class="brush: js">data.append("myfile", myBlob, "filename.txt");


### PR DESCRIPTION
When using XMLHttpRequest or Fetch API to POST data to a server, it's common to set the Content-Type HTTP header to tell the server how to interpret the request body. With FormData objects that have Blobs or Files appended to them, the Content-Type of the request must be `multipart/form-data`. But there is an additional `boundary` parameter that the browser must add to the Content-Type to be able to delimit the files from the other form fields. In these cases, it's necessary to not set the Content-Type header, so that the browser can set it automatically, filling in the boundary delimiter it will use when writing the request body.