### PR TITLE
Remove optional flag of WebAssembly.instantiateStreaming's second argument

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.html
@@ -31,7 +31,7 @@ tags:
       title="The Response interface of the Fetch API represents the response to a request."><code>Response</code></a>
     object or a promise that will fulfill with one, representing the underlying source of
     a .wasm module you want to stream, compile, and instantiate.</dd>
-  <dt><em>importObject</em> {{optional_inline}}</dt>
+  <dt><em>importObject</em></dt>
   <dd>An object containing the values to be imported into the newly-created
     <code>Instance</code>, such as functions or {{jsxref("WebAssembly.Memory")}} objects.
     There must be one matching property for each declared import of the compiled module or


### PR DESCRIPTION
I opened a stackoverflow thread about this: https://stackoverflow.com/questions/66008362/webassembly-instantiatestreaming-requires-an-optional-argument

To sum up, the second argument of `WebAssembly.instantiateStreaming` is marked as optional in the documentation but is actually required in the browser (tested on firefox and chrome). I suggest to remove the `optional` flag from the documentation.