### PR TITLE
Wiki Special:tags and friends

### DIFF
--- a/files/en-us/mozilla/developer_guide/build_instructions/how_mozilla_s_build_system_works/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/how_mozilla_s_build_system_works/index.html
@@ -10,7 +10,10 @@ tags:
 
 <p>For many developers, typing <code>mach build</code> to build the tree is sufficient to work with the source tree. This document explains how the build system works.</p>
 
-<p>Note: This document is not intended for developers who just want to build Mozilla. For that, see the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build Documentation</a>.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>NThis document is not intended for developers who just want to build Mozilla. For that, see the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build Documentation</a>.</p>
+</div>
 
 <h2 id="Concepts">Phases</h2>
 
@@ -321,9 +324,9 @@ include $(topsrcdir)/config/rules.mk
 
 <p>As you can see, there are no extra variables to define. If a <strong><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/JAR_Manifests">jar.mn</a></strong> file exists in the same directory as this Makefile.in, it will automatically be processed. Although the common practice is to have a <strong>resources</strong> directory that contains the jar.mn and chrome files, you may also put a jar.mn file in a directory that creates a library, in which case it will be processed.</p>
 
-<h2 id="Related_Links">Related Links</h2>
+<h2 id="Related_links">Related links</h2>
 
-<p>See the <a href="/en-US/docs/tag/Build%20Glossary">glossary of makefile variables</a> for information about specific variables and how to use them.</p>
+<p>See <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/How_Mozilla_s_build_system_works/Makefile_-_variables">Makefile - variables</a> for information about specific variables and how to use them.</p>
 
 <div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>

--- a/files/en-us/mozilla/developer_guide/build_instructions/how_mozilla_s_build_system_works/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/how_mozilla_s_build_system_works/index.html
@@ -12,7 +12,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>NThis document is not intended for developers who just want to build Mozilla. For that, see the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build Documentation</a>.</p>
+  <p>This document is not intended for developers who just want to build Mozilla. For that, see the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build Documentation</a>.</p>
 </div>
 
 <h2 id="Concepts">Phases</h2>

--- a/files/en-us/mozilla/developer_guide/build_instructions/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/index.html
@@ -5,10 +5,10 @@ tags:
   - Build documentation
   - Developing Mozilla
 ---
-<div class="note">
-<p>The mechanism used to build Firefox for Android also <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_for_Android_build">has its own page</a>.</p>
-
-<p>The mechanism used to build Firefox for iOS also <a href="https://github.com/mozilla/firefox-ios">has its own github</a>.</p>
+<div class="notecard note">
+	<h4>Note</h4>
+	<p>The mechanism used to build Firefox for Android also <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_for_Android_build">has its own page</a>.</p>
+	<p>The mechanism used to build Firefox for iOS also <a href="https://github.com/mozilla/firefox-ios">has its own github</a>.</p>
 </div>
 
 <h2 id="This_page_is_about_building_Firefox_Desktop">This page is about building Firefox Desktop</h2>
@@ -97,10 +97,6 @@ tags:
 	<li><a href="/en-US/docs/Mozilla/Firefox/Building_Firefox_with_Rust_code">Building Firefox with Rust Code</a></li>
 	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Mozilla_Release_Build_Notes">Notes on how mozilla.org does release builds</a> (circa 2007)</li>
 	<li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites">Building Firefox on Windows with clang-cl</a></li>
-</ul>
-
-<ul>
-	<li><a class="internal" href="/en-US/docs/tag/Build_documentation">All build documentation</a></li>
 </ul>
 
 <h2 id="Hacking_the_Build_System">Hacking the Build System</h2>

--- a/files/en-us/mozilla/developer_guide/build_instructions/toc/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/toc/index.html
@@ -2,13 +2,12 @@
 title: TOC
 slug: Mozilla/Developer_guide/Build_Instructions/TOC
 ---
-<div class="callout-box" style="text-align: left;"><a href="/en-US/Developer_Guide/Build_Instructions">Build Instructions</a>:
+<div class="callout-box" style="text-align: left;"><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build Instructions</a>:
 <ul>
- <li><a href="/en-US/Developer_Guide/Build_Instructions#build_prerequisites">Requirements</a></li>
- <li><a href="/en-US/Developer_Guide/Build_Instructions#get_the_source">Source</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions#build_prerequisites">Requirements</a></li>
+ <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions#get_the_source">Source</a></li>
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Configuring_Build_Options">Configuration</a></li>
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions">Build</a></li>
  <li><a href="/en-US/docs/Mozilla/Developer_guide/Mozilla_build_FAQ">Frequently Asked Questions</a></li>
