### PR TITLE
Fix a link that is no longer valid

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.html
@@ -118,7 +118,7 @@ server.listen(port, hostname, () =&gt; {
 
 <p>The popularity of a web framework is important because it is an indicator of whether it will continue to be maintained, and what resources are likely to be available in terms of documentation, add-on libraries, and technical support.</p>
 
-<p>There isn't any readily-available and definitive measure of the popularity of server-side frameworks (although sites like <a href="http://hotframeworks.com/">Hot Frameworks</a> attempt to assess popularity using mechanisms like counting the number of GitHub projects and StackOverflow questions for each platform). A better question is whether Node and Express are "popular enough" to avoid the problems of unpopular platforms. Are they continuing to evolve? Can you get help if you need it? Is there an opportunity for you to get paid work if you learn Express?</p>
+<p>There isn't any readily-available and definitive measure of the popularity of server-side frameworks (although you can estimate popularity using mechanisms like counting the number of GitHub projects and StackOverflow questions for each platform). A better question is whether Node and Express are "popular enough" to avoid the problems of unpopular platforms. Are they continuing to evolve? Can you get help if you need it? Is there an opportunity for you to get paid work if you learn Express?</p>
 
 <p>Based on the number of <a href="https://expressjs.com/en/resources/companies-using-express.html">high profile companies</a> that use Express, the number of people contributing to the codebase, and the number of people providing both free and paid for support, then yes, <em>Express</em> is a popular framework!</p>
 


### PR DESCRIPTION
The express tutorial linked to http://hotframeworks.com/, which has since closed down (i.e. domain is now up for sale). I've removed the link and made the tutorial sane.

Fixes #1976