### PR TITLE
Add 0n,-0n to the JS “sameness” comparison table

### DIFF
--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -289,6 +289,14 @@ function attemptMutation(v) {
    <td style="background-color: rgb(144, 255, 144); text-align: center;"><code>true</code></td>
   </tr>
   <tr>
+   <td><code>0n</code></td>
+   <td><code>-0n</code></td>
+   <td style="background-color: rgb(144, 255, 144); text-align: center;"><code>true</code></td>
+   <td style="background-color: rgb(144, 255, 144); text-align: center;"><code>true</code></td>
+   <td style="background-color: rgb(144, 255, 144); text-align: center;"><code>true</code></td>
+   <td style="background-color: rgb(144, 255, 144); text-align: center;"><code>true</code></td>
+  </tr>
+  <tr>
    <td><code>0</code></td>
    <td><code>false</code></td>
    <td style="background-color: rgb(144, 255, 144); text-align: center;"><code>true</code></td>


### PR DESCRIPTION
Add comparison between `0n` and `-0n` to the comparisons table based on issue https://github.com/mdn/content/issues/1309