### PR TITLE
Web console flaws

### DIFF
--- a/files/en-us/tools/web_console/helpers/index.html
+++ b/files/en-us/tools/web_console/helpers/index.html
@@ -27,9 +27,9 @@ tags:
 	<dt id="$_"><code>$_</code></dt>
 	<dd>Stores the result of the last expression executed in the console's command line. For example, if you type "2+2 &lt;enter&gt;", then "$_ &lt;enter&gt;", the console will print 4.</dd>
 	<dt id="$x"><code>$x(xpath, element, resultType)</code></dt>
-	<dd>Evaluates the <a href="/en-US/docs/XPath">XPath</a> <code>xpath</code> expression in the context of <code>element</code> and returns an array of matching nodes. If unspecified, <code>element</code> defaults to <code>document</code>. The resultType parameter specifies the type of result to return; it can be an <a href="/en-US/docs/Web/API/XPathResult#Constants">XPathResult constant</a>, or a corresponding string: <code>"number"</code>, <code>"string"</code>, <code>"bool"</code>, <code>"node"</code>, or <code>"nodes"</code>; if not provided, <code>ANY_TYPE</code> is used.</dd>
+	<dd>Evaluates the <a href="/en-US/docs/Web/XPath">XPath</a> <code>xpath</code> expression in the context of <code>element</code> and returns an array of matching nodes. If unspecified, <code>element</code> defaults to <code>document</code>. The resultType parameter specifies the type of result to return; it can be an <a href="/en-US/docs/Web/API/XPathResult#constants">XPathResult constant</a>, or a corresponding string: <code>"number"</code>, <code>"string"</code>, <code>"bool"</code>, <code>"node"</code>, or <code>"nodes"</code>; if not provided, <code>ANY_TYPE</code> is used.</dd>
 	<dt><code>:block</code></dt>
-	<dd>(Starting in Firefox 80) Followed by an unquoted string, blocks requests where the URL contains that string. In the <strong><a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a></strong>, the string now appears and is selected in the <a href="/en-US/docs/Tools/Network_Monitor/request_list#Blocking_specific_URLs"><strong>Request Blocking</strong> sidebar</a>.  Unblock with <code>:unblock</code>.</dd>
+	<dd>(Starting in Firefox 80) Followed by an unquoted string, blocks requests where the URL contains that string. In the <strong><a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a></strong>, the string now appears and is selected in the <a href="/en-US/docs/Tools/Network_Monitor/request_list#blocking_specific_urls"><strong>Request Blocking</strong> sidebar</a>.  Unblock with <code>:unblock</code>.</dd>
 	<dt id="help"><code>cd()</code> {{deprecated_inline("gecko74")}}</dt>
 	<dd>
 	<p>Switches JavaScript evaluation context to a different iframe in the page. This helper accepts multiple different ways of identifying the frame to switch to. You can supply any of the following:</p>
@@ -45,7 +45,7 @@ tags:
 	<dt><code>clear()</code></dt>
 	<dd>Clears the console output area.</dd>
 	<dt id="clearHistory"><code>clearHistory()</code></dt>
-	<dd>Just like a normal command line, the console command line <a href="/en-US/docs/Tools/Web_Console#Command_history">remembers the commands you've typed</a>. Use this function to clear the console's command history.</dd>
+	<dd>Just like a normal command line, the console command line <a href="/en-US/docs/Tools/Web_Console#command_history">remembers the commands you've typed</a>. Use this function to clear the console's command history.</dd>
 	<dt><code>copy()</code></dt>
 	<dd>Copies the argument to the clipboard. If the argument is a string, it's copied as-is. If the argument is a DOM node, its <code><a href="/en-US/docs/Web/API/Element/outerHTML">outerHTML</a></code> is copied. Otherwise, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify">JSON.stringify</a></code> will be called on the argument, and the result will be copied to the clipboard.</dd>
 	<dt><code>help()</code>{{Deprecated_Inline(62)}}<br>
