### PR TITLE
Fix image types doc - FF86 update and flaws

### DIFF
--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -271,7 +271,8 @@ tags:
 
 <p>AVIF does not support progressive rendering, so files must be fully downloaded before they can be displayed. This often has little impact on real-world user experience because AVIF files are much smaller than the equivalent JPEG or PNG files, and hence can be downloaded and displayed much faster. For larger file size the impact can become significant, and you should consider using a format that supports progressive rendering.</p>
 
-<p>AVIF is supported on desktop in Chrome 85, Opera 71 and Firefox 77 (requires the feature flag <code>image.avif.enable</code> set <code>true</code>). As support is not yet comprehensive (and has no historical depth) you should provide a fallback in either {{anch("JPEG")}} or {{anch("PNG")}} format using <a href="/en-US/docs/Web/HTML/Element/picture">the <code>&lt;picture&gt;</code> element</a> (or some other approach).</p>
+<p>AVIF is supported on desktop in Chrome, Opera and Firefox (in current versions).
+  As support is not yet comprehensive (and has no historical depth) you should provide a fallback in either {{anch("JPEG")}} or {{anch("PNG")}} format using <a href="/en-US/docs/Web/HTML/Element/picture">the <code>&lt;picture&gt;</code> element</a> (or some other approach).</p>
 
 <table class="standard-table">
  <tbody>
@@ -291,7 +292,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Browser compatibility</th>
-   <td>Chrome 85, Opera 71, and Firefox 86 (From Firefox 77 to 85 requires the preference <code>image.avif.enable</code> set <code>true</code>).</td>
+   <td>Chrome 85, Opera 71, and Firefox 86 (Firefox 77 to 85 require the preference <code>image.avif.enable</code> set <code>true</code>).</td>
   </tr>
   <tr>
    <th scope="row">Maximum dimensions</th>
