### PR TITLE
FF86 Release notes for AVIF addition

### DIFF
--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -32,8 +32,8 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
-  <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> image format).</li>
- </ul>
+  <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> image format). ({{bug(1641208)}}).</li>
+</ul>
 
 <h4 id="Removals_5">Removals</h4>
 
@@ -62,7 +62,7 @@ tags:
 <ul>
   <li>Basic support for <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> images is now enabled by default ({{bug(1682995)}}).
     <ul>
-      <li><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> is a new image format with excellent compression and no patent restrictions developed by the Alliance for Open Media.</li>
+      <li><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> is a new image format with excellent compression and no patent restrictions (developed by the <a href="http://aomedia.org/">Alliance for Open Media</a>).</li>
       <li>Some advanced features are still in development, including animated images and colorspace support ({{bug(1682995)}}).</li>
     </ul>
 </ul>

--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -31,6 +31,10 @@ tags:
 
 <h3 id="HTTP">HTTP</h3>
 
+<ul>
+  <li>The default HTTP {{HTTPHeader("ACCEPT")}} header for <em>images</em> changed to: <code>image/avif,image/webp,*/*</code> (following addition of support for the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> image format).</li>
+ </ul>
+
 <h4 id="Removals_5">Removals</h4>
 
 <h3 id="Security">Security</h3>
@@ -52,6 +56,17 @@ tags:
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
 <h4 id="Removals_9">Removals</h4>
+
+<h3 id="Other">Other</h3>
+
+<ul>
+  <li>Basic support for <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> images is now enabled by default ({{bug(1682995)}}).
+    <ul>
+      <li><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a> is a new image format with excellent compression and no patent restrictions developed by the Alliance for Open Media.</li>
+      <li>Some advanced features are still in development, including animated images and colorspace support ({{bug(1682995)}}).</li>
+    </ul>
+</ul>
+
 
 <h2 id="Older_versions">Older versions</h2>
 


### PR DESCRIPTION
Adds release notes about 
- addition of basic AVIF support. 
- Update of HTTP header ACCEPT for HTML files following AVIF support.