### PR TITLE
fixing some sectioning flaws

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/index.html
@@ -75,7 +75,7 @@ tags:
 </dl>
 
 <div class="note">
-<h2 id="Feedback">Feedback</h2>
+<h4 id="Feedback">Feedback</h4>
 
 <p>Help us improve our guides and tutorials like this one by taking <a href="https://www.surveygizmo.com/s3/4871248/MDN-Guides-Survey">our survey here</a>.</p>
 </div>

--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.html
@@ -253,7 +253,6 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<div>
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
@@ -264,4 +263,3 @@ tags:
  <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images">Responsive images</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page">Mozilla splash page</a></li>
 </ul>
-</div>

--- a/files/en-us/web/css/index.html
+++ b/files/en-us/web/css/index.html
@@ -12,11 +12,11 @@ tags:
   - Style Sheets
   - Styles
   - Stylesheets
-  - 'l10n:priority'
+  - l10n:priority
 ---
 <div>{{CSSRef}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>Cascading Style Sheets</strong> (<strong>CSS</strong>) is a <a href="/en-US/docs/DOM/stylesheet">stylesheet</a> language used to describe the presentation of a document written in <a href="/en-US/docs/Web/HTML" title="HyperText Markup Language">HTML</a></span> or <a href="/en-US/docs/XML_introduction">XML</a> (including XML dialects such as <a href="/en-US/docs/Web/SVG">SVG</a>, <a href="/en-US/docs/Web/MathML">MathML</a> or {{Glossary("XHTML")}}). CSS describes how elements should be rendered on screen, on paper, in speech, or on other media.</p>
+<p class="summary"><span class="seoSummary"><strong>Cascading Style Sheets</strong> (<strong>CSS</strong>) is a <a href="/en-US/docs/Web/API/StyleSheet">stylesheet</a> language used to describe the presentation of a document written in <a href="/en-US/docs/Web/HTML" title="HyperText Markup Language">HTML</a></span> or <a href="/en-US/docs/Web/XML/XML_introduction">XML</a> (including XML dialects such as <a href="/en-US/docs/Web/SVG">SVG</a>, <a href="/en-US/docs/Web/MathML">MathML</a> or {{Glossary("XHTML")}}). CSS describes how elements should be rendered on screen, on paper, in speech, or on other media.</p>
 
 <p>CSS is among the core languages of the <strong>open web</strong> and is standardized across Web browsers according to <a class="external" href="http://w3.org/Style/CSS/#specs">W3C specifications</a>. Previously, development of various parts of CSS specification was done synchronously, which allowed versioning of the latest recommendations. You might have heard about CSS1, CSS2.1, CSS3. However, CSS4 has never become an official version.</p>
 
@@ -40,12 +40,10 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/docs/Learn/Front-end_web_developer">Get started</a>
+  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
   </p>
 </div>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Documentation" id="Tutorials">Tutorials</h2>
 
 <p>Our <a href="/en-US/docs/Learn/CSS">CSS Learning Area</a> features multiple modules that teach CSS from the ground up — no previous knowledge required.</p>
@@ -66,9 +64,8 @@ tags:
  <dt><a href="/en-US/docs/Learn/CSS/Howto">Use CSS to solve common problems</a></dt>
  <dd>This module provides links to sections of content explaining how to use CSS to solve common problems when creating a web page.</dd>
 </dl>
-</div>
 
-<div class="section">
+
 <h2 class="Tools" id="Reference">Reference</h2>
 
 <ul>
@@ -76,11 +73,11 @@ tags:
  <li>CSS key concepts:
   <ul>
    <li>The <a href="/en-US/docs/Web/CSS/Syntax">syntax and forms of the language</a></li>
-   <li><a href="/en-US/docs/Web/CSS/Specificity">Specificity</a>, <a href="/en-US/docs/Web/CSS/Inheritance">inheritance</a>, and <a href="/en-US/docs/Web/CSS/Cascade">the Cascade</a></li>
+   <li><a href="/en-US/docs/Web/CSS/Specificity">Specificity</a>, <a href="/en-US/docs/Web/CSS/inheritance">inheritance</a>, and <a href="/en-US/docs/Web/CSS/Cascade">the Cascade</a></li>
    <li><a href="/en-US/docs/Web/CSS/CSS_Values_and_Units">CSS units and values</a> and <a href="/en-US/docs/Web/CSS/CSS_Functions">functional notations</a></li>
-   <li><a href="/en-US/docs/Web/CSS/box_model">Box model</a> and <a href="/en-US/docs/Web/CSS/margin_collapsing">margin collapse</a></li>
-   <li>The <a href="/en-US/docs/Web/CSS/All_About_The_Containing_Block">containing block</a></li>
-   <li><a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context" title="The stacking context">Stacking</a> and <a href="/en-US/docs/Web/CSS/block_formatting_context" title="block formatting context">block-formatting</a> contexts</li>
+   <li><a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">Box model</a> and <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">margin collapse</a></li>
+   <li>The <a href="/en-US/docs/Web/CSS/Containing_block">containing block</a></li>
+   <li><a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context" title="The stacking context">Stacking</a> and <a href="/en-US/docs/Web/Guide/CSS/Block_formatting_context" title="block formatting context">block-formatting</a> contexts</li>
    <li><a href="/en-US/docs/Web/CSS/initial_value">Initial</a>, <a href="/en-US/docs/Web/CSS/computed_value">computed</a>, <a href="/en-US/docs/Web/CSS/used_value">used</a>, and <a href="/en-US/docs/Web/CSS/actual_value">actual</a> values</li>
    <li><a href="/en-US/docs/Web/CSS/Shorthand_properties">CSS shorthand properties</a></li>
    <li><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout">CSS Flexible Box Layout</a></li>
@@ -110,14 +107,12 @@ tags:
 <ul>
  <li>Firefox: {{bug(1323667)}}</li>
 </ul>
-</div>
-</div>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Demos_of_open_web_technologies#CSS">CSS demos</a>: Get a creative boost by exploring examples of the latest CSS technologies in action.</li>
- <li>Web languages to which CSS is often applied: <a href="/en-US/docs/Web/HTML">HTML</a>, <a href="/en-US/docs/Web/SVG">SVG</a>, <a href="/en-US/docs/Web/MathML">MathML</a>, {{Glossary("XHTML")}}, and <a href="/en-US/docs/XML_introduction">XML</a>.</li>
+ <li><a href="/en-US/docs/Web/Demos_of_open_web_technologies#css">CSS demos</a>: Get a creative boost by exploring examples of the latest CSS technologies in action.</li>
+ <li>Web languages to which CSS is often applied: <a href="/en-US/docs/Web/HTML">HTML</a>, <a href="/en-US/docs/Web/SVG">SVG</a>, <a href="/en-US/docs/Web/MathML">MathML</a>, {{Glossary("XHTML")}}, and <a href="/en-US/docs/Web/XML/XML_introduction">XML</a>.</li>
  <li>Mozilla technologies that make extensive use of CSS: <a href="/en-US/docs/Mozilla/Firefox">Firefox</a>, and <a href="/en-US/docs/Mozilla/Thunderbird">Thunderbird</a> <a href="/en-US/docs/Mozilla/Add-ons">extensions</a> and <a href="/en-US/docs/Mozilla/Add-ons/Themes">themes</a>.</li>
  <li><a href="https://lists.mozilla.org/listinfo/dev-tech-layout">Mozilla mailing list</a></li>
  <li><a href="https://stackoverflow.com/questions/tagged/css">Stack Overflow questions about CSS</a></li>

--- a/files/en-us/web/guide/html/html5/index.html
+++ b/files/en-us/web/guide/html/html5/index.html
@@ -9,7 +9,7 @@ tags:
   - Web
   - Web Development
 ---
-<p class="summary">HTML5 is the latest evolution of the standard that defines <a href="/en-US/docs/HTML">HTML</a>. The term represents two different concepts. It is a new version of the language HTML, with new elements, attributes, and behaviors, <strong>and</strong> a larger set of technologies that allows the building of more diverse and powerful Web sites and applications. This set is sometimes called HTML5 &amp; friends and often shortened to just HTML5.</p>
+<p class="summary">HTML5 is the latest evolution of the standard that defines <a href="/en-US/docs/Web/HTML">HTML</a>. The term represents two different concepts. It is a new version of the language HTML, with new elements, attributes, and behaviors, <strong>and</strong> a larger set of technologies that allows the building of more diverse and powerful Web sites and applications. This set is sometimes called HTML5 &amp; friends and often shortened to just HTML5.</p>
 
 <p>Designed to be usable by all Open Web developers, this reference page links to numerous resources about HTML5 technologies, classified into several groups based on their function.</p>
 
@@ -24,22 +24,20 @@ tags:
  <li><em>Styling</em>: letting authors write more sophisticated themes.</li>
 </ul>
 
-<div class="cleared row topicpage-table">
-<div class="section">
 <h2 id="Semantics">Semantics</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Sections_and_Outlines_of_an_HTML5_document" title="Sections and Outlines of an HTML5 document">Sections and outlines in HTML5</a></dt>
+ <dt><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines" title="Sections and Outlines of an HTML5 document">Sections and outlines in HTML5</a></dt>
  <dd>A look at the new outlining and sectioning elements in HTML5: {{HTMLElement("section")}}, {{HTMLElement("article")}}, {{HTMLElement("nav")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}} and {{HTMLElement("aside")}}.</dd>
- <dt><a href="/en-US/docs/Using_HTML5_audio_and_video" title="Using_audio_and_video_in_Firefox">Using HTML5 audio and video</a></dt>
+ <dt><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content" title="Using_audio_and_video_in_Firefox">Using HTML5 audio and video</a></dt>
  <dd>The {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements embed and allow the manipulation of new multimedia content.</dd>
- <dt><a href="/en-US/docs/Learn/HTML/Forms">Forms improvements</a></dt>
- <dd>A look at the <a href="/en-US/docs/Learn/HTML/Forms/Form_validation">constraint validation API</a>, several new attributes, new values for the {{HTMLElement("input")}} attribute {{htmlattrxref("type", "input")}} and the new {{HTMLElement("output")}} element.</dd>
+ <dt><a href="/en-US/docs/Learn/Forms">Forms improvements</a></dt>
+ <dd>A look at the <a href="/en-US/docs/Learn/Forms/Form_validation">constraint validation API</a>, several new attributes, new values for the {{HTMLElement("input")}} attribute {{htmlattrxref("type", "input")}} and the new {{HTMLElement("output")}} element.</dd>
  <dt>New semantic elements</dt>
  <dd>Beside sections, media and forms elements, there are numerous new elements, like {{HTMLElement("mark")}}, {{HTMLElement("figure")}}, {{HTMLElement("figcaption")}}, {{HTMLElement("data")}}, {{HTMLElement("time")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}}, or {{HTMLElement("meter")}} and {{HTMLElement("main")}}, increasing the number of <a href="/en-US/docs/Web/HTML/HTML5/HTML5_element_list">valid HTML5 elements</a>.</dd>
  <dt>Improvement in {{HTMLElement("iframe")}}</dt>
  <dd>Using the {{htmlattrxref("sandbox", "iframe")}} and {{htmlattrxref("srcdoc", "iframe")}} attributes, authors can now be precise about the level of security and the wished rendering of an {{HTMLElement("iframe")}} element.</dd>
- <dt><a href="/en-US/docs/MathML">MathML</a></dt>
+ <dt><a href="/en-US/docs/Web/MathML">MathML</a></dt>
  <dd>Allows directly embedding mathematical formulas.</dd>
  <dt><a href="/en-US/docs/Web/HTML/HTML5/Introduction_to_HTML5">Introduction to HTML5</a></dt>
  <dd>This article introduces how to indicate to the browser that you are using HTML5 in your web design or web application.</dd>
@@ -58,11 +56,11 @@ tags:
 <h2 id="Connectivity">Connectivity</h2>
 
 <dl>
- <dt><a href="/en-US/docs/WebSockets">Web Sockets</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebSockets_API">Web Sockets</a></dt>
  <dd>Allows creating a permanent connection between the page and the server and to exchange non-HTML data through that means.</dd>
- <dt><a href="/en-US/docs/Server-sent_events/Using_server-sent_events" title="Server-sent_events/Using_server-sent_events">Server-sent events</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events" title="Server-sent_events/Using_server-sent_events">Server-sent events</a></dt>
  <dd>Allows a server to push events to a client, rather than the classical paradigm where the server could send data only in response to a client's request.</dd>
- <dt><a href="/en-US/docs/WebRTC">WebRTC</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></dt>
  <dd>This technology, where RTC stands for Real-Time Communication, allows connecting to other people and controlling videoconferencing directly in the browser, without the need for a plugin or an external application.</dd>
 </dl>
 
@@ -72,22 +70,22 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Web/HTML/Using_the_application_cache">Offline resources: The application cache</a></dt>
  <dd>Firefox fully supports the HTML5 offline resource specification. Most others have offline resource support at some level.</dd>
- <dt><a href="/en-US/docs/Online_and_offline_events">Online and offline events</a></dt>
+ <dt><a href="/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events">Online and offline events</a></dt>
  <dd>Firefox 3 supports WHATWG online and offline events, which let applications and extensions detect whether or not there's an active Internet connection, as well as to detect when the connection goes up and down.</dd>
- <dt><a href="/en-US/docs/DOM/Storage">WHATWG client-side session and persistent storage (aka DOM storage)</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Web_Storage_API">WHATWG client-side session and persistent storage (aka DOM storage)</a></dt>
  <dd>Client-side session and persistent storage allows web applications to store structured data on the client side.</dd>
- <dt><a href="/en-US/docs/IndexedDB">IndexedDB</a></dt>
+ <dt><a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB</a></dt>
  <dd>IndexedDB is a web standard for the storage of significant amounts of structured data in the browser and for high performance searches on this data using indexes.</dd>
- <dt><a href="/en-US/docs/Using_files_from_web_applications">Using files from web applications</a></dt>
- <dd>Support for the new HTML5 File API has been added to Gecko, making it possible for web applications to access local files selected by the user. This includes support for selecting multiple files using the <span style="font-family: monospace;">{{HTMLElement("input")}}</span> of <a href="/en-US/docs/Web/HTML/Element/Input#attr-type"><strong>type</strong></a> <span style="font-family: courier new;">file</span> HTML element's new <a href="/en-US/docs/Web/HTML/Element/Input#attr-multiple"><strong>multiple</strong></a> attribute. There also is <a href="/en-US/docs/DOM/FileReader"><code>FileReader</code></a>.</dd>
+ <dt><a href="/en-US/docs/Web/API/File/Using_files_from_web_applications">Using files from web applications</a></dt>
+ <dd>Support for the new HTML5 File API has been added to Gecko, making it possible for web applications to access local files selected by the user. This includes support for selecting multiple files using the <span style="font-family: monospace;">{{HTMLElement("input")}}</span> of <a href="/en-US/docs/Web/HTML/Element/input#attr-type"><strong>type</strong></a> <span style="font-family: courier new;">file</span> HTML element's new <a href="/en-US/docs/Web/HTML/Element/input#attr-multiple"><strong>multiple</strong></a> attribute. There also is <a href="/en-US/docs/Web/API/FileReader"><code>FileReader</code></a>.</dd>
 </dl>
 
 <h2 id="Multimedia">Multimedia</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Using_HTML5_audio_and_video" title="Using_audio_and_video_in_Firefox">Using HTML5 audio and video</a></dt>
+ <dt><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content" title="Using_audio_and_video_in_Firefox">Using HTML5 audio and video</a></dt>
  <dd>The {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements embed and allow the manipulation of new multimedia content.</dd>
- <dt><a href="/en-US/docs/WebRTC">WebRTC</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></dt>
  <dd>This technology, where RTC stands for Real-Time Communication, allows connecting to other people and controlling videoconferencing directly in the browser, without the need for a plugin or an external application.</dd>
  <dt>Track and WebVTT</dt>
  <dd>The {{HTMLElement("track")}} element allows subtitles and chapters. <a href="/en-US/docs/Web/HTML/WebVTT">WebVTT</a> is a text track format.</dd>
@@ -96,44 +94,42 @@ tags:
 <h2 id="2D3D_graphics_AND_effects">2D/3D graphics AND effects</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Canvas_tutorial" title="Canvas tutorial">Canvas tutorial</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Canvas_API/Tutorial" title="Canvas tutorial">Canvas tutorial</a></dt>
  <dd>Learn about the new <code>{{HTMLElement("canvas")}}</code> element and how to draw graphs and other objects in Firefox.</dd>
- <dt><a href="/en-US/docs/Drawing_text_using_a_canvas">HTML5 Text API for <code>&lt;canvas&gt;</code> elements</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_text">HTML5 Text API for <code>&lt;canvas&gt;</code> elements</a></dt>
  <dd>The HTML5 text API is now supported by {{HTMLElement("canvas")}} elements.</dd>
- <dt><a href="/en-US/docs/WebGL">WebGL</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebGL_API">WebGL</a></dt>
  <dd>WebGL brings 3D graphics to the Web by introducing an API that closely conforms to OpenGL ES 2.0 that can be used in HTML5 {{HTMLElement("canvas")}} elements.</dd>
- <dt><a href="/en-US/docs/SVG">SVG</a></dt>
+ <dt><a href="/en-US/docs/Web/SVG">SVG</a></dt>
  <dd>An XML-based format of vectorial images that can directly be embedded in the HTML.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 id="Performance_and_Integration">Performance and Integration</h2>
 
 <dl>
- <dt><a href="/en-US/docs/DOM/Using_web_workers" title="Using web workers">Web Workers</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers" title="Using web workers">Web Workers</a></dt>
  <dd>Allows delegation of JavaScript evaluation to background threads, allowing these activities to prevent slowing down interactive events.</dd>
- <dt><code><a href="/en-US/docs/DOM/XMLHttpRequest">XMLHttpRequest</a></code> level 2</dt>
- <dd>Allows fetching asynchronously some parts of the page, allowing it to display dynamic content, varying according to the time and user actions. This is the technology behind <a href="/en-US/docs/AJAX">Ajax</a>.</dd>
+ <dt><code><a href="/en-US/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a></code> level 2</dt>
+ <dd>Allows fetching asynchronously some parts of the page, allowing it to display dynamic content, varying according to the time and user actions. This is the technology behind <a href="/en-US/docs/Web/Guide/AJAX">Ajax</a>.</dd>
  <dt>JIT-compiling JavaScript engines</dt>
  <dd>The new generation of JavaScript engines is much more powerful, leading to greater performance.</dd>
- <dt><a href="/en-US/docs/DOM/Manipulating_the_browser_history">History API</a></dt>
+ <dt><a href="/en-US/docs/Web/API/History_API">History API</a></dt>
  <dd>Allows the manipulation of the browser history. This is especially useful for pages loading interactively new information.</dd>
- <dt><a href="/en-US/docs/Web/HTML/Content_Editable" title="HTML/Content Editable">The contentEditable Attribute: Transform your website to a wiki!</a></dt>
+ <dt><a href="/en-US/docs/Web/Guide/HTML/Editable_content" title="HTML/Content Editable">The contentEditable Attribute: Transform your website to a wiki!</a></dt>
  <dd>HTML5 has standardized the contentEditable attribute. Learn more about this feature.</dd>
- <dt><a href="/en-US/docs/DragDrop/Drag_and_Drop">Drag and drop</a></dt>
+ <dt><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></dt>
  <dd>The HTML5 drag and drop API allows support for dragging and dropping items within and between web sites. This also provides a simpler API for use by extensions and Mozilla-based applications.</dd>
- <dt><a href="/en-US/docs/Focus_management_in_HTML">Focus management in HTML</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Document/hasFocus">Focus management in HTML</a></dt>
  <dd>The new HTML5 <code>activeElement</code> and <code>hasFocus</code> attributes are supported.</dd>
- <dt><a href="/en-US/docs/Web-based_protocol_handlers" title="Web-based_protocol_handlers">Web-based protocol handlers</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers" title="Web-based_protocol_handlers">Web-based protocol handlers</a></dt>
  <dd>You can now register web applications as protocol handlers using the <code>navigator.registerProtocolHandler()</code> method.</dd>
- <dt><a href="/en-US/docs/Web/API/Window/requestAnimationFrame" style="font-weight: bold;" title="Web-based_protocol_handlers">requestAnimationFrame</a></dt>
+ <dt><a href="/en-US/docs/Web/API/window/requestAnimationFrame" style="font-weight: bold;" title="Web-based_protocol_handlers">requestAnimationFrame</a></dt>
  <dd>Allows control of animations rendering to obtain optimal performance.</dd>
- <dt><a href="/en-US/docs/DOM/Using_full-screen_mode">Fullscreen API</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Fullscreen_API">Fullscreen API</a></dt>
  <dd>Controls the usage of the whole screen for a Web page or application, without the browser UI displayed.</dd>
- <dt><a href="/en-US/docs/API/Pointer_Lock_API">Pointer Lock API</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Pointer_Lock_API">Pointer Lock API</a></dt>
  <dd>Allows locking the pointer to the content, so games and similar applications don't lose focus when the pointer reaches the window limit.</dd>
- <dt><a href="/en-US/docs/Online_and_offline_events">Online and offline events</a></dt>
+ <dt><a href="/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events">Online and offline events</a></dt>
  <dd>In order to build a good offline-capable web application, you need to know when your application is actually offline. Incidentally, you also need to know when your application has returned to an online status again.</dd>
 </dl>
 
@@ -142,31 +138,29 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/DOM/Using_the_Camera_API">Using the Camera API</a></dt>
  <dd>Allows using, manipulating, and storing an image from the computer's camera.</dd>
- <dt><a href="/en-US/docs/DOM/Touch_events">Touch events</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Touch_events">Touch events</a></dt>
  <dd>Handlers to react to events created by a user pressing touch screens.</dd>
- <dt><a href="/en-US/docs/Using_geolocation" title="Using geolocation">Using geolocation</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Geolocation_API" title="Using geolocation">Using geolocation</a></dt>
  <dd>Let browsers locate the position of the user using geolocation.</dd>
- <dt><a href="/en-US/docs/Detecting_device_orientation">Detecting device orientation</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Detecting_device_orientation">Detecting device orientation</a></dt>
  <dd>Get the information when the device on which the browser runs changes orientation. This can be used as an input device (e.g., to make games that react to the position of the device) or to adapt the layout of a page to the orientation of the screen (portrait or landscape).</dd>
- <dt><a href="/en-US/docs/API/Pointer_Lock_API">Pointer Lock API</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Pointer_Lock_API">Pointer Lock API</a></dt>
  <dd>Allows locking the pointer to the content, so games and similar application don't lose focus when the pointer reaches the window limit.</dd>
 </dl>
 
 <h2 id="Styling">Styling</h2>
 
-<p id="CSS_has_been_extended_to_be_able_to_style_elements_in_a_much_more_complex_way._This_is_often_referred_as_CSS3_though_CSS_is_not_a_monolithic_specification_any_more_and_the_different_modules_are_not_all_at_level_3_some_are_at_level_1_and_others_at_level_4_with_all_the_intermediate_levels_covered."><a href="/en-US/docs/CSS">CSS</a> has been extended to be able to style elements in a much more complex way. This is often referred as <a href="/en-US/docs/CSS/CSS3">CSS3</a>, though CSS is not a monolithic specification any more and the different modules are not all at level 3: some are at level 1 and others at level 4, with all the intermediate levels covered.</p>
+<p id="CSS_has_been_extended_to_be_able_to_style_elements_in_a_much_more_complex_way._This_is_often_referred_as_CSS3_though_CSS_is_not_a_monolithic_specification_any_more_and_the_different_modules_are_not_all_at_level_3_some_are_at_level_1_and_others_at_level_4_with_all_the_intermediate_levels_covered."><a href="/en-US/docs/Web/CSS">CSS</a> has been extended to be able to style elements in a much more complex way. This is often referred as <a href="/en-US/docs/CSS/CSS3">CSS3</a>, though CSS is not a monolithic specification any more and the different modules are not all at level 3: some are at level 1 and others at level 4, with all the intermediate levels covered.</p>
 
 <dl>
  <dt>New background styling features</dt>
- <dd>It is now possible to put shadows on elements using {{cssxref("box-shadow")}}, <a href="/en-US/docs/CSS/Multiple_backgrounds">multiple backgrounds</a>, and CSS {{cssxref("filter")}}s. You can learn more about these by reading <a href="/en-US/docs/Learn/CSS/Styling_boxes/Advanced_box_effects">Advanced box effects</a>.</dd>
+ <dd>It is now possible to put shadows on elements using {{cssxref("box-shadow")}}, <a href="/en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds">multiple backgrounds</a>, and CSS {{cssxref("filter")}}s. You can learn more about these by reading <a href="/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects">Advanced box effects</a>.</dd>
  <dt>More fancy borders</dt>
  <dd>Not only it is now possible to use images to style borders, using {{cssxref("border-image")}} and its associated longhand properties, but rounded borders are supported via the {{cssxref("border-radius")}} property.</dd>
  <dt>Animating your style</dt>
- <dd>Using <a href="/en-US/docs/CSS/Using_CSS_transitions">CSS Transitions</a> to animate between different states or using <a href="/en-US/docs/CSS/Using_CSS_animations">CSS Animations</a> to animate parts of the page without a triggering event, you can now control mobile elements on your page.</dd>
+ <dd>Using <a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS Transitions</a> to animate between different states or using <a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations">CSS Animations</a> to animate parts of the page without a triggering event, you can now control mobile elements on your page.</dd>
  <dt>Typography improvement</dt>
- <dd>Authors have better control to reach better typography. They can control {{cssxref("text-overflow")}} and <a href="/en-US/docs/CSS/hyphens">hyphenation</a>, but also can add a <a href="/en-US/docs/CSS/text-shadow">shadow</a> to it or control more precisely its <a href="/en-US/docs/CSS/text-decoration">decorations</a>. Custom typefaces can be downloaded and applied thanks to the new {{cssxref("@font-face")}} at-rule.</dd>
+ <dd>Authors have better control to reach better typography. They can control {{cssxref("text-overflow")}} and <a href="/en-US/docs/Web/CSS/hyphens">hyphenation</a>, but also can add a <a href="/en-US/docs/Web/CSS/text-shadow">shadow</a> to it or control more precisely its <a href="/en-US/docs/Web/CSS/text-decoration">decorations</a>. Custom typefaces can be downloaded and applied thanks to the new {{cssxref("@font-face")}} at-rule.</dd>
  <dt>New presentational layouts</dt>
- <dd>In order to improve the flexibility of designs, two new layouts have been added: the <a href="/en-US/docs/CSS/Using_CSS_multi-column_layouts">CSS multi-column layouts</a> and <a href="/en-US/docs/CSS/Flexbox">CSS flexible box layout</a>.</dd>
+ <dd>In order to improve the flexibility of designs, two new layouts have been added: the <a href="/en-US/docs/Web/CSS/CSS_Columns/Using_multi-column_layouts">CSS multi-column layouts</a> and <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">CSS flexible box layout</a>.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/web/html/index.html
+++ b/files/en-us/web/html/index.html
@@ -42,8 +42,6 @@ tags:
   </p>
 </div>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Tools" id="Beginners_tutorials">Beginner's tutorials</h2>
 
 <p>Our <a href="/en-US/docs/Learn/HTML">HTML Learning Area</a> features multiple modules that teach HTML from the ground up — no previous knowledge required.</p>
@@ -71,9 +69,7 @@ tags:
  <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Preloading_content">Preloading content with rel="preload"</a></dt>
  <dd class="landingPageList">The <code>preload</code> value of the {{htmlelement("link")}} element's {{htmlattrxref("rel", "link")}} attribute allows you to write declarative fetch requests in your HTML {{htmlelement("head")}}, specifying resources that your pages will need very soon after loading, which you therefore want to start preloading early in the lifecycle of a page load, before the browser's main rendering machinery kicks in. This ensures that they are made available earlier and are less likely to block the page's first render, leading to performance improvements. This article provides a basic guide to how <code>preload</code> works.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 class="Documentation" id="References">References</h2>
 
 <dl>
@@ -103,5 +99,3 @@ tags:
  <dt><a href="/en-US/docs/Web/HTML/Applying_color">Applying color to HTML elements using CSS</a></dt>
  <dd>This article covers most of the ways you use CSS to add color to HTML content, listing what parts of HTML documents can be colored and what CSS properties to use when doing so. Includes examples, links to palette-building tools, and more.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/web/http/index.html
+++ b/files/en-us/web/http/index.html
@@ -8,14 +8,12 @@ tags:
   - TCP/IP
   - Web
   - Web Development
-  - 'l10n:priority'
+  - l10n:priority
 ---
 <div>{{HTTPSidebar}}</div>
 
 <p class="summary"><strong><dfn>Hypertext Transfer Protocol (HTTP)</dfn></strong> is an <a href="https://en.wikipedia.org/wiki/Application_Layer">application-layer</a> protocol for transmitting hypermedia documents, such as HTML. It was designed for communication between web browsers and web servers, but it can also be used for other purposes. HTTP follows a classical <a href="https://en.wikipedia.org/wiki/Client%E2%80%93server_model">client-server model</a>, with a client opening a connection to make a request, then waiting until it receives a response. HTTP is a <a href="https://en.wikipedia.org/wiki/Stateless_protocol">stateless protocol</a>, meaning that the server does not keep any data (state) between two requests. Though often based on a TCP/IP layer, it can be used on any reliable <a href="https://en.wikipedia.org/wiki/Transport_Layer">transport layer</a>, that is, a protocol that doesn't lose messages silently like UDP does. <a href="https://en.wikipedia.org/wiki/Reliable_User_Datagram_Protocol">RUDP</a> — the reliable update of UDP — is a suitable alternative.</p>
 
-<div class="column-container">
-<div class="column-half">
 <h2 id="Tutorials">Tutorials</h2>
 
 <p>Learn how to use HTTP with guides and tutorials.</p>
@@ -40,9 +38,7 @@ tags:
  <dt><a href="/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x">Connection management in HTTP/1.x</a></dt>
  <dd>Describes the three connection management models available in HTTP/1.x, their strengths, and their weaknesses.</dd>
 </dl>
-</div>
 
-<div class="column-half">
 <h2 id="Reference">Reference</h2>
 
 <p>Browse through detailed HTTP reference documentation.</p>
@@ -52,7 +48,7 @@ tags:
  <dd>HTTP message headers are used to describe a resource, or the behavior of the server or the client. Custom proprietary headers can be added using the <code>X-</code> prefix; others in an <a href="https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers">IANA registry</a>, whose original content was defined in <a href="https://tools.ietf.org/html/rfc4229">RFC 4229</a>. IANA also maintains a <a href="https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers">registry of proposed new HTTP message headers</a>.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Methods">HTTP Request Methods</a></dt>
  <dd>The different operations that can be done with HTTP: {{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}, and also less common requests like {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.</dd>
- <dt><a href="/en-US/docs/Web/HTTP/Response_codes">HTTP Status Response Codes</a></dt>
+ <dt><a href="/en-US/docs/Web/HTTP/Status">HTTP Status Response Codes</a></dt>
  <dd>HTTP response codes indicate whether a specific HTTP request has been successfully completed. Responses are grouped in five classes: informational responses, successful responses, redirections, client errors, and servers errors.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy">CSP directives</a></dt>
  <dd>The {{HTTPHeader("Content-Security-Policy")}} response header fields allows web site administrators to control resources the user agent is allowed to load for a given page. With a few exceptions, policies mostly involve specifying server origins and script endpoints.</dd>
@@ -74,5 +70,3 @@ tags:
  <dt><a href="https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/">How Browsers Work</a></dt>
  <dd>A very comprehensive article on browser internals and request flow through HTTP protocol. A MUST-READ for any web developer.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/web/index.html
+++ b/files/en-us/web/index.html
@@ -7,8 +7,6 @@ tags:
 ---
 <p>The open Web presents incredible opportunities for developers. To take full advantage of these technologies, you need to know how to use them. Below you'll find links to our Web technology documentation.</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Documentation" id="Docs_for_add-on_developers">Documentation for Web developers</h2>
 
 <dl>
@@ -24,7 +22,6 @@ tags:
 
 </div>
 
-<div class="section">
 <h2 class="Documentation" id="Web_technology_references">Web technology references</h2>
 
 <dl>
@@ -41,8 +38,6 @@ tags:
  <dt><a href="/en-US/docs/Web/MathML">MathML</a></dt>
  <dd>The Mathematical Markup Language makes it possible to display complex mathematical equations and syntax.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Temporary">Temporary</h3>
 

--- a/files/en-us/web/index.html
+++ b/files/en-us/web/index.html
@@ -20,8 +20,6 @@ tags:
  <dd>Progressive Web Apps are web apps that use emerging web browser APIs and features along with traditional progressive enhancement strategy to bring a native app-like user experience to cross-platform web applications.</dd>
 </dl>
 
-</div>
-
 <h2 class="Documentation" id="Web_technology_references">Web technology references</h2>
 
 <dl>

--- a/files/en-us/web/javascript/index.html
+++ b/files/en-us/web/javascript/index.html
@@ -6,7 +6,7 @@ tags:
   - Landing
   - Landing page
   - Learn
-  - 'l10n:priority'
+  - l10n:priority
 ---
 <div>{{JsSidebar}}</div>
 
@@ -25,12 +25,10 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/docs/Learn/Front-end_web_developer">Get started</a>
+  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
   </p>
 </div>
 
-<div class="column-container">
-<div class="column-half">
 <h2 id="Tutorials">Tutorials</h2>
 
 <p>Learn how to program in JavaScript with guides and tutorials.</p>
@@ -90,9 +88,7 @@ tags:
  <dt><a href="/en-US/docs/Web/JavaScript/EventLoop">Concurrency model and Event Loop</a></dt>
  <dd>JavaScript has a concurrency model based on an "event loop".</dd>
 </dl>
-</div>
 
-<div class="column-half">
 <h2 id="Reference">Reference</h2>
 
 <p>Browse the complete <a href="/en-US/docs/Web/JavaScript/Reference">JavaScript reference</a> documentation.</p>
@@ -114,7 +110,7 @@ tags:
 
 <dl>
  <dt><a href="/en-US/docs/Tools">Firefox Developer Tools</a></dt>
- <dd><a href="/en-US/docs/Tools/Web_Console">Web Console</a>, <a href="/en-US/docs/Tools/Profiler">JavaScript Profiler</a>, <a href="/en-US/docs/Tools/Debugger">Debugger</a>, and more.</dd>
+ <dd><a href="/en-US/docs/Tools/Web_Console">Web Console</a>, <a href="/en-US/docs/Tools/Performance">JavaScript Profiler</a>, <a href="/en-US/docs/Tools/Debugger">Debugger</a>, and more.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Shells">JavaScript Shells</a></dt>
  <dd>A JavaScript shell allows you to quickly test snippets of JavaScript code.</dd>
  <dt><a href="https://learnjavascript.online/">Learn JavaScript</a></dt>
@@ -142,5 +138,3 @@ tags:
  <p>StackBlitz is another online playground/debugging tool, which can host and deploy full-stack applications using React, Angular, etc.</p>
  </dd>
 </dl>
-</div>
-</div>


### PR DESCRIPTION
`sectioning` flaw is there's a `<h2>` or a `<h3>` that isn't at the "root level". 
We used to have, in the Wiki, columns for content. We learned recently that this is causing problems and it's also going to be a problem when we move to simpler content structures with Markdown. 
The problem is that any `<h2>` or `<h3>` that sits inside a `<div>` (or any other block tag actually) wouldn't become part of the Table of contents and you wouldn't be able to click the on the heading to make a link directly to that section.

This PR takes care of the 10 most popular pages that had this problem. Also, I killed some fixable flaws whilst I was in there. 