### PR TITLE
Mistake in reduce syntax

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -41,7 +41,7 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js notranslate"><var>arr</var>.reduce(<var>callback</var>( <var>accumulator</var>, <var>currentValue, </var>[, <var>index</var>[, <var>array</var>]] )[, <var>initialValue</var>])</pre>
+  class="brush: js notranslate"><var>arr</var>.reduce(<var>callback</var>( <var>accumulator</var>, <var>currentValue</var>, <var>index</var>, <var>array</var> ), <var>initialValue</var>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 


### PR DESCRIPTION
```
arr.reduce(callback( accumulator, currentValue, [, index[, array]] )[, initialValue])
```
changed to
```
arr.reduce(callback( accumulator, currentValue, index, array ), initialValue)
```