- <li><a href="/en-US/docs/tag/Build%20documentation" title="More documentation about building Mozilla">More...</a></li>
 </ul>
 </div>

--- a/files/en-us/mozilla/firefox/releases/12/index.html
+++ b/files/en-us/mozilla/firefox/releases/12/index.html
@@ -69,7 +69,7 @@ tags:
 <h3 id="MathML">MathML</h3>
 
 <ul>
- <li>To control the directionality of MathML formulas, the <code>dir</code> attribute is now supported on the {{MathMLElement("math")}}, {{MathMLElement("mrow")}}, and {{MathMLElement("mstyle")}} elements as well as on <a href="/Special:Tags?tag=MathML:Token+Elements" title="Special:Tags?tag=MathML:Token+Elements">MathML Token Elements</a>. This is particularly important for some <a class="external" href="https://www.w3.org/TR/arabic-math/">Arabic mathematical notations</a>.</li>
+ <li>To control the directionality of MathML formulas, the <code>dir</code> attribute is now supported on the {{MathMLElement("math")}}, {{MathMLElement("mrow")}}, and {{MathMLElement("mstyle")}} elements as well as on <a href="https://developer.mozilla.org/en-US/docs/Web/MathML/Element#token_elements">MathML Token Elements</a>. This is particularly important for some <a class="external" href="https://www.w3.org/TR/arabic-math/">Arabic mathematical notations</a>.</li>
  <li>The alignment attribute <code>align</code> defined in MathML3 has been implemented for {{MathMLElement("munder")}}, {{MathMLElement("mover")}}, and {{MathMLElement("munderover")}}.</li>
 </ul>
 

--- a/files/en-us/mozilla/firefox/releases/12/index.html
+++ b/files/en-us/mozilla/firefox/releases/12/index.html
@@ -69,7 +69,7 @@ tags:
 <h3 id="MathML">MathML</h3>
 
 <ul>
- <li>To control the directionality of MathML formulas, the <code>dir</code> attribute is now supported on the {{MathMLElement("math")}}, {{MathMLElement("mrow")}}, and {{MathMLElement("mstyle")}} elements as well as on <a href="https://developer.mozilla.org/en-US/docs/Web/MathML/Element#token_elements">MathML Token Elements</a>. This is particularly important for some <a class="external" href="https://www.w3.org/TR/arabic-math/">Arabic mathematical notations</a>.</li>
+ <li>To control the directionality of MathML formulas, the <code>dir</code> attribute is now supported on the {{MathMLElement("math")}}, {{MathMLElement("mrow")}}, and {{MathMLElement("mstyle")}} elements as well as on <a href="/en-US/docs/Web/MathML/Element#token_elements">MathML Token Elements</a>. This is particularly important for some <a class="external" href="https://www.w3.org/TR/arabic-math/">Arabic mathematical notations</a>.</li>
  <li>The alignment attribute <code>align</code> defined in MathML3 has been implemented for {{MathMLElement("munder")}}, {{MathMLElement("mover")}}, and {{MathMLElement("munderover")}}.</li>
 </ul>
 

--- a/files/en-us/web/accessibility/index.html
+++ b/files/en-us/web/accessibility/index.html
@@ -52,8 +52,6 @@ tags:
  <dt><a href="/en-US/docs/Web/Accessibility/Seizure_disorders">Accessibility for seizure disorders</a></dt>
  <dd>Some types of visual web content can induce seizures in people with certain brain disorders. Understand the types of content that can be problematic, and find tools and strategies to help you avoid them.</dd>
 </dl>
-
-<p><span class="alllinks"><a href="/en-US/docs/tag/Accessibility">View all articles about Accessibility...</a></span></p>
 </div>
 </div>
 

--- a/files/en-us/web/guide/ajax/index.html
+++ b/files/en-us/web/guide/ajax/index.html
@@ -29,9 +29,9 @@ An introduction to Ajax.</div>
  <dt><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest">Using the <code>XMLHttpRequest</code> API</a></dt>
  <dd>The {{domxref("XMLHttpRequest")}} API is the core of Ajax. This article will explain how to use some Ajax techniques, like:
  <ul>
