### PR TITLE
Mistake in forEach syntax

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -18,9 +18,9 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate"><var>arr</var>.forEach(<var>callback(currentValue[, index[, array]]) {
+<pre class="brush: js notranslate"><var>arr</var>.forEach(<var>callback(currentValue, index, array) {
 </var>  // execute something
-<var>}</var>[, <var>thisArg</var>]);</pre>
+<var>}</var>, <var>thisArg</var>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 


### PR DESCRIPTION
```
arr.forEach(callback(currentValue[, index[, array]]) {
  // execute something
}[, thisArg]);
```
changed to
```
arr.forEach(callback(currentValue, index, array) {
  // execute something
}, thisArg);
```