### PR TITLE
entries() returns iterator object that can also be an iterable

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/entries/index.html
@@ -12,9 +12,9 @@ tags:
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>entries()</code></strong> method returns a new <strong><a
-      href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></strong>
+      href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterable</a></strong>
   object that contains the <code>[key, value]</code> pairs for each element in the
-  <code>Map</code> object in insertion order.</p>
+  <code>Map</code> object in insertion order. In this particular case, this iterable object is also an iterator.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-entries.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/entries/index.html
@@ -12,9 +12,11 @@ tags:
 <div>{{JSRef}}</div>
 
 <p>The <strong><code>entries()</code></strong> method returns a new <strong><a
-      href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterable</a></strong>
+      href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></strong>
   object that contains the <code>[key, value]</code> pairs for each element in the
-  <code>Map</code> object in insertion order. In this particular case, this iterable object is also an iterator.</p>
+  <code>Map</code> object in insertion order. In this particular case, this iterator object is also an iterable, so the for-of loop can be used.
+  When the protocol <code>[Symbol.iterator]</code> is used, it returns a function that, when invoked, returns this iterator itself.
+</p>
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-entries.html")}}</div>
 


### PR DESCRIPTION
If entries() just returns a iterator object, then it is not subject to `for-of` loop. In order for something to be usable in a for-of loop, it has to be an iterable.

So in this case, entries() returns an object that is both an iterable and iterator:

```
map = new Map([["a", 3], ["b", 'hi'], ["c", true]]);

for (const e of map.entries()) {
    console.log(e);
}

const someEntries = map.entries();

console.log(someEntries.next());

console.log(someEntries[Symbol.iterator]);

console.log(someEntries[Symbol.iterator]().next());
```

and we can see that the object follows both the iterable and iterator protocol:

```
$ node try.js
[ 'a', 3 ]
[ 'b', 'hi' ]
[ 'c', true ]
{ value: [ 'a', 3 ], done: false }
[Function: [Symbol.iterator]]
{ value: [ 'b', 'hi' ], done: false }
```
We can see `someEntries[Symbol.iterator]` returns a function that, when invoked, simply returns the iterator itself.