-  <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Handling_responses">Analyzing and manipulating the response of the server</a></li>
-  <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress">Monitoring the progress of a request</a></li>
-  <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Submitting_forms_and_uploading_files">Submitting forms and upload binary files</a> – in <em>pure</em> Ajax, or using {{domxref("FormData")}} objects</li>
+  <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#handling_responses">Analyzing and manipulating the response of the server</a></li>
+  <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#monitoring_progress">Monitoring the progress of a request</a></li>
+  <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files">Submitting forms and upload binary files</a> – in <em>pure</em> Ajax, or using {{domxref("FormData")}} objects</li>
   <li>Using Ajax within <a href="/en-US/docs/Web/API/Worker">Web workers</a></li>
  </ul>
  </dd>
@@ -48,14 +48,12 @@ An introduction to Ajax.</div>
  <dt><a href="/en-US/docs/Web/Guide/Parsing_and_serializing_XML">Parsing and serializing XML</a></dt>
  <dd>How to parse an XML document from a string, a file or via javascript and how to serialize XML documents to strings, Javascript Object trees (JXON) or files.</dd>
  <dt><a href="/en-US/docs/Web/XPath">XPath</a></dt>
- <dd>XPath stands for <strong>X</strong>ML <strong>Path</strong> Language, it uses a non-XML syntax that provides a flexible way of addressing (pointing to) different parts of an <a href="/en-US/docs/XML">XML</a> document. As well as this, it can also be used to test addressed nodes within a document to determine whether they match a pattern or not.</dd>
+ <dd>XPath stands for <strong>X</strong>ML <strong>Path</strong> Language, it uses a non-XML syntax that provides a flexible way of addressing (pointing to) different parts of an <a href="/en-US/docs/Web/XML">XML</a> document. As well as this, it can also be used to test addressed nodes within a document to determine whether they match a pattern or not.</dd>
  <dt>{{domxref("FileReader")}} API</dt>
  <dd>The <code>FileReader</code> API lets web applications asynchronously read the contents of files (or raw data buffers) stored on the user's computer, using {{domxref("File")}} or {{domxref("Blob")}} objects to specify the file or data to read. File objects may be obtained from a {{domxref("FileList")}} object returned as a result of a user selecting files using the {{HTMLElement("input")}} element, from a drag and drop operation's {{domxref("DataTransfer")}} object, or from the <code>mozGetAsFile()</code> API on an {{domxref("HTMLCanvasElement")}}.</dd>
  <dt><a href="/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest">HTML in XMLHttpRequest</a></dt>
  <dd>The <a class="external" href="https://xhr.spec.whatwg.org/">XMLHttpRequest</a> specification adds HTML parsing support to {{domxref("XMLHttpRequest")}}, which originally supported only XML parsing. This feature allows Web apps to obtain an HTML resource as a parsed DOM using <code>XMLHttpRequest</code>.</dd>
 </dl>
-
-<p><span class="alllinks"><a href="/en-US/docs/tag/AJAX">View All...</a></span></p>
 </div>
 
 <div class="section">

--- a/files/en-us/web/guide/graphics/index.html
+++ b/files/en-us/web/guide/graphics/index.html
@@ -19,29 +19,27 @@ tags:
 <h2 class="Documentation" id="2D_Graphics">2D Graphics</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Web/HTML/Canvas">Canvas</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Canvas_API">Canvas</a></dt>
  <dd>The {{HTMLElement("canvas")}} element provides APIs to draw 2D graphics using JavaScript.</dd>
  <dt><a href="/en-US/docs/Web/SVG">SVG</a></dt>
  <dd>Scalable Vector Graphics (SVG) lets you use lines, curves, and other geometric shapes to render graphics. With vectors, you can create images that scale cleanly to any size.</dd>
 </dl>
-
-<p><span class="alllinks"><a href="/en-US/docs/tag/Graphics">View All...</a></span></p>
 </div>
 
 <div class="section">
 <h2 class="Documentation" id="3D_Graphics">3D Graphics</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Web/WebGL">WebGL</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebGL_API">WebGL</a></dt>
  <dd>A guide to getting started with WebGL, the 3D graphics API for the Web. This technology lets you use standard OpenGL ES in web content.</dd>
 </dl>
 
 <h2 id="Video">Video</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Web/Guide/HTML/Using_HTML5_audio_and_video">Using HTML5 audio and video</a></dt>
+ <dt><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content">Using HTML5 audio and video</a></dt>
  <dd>Embedding video and/or audio in a web page and controlling its playback.</dd>
