### PR TITLE
Fix various breakage in File System Access docs

### DIFF
--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
@@ -2,13 +2,13 @@
 title: FileSystemFileHandle.createWritable()
 slug: Web/API/FileSystemFileHandle/createWritable
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemFileHandle
-- Method
-- stream
-- working with files
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemFileHandle
+  - Method
+  - stream
+  - working with files
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -79,9 +79,8 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System
-        Access','#dom-filesystemfilehandle-createwritable','createWritable')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemfilehandle-createwritable','createWritable')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -94,7 +93,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.html
@@ -2,13 +2,13 @@
 title: FileSystemFileHandle.getFile()
 slug: Web/API/FileSystemFileHandle/getFile
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemFileHandle
-- Method
-- getFile
-- working with files
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemFileHandle
+  - Method
+  - getFile
+  - working with files
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -64,9 +64,9 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access','#api-filesystemfilehandle-getfile','getFile')}}
+      <td>{{SpecName('File System Access API','#api-filesystemfilehandle-getfile','getFile')}}
       </td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -79,7 +79,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemfilehandle/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/index.html
@@ -68,8 +68,8 @@ tags:
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('File System Access','#api-filesystemfilehandle','FileSystemFileHandle')}}</td>
-   <td>{{Spec2('File System Access')}}</td>
+   <td>{{SpecName('File System Access API','#api-filesystemfilehandle','FileSystemFileHandle')}}</td>
+   <td>{{Spec2('File System Access API')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>
@@ -82,6 +82,6 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+ <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
  <li><a href="https://web.dev/file-system-access/">The File System Access API: simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemhandle/index.html
+++ b/files/en-us/web/api/filesystemhandle/index.html
@@ -117,8 +117,8 @@ async function verifyPermission(fileHandle, withWrite) {
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('File System Access','#api-filesystemhandle','FileSystemHandle')}}</td>
-   <td>{{Spec2('File System Access')}}</td>
+   <td>{{SpecName('File System Access API','#api-filesystemhandle','FileSystemHandle')}}</td>
+   <td>{{Spec2('File System Access API')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>
@@ -131,6 +131,6 @@ async function verifyPermission(fileHandle, withWrite) {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+ <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
  <li><a href="https://web.dev/file-system-access/">The File System Access API: simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.html
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.html
@@ -2,11 +2,11 @@
 title: FileSystemHandle.isSameEntry()
 slug: Web/API/FileSystemHandle/isSameEntry
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemHandle
-- Method
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemHandle
+  - Method
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -59,9 +59,8 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System
-        Access','#dom-filesystemhandle-issameentry','isSameEntry')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemhandle-issameentry','isSameEntry')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -74,7 +73,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemhandle/kind/index.html
+++ b/files/en-us/web/api/filesystemhandle/kind/index.html
@@ -2,13 +2,13 @@
 title: FileSystemHandle.kind
 slug: Web/API/FileSystemHandle/kind
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemHandle
-- Property
-- Read-only
-- handle
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemHandle
+  - Property
+  - Read-only
+  - handle
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -68,8 +68,8 @@ async function getFile() {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access','#dom-filesystemhandle-kind','kind')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemhandle-kind','kind')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -82,7 +82,7 @@ async function getFile() {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemhandle/name/index.html
+++ b/files/en-us/web/api/filesystemhandle/name/index.html
@@ -2,12 +2,12 @@
 title: FileSystemHandle.name
 slug: Web/API/FileSystemHandle/name
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemHandle
-- Property
-- Read-only
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemHandle
+  - Property
+  - Read-only
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -22,7 +22,7 @@ tags:
 
 <h3 id="Value">Value</h3>
 
-<p>{{jsxref('USVString')}}</p>
+<p>{{domxref('USVString')}}</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -51,8 +51,8 @@ async function getFile() {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access','#dom-filesystemhandle-name','name')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemhandle-name','name')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -65,7 +65,7 @@ async function getFile() {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.html
@@ -2,11 +2,11 @@
 title: FileSystemHandle.queryPermission()
 slug: Web/API/FileSystemHandle/queryPermission
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemHandle
-- Method
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemHandle
+  - Method
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -87,9 +87,8 @@ async function verifyPermission(fileHandle, withWrite) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System
-        Access','#api-filesystemhandle-querypermission','queryPermission')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemhandle-querypermission','queryPermission')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -102,7 +101,7 @@ async function verifyPermission(fileHandle, withWrite) {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.html
@@ -2,11 +2,11 @@
 title: FileSystemHandle.requestPermission()
 slug: Web/API/FileSystemHandle/requestPermission
 tags:
-- Directory
-- File
-- File System Access API
-- FileSystemHandle
-- Method
+  - Directory
+  - File
+  - File System Access API
+  - FileSystemHandle
+  - Method
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -84,9 +84,8 @@ async function verifyPermission(fileHandle, withWrite) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System
-        Access','#api-filesystemhandle-requestpermission','requestPermission')}}</td>
-      <td>{{Spec2('File System Access')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemhandle-requestpermission','requestPermission')}}</td>
+      <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>
   </tbody>
@@ -99,7 +98,7 @@ async function verifyPermission(fileHandle, withWrite) {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/docs/Web/API/File_System_Access_API">File System Access API</a></li>
+  <li><a href="/en-US/docs/Web/API/File_System_Access_API">File System Access API</a></li>
   <li><a href="https://web.dev/file-system-access/">The File System Access API:
       simplifying access to local files</a></li>
 </ul>


### PR DESCRIPTION
- Correct the spec name in SpecName/Spec2 macros
- Fix other broken macro references
- Push the “fix fixable flaws” button