### PR TITLE
caretPositionFromPoint: Fix broken macro link to CSSOM spec

### DIFF
--- a/files/en-us/web/api/documentorshadowroot/caretpositionfrompoint/index.html
+++ b/files/en-us/web/api/documentorshadowroot/caretpositionfrompoint/index.html
@@ -94,8 +94,7 @@ window.onload = function (){
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSSOM
-        View','#dom-document-caretpositionfrompoint','caretPositionFromPoint()')}}</td>
+      <td>{{SpecName('CSSOM View','#dom-document-caretpositionfrompoint','caretPositionFromPoint()')}}</td>
       <td>{{Spec2('CSSOM View')}}</td>
       <td>Initial definition.</td>
     </tr>


### PR DESCRIPTION
It seems the new line broke the link to the specs (rendered as "Unknown" currently).  
Hopefully this fixes it (checked on other pages where the link is correct and this format seems to be fine).