### PR TITLE
Fix endIndex description for String.prototype.slice()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.html
@@ -45,20 +45,15 @@ tags:
       string. If negative, it is treated as
       <code><var>str</var>.length + <var>endIndex</var></code>. (For example, if
       <code><var>endIndex</var></code> is <code>-3</code>, it is treated as
-      <code><var>str</var>.length - 3</code>.) If it is not undefined and not a number
-      after <code>Number(<var>endIndex</var>)</code>, an empty string is returned.</p>
+      <code><var>str</var>.length - 3</code>.) If it is not undefined, and
+      <code>Number(<var>endIndex</var>)</code> is not positive,
+      an empty string is returned.</p>
 
-    <p>If <code><var>endIndex</var></code> is specified and
-      <code><var>beginIndex</var></code> is negative, <code><var>endIndex</var></code>
-      should be negative, otherwise an empty string is returned. (For example,
-      <code>slice(-3, 0)</code> returns <code>""</code>.)</p>
-
-    <p>If <code><var>endIndex</var></code> is specified, and
-      <code><var>beginIndex</var></code> and <code><var>endIndex</var></code> are both
-      positive or negative, <code><var>endIndex</var></code> should be greater than
-      <code><var>beginIndex</var></code>, otherwise an empty string is returned. (For
-      example, <code>slice(-1, -3)</code> or <code>slice(3, 1)</code> returns
-      <code>""</code>.)</p>
+    <p>If <code><var>endIndex</var></code> is specified,
+      <code><var>endIndex</var></code> should be greater than
+      <code><var>beginIndex</var></code>, otherwise an empty string is returned. (For
+      example, <code>slice(-3, 0)</code>, <code>slice(-1, -3)</code>, or <code>slice(3, 1)</code>
+      returns <code>""</code>.)</p>
   </dd>
 </dl>
 


### PR DESCRIPTION
Fixes #1838 by merging the last two paragraphs with correct info

new:
> The zero-based index _before_ which to end extraction. The character at this index will not be included.
>
> If `endIndex` is omitted or undefined, or greater than `str.length`, `slice()` extracts to the end of the string. If negative, it is treated as `str.length + endIndex`. (For example, if `endIndex` is `-3`, it is treated as `str.length - 3`.) If it is not undefined, and `Number(endIndex)` is not positive, an empty string is returned.
>
> If `endIndex` is specified, `endIndex` should be greater than `beginIndex`, otherwise an empty string is returned. (For example, `slice(-3, 0)`, `slice(-1, -3)`, or `slice(3, 1)` returns `""`.)

old:
> The zero-based index _before_ which to end extraction. The character at this index will not be included.
>
> If `endIndex` is omitted or undefined, or greater than `str.length`, `slice()` extracts to the end of the string. If negative, it is treated as `str.length + endIndex`. (For example, if `endIndex` is `-3`, it is treated as `str.length - 3`.) If it is not undefined and not a number after `Number(endIndex)`, an empty string is returned.
>
> If `endIndex` is specified and `beginIndex` is negative, `endIndex` should be negative, otherwise an empty string is returned. (For example, `slice(-3, 0)` returns `""`.)
>
> If `endIndex` is specified, and `beginIndex` and `endIndex` are both positive or negative, `endIndex` should be greater than `beginIndex`, otherwise an empty string is returned. (For example, `slice(-1, -3)` or `slice(3, 1)` returns `""`.)