### PR TITLE
FF86: Add release note for removal of cd()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -15,6 +15,10 @@ tags:
 
 <h3 id="Developer_Tools">Developer Tools</h3>
 
+<ul>
+  <li>The <code>cd()</code> <a href="/en-US/docs/Tools/Web_Console/Helpers">web console helper function</a>, which was deprecated in Firefox 74, has now been removed. Developers must now use the (much better) iframe context picker tool described in <a href="/en-US/docs/Tools/Working_with_iframes">Working with iframes</a> for the same purpose. For more information see {{bug(1607741)}}.</li>
+</ul>
+
 <h4 id="Removals">Removals</h4>
 
 <h3 id="HTML">HTML</h3>

--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -16,7 +16,7 @@ tags:
 <h3 id="Developer_Tools">Developer Tools</h3>
 
 <ul>
-  <li>The <code>cd()</code> <a href="/en-US/docs/Tools/Web_Console/Helpers">web console helper function</a>, which was deprecated in Firefox 74, has now been removed. Developers must now use the (much better) iframe context picker tool described in <a href="/en-US/docs/Tools/Working_with_iframes">Working with iframes</a> for the same purpose. For more information see {{bug(1607741)}}.</li>
+  <li>The <code>cd()</code> <a href="/en-US/docs/Tools/Web_Console/Helpers">web console helper function</a>, which was deprecated in Firefox 74, has now been removed. The iframe context picker tool described in <a href="/en-US/docs/Tools/Working_with_iframes">Working with iframes</a> serves the same purpose, but is much better! For more information see {{bug(1607741)}}.</li>
 </ul>
 
 <h4 id="Removals">Removals</h4>


### PR DESCRIPTION
Adds release note for removal of `cd()` - for more info see #1729