@@ -1370,5 +1371,5 @@ static unsigned char square8_bits[] = {
  <li><a href="/en-US/docs/Web/Media/Formats/Video_codecs">Guide to video codecs used on the web</a></li>
  <li>The {{Glossary("HTML")}} {{HTMLElement("img")}} and {{HTMLElement("picture")}} elements</li>
  <li>The CSS {{cssxref("background-image")}} property</li>
- <li>The {{domxref("HTMLImageElement/Image")}} constructor and the {{domxref("HTMLImageElement")}} interface</li>
+ <li>The {{domxref("HTMLImageElement.Image()")}} constructor and the {{domxref("HTMLImageElement")}} interface</li>
 </ul>

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -60,7 +60,7 @@ tags:
    <td><code>.avif</code></td>
    <td>
     <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than {{anch("PNG")}} or {{anch("JPEG")}} with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
-     <strong>Supported:</strong> Chrome, Opera, Firefox.</p>
+     <strong>Supported:</strong> Chrome, Opera, Firefox (basic).</p>
    </td>
   </tr>
   <tr>
@@ -166,7 +166,8 @@ tags:
 
 <p>In the tables below, the term <strong>bits per component</strong> refers to the number of bits used to represent each color component. For example, an RGB color depth of 8 indicates that each of the red, green, and blue components are represented by an 8-bit value. <strong>Bit depth</strong>, on the other hand, is the total number of bits used to represent each pixel in memory.</p>
 
-<h3 id="APNG_Animated_Portable_Network_Graphics"><a id="apng">APNG</a> (Animated Portable Network Graphics)</h3>
+<a id="apng"></a>
+<h3 id="APNG_Animated_Portable_Network_Graphics">APNG (Animated Portable Network Graphics)</h3>
 
 <p>APNG is a file format first introduced by Mozilla which extends the {{anch("PNG")}} standard to add support for animated images. Conceptually similar to the animated GIF format which has been in use for decades, APNG is more capable in that it supports a variety of {{interwiki("wikipedia", "color depth", "color depths")}}, whereas animated GIF supports only 8-bit {{interwiki("wikipedia", "indexed color")}}.</p>
 
@@ -246,7 +247,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="AVIF_image"><a id="avif">AVIF image</a></h3>
+<a id="avif"></a>
+<h3 id="AVIF_image">AVIF image</h3>
 
 <p>AV1 Image File Format (AVIF) is a powerful new, open source, royalty-free file format that encodes <dfn>AV1 bitstreams in the High Efficiency Image File Format (HEIF) container. </dfn></p>
 
@@ -278,7 +280,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">MIME type</th>
-   <td>Firefox and Chrome use <code>image/avif</code> for both still images and sequences. Type not yet <a href="https://www.iana.org/assignments/media-types/media-types.xhtml#image">registered</a> as of November 2020.</td>
+   <td><code>image/avif</code></td>
   </tr>
   <tr>
    <th scope="row">File extension(s)</th>
@@ -292,7 +294,12 @@ tags:
   </tr>
   <tr>
    <th scope="row">Browser compatibility</th>
-   <td>Chrome 85, Opera 71, and Firefox 86 (Firefox 77 to 85 require the preference <code>image.avif.enable</code> set <code>true</code>).</td>
+   <td>Chrome 85, Opera 71, and Firefox 86.
+    <ul>
+      <li>Firefox 86 provides <em>basic</em> support for AVIF images. More advanced features are still in development — including animated images and colorspace support ({{bug(1682995)}}).</li>
+      <li>Firefox 77 to 85 require the preference <code>image.avif.enable</code> set <code>true</code></li>
+    </ul>
+   </td>
   </tr>
   <tr>
    <th scope="row">Maximum dimensions</th>
@@ -327,8 +334,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="BMP_Bitmap_file"><a id="bmp"><br>
- BMP</a> (Bitmap file)</h3>
+<a id="bmp"></a>
+<h3 id="BMP_Bitmap_file">BMP (Bitmap file)</h3>
 
 <p>The <strong>BMP</strong> (<strong>Bitmap image</strong>) file type is most prevalent on Windows computers, and is generally used only for special cases in web apps and content.</p>
 
@@ -417,7 +424,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="GIF_Graphics_Interchange_Format"><a id="gif">GIF</a> (Graphics Interchange Format)</h3>
+<a id="gif"></a>
+<h3 id="GIF_Graphics_Interchange_Format">GIF (Graphics Interchange Format)</h3>
 
 <p>In 1987, the CompuServe online service provider introduced the <strong>{{interwiki("wikipedia", "GIF")}}</strong> (<strong>Graphics Interchange Format</strong>) image file format to provide a compressed graphics format that all members of their service would be able to use. GIF uses the {{interwiki("wikipedia", "Lempel-Ziv-Welch")}} (LZW) algorithm to losslessly compress 8-bit indexed color graphics. GIF was one of the first two graphics formats supported by {{Glossary("HTML")}}, along with {{anch("XBM")}}.</p>
 
@@ -508,7 +516,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="ICO_Microsoft_Windows_icon"><a id="ico">ICO</a> (Microsoft Windows icon)</h3>
+<a id="ico"></a>
+<h3 id="ICO_Microsoft_Windows_icon">ICO (Microsoft Windows icon)</h3>
 
 <p>The ICO (Microsoft Windows icon) file format was designed by Microsoft for desktop icons of Windows systems. However, early versions of Internet Explorer introduced the ability for a web site to provide a ICO file named <code>favicon.ico</code> in a web site's root directory to specify a <strong><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_custom_icons_to_your_site">favicon</a></strong> — an icon to be displayed in the Favorites menu, and other places where an iconic representation of the site would be useful.</p>
 
@@ -628,7 +637,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="JPEG_Joint_Photographic_Experts_Group_image"><a id="jpeg">JPEG</a> (Joint Photographic Experts Group image)</h3>
+<a id="jpeg"></a>
+<h3 id="JPEG_Joint_Photographic_Experts_Group_image">JPEG (Joint Photographic Experts Group image)</h3>
 
 <p>The {{Glossary("JPEG")}} (typically pronounced "<strong>jay-peg</strong>") image format is currently the most widely used lossy compression format for still images. It's particulary useful for photographs; applying lossy compression to content requiring sharpness, like diagrams or charts, can produce unsatisfactory results.</p>
 
@@ -708,7 +718,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="PNG_Portable_Network_Graphics"><a id="png">PNG</a> (Portable Network Graphics)</h3>
+<a id="png"></a>
+<h3 id="PNG_Portable_Network_Graphics">PNG (Portable Network Graphics)</h3>
 
 <p>The {{Glossary("PNG")}} (pronounced "<strong>ping</strong>") image format uses lossless or lossy compression to provide more efficient compression, and supports higher color depths than {{anch("GIF")}}, as well as full alpha transparency support.</p>
 
@@ -851,7 +862,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="SVG_Scalable_Vector_Graphics"><a id="svg">SVG</a> (Scalable Vector Graphics)</h3>
+<a id="svg"></a>
+<h3 id="SVG_Scalable_Vector_Graphics">SVG (Scalable Vector Graphics)</h3>
 
 <p>SVG is an <a href="/en-US/docs/Glossary/XML">XML</a>-based {{interwiki("wikipedia", "vector graphics")}} format that specifies the contents of an image as a set of drawing commands that create shapes, lines, apply colors, filters, and so forth. SVG files are ideal for diagrams, icons, and other images which can be accurately drawn at any size. As such, SVG is popular for user interface elements in modern Web design.</p>
 
@@ -943,7 +955,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="TIFF_Tagged_Image_File_Format"><a id="tiff">TIFF</a> (Tagged Image File Format)</h3>
+<a id="tiff"></a>
+<h3 id="TIFF_Tagged_Image_File_Format">TIFF (Tagged Image File Format)</h3>
 
 <p>{{interwiki("wikipedia", "TIFF")}} is a raster graphics file format which was created to store scanned photos, although it can be any kind of image. It is a somewhat "heavy" format, in that TIFF files have a tendency to be larger than images in other formats. This is because of the metadata often included, as well as the fact that most TIFF images are either uncompressed or use compression algorithms that still leave fairly large files after compression.</p>
 
@@ -1080,7 +1093,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="WebP_image"><a id="webp">WebP image</a></h3>
+<a id="webp"></a>
+<h3 id="WebP_image">WebP image</h3>
 
 <p>WebP supports lossy compression via predictive coding based on the VP8 video codec, and lossless compression that uses substitutions for repeating data. Lossy WebP images average 25–35% smaller than JPEG images of visually similar compression levels. Lossless WebP images are typically 26% smaller than the same images in PNG format.</p>
 
@@ -1178,7 +1192,8 @@ tags:
   <p>Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
 </div>
 
-<h3 id="XBM_X_Window_System_Bitmap_file"><a id="xbm">XBM</a> (X Window System Bitmap file)</h3>
+<a id="xbm"></a>
+<h3 id="XBM_X_Window_System_Bitmap_file">XBM (X Window System Bitmap file)</h3>
 
 <p>XBM (X Bitmap) files were the first to be supported on the Web, but are no longer used and should be avoided, as their format has potential security concerns. Modern browsers have not supported XBM files in many years, but when dealing with older content, you may find some still around.</p>
 

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -60,7 +60,7 @@ tags:
    <td><code>.avif</code></td>
    <td>
     <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than {{anch("PNG")}} or {{anch("JPEG")}} with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
-     <strong>Supported:</strong> Chrome, Opera, Firefox (basic).</p>
+     <strong>Supported:</strong> Chrome, Opera, Firefox (basic support only; advanced features like animated images and colorspace support yet to the implemented).</p>
    </td>
   </tr>
   <tr>

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -60,7 +60,7 @@ tags:
    <td><code>.avif</code></td>
    <td>
     <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than {{anch("PNG")}} or {{anch("JPEG")}} with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
-     <strong>Supported:</strong> Chrome, Opera, Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#AVIF_AV1_Image_File_format_support">preference</a>).</p>
+     <strong>Supported:</strong> Chrome, Opera, Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>).</p>
    </td>
   </tr>
   <tr>
