### PR TITLE
Put reference to if statement in <code> brackets

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.html
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.html
@@ -465,7 +465,7 @@ for (let i = 1; i &lt;= num; i++) {
  <li>In this case, the input should be a number (<code>num</code>). The <code>for</code> loop is given a counter starting at 1 (as we are not interested in 0 in this case), an exit condition that says the loop will stop when the counter becomes bigger than the input <code>num</code>, and an iterator that adds 1 to the counter each time.</li>
  <li>Inside the loop, we find the square root of each number using <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt">Math.sqrt(i)</a>, then check whether the square root is an integer by testing whether it is the same as itself when it has been rounded down to the nearest integer (this is what <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor">Math.floor()</a> does to the number it is passed).</li>
  <li>If the square root and the rounded down square root do not equal one another (<code>!==</code>), it means that the square root is not an integer, so we are not interested in it. In such a case, we use the <code>continue</code> statement to skip on to the next loop iteration without recording the number anywhere.</li>
- <li>If the square root is an integer, we skip past the if block entirely, so the <code>continue</code> statement is not executed; instead, we concatenate the current <code>i</code> value plus a space on to the end of the paragraph content.</li>
+ <li>If the square root is an integer, we skip past the <code>if</code> block entirely, so the <code>continue</code> statement is not executed; instead, we concatenate the current <code>i</code> value plus a space on to the end of the paragraph content.</li>
 </ol>
 
 <div class="note">


### PR DESCRIPTION
I made this change as I think it improves readability (as 'if' is so small and can be missed, causing confusion) and since the 'if' is a code keyword like <code>continue</code>, <code>num</code> and <code>!==</code> in the same paragraph, it provides consistency.