### PR TITLE
Update spec URL for window.isSecureContext

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/issecurecontext/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/issecurecontext/index.html
@@ -25,7 +25,7 @@ tags:
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}.</p>
+<p>Boolean <code>true</code> or <code>false</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -34,13 +34,10 @@ tags:
     <tr>
       <th scope="col">Specification</th>
       <th scope="col">Status</th>
-      <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Secure Contexts', '#dom-windoworworkerglobalscope-issecurecontext',
-        'WindowOrWorkerGlobalScope.isSecureContext')}}</td>
-      <td>{{Spec2('Secure Contexts')}}</td>
-      <td>Initial definition.</td>
+      <td>{{SpecName('HTML WHATWG', 'webappapis.html#dom-issecurecontext', 'isSecureContext')}}</td>
+      <td>{{Spec2('HTML WHATWG')}}</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
The normative definition of `isSecureContext` has been moved out of the Secure Contexts spec and into the HTML spec.