- <dt><a href="/en-US/docs/WebRTC">WebRTC</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></dt>
  <dd>The RTC in WebRTC stands for Real-Time Communications, a technology that enables audio/video streaming and data sharing between browser clients (peers).</dd>
 </dl>
 </div>

--- a/files/en-us/web/html/index.html
+++ b/files/en-us/web/html/index.html
@@ -6,7 +6,7 @@ tags:
   - HTML5
   - Landing
   - Web
-  - 'l10n:priority'
+  - l10n:priority
 ---
 <div>{{HTMLSidebar}}</div>
 
@@ -38,7 +38,7 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
   
-  <p><a class="button primary" href="/docs/Learn/Front-end_web_developer">Get started</a>
+  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
   </p>
 </div>
 
@@ -105,5 +105,3 @@ tags:
 </dl>
 </div>
 </div>
-
-<p><span class="alllinks"><a href="/en-US/docs/tag/HTML">View All...</a></span></p>

--- a/files/en-us/web/html/reference/index.html
+++ b/files/en-us/web/html/reference/index.html
@@ -26,4 +26,3 @@ tags:
  <dd>Certain HTML elements allow you to specify dates and/or times as the value or as the value of an attribute. These include the date and time variations of the {{HTMLElement("input")}} element as well as the {{HTMLElement("ins")}} and {{HTMLElement("del")}} elements.</dd>
 </dl>
 
-<p><span class="alllinks"><a href="/en-US/docs/tag/HTML" title="Article tagged: HTML">View all pages tagged "HTML"...</a></span></p>

--- a/files/en-us/web/index.html
+++ b/files/en-us/web/index.html
@@ -22,7 +22,6 @@ tags:
  <dd>Progressive Web Apps are web apps that use emerging web browser APIs and features along with traditional progressive enhancement strategy to bring a native app-like user experience to cross-platform web applications.</dd>
 </dl>
 
-<p><span class="alllinks"><a href="/en-US/docs/tag/Web">View All...</a></span></p>
 </div>
 
 <div class="section">
@@ -37,7 +36,7 @@ tags:
  <dd>Cascading Style Sheets are used to describe the appearance of Web content.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript">JavaScript</a></dt>
  <dd>JavaScript is a programming language used to add interactivity to a website.</dd>
- <dt><a href="/en-US/docs/SVG">SVG</a></dt>
+ <dt><a href="/en-US/docs/Web/SVG">SVG</a></dt>
  <dd>Scalable Vector Graphics let you describe images as sets of vectors and shapes in order to allow them to scale smoothly regardless of the size at which they're drawn.</dd>
  <dt><a href="/en-US/docs/Web/MathML">MathML</a></dt>
  <dd>The Mathematical Markup Language makes it possible to display complex mathematical equations and syntax.</dd>

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.html
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.html
@@ -183,7 +183,7 @@ tags:
 <h3 id="String_methods">String methods</h3>
 
 <ul>
- <li><a href="/en-US/docs/tag/HTML%20wrapper%20methods">HTML wrapper methods</a> like {{jsxref("String.prototype.fontsize")}} and {{jsxref("String.prototype.big")}}.</li>
+ <li>HTML wrapper methods like {{jsxref("String.prototype.fontsize")}} and {{jsxref("String.prototype.big")}}.</li>
  <li>{{jsxref("String.prototype.quote")}} is removed from Firefox 37.</li>
  <li>non standard <code>flags</code> parameter in {{jsxref("String.prototype.search")}}, {{jsxref("String.prototype.match")}}, and {{jsxref("String.prototype.replace")}} are deprecated.</li>
  <li>{{jsxref("String.prototype.substr")}} probably won't be removed anytime soon, but it's defined in <a href="https://www.ecma-international.org/ecma-262/9.0/index.html#sec-string.prototype.substr" rel="noopener">Annex B</a> of the ECMA-262 standard, whose <a href="https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers">introduction</a> states: "… Programmers should not use or assume the existence of these features and behaviors when writing new ECMAScript code. …"</li>

--- a/files/en-us/web/mathml/element/mglyph/index.html
+++ b/files/en-us/web/mathml/element/mglyph/index.html
@@ -4,25 +4,25 @@ slug: Web/MathML/Element/mglyph
 tags:
   - MathML
   - MathML Reference
-  - 'MathML:Element'
+  - MathML:Element
 ---
 <div>{{MathMLRef}}</div>
 
