### PR TITLE
Remove assertion that HTML is not a programming language

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/html_basics/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/html_basics/index.html
@@ -20,7 +20,7 @@ tags:
 
 <h2 id="So_what_is_HTML">So what is HTML?</h2>
 
-<p>HTML is not a programming language; it is a <em>markup language</em> that defines the structure of your content. HTML consists of a series of <strong>{{Glossary("element", "elements")}}</strong>, which you use to enclose, or wrap, different parts of the content to make it appear a certain way, or act a certain way. The enclosing {{Glossary("tag", "tags")}} can make a word or image hyperlink to somewhere else, can italicize words, can make the font bigger or smaller, and so on.  For example, take the following line of content:</p>
+<p>HTML is a <em>markup language</em> that defines the structure of your content. HTML consists of a series of <strong>{{Glossary("element", "elements")}}</strong>, which you use to enclose, or wrap, different parts of the content to make it appear a certain way, or act a certain way. The enclosing {{Glossary("tag", "tags")}} can make a word or image hyperlink to somewhere else, can italicize words, can make the font bigger or smaller, and so on.  For example, take the following line of content:</p>
 
 <pre class="notranslate">My cat is very grumpy</pre>
 


### PR DESCRIPTION
I don't think we gain much by dwelling on what HTML is not; we're here because we want to know what HTML *is*, so let's jump straight into that 😄 

I can see how at the time of writing the statement may have been written to make HTML seem approachable or less intimidating maybe. But I've also seen this sentiment bandied about widely to belittle front-end developers, or draw lines in the sand between people who work on markup and styles and people who do "real programming", whatever that means. I don't think that's something we really want to echo or get drawn into here.