@@ -110,18 +110,18 @@ tags:
 	</table>
 	</dd>
 	<dt><code>:unblock</code></dt>
-	<dd>(Starting in Firefox 80) Followed by an unquoted string, removes blocking for URLs containing that string. In the <strong><a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a></strong>, the string is removed from the <a href="/en-US/docs/Tools/Network_Monitor/request_list#Blocking_specific_URLs"><strong>Request Blocking</strong> sidebar</a>. No error is given if the string was not previously blocked.</dd>
+	<dd>(Starting in Firefox 80) Followed by an unquoted string, removes blocking for URLs containing that string. In the <strong><a href="/en-US/docs/Tools/Network_Monitor">Network Monitor</a></strong>, the string is removed from the <a href="/en-US/docs/Tools/Network_Monitor/request_list#blocking_specific_urls"><strong>Request Blocking</strong> sidebar</a>. No error is given if the string was not previously blocked.</dd>
 	<dt id="values"><code>values()</code></dt>
 	<dd>Given an object, returns a list of the values on that object; serves as a companion to <code>keys()</code>.</dd>
 </dl>
 
-<p>Please refer to the <a href="/en-US/docs/Web/API/console">Console API</a> for more information about logging from content.</p>
+<p>Please refer to the <a href="/en-US/docs/Web/API/Console">Console API</a> for more information about logging from content.</p>
 
 <h2 id="Variables">Variables</h2>
 
 <dl>
 	<dt id="tempN">temp<em>N</em></dt>
-	<dd>The <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#Use_in_Console">"Use in Console"</a> option in the Inspector generates a variable for a node named <code>temp0</code>, <code>temp1</code>, <code>temp2</code>, etc. referencing the node.</dd>
+	<dd>The <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#use_in_console">"Use in Console"</a> option in the Inspector generates a variable for a node named <code>temp0</code>, <code>temp1</code>, <code>temp2</code>, etc. referencing the node.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/tools/web_console/index.html
+++ b/files/en-us/tools/web_console/index.html
@@ -7,8 +7,8 @@ tags:
   - Security
   - Tools
   - Web Development
-  - 'Web Development:Tools'
-  - 'l10n:priority'
+  - Web Development:Tools
+  - l10n:priority
   - web console
 ---
 <div>{{ToolsSidebar}}</div>
@@ -25,7 +25,7 @@ tags:
 <div class="column-container">
 <div class="column-half">
 <dl>
- <dt><a href="/en-US/docs/Tools/Web_Console/Opening_the_Web_Console">User interface of the Web Console</a></dt>
+ <dt><a href="/en-US/docs/Tools/Web_Console/UI_Tour">User interface of the Web Console</a></dt>
  <dd>Parts of the Web Console UI.</dd>
  <dt><a href="/en-US/docs/Tools/Web_Console/The_command_line_interpreter">The JavaScript input interpreter</a></dt>
  <dd>How to interact with a document using the Console.</dd>
@@ -57,4 +57,4 @@ tags:
  <li>Press the <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> (<kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>K</kbd> on OS X) keyboard shortcut.</li>
 </ul>
 
-<p>The <a href="/en-US/docs/Tools/DevTools_Window">Toolbox</a> appear at the bottom, left, or right of the browser window (depending on your docking settings), with the Web Console activated (it's just called <strong>Console</strong> in the <a href="/en-US/docs/Tools/DevTools_Window#Toolbar">DevTools toolbar</a>).</p>
+<p>The <a href="/en-US/docs/Tools/Tools_Toolbox">Toolbox</a> appear at the bottom, left, or right of the browser window (depending on your docking settings), with the Web Console activated (it's just called <strong>Console</strong> in the <a href="/en-US/docs/Tools/Tools_Toolbox#toolbar">DevTools toolbar</a>).</p>


### PR DESCRIPTION
There is a non-fixable flaw in that macro exists  `{{deprecated_inline("gecko74")}}`  and should be removed `{{deprecated_inline("gecko74")}}`. What I should I replace it with?

Doing this in preparation for fixing https://github.com/mdn/content/issues/1729

