### PR TITLE
Fix various breakage in IndexedDB docs

### DIFF
--- a/files/en-us/web/api/idbcursor/direction/index.html
+++ b/files/en-us/web/api/idbcursor/direction/index.html
@@ -31,7 +31,7 @@ tags:
 <h3 id="Value">Value</h3>
 
 <p>A string (defined by the <a
-    href="https://dvcs.w3.org/hg/IndexedDB/raw-file/default/Overview.html#idl-def-IDBCursorDirection"><code>IDBCursorDirection</code>
+    href="https://w3c.github.io/IndexedDB/#enumdef-idbcursordirection"><code>IDBCursorDirection</code>
     enum</a>) indicating the direction in which the cursor is traversing the data.
   Possible values are:</p>
 

--- a/files/en-us/web/api/idbcursor/source/index.html
+++ b/files/en-us/web/api/idbcursor/source/index.html
@@ -72,8 +72,7 @@ tags:
   };
 };</pre>
 
-<h2 id="Specifications"><span
-    style="font-size: 2.14285714285714rem;">Specifications</span></h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbcursorwithvalue/value/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/value/index.html
@@ -65,8 +65,7 @@ tags:
   };
 };</pre>
 
-<h2 id="Specifications"><span
-    style="font-size: 2.14285714285714rem;">Specifications</span></h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>
@@ -76,12 +75,12 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('IndexedDB', '#dom-idbcursor-source', 'source')}}</td>
+      <td>{{SpecName('IndexedDB', '#dom-idbcursorwithvalue-value', 'source')}}</td>
       <td>{{Spec2('IndexedDB')}}</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName("IndexedDB 2", "#database-interface", "IDBDatabase")}}</td>