@@ -111,8 +111,9 @@ tags:
 </table>
 </div>
 
-<div class="note">
-<p><strong>Note:</strong> The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).</p>
 </div>
 
 <p>The following list includes image formats that appear on the web, but which should be avoided for web content (generally this is because either they do not have wide browser support, or because there are better alternatives).</p>
@@ -154,8 +155,9 @@ tags:
 </table>
 </div>
 
-<div class="note">
-<p><strong>Note:</strong> The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).</p>
 </div>
 
 <h2 id="Image_file_type_details">Image file type details</h2>
@@ -164,7 +166,7 @@ tags:
 
 <p>In the tables below, the term <strong>bits per component</strong> refers to the number of bits used to represent each color component. For example, an RGB color depth of 8 indicates that each of the red, green, and blue components are represented by an 8-bit value. <strong>Bit depth</strong>, on the other hand, is the total number of bits used to represent each pixel in memory.</p>
 
-<h3 id="APNG_Animated_Portable_Network_Graphics"><a id="APNG">APNG</a> (Animated Portable Network Graphics)</h3>
+<h3 id="APNG_Animated_Portable_Network_Graphics"><a id="apng">APNG</a> (Animated Portable Network Graphics)</h3>
 
 <p>APNG is a file format first introduced by Mozilla which extends the {{anch("PNG")}} standard to add support for animated images. Conceptually similar to the animated GIF format which has been in use for decades, APNG is more capable in that it supports a variety of {{interwiki("wikipedia", "color depth", "color depths")}}, whereas animated GIF supports only 8-bit {{interwiki("wikipedia", "indexed color")}}.</p>
 
