### PR TITLE
HTTP Accept header with avif FF86

### DIFF
--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -25,11 +25,9 @@ tags:
   <tr>
    <td>Firefox</td>
    <td>
-    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (since Firefox 66)<br>
-     <br>
-     <code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (in Firefox 65)<br>
-     <br>
-     <code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (before)</p>
+    <p><code>*/*</code> (since Firefox 66)<br></p>
+    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (in Firefox 65)</p>
+    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (before)</p>
    </td>
    <td>In Firefox 65 and earlier, this value can be modified using the <a class="external" href="http://kb.mozillazine.org/Network.http.accept.default"><code>network.http.accept.default</code></a> parameter. (<a class="external" href="https://hg.mozilla.org/mozilla-central/file/tip/modules/libpref/init/all.js#l1750">source)</a></td>
   </tr>
@@ -79,9 +77,10 @@ tags:
   <tr>
    <td>Firefox</td>
    <td>
-    <p><code>image/webp,*/*</code> (since Firefox 65)<br>
-     <code>*/*</code> (since Firefox 47)<br>
-     <code>image/png,image/*;q=0.8,*/*;q=0.5</code> (before)</p>
+     <p><code>image/avif,image/webp,*/*</code> (since Firefox 86)</p>
+     <p><code>image/webp,*/*</code> (since Firefox 65)</p>
+     <p><code>*/*</code> (since Firefox 47)</p>
+     <p><code>image/png,image/*;q=0.8,*/*;q=0.5</code> (before)</p>
    </td>
    <td>This value can be modified using the <code>image.http.accept</code> parameter. <a class="external" href="https://hg.mozilla.org/mozilla-central/file/tip/modules/libpref/init/all.js#l3779"><span style="font-size: x-small;">source</span></a></td>
   </tr>


### PR DESCRIPTION
Captures that
- The accept header for images changed to `image/avif,image/webp,*/*` in FF86
- The default accept header changed to *\* back in FF66. See https://bugzilla.mozilla.org/show_bug.cgi?id=1417463 and https://github.com/mdn/browser-compat-data/pull/3574

Note, both verified by testing.