### PR TITLE
Fix typo: collator should be collation

### DIFF
--- a/files/en-us/mozilla/firefox/releases/85/index.html
+++ b/files/en-us/mozilla/firefox/releases/85/index.html
@@ -51,7 +51,7 @@ tags:
 // Old method
 let pinyin = new Intl.Collator(["zh-u-co-pinyin"]);
 // New method
-let pinyin = new Intl.Collator("zh", {collator: "pinyin"});</pre>
+let pinyin = new Intl.Collator("zh", {collation: "pinyin"});</pre>
   </li>
  </ul>
 


### PR DESCRIPTION
The text right above correctly uses `collation`.