@@ -244,12 +246,13 @@ tags:
  </tbody>
 </table>
 
-<h3 id="AVIF_image"><a id="AVIF">AVIF image</a></h3>
+<h3 id="AVIF_image"><a id="avif">AVIF image</a></h3>
 
 <p>AV1 Image File Format (AVIF) is a powerful new, open source, royalty-free file format that encodes <dfn>AV1 bitstreams in the High Efficiency Image File Format (HEIF) container. </dfn></p>
 
-<div class="note">
-<p><strong>Note:</strong> AVIF has potential to become the "next big thing" for sharing images in web content. It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>AVIF has potential to become the "next big thing" for sharing images in web content. It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.</p>
 </div>
 
 <p><dfn>AV1 is a coding format that was originally designed for video transmission over the Internet. The format benefits from the signficant advances in video encoding in recent years, and may potentially benefit from the associated support for hardware rendering. However it also has disadvantages for some cases, as video and image encoding have some different requirements.</dfn></p>
@@ -323,13 +326,14 @@ tags:
  </tbody>
 </table>
 
-<h3 id="BMP_Bitmap_file"><a id="BMP"><br>
+<h3 id="BMP_Bitmap_file"><a id="bmp"><br>
  BMP</a> (Bitmap file)</h3>
 
 <p>The <strong>BMP</strong> (<strong>Bitmap image</strong>) file type is most prevalent on Windows computers, and is generally used only for special cases in web apps and content.</p>
 
 <div class="notecard warning">
-<p><strong>Note:</strong> You should typically avoid using BMP files for web site content. The most common form of BMP file represents the data as an uncompressed raster image, resulting in large file sizes compared to png or jpg image tpes.  More efficient BMP formats exist but are not widely used, and rarely supported in web browsers.</p>
+  <h4>Warning</h4>
+  <p>You should typically avoid using BMP files for web site content. The most common form of BMP file represents the data as an uncompressed raster image, resulting in large file sizes compared to png or jpg image tpes.  More efficient BMP formats exist but are not widely used, and rarely supported in web browsers.</p>
 </div>
 
 <p>BMP theoretically supports a variety of internal data representations. The simplest, and most commonly used, form of BMP file is an uncompressed raster image, with each pixel occupying 3 bytes representing its red, green, and blue components, and each row padded with <code>0x00</code> bytes to a multiple of 4 bytes wide.</p>
@@ -412,7 +416,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="GIF_Graphics_Interchange_Format"><a id="GIF">GIF</a> (Graphics Interchange Format)</h3>
+<h3 id="GIF_Graphics_Interchange_Format"><a id="gif">GIF</a> (Graphics Interchange Format)</h3>
 
 <p>In 1987, the CompuServe online service provider introduced the <strong>{{interwiki("wikipedia", "GIF")}}</strong> (<strong>Graphics Interchange Format</strong>) image file format to provide a compressed graphics format that all members of their service would be able to use. GIF uses the {{interwiki("wikipedia", "Lempel-Ziv-Welch")}} (LZW) algorithm to losslessly compress 8-bit indexed color graphics. GIF was one of the first two graphics formats supported by {{Glossary("HTML")}}, along with {{anch("XBM")}}.</p>
 