-<p class="summary">The MathML <code>&lt;mglyph&gt;</code> element is used to display non-standard symbols where existing Unicode characters are not available. It may be used within <a href="/en-US/docs/tag/MathML:Token%20Elements">token elements</a>.</p>
+<p class="summary">The MathML <code>&lt;mglyph&gt;</code> element is used to display non-standard symbols where existing Unicode characters are not available. It may be used within token elements.</p>
 
 <h2 id="Attributes">Attributes</h2>
 
 <dl>
 	<dt id="attr-alt">alt</dt>
-	<dd>This attribute defines the alternative text describing the image. Users will see this displayed if the image URL is wrong, the image is not in one of the <a href="/en-US/docs/Web/HTML/Element/Img#Supported_image_formats">supported formats</a>, or until the image is downloaded.</dd>
+	<dd>This attribute defines the alternative text describing the image. Users will see this displayed if the image URL is wrong, the image is not in one of the <a href="/en-US/docs/Web/HTML/Element/img#supported_image_formats">supported formats</a>, or until the image is downloaded.</dd>
 	<dt id="attr-class-id-style">class, id, style</dt>
-	<dd>Provided for use with <a href="/en-US/docs/CSS">stylesheets</a>.</dd>
+	<dd>Provided for use with <a href="/en-US/docs/Web/CSS">stylesheets</a>.</dd>
 	<dt id="attr-height">height</dt>
 	<dd>The height of the image.</dd>
 	<dt id="attr-href">href</dt>
 	<dd>Used to set a hyperlink to a specified URI.</dd>
 	<dt id="attr-mathbackground">mathbackground</dt>
-	<dd>The background color (if the image has transparency). You can use <code>#rgb</code>, <code>#rrggbb</code> and <a href="/en-US/docs/CSS/color_value#Color_Keywords">HTML color names</a>.</dd>
+	<dd>The background color (if the image has transparency). You can use <code>#rgb</code>, <code>#rrggbb</code> and <a href="/en-US/docs/Web/CSS/color_value#color_keywords">HTML color names</a>.</dd>
 	<dt id="attr-src">src</dt>
 	<dd>The image URL.</dd>
 	<dt id="attr-valign">valign</dt>
@@ -66,4 +66,3 @@ tags:
 
 
 <p>{{Compat("mathml.elements.mglyph")}}</p>
-

--- a/files/en-us/web/mathml/index.html
+++ b/files/en-us/web/mathml/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{MathMLRef}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>Mathematical Markup Language (MathML)</strong> is a dialect of <a href="/en-US/docs/XML">XML</a> for describing mathematical notation and capturing both its structure and content.</span></p>
+<p class="summary"><span class="seoSummary"><strong>Mathematical Markup Language (MathML)</strong> is a dialect of <a href="/en-US/docs/Web/XML">XML</a> for describing mathematical notation and capturing both its structure and content.</span></p>
 
 <p>Here you'll find links to documentation, examples, and tools to help you work with this powerful technology. For a quick overview, see the <a href="https://fred-wang.github.io/MozSummitMathML/index.html">slides for the innovation fairs at Mozilla Summit 2013</a>.</p>
 
@@ -29,7 +29,6 @@ tags:
  <dd>Suggestions and tips for writing MathML, including suggested MathML editors and how to integrate their output into Web content.</dd>
 </dl>
 
-<p><a href="/en-US/docs/tag/MathML">View All...</a></p>
 </div>
 
 <div class="section">

--- a/files/en-us/web/svg/index.html
+++ b/files/en-us/web/svg/index.html
@@ -13,16 +13,16 @@ tags:
   - Scalable Images
   - Vector Graphics
   - Web
-  - 'l10n:priority'
+  - l10n:priority
 ---
 <div>{{SVGRef}}</div>
 
-<div class="callout-box"><strong><a href="/en-US/docs/SVG/Tutorial">Getting Started</a></strong><br>
+<div class="callout-box"><strong><a href="/en-US/docs/Web/SVG/Tutorial">Getting Started</a></strong><br>
 This tutorial will help get you started using SVG.</div>
 
