### PR TITLE
Delete glossary links that don't work

### DIFF
--- a/files/en-us/mozilla/developer_guide/build_instructions/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/index.html
@@ -107,6 +107,5 @@ tags:
 
 <ul>
 	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works">How Mozilla's build system works</a></li>
-	<li><a class="internal" href="/Special:Tags?tag=Build_Glossary">Build Glossary</a> <a class="external" href="https://www.mozilla.org/build/glossary.html">(old glossary)</a></li>
 	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build and Register Chrome JARs with JAR Manifests</a></li>
 </ul>


### PR DESCRIPTION
There are two links here for a build glossary, both of which are broken, and which nothing else shows up on MDN. The first link is an old wiki link that shows up/is discussed in https://github.com/mdn/content/issues/551#issuecomment-770377247

The only info that this might refer to that I was able to find on the net was this: https://firefox-source-docs.mozilla.org/build/buildsystem/glossary.html

@chrisdavidmills Do you see this as useful? If so, is this a mozilla-owned resource. I am assuming not, so the decision is that we lose this information or that we copy it into the doc, perhaps as a sub page?