@@ -503,14 +507,15 @@ tags:
  </tbody>
 </table>
 
-<h3 id="ICO_Microsoft_Windows_icon"><a id="ICO">ICO</a> (Microsoft Windows icon)</h3>
+<h3 id="ICO_Microsoft_Windows_icon"><a id="ico">ICO</a> (Microsoft Windows icon)</h3>
 
-<p>The ICO (Microsoft Windows icon) file format was designed by Microsoft for desktop icons of Windows systems. However, early versions of Internet Explorer introduced the ability for a web site to provide a ICO file named <code>favicon.ico</code> in a web site's root directory to specify a <strong><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#Adding_custom_icons_to_your_site">favicon</a></strong> — an icon to be displayed in the Favorites menu, and other places where an iconic representation of the site would be useful.</p>
+<p>The ICO (Microsoft Windows icon) file format was designed by Microsoft for desktop icons of Windows systems. However, early versions of Internet Explorer introduced the ability for a web site to provide a ICO file named <code>favicon.ico</code> in a web site's root directory to specify a <strong><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_custom_icons_to_your_site">favicon</a></strong> — an icon to be displayed in the Favorites menu, and other places where an iconic representation of the site would be useful.</p>
 
 <p>An ICO file can contain multiple icons, and begins with a directory listing details about each. Following the directory comes the data for the icons. Each icon's data can be either a {{anch("BMP")}} image without the file header, or a complete {{anch("PNG")}} image (including the file header). If you use ICO files, you should use the BMP format, as support for PNG inside ICO files wasn't added until Windows Vista and may not be well supported.</p>
 
 <div class="notecard warning">
-<p>ICO files <em>should not</em> be used in web content. Additionally, their use for favicons has subsided in favor of using a PNG file and the {{HTMLElement("link")}} element, as described in {{SectionOnPage("/en-US/docs/Web/HTML/Element/link", "Providing icons for different usage contexts")}}.</p>
+  <h4>Warning</h4>
+  <p>ICO files <em>should not</em> be used in web content. Additionally, their use for favicons has subsided in favor of using a PNG file and the {{HTMLElement("link")}} element, as described in {{SectionOnPage("/en-US/docs/Web/HTML/Element/link", "Providing icons for different usage contexts")}}.</p>
 </div>
 
 <table class="standard-table">
@@ -622,7 +627,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="JPEG_Joint_Photographic_Experts_Group_image"><a id="JPEG">JPEG</a> (Joint Photographic Experts Group image)</h3>
+<h3 id="JPEG_Joint_Photographic_Experts_Group_image"><a id="jpeg">JPEG</a> (Joint Photographic Experts Group image)</h3>
 
 <p>The {{Glossary("JPEG")}} (typically pronounced "<strong>jay-peg</strong>") image format is currently the most widely used lossy compression format for still images. It's particulary useful for photographs; applying lossy compression to content requiring sharpness, like diagrams or charts, can produce unsatisfactory results.</p>
 
@@ -702,7 +707,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="PNG_Portable_Network_Graphics"><a id="PNG">PNG</a> (Portable Network Graphics)</h3>
+<h3 id="PNG_Portable_Network_Graphics"><a id="png">PNG</a> (Portable Network Graphics)</h3>
 
 <p>The {{Glossary("PNG")}} (pronounced "<strong>ping</strong>") image format uses lossless or lossy compression to provide more efficient compression, and supports higher color depths than {{anch("GIF")}}, as well as full alpha transparency support.</p>
 
