### PR TITLE
Fix spec name typo

### DIFF
--- a/files/en-us/web/api/mediasession/setactionhandler/index.html
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.html
@@ -181,8 +181,7 @@ function handleSeek(details) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasession-setactionhandler','MediaSession.setActionHandler()')}}
+      <td>{{SpecName('Media Session','#dom-mediasession-setactionhandler','MediaSession.setActionHandler()')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>


### PR DESCRIPTION
An unexpected line break rendered this link unusable. This PR is fixing this.