### PR TITLE
fix: a JavaScript instance and a constructor function have different prototype objects

### DIFF
--- a/files/en-us/learn/javascript/objects/object_prototypes/index.html
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.html
@@ -50,7 +50,7 @@ tags:
 <div class="note">
 <p><strong>Note:</strong> It's important to understand that there is a distinction between <strong>an object's <code>prototype</code></strong> (available via <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf">Object.getPrototypeOf(<var>obj</var>)</a></code>, or via the deprecated <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a></code> property) and <strong>the <code>prototype</code> property on constructor functions</strong>.</p>
 
-<p>The former is the property on each instance, and the latter is the property on the constructor. That is, <code>Object.getPrototypeOf(new <var>Foobar</var>())</code> refers to the same object as <code><var>Foobar</var>.prototype</code>.</p>
+<p>The former is the property on each instance, and the latter is the property on the constructor. That is, <code>Object.getPrototypeOf(new <var>Foobar</var>())</code> refers to a different object than <code><var>Foobar</var>.prototype</code>.</p>
 </div>
 
 <p>Let's look at an example to make this a bit clearer.</p>


### PR DESCRIPTION
Correct the example illustrating that the prototype object of an instance is not the same object as the prototype object of its constructor function.