@@ -845,7 +850,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="SVG_Scalable_Vector_Graphics"><a id="SVG">SVG</a> (Scalable Vector Graphics)</h3>
+<h3 id="SVG_Scalable_Vector_Graphics"><a id="svg">SVG</a> (Scalable Vector Graphics)</h3>
 
 <p>SVG is an <a href="/en-US/docs/Glossary/XML">XML</a>-based {{interwiki("wikipedia", "vector graphics")}} format that specifies the contents of an image as a set of drawing commands that create shapes, lines, apply colors, filters, and so forth. SVG files are ideal for diagrams, icons, and other images which can be accurately drawn at any size. As such, SVG is popular for user interface elements in modern Web design.</p>
 
@@ -937,7 +942,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="TIFF_Tagged_Image_File_Format"><a id="TIFF">TIFF</a> (Tagged Image File Format)</h3>
+<h3 id="TIFF_Tagged_Image_File_Format"><a id="tiff">TIFF</a> (Tagged Image File Format)</h3>
 
 <p>{{interwiki("wikipedia", "TIFF")}} is a raster graphics file format which was created to store scanned photos, although it can be any kind of image. It is a somewhat "heavy" format, in that TIFF files have a tendency to be larger than images in other formats. This is because of the metadata often included, as well as the fact that most TIFF images are either uncompressed or use compression algorithms that still leave fairly large files after compression.</p>
 
@@ -1074,7 +1079,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="WebP_image"><a id="WebP">WebP image</a></h3>
+<h3 id="WebP_image"><a id="webp">WebP image</a></h3>
 
 <p>WebP supports lossy compression via predictive coding based on the VP8 video codec, and lossless compression that uses substitutions for repeating data. Lossy WebP images average 25–35% smaller than JPEG images of visually similar compression levels. Lossless WebP images are typically 26% smaller than the same images in PNG format.</p>
 
@@ -1168,10 +1173,11 @@ tags:
 </table>
 
 <div class="notecard note">
-<p><strong>Note:</strong> Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
+  <h4>Note</h4>
+  <p>Despite having <a href="https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174">announced support</a> for WebP in Safari 14, as of version 14.0 .webp images do not display natively on a macOS desktop, whereas Safari on iOS 14 does display .webp images properly.</p>
 </div>
 
-<h3 id="XBM_X_Window_System_Bitmap_file"><a id="XBM">XBM</a> (X Window System Bitmap file)</h3>
+<h3 id="XBM_X_Window_System_Bitmap_file"><a id="xbm">XBM</a> (X Window System Bitmap file)</h3>
 
 <p>XBM (X Bitmap) files were the first to be supported on the Web, but are no longer used and should be avoided, as their format has potential security concerns. Modern browsers have not supported XBM files in many years, but when dealing with older content, you may find some still around.</p>
 
@@ -1364,5 +1370,5 @@ static unsigned char square8_bits[] = {
  <li><a href="/en-US/docs/Web/Media/Formats/Video_codecs">Guide to video codecs used on the web</a></li>
  <li>The {{Glossary("HTML")}} {{HTMLElement("img")}} and {{HTMLElement("picture")}} elements</li>
  <li>The CSS {{cssxref("background-image")}} property</li>
- <li>The {{domxref("Image()")}} constructor and the {{domxref("HTMLImageElement")}} interface</li>
+ <li>The {{domxref("HTMLImageElement/Image")}} constructor and the {{domxref("HTMLImageElement")}} interface</li>
 </ul>

--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -60,7 +60,7 @@ tags:
    <td><code>.avif</code></td>
    <td>
     <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than {{anch("PNG")}} or {{anch("JPEG")}} with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
-     <strong>Supported:</strong> Chrome, Opera, Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>).</p>
+     <strong>Supported:</strong> Chrome, Opera, Firefox.</p>
    </td>
   </tr>
   <tr>
@@ -291,7 +291,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Browser compatibility</th>
-   <td>Chrome 85, Opera 71, and Firefox 77 (requires the preference <code>image.avif.enable</code> set <code>true</code>).</td>
+   <td>Chrome 85, Opera 71, and Firefox 86 (From Firefox 77 to 85 requires the preference <code>image.avif.enable</code> set <code>true</code>).</td>
   </tr>
   <tr>
    <th scope="row">Maximum dimensions</th>


### PR DESCRIPTION
- Fix flaws in Image types doc (broken links, wrong macros, bad notecards)
- Change preference info to indicate AVIF supported by FF86