+      <td>{{SpecName("IndexedDB 2", "#dom-idbcursorwithvalue-value", "IDBDatabase")}}</td>
       <td>{{Spec2("IndexedDB 2")}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.html
@@ -2,13 +2,13 @@
 title: IDBDatabase.deleteObjectStore()
 slug: Web/API/IDBDatabase/deleteObjectStore
 tags:
-- API
-- Database
-- IDBDatabase
-- IndexedDB
-- Method
-- Reference
-- Storage
+  - API
+  - Database
+  - IDBDatabase
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -20,7 +20,7 @@ tags:
 
 <p>As with {{ domxref("IDBDatabase.createObjectStore") }}, this method can be called
   <em>only</em> within a <a
-    href="/en-US/docs/IndexedDB/IDBTransaction#VERSION_CHANGE"><code>versionchange</code></a>
+    href="/en-US/docs/Web/API/IDBTransaction#version_change"><code>versionchange</code></a>
   transaction.</p>
 
 <p>{{AvailableInWorkers}}</p>
@@ -90,8 +90,7 @@ request.onupgradeneeded = function(e) {
   // etc. for version &lt; 3, 4...
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbdatabase/transaction/index.html
+++ b/files/en-us/web/api/idbdatabase/transaction/index.html
@@ -2,13 +2,13 @@
 title: IDBDatabase.transaction()
 slug: Web/API/IDBDatabase/transaction
 tags:
-- API
-- Database
-- IDBDatabase
-- IndexedDB
-- Method
-- Reference
-- Storage
+  - API
+  - Database
+  - IDBDatabase
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -114,7 +114,7 @@ var transaction = db.transaction('my-store-name');</pre>
   <tbody>
     <tr>
       <td>
-        <code><a href="/en-US/docs/IndexedDB/IDBDatabaseException#NOT_ALLOWED_ERR">InvalidStateError</a></code>
+        <code><a href="/en-US/docs/Web/API/IDBDatabaseException#not_allowed_err">InvalidStateError</a></code>
       </td>
       <td>
         <p>The <code>close()</code> method has previously been called on this
@@ -182,8 +182,7 @@ transaction.onerror = function(event) {
 var objectStore = transaction.objectStore("toDoList");
 // etc.</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbindex/count/index.html
+++ b/files/en-us/web/api/idbindex/count/index.html
@@ -118,8 +118,7 @@ var <em>request</em> = <em>myIndex</em>.count(<em>key</em>);</pre>
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbindex/get/index.html
+++ b/files/en-us/web/api/idbindex/get/index.html
@@ -124,8 +124,7 @@ tags:
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbindex/getkey/index.html
+++ b/files/en-us/web/api/idbindex/getkey/index.html
@@ -123,8 +123,7 @@ tags:
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbindex/opencursor/index.html
+++ b/files/en-us/web/api/idbindex/opencursor/index.html
@@ -2,42 +2,28 @@
 title: IDBIndex.openCursor()
 slug: Web/API/IDBIndex/openCursor
 tags:
-- API
-- Database
-- IDBIndex
-- IndexedDB
-- Method
-- Reference
-- Storage
-- openCursor
+  - API
+  - Database
+  - IDBIndex
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
+  - openCursor
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
 <div>
   <p>The <strong><code>openCursor()</code></strong> method of the {{domxref("IDBIndex")}}
     interface returns an {{domxref("IDBRequest")}} object, and, in a separate thread,
-    creates a <a href="/en-US/docs/IndexedDB#gloss_cursor">cursor</a> over the specified key
+    creates a <a href="/en-US/docs/Web/API/IndexedDB_API#gloss_cursor">cursor</a> over the specified key
     range.</p>
 </div>
 
 <p>The method sets the position of the cursor to the appropriate record, based on the
   specified direction.</p>
 
-<ul>
-  <li>If the key range is not specified or is null, then the range includes all the
-    records.</li>
-  <li>A <a href="/en-US/docs/IndexedDB/IDBSuccessEvent">success event</a> is always fired on the
-    result object.
-    <ul>
-      <li>If at least one record matches the key range, then the <code>result</code>
-        property of the event is set to the new {{domxref("IDBCursorWithValue")}} object;
-        the <code><a href="/en-US/docs/IndexedDB/IDBCursor#attr_value">value</a></code> of the
-        cursor object is set to a structured clone of the referenced value.</li>
-      <li>If no records match the key range then the <code>result</code> property of the
-        event is set to <code>null</code>.</li>
-    </ul>
-  </li>
-</ul>
+<p>If the key range is not specified or is null, then the range includes all the records.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -55,8 +41,8 @@ var <em>request</em> = <em>myIndex</em>.openCursor(range, direction);</pre>
     passed, this will default to a key range that selects all the records in this object
     store.</dd>
   <dt>direction {{optional_inline}}</dt>
-  <dd>The cursor's <a href="/en-US/docs/IndexedDB/IDBCursor#Constants">direction</a>. See <a
-      href="/en-US/docs/IndexedDB/IDBCursor#Constants">IDBCursor Constants</a> for possible
+  <dd>The cursor's <a href="/en-US/docs/Web/API/IDBCursor#constants">direction</a>. See <a
+      href="/en-US/docs/Web/API/IDBCursor#constants">IDBCursor Constants</a> for possible
     values.</dd>
 </dl>
 
@@ -140,8 +126,7 @@ var <em>request</em> = <em>myIndex</em>.openCursor(range, direction);</pre>
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbindex/openkeycursor/index.html
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.html
@@ -2,14 +2,14 @@
 title: IDBIndex.openKeyCursor()
 slug: Web/API/IDBIndex/openKeyCursor
 tags:
-- API
-- Database
-- IDBIndex
-- IndexedDB
-- Method
-- Reference
-- Storage
-- openKeyCursor
+  - API
+  - Database
+  - IDBIndex
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
+  - openKeyCursor
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -23,22 +23,7 @@ tags:
 <p>The method sets the position of the cursor to the appropriate key, based on the
   specified direction.</p>
 
-<ul>
-  <li>If the key range is not specified or is null, then the range includes all the keys.
-  </li>
-  <li>A <a href="/en-US/docs/IndexedDB/IDBSuccessEvent">success event</a> is always fired on the
-    result object.
-    <ul>
-      <li>If at least one key matches the key range, then the <code>result</code> property
-        of the event is set to the new {{domxref("IDBCursor")}} object; the
-        <code>key</code> property of the cursor object is set to the found key and the
-        <code>primaryKey</code> property is set to the corresponding primary key of the
-        found record.</li>
-      <li>If no keys match the key range, then the <code>result</code> property of the
-        event is set to <code>null</code>. </li>
-    </ul>
-  </li>
-</ul>
+<p>If the key range is not specified or is null, then the range includes all the keys.</p>
 
 <div class="note">
   <p><strong>Note:</strong> Cursors returned by <code>openKeyCursor()</code> do not
@@ -64,8 +49,8 @@ var <em>request</em> = <em>myIndex</em>.openKeyCursor(<em>range</em>, <em>direct
     passed, this will default to a key range that selects all the records in this object
     store.</dd>
   <dt>direction {{optional_inline}}</dt>
-  <dd>The cursor's <a href="/en-US/docs/IndexedDB/IDBCursor#Constants">direction</a>. See <a
-      href="/en-US/docs/IndexedDB/IDBCursor#Constants">IDBCursor Constants</a> for possible
+  <dd>The cursor's <a href="/en-US/docs/Web/API/IDBCursor#constants">direction</a>. See <a
+      href="/en-US/docs/Web/API/IDBCursor#constants">IDBCursor Constants</a> for possible
     values.</dd>
 </dl>
 
@@ -143,8 +128,7 @@ var <em>request</em> = <em>myIndex</em>.openKeyCursor(<em>range</em>, <em>direct
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbkeyrange/lowerbound/index.html
+++ b/files/en-us/web/api/idbkeyrange/lowerbound/index.html
@@ -112,8 +112,7 @@ var <em>myIDBKeyRange</em> = <em>IDBKeyRange</em>.lowerBound(<em>lower</em>, <em
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName("IndexedDB 2", "#dom-idbkeyrange-lowerbound-lower-loweropen",
-        "lowerBound()")}}</td>
+      <td>{{SpecName("IndexedDB 2", "#dom-idbkeyrange-lowerbound", "lowerBound()")}}</td>
       <td>{{Spec2("IndexedDB 2")}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/idbkeyrange/upperbound/index.html
+++ b/files/en-us/web/api/idbkeyrange/upperbound/index.html
@@ -99,8 +99,7 @@ tags:
     };
   };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>
@@ -110,7 +109,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('IndexedDB 2', '#dom-idbkeyrange-upperbound-upper-upperopen',
+      <td>{{SpecName('IndexedDB 2', '#dom-idbkeyrange-upperbound',
         'upperBound()')}}</td>
       <td>{{Spec2('IndexedDB 2')}}</td>
       <td></td>

--- a/files/en-us/web/api/idbobjectstore/add/index.html
+++ b/files/en-us/web/api/idbobjectstore/add/index.html
@@ -2,13 +2,13 @@
 title: IDBObjectStore.add()
 slug: Web/API/IDBObjectStore/add
 tags:
-- API
-- Database
-- IDBObjectStore
-- IndexedDB
-- Method
-- Reference
-- Storage
+  - API
+  - Database
+  - IDBObjectStore
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -68,7 +68,7 @@ var <em>request</em> = objectStore.add(<em>value</em>, <em>key</em>);
     <tr>
       <td><code>ReadOnlyError</code></td>
       <td>The transaction associated with this operation is in read-only <a
-          href="/en-US/docs/IndexedDB/IDBTransaction#mode_constants">mode</a>.</td>
+          href="/en-US/docs/Web/API/IDBTransaction#mode_constants">mode</a>.</td>
     </tr>
     <tr>
       <td><code>TransactionInactiveError</code></td>
@@ -161,8 +161,7 @@ function addData() {
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbobjectstore/count/index.html
+++ b/files/en-us/web/api/idbobjectstore/count/index.html
@@ -2,14 +2,14 @@
 title: IDBObjectStore.count()
 slug: Web/API/IDBObjectStore/count
 tags:
-- API
-- Database
-- IDBObjectStore
-- IndexedDB
-- Method
-- Reference
-- count
-- data
+  - API
+  - Database
+  - IDBObjectStore
+  - IndexedDB
+  - Method
+  - Reference
+  - count
+  - data
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -25,8 +25,8 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js notranslate">var <code>request</code> = <em>ObjectStore</em>.count();
-var <code>request</code> = <em>ObjectStore</em>.count(<em>query</em>);
+<pre class="brush: js notranslate">var request = ObjectStore.count();
+var request = ObjectStore.count(query);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -84,8 +84,7 @@ countRequest.onsuccess = function() {
 }
 </pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbobjectstore/deleteindex/index.html
+++ b/files/en-us/web/api/idbobjectstore/deleteindex/index.html
@@ -135,9 +135,7 @@ DBOpenRequest.onupgradeneeded = function(event) {
 
 };</pre>
 
-<h2 id="Specifications"><span
-    style="font-size: 2.14285714285714rem; letter-spacing: -1px; line-height: 30px;">Specifications</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbobjectstore/get/index.html
+++ b/files/en-us/web/api/idbobjectstore/get/index.html
@@ -2,13 +2,13 @@
 title: IDBObjectStore.get()
 slug: Web/API/IDBObjectStore/get
 tags:
-- API
-- Database
-- IDBObjectStore
-- IndexedDB
-- Method
-- Reference
-- Storage
+  - API
+  - Database
+  - IDBObjectStore
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -20,7 +20,7 @@ tags:
 </div>
 
 <p>If a value is successfully found, then a structured clone of it is created and set as
-  the <code><a href="/en-US/docs/IndexedDB/IDBRequest#attr_result">result</a></code> of the
+  the <code><a href="/en-US/docs/Web/API/IDBRequest#attr_result">result</a></code> of the
   request object.</p>
 
 <p>{{ Note("This method produces the same result for: a) a record that doesn't exist in
@@ -132,8 +132,7 @@ function getData() {
 
 };</pre>
 
-<h2 id="Specifications"><span
-    style="font-size: 2.14285714285714rem;">Specifications</span></h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbobjectstore/index/index.html
+++ b/files/en-us/web/api/idbobjectstore/index/index.html
@@ -105,8 +105,7 @@ tags:
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbobjectstore/opencursor/index.html
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.html
@@ -40,7 +40,7 @@ var <em>request</em> = <em>ObjectStore</em>.openCursor(<em>query</em>, <em>direc
     this will default to a range containing only that key. If nothing is passed, this will
     default to a key range that selects all the records in this object store.</dd>
   <dt>direction {{optional_inline}}</dt>
-  <dd>An {{domxref("IDBCursorDirection")}} telling the cursor what direction to travel.
+  <dd>An <a href="https://w3c.github.io/IndexedDB/#enumdef-idbcursordirection"><code>IDBCursorDirection</code></a> telling the cursor what direction to travel.
     Valid values are <code>"next"</code>, <code>"nextunique"</code>, <code>"prev"</code>,
     and <code>"prevunique"</code>. The default is <code>"next"</code>.</dd>
 </dl>
@@ -99,8 +99,7 @@ request.onsuccess = function(event) {
 };
 </pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>

--- a/files/en-us/web/api/idbobjectstore/openkeycursor/index.html
+++ b/files/en-us/web/api/idbobjectstore/openkeycursor/index.html
@@ -38,7 +38,7 @@ var <em>request</em> = <em>objectStore</em>.openKeyCursor(<em>query</em>, <em>di
     range containing only that key. If nothing is passed, this will default to a key range
     that selects all the records in this object store.</dd>
   <dt><em>direction </em>{{optional_inline}}</dt>
-  <dd>An {{domxref("IDBCursorDirection")}} telling the cursor what direction to travel.
+  <dd>An <a href="https://w3c.github.io/IndexedDB/#enumdef-idbcursordirection"><code>IDBCursorDirection</code></a> telling the cursor what direction to travel.
     Valid values are <code>"next"</code>, <code>"nextunique"</code>, <code>"prev"</code>,
     and <code>"prevunique"</code>. The default is <code>"next"</code>.</dd>
 </dl>

--- a/files/en-us/web/api/idbobjectstore/put/index.html
+++ b/files/en-us/web/api/idbobjectstore/put/index.html
@@ -2,14 +2,14 @@
 title: IDBObjectStore.put()
 slug: Web/API/IDBObjectStore/put
 tags:
-- API
-- Database
-- IDBObjectStore
-- IndexedDB
-- Method
-- Reference
-- Storage
-- put
+  - API
+  - Database
+  - IDBObjectStore
+  - IndexedDB
+  - Method
+  - Reference
+  - Storage
+  - put
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -20,7 +20,7 @@ tags:
 <p>The put method is an<span class="database"> <em>update or insert</em> </span>method.
   See the {{domxref("IDBObjectStore.add")}} method for an <em>insert only</em> method.</p>
 
-<p>Bear in mind that if you have a {{domxref("cursor","IDBCursor")}} to the record you
+<p>Bear in mind that if you have a {{domxref("IDBCursor","IDBCursor")}} to the record you
   want to update, updating it with {{domxref("IDBCursor.update()")}} is preferable to
   using {{domxref("IDBObjectStore.put()")}}. Doing so makes it clear that an existing
   record will be updated, instead of a new record being inserted.</p>
@@ -65,7 +65,7 @@ let <em>request</em> = <em>objectStore</em>.put(<em>item</em>, <em>key</em>);</p
     <tr>
       <td><code>ReadOnlyError</code></td>
       <td>The transaction associated with this operation is in read-only <a
-          href="/en-US/docs/IndexedDB/IDBTransaction#mode_constants">mode</a>.</td>
+          href="/en-US/docs/Web/API/IDBTransaction#mode_constants">mode</a>.</td>
     </tr>
     <tr>
       <td><code>TransactionInactiveError</code></td>
@@ -152,8 +152,7 @@ objectStoreTitleRequest.onsuccess = () =&gt; {
   };
 };</pre>
 
-<h2 id="Specification"><span style="font-size: 2.14285714285714rem;">Specification</span>
-</h2>
+<h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
   <tbody>


### PR DESCRIPTION
- Un-bork markup for Specifications headings
- Correct fragment IDs in spec references
- Drop text about IDBSuccessEvent, which no longer exists
- Replace IDBCursorDirection internal broken link with external link
- Push “fixable flaws” button