### PR TITLE
Fix browser-compat section markup in various docs

### DIFF
--- a/files/en-us/web/api/htmltableelement/tfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/tfoot/index.html
@@ -62,13 +62,11 @@ tags:
   </tbody>
 </table>
 
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
 <div>
-  <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-  <div>
-
-    <p>{{Compat("api.HTMLTableElement.tFoot")}}</p>
-  </div>
+  <p>{{Compat("api.HTMLTableElement.tFoot")}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserver/observe/index.html
+++ b/files/en-us/web/api/intersectionobserver/observe/index.html
@@ -63,16 +63,14 @@ tags:
   </tbody>
 </table>
 
-<div>
-  <h2 id="Browser_compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
-  <p class="hidden">The compatibility table in this page is generated from structured
-    data. If you'd like to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
+<p class="hidden">The compatibility table in this page is generated from structured
+  data. If you'd like to contribute to the data, please check out <a
+    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+  and send us a pull request.</p>
 
-  <p>{{Compat("api.IntersectionObserver.observe")}}</p>
-</div>
+<p>{{Compat("api.IntersectionObserver.observe")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/rootmargin/index.html
+++ b/files/en-us/web/api/intersectionobserver/rootmargin/index.html
@@ -67,13 +67,11 @@ tags:
   </tbody>
 </table>
 
-<div>
-  <h2 id="Browser_compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
-  <p class="hidden">The compatibility table in this page is generated from structured
-    data. If you'd like to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
+<p class="hidden">The compatibility table in this page is generated from structured
+  data. If you'd like to contribute to the data, please check out <a
+    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+  and send us a pull request.</p>
 
-  <p>{{Compat("api.IntersectionObserver.rootMargin")}}</p>
-</div>
+<p>{{Compat("api.IntersectionObserver.rootMargin")}}</p>

--- a/files/en-us/web/api/mediasessionaction/index.html
+++ b/files/en-us/web/api/mediasessionaction/index.html
@@ -44,6 +44,7 @@ tags:
  <dt><a id="stop"><code>stop</code></a></dt>
  <dd>Halts playback entirely.</dd>
 </dl>
+</div>
 
 <h2 id="Description">Description</h2>
 
@@ -132,9 +133,4 @@ function handleSeek(details) {
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div>
-
 <p>{{Compat("api.MediaSessionAction")}}</p>
-</div>
-</div>


### PR DESCRIPTION
Yari chokes on the extra/unexpected div elements in these cases.