### PR TITLE
Fix broken link in setInterval doc

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/setinterval/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/setinterval/index.html
@@ -43,9 +43,8 @@ var <em>intervalID</em> = <em>scope</em>.setInterval(function[, delay]);
     security risk.</dd>
   <dt><code>delay</code>{{optional_inline}}</dt>
   <dd>The time, in milliseconds (thousandths of a second), the timer should delay in
-    between executions of the specified function or code. See {{anch("Delay
-    restrictions")}} below for details on the permitted range of <code>delay</code>
-    values.</dd>
+    between executions of the specified function or code. See {{anch("Delay restrictions")}}
+    below for details on the permitted range of <code>delay</code> values.</dd>
   <dt><code>arg1, ..., argN</code> {{optional_inline}}</dt>
   <dd>Additional arguments which are passed through to the function specified by
     <em>func</em> once the timer expires.</dd>


### PR DESCRIPTION
https://developer.mozilla.org/en-us/docs/Web/API/WindowOrWorkerGlobalScope/setInterval has a broken link to 
https://developer.mozilla.org/en-us/docs/Web/API/WindowOrWorkerGlobalScope/setInterval#Delay_restrictions on the same page.
It seems like the link is broken because of the line break inside the link introduced in #1124.
