### PR TITLE
Remove EmbedDistLiveSample macro link

### DIFF
--- a/files/en-us/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/index.html
+++ b/files/en-us/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/index.html
@@ -148,7 +148,7 @@ document.addEventListener('click', function (e) {
 
 <p>The previous example is okay if you want to embed basic active learning content. However, if you want to deal with complex code, it can become a bit awkward to deal with that <code>hidden</code> class wrapper.</p>
 
-<p>So another option is to write the code of your learning content on an MDN page and then embed it into another page. To do this we can use the {{TemplateLink("EmbedDistLiveSample")}} macro instead of the {{TemplateLink("EmbedLiveSample")}} macro.</p>
+<p>So another option is to write the code of your learning content on an MDN page and then embed it into another page. To do this we can still use the {{TemplateLink("EmbedLiveSample")}} macro, but we'll also have to pass it the page from where to extract your code.</p>
 
 <p>Let's how that sample looks when configured as if it were being embedded from a remote origin:</p>
 


### PR DESCRIPTION
Remove reference to `EmbedDistLiveSample` macro, which hasn't existed for some time.