### PR TITLE
Using two selectors description change

### DIFF
--- a/files/en-us/web/css/_colon_not/index.html
+++ b/files/en-us/web/css/_colon_not/index.html
@@ -42,7 +42,7 @@ tags:
  <li>This pseudo-class can increase the <a href="/en-US/docs/Web/CSS/Specificity">specificity</a> of a rule. For example, <code>#foo:not(#bar)</code> will match the same element as the simpler <code>#foo</code>, but has a higher specificity.</li>
  <li><code>:not(.foo)</code> will match anything that isn't <code>.foo</code>, <em>including {{HTMLElement("html")}} and {{HTMLElement("body")}}.</em></li>
  <li>This selector only applies to one element; you cannot use it to exclude all ancestors. For instance, <code>body :not(table) a</code> will still apply to links inside of a table, since {{HTMLElement("tr")}} will match with the <code>:not()</code> part of the selector.</li>
- <li>Using two selectors at the same time might not work for some browsers. Example: <code>:not(.foo, .bar)</code>. Instead you could use, <code>:not(.foo):not(.bar)</code></li>
+ <li>Using two selectors at the same time is not yet supported in all browsers. Example: <code>:not(.foo, .bar)</code>. For wider support you could use, <code>:not(.foo):not(.bar)</code></li>
 </ul>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/css/_colon_not/index.html
+++ b/files/en-us/web/css/_colon_not/index.html
@@ -42,7 +42,7 @@ tags:
  <li>This pseudo-class can increase the <a href="/en-US/docs/Web/CSS/Specificity">specificity</a> of a rule. For example, <code>#foo:not(#bar)</code> will match the same element as the simpler <code>#foo</code>, but has a higher specificity.</li>
  <li><code>:not(.foo)</code> will match anything that isn't <code>.foo</code>, <em>including {{HTMLElement("html")}} and {{HTMLElement("body")}}.</em></li>
  <li>This selector only applies to one element; you cannot use it to exclude all ancestors. For instance, <code>body :not(table) a</code> will still apply to links inside of a table, since {{HTMLElement("tr")}} will match with the <code>:not()</code> part of the selector.</li>
- <li>Using two selectors at the same time will not work. For example, <code>:not(.foo,bar)</code> is invalid. Instead, <code>:not(.foo):not(.bar)</code> should be used.</li>
+ <li>Using two selectors at the same time might not work for some browsers. Example: <code>:not(.foo, .bar)</code>. Instead you could use, <code>:not(.foo):not(.bar)</code></li>
 </ul>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
"__Using two selectors at the same time will not work. For example, :not(.foo,bar) is invalid. Instead, :not(.foo):not(.bar) should be used.__". 
This line in the description is no longer true. 

At least Chrome 88, Firefox 84, Edge 88 support this compound selector. [Code example](http://bit.ly/39qFXFQ)
Although, Opera 87 still doesn't support it. 

So we can either remove this line altogether or change it, so it won't say that this is an invalid way to use `:not` pseudo-class.