### PR TITLE
Delete Special:Tags - XPCOM that is not rendered

### DIFF
--- a/files/en-us/mozilla/developer_guide/interface_development_guide/index.html
+++ b/files/en-us/mozilla/developer_guide/interface_development_guide/index.html
@@ -26,8 +26,6 @@ tags:
             others understand your interface, but to ensure that the documentation here on MDC is as accurate as
             possible.</dd>
         </dl>
-        <p><span class="alllinks"><a class="internal" href="/Special:Tags?tag=XPCOM" title="Special:Tags?tag=XPCOM">View
-              all pages tagged with "XPCOM"...</a></span></p>
       </td>
       <td>
         <h3 id="Community">Community</h3>


### PR DESCRIPTION
This link/section is broken (see https://github.com/mdn/content/issues/551). Because the link and text are not even rendered what I have done is deleted it.

Another possible solution is to provide a link that does work and is displayed. @chrisdavidmills How do we provide a link to display a set of tags in the wiki (there are 18 tagged with XPCOM. 