### PR TITLE
Drop SVG font-size-adjust ad-hoc navigation cruft

### DIFF
--- a/files/en-us/web/svg/attribute/font-size-adjust/index.html
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.html
@@ -5,8 +5,6 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<p>« <a href="/en-US/docs/SVG/Attribute">SVG Attribute reference home</a></p>
-
 <p>The <code>font-size-adjust</code> attribute allows authors to specify an aspect value for an element that will preserve the x-height of the first choice font in a substitute font.</p>
 
 <p class="note"><strong>Note:</strong> As a presentation attribute, <code>font-size-adjust</code> can be used as a CSS property. See the {{cssxref("font-size-adjust", "CSS font-size-adjust")}} property for more information.</p>


### PR DESCRIPTION
This ad-hoc navigation bit is unnecessary, and breaks the identification of the `summary` field in the index.json output.