-<p class="summary" style="border-top-width: 0; padding-top: 0;"><span class="seoSummary"><strong>Scalable Vector Graphics (SVG)</strong> are an <a href="/en-US/docs/XML">XML</a>-based markup language for describing two-dimensional based <a class="external" href="https://en.wikipedia.org/wiki/Vector_graphics">vector graphics</a>.</span> As such, it's a text-based, open Web standard for describing images that can be rendered cleanly at any size and are designed specifically to work well with other web standards including <a href="/en-US/docs/CSS">CSS</a>, <a href="/en-US/docs/DOM">DOM</a>, <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, and <a href="/en-US/docs/Web/SVG/SVG_animation_with_SMIL">SMIL</a>. SVG is, essentially, to graphics what <a href="/en-US/docs/Web/HTML">HTML</a> is to text.</p>
+<p class="summary" style="border-top-width: 0; padding-top: 0;"><span class="seoSummary"><strong>Scalable Vector Graphics (SVG)</strong> are an <a href="/en-US/docs/Web/XML">XML</a>-based markup language for describing two-dimensional based <a class="external" href="https://en.wikipedia.org/wiki/Vector_graphics">vector graphics</a>.</span> As such, it's a text-based, open Web standard for describing images that can be rendered cleanly at any size and are designed specifically to work well with other web standards including <a href="/en-US/docs/Web/CSS">CSS</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, and <a href="/en-US/docs/Web/SVG/SVG_animation_with_SMIL">SMIL</a>. SVG is, essentially, to graphics what <a href="/en-US/docs/Web/HTML">HTML</a> is to text.</p>
 
-<p>SVG images and their related behaviors are defined in <span class="seoSummary"><a href="/en-US/docs/XML">XML</a></span> text files, which means they can be searched, indexed, scripted, and compressed. Additionally, this means they can be created and edited with any text editor or with drawing software.</p>
+<p>SVG images and their related behaviors are defined in <span class="seoSummary"><a href="/en-US/docs/Web/XML">XML</a></span> text files, which means they can be searched, indexed, scripted, and compressed. Additionally, this means they can be created and edited with any text editor or with drawing software.</p>
 
 <p>Compared to classic bitmapped image formats such as {{Glossary("JPEG")}} or {{Glossary("PNG")}}, SVG-format vector images can be rendered at any size without loss of quality and can be easily localized by updating the text within them, without the need of a graphical editor to do so. With proper libraries, SVG files can even be localized on-the-fly.</p>
 
@@ -37,13 +37,11 @@ This tutorial will help get you started using SVG.</div>
  <dd>Details about each SVG element.</dd>
  <dt><a href="/en-US/docs/Web/SVG/Attribute">SVG attribute reference</a></dt>
  <dd>Details about each SVG attribute.</dd>
- <dt><a href="/en-US/docs/Web/API/Document_Object_Model#SVG_interfaces">SVG DOM interface reference</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Document_Object_Model#svg_interfaces">SVG DOM interface reference</a></dt>
  <dd>Details about the SVG DOM API, for interaction with JavaScript.</dd>
  <dt><a href="/en-US/docs/Web/SVG/Applying_SVG_effects_to_HTML_content">Applying SVG effects to HTML content</a></dt>
  <dd>SVG works together with {{Glossary("HTML")}}, {{Glossary("CSS")}} and {{Glossary("JavaScript")}}. Use SVG to <a href="/en-US/docs/Web/SVG/Tutorial/SVG_In_HTML_Introduction">enhance a regular HTML page or web application</a>.</dd>
 </dl>
-
-<p><span class="alllinks"><a href="/en-US/docs/tag/SVG">View All...</a></span></p>
 
 <h2 id="Community">Community</h2>
 
@@ -56,8 +54,7 @@ This tutorial will help get you started using SVG.</div>
 <ul>
  <li><a href="https://github.com/w3c/svgwg/wiki/Testing">SVG Test Suite</a></li>
  <li><a href="https://validator.w3.org/#validate_by_input">Markup Validator</a></li>
- <li><a href="/en-US/docs/tag/SVG:Tools">More Tools...</a></li>
- <li>Other resources: <a href="/en-US/docs/XML">XML</a>, <a href="/en-US/docs/CSS">CSS</a>, <a href="/en-US/docs/DOM">DOM</a>, <a href="/en-US/docs/Web/HTML/Canvas">Canvas</a></li>
+ <li>Other resources: <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/CSS">CSS</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/Web/API/Canvas_API">Canvas</a></li>
 </ul>
 </div>
 
@@ -70,8 +67,8 @@ This tutorial will help get you started using SVG.</div>
  <li><a href="http://jwatt.org/svg/authoring/">SVG authoring guidelines</a></li>
  <li>An overview of the <a href="/en-US/docs/Mozilla_SVG_Project">Mozilla SVG Project</a></li>
  <li><a href="/en-US/docs/SVG/FAQ">Frequently asked questions</a> regarding SVG and Mozilla</li>
- <li><a href="/en-US/docs/SVG/SVG_as_an_Image">SVG as an image</a></li>
- <li><a href="/en-US/docs/SVG/SVG_animation_with_SMIL">SVG animation with SMIL</a></li>
+ <li><a href="/en-US/docs/Web/SVG/SVG_as_an_Image">SVG as an image</a></li>
+ <li><a href="/en-US/docs/Web/SVG/SVG_animation_with_SMIL">SVG animation with SMIL</a></li>
  <li><a href="http://plurib.us/1shot/2007/svg_gallery/">SVG art gallery</a></li>
 </ul>
 

--- a/files/en-us/web/xpath/index.html
+++ b/files/en-us/web/xpath/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{XSLTRef}}</div>
 
-<p><span class="seoSummary">XPath stands for XML Path Language. It uses a non-XML syntax to provide a flexible way of addressing (pointing to) different parts of an <a href="/en-US/docs/XML_Introduction">XML</a> document. It can also be used to test addressed nodes within a document to determine whether they match a pattern or not.</span></p>
+<p><span class="seoSummary">XPath stands for XML Path Language. It uses a non-XML syntax to provide a flexible way of addressing (pointing to) different parts of an <a href="/en-US/docs/Web/XML/XML_introduction">XML</a> document. It can also be used to test addressed nodes within a document to determine whether they match a pattern or not.</span></p>
 
 <p>XPath is mainly used in <a href="/en-US/docs/Web/XSLT">XSLT</a>, but can also be used as a much more powerful way of navigating through the <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> of any XML-like language document using {{DOMxRef("XPathExpression")}}, such as <a href="/en-US/docs/Web/HTML">HTML</a> and <a href="/en-US/docs/Web/SVG">SVG</a>, instead of relying on the {{DOMxRef("Document.getElementById()")}} or {{DOMxRef("ParentNode.querySelectorAll()")}} methods, the {{DOMxRef("Node.childNodes")}} properties, and other DOM Core features.</p>
 
@@ -28,23 +28,22 @@ tags:
 <h2 id="Documentation">Documentation</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Introduction_to_using_XPath_in_JavaScript">Introduction to using XPath in JavaScript</a></dt>
+ <dt><a href="/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript">Introduction to using XPath in JavaScript</a></dt>
  <dd>Describes a non-XSLT use of XPath.</dd>
  <dt><a href="/en-US/docs/Web/XPath/Axes">XPath:Axes</a></dt>
  <dd>List and definition of the axes defined in the XPath specification. Axes are used to describe the relationships between nodes.</dd>
  <dt><a href="/en-US/docs/Web/XPath/Functions">XPath:Functions</a></dt>
  <dd>List and description of the core XPath functions and XSLT-specific additions to XPath.</dd>
- <dt><a href="/en-US/docs/Transforming_XML_with_XSLT">Transforming XML with XSLT</a></dt>
+ <dt><a href="/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT">Transforming XML with XSLT</a></dt>
  <dd>XSLT uses XPath to address code segments in an XML document that it wishes to transform.</dd>
  <dt><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></dt>
  <dd>These are JavaScript utility functions, that can be used in your own code, based on  <a class="external external-icon" href="https://www.w3.org/TR/DOM-Level-3-XPath/">DOM Level 3 XPath </a>APIs.</dd>
  <dt><a class="external" href="http://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></dt>
  <dd>This extensive introduction to XSLT and XPath assumes no prior knowledge of the technologies, and guides the reader through background, context, structure, concepts, and introductory terminology.</dd>
  <dt><a href="/en-US/docs/JXON">JXON</a></dt>
- <dd><strong>JXON</strong> (lossless <strong>J</strong>avaScript <strong>X</strong>ML <strong>O</strong>bject <strong>N</strong>otation) is a generic name by which is defined the representation of JavaScript Objects using <a href="/en/XML">XML</a>. There are some cases in which the whole content of an XML document must be read from the JavaScript interpreter (like for web-apps languages or settings XML documents, for example). In these cases JXON could represent the most practical way and valid alternative to XPath.</dd>
+ <dd><strong>JXON</strong> (lossless <strong>J</strong>avaScript <strong>X</strong>ML <strong>O</strong>bject <strong>N</strong>otation) is a generic name by which is defined the representation of JavaScript Objects using <a href="/en-US/XML">XML</a>. There are some cases in which the whole content of an XML document must be read from the JavaScript interpreter (like for web-apps languages or settings XML documents, for example). In these cases JXON could represent the most practical way and valid alternative to XPath.</dd>
 </dl>
 
-<p><span class="alllinks"><a href="/en-US/docs/tag/XPath">View All...</a></span></p>
 </div>
 
 <div class="section">
@@ -62,8 +61,8 @@ tags:
 <h2 id="Related_Topics">Related Topics</h2>
 
 <ul>
- <li><a href="/en-US/docs/XSLT">XSLT</a>, <a href="/en-US/docs/XQuery">XQuery</a>, <a href="/en-US/docs/XML">XML</a>, <a href="/en-US/docs/DOM">DOM</a>, <a href="/en-US/docs/JXON">JXON</a>, <a href="/en-US/docs/JSON/JSONPath">JSONPath</a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Selectors/Comparison_with_XPath">Comparison of CSS Selectors and XPath</a></li>
+ <li><a href="/en-US/docs/Web/XSLT">XSLT</a>, <a href="/en-US/docs/XQuery">XQuery</a>, <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/JXON">JXON</a>, <a href="/en-US/docs/JSON/JSONPath">JSONPath</a></li>
+ <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li>
 </ul>
 </div>
 </div>

--- a/files/en-us/web/xslt/index.html
+++ b/files/en-us/web/xslt/index.html
@@ -30,7 +30,7 @@ tags:
 </section>
 {{QuickLinksWithSubpages("/en-US/docs/Web/XSLT")}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>Extensible Stylesheet Language Transformations (XSLT)</strong> is an <a href="/en-US/docs/XML_introduction">XML</a>-based language used, in conjunction with specialized processing software, for the transformation of XML documents.</span></p>
+<p class="summary"><span class="seoSummary"><strong>Extensible Stylesheet Language Transformations (XSLT)</strong> is an <a href="/en-US/docs/Web/XML/XML_introduction">XML</a>-based language used, in conjunction with specialized processing software, for the transformation of XML documents.</span></p>
 
 <p>Although the process is referred to as "transformation," the original document is not changed; rather, a new XML document is created based on the content of an existing document. Then, the new document may be serialized (output) by the processor in standard XML syntax or in another format, such as <a href="/en-US/docs/Web/HTML">HTML</a> or plain text.</p>
 
@@ -55,13 +55,12 @@ tags:
  <dd>This <a class="external" href="http://www.w3schools.com">W3Schools</a> tutorial teaches the reader how to use XSLT to transform XML documents into other formats, like XHTML.</dd>
  <dt><a class="external" href="http://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></dt>
  <dd>This extensive introduction to XSLT and XPath assumes no prior knowledge of the technologies and guides the reader through background, context, structure, concepts and introductory terminology.</dd>
- <dt><a href="/en-US/docs/Web/XSLT/Common_Errors">Common XSLT Errors</a></dt>
+ <dt><a href="/en-US/docs/Web/XSLT/Common_errors">Common XSLT Errors</a></dt>
  <dd>This article lists some common problems using XSLT in Firefox.</dd>
  <dt><a href="/en-US/docs/Mozilla/Tech/XSLT_2.0">XSLT 2.0</a> (new)</dt>
  <dd></dd>
 </dl>
 
-<p><span class="alllinks"><a href="/en-US/docs/tag/XSLT">View All...</a></span></p>
 </div>
 
 <div class="section">
@@ -74,7 +73,7 @@ tags:
 <h4 id="Related_Topics">Related Topics</h4>
 
 <ul>
- <li><a href="/en-US/docs/XML_introduction">XML</a>, <a href="/en-US/docs/Web/XPath">XPath</a>, <a href="/en-US/docs/Archive/XQuery">XQuery</a></li>
+ <li><a href="/en-US/docs/Web/XML/XML_introduction">XML</a>, <a href="/en-US/docs/Web/XPath">XPath</a>, <a href="/en-US/docs/Archive/XQuery">XQuery</a></li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
- Fix last instance of /Special:Tags as described in #551. 
- Fix the direct equivalent (not working) links that go to ../docs/tags/...
- Fix fixable flags on all touch docs. 

Note, a lot of these docs still have flaws/broken internal links. 
