### PR TITLE
variable fonts: use the name of macOS for variable font support (not just the number)

### DIFF
--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.html
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.html
@@ -14,7 +14,7 @@ tags:
 <p class="summary"><strong>Variable fonts</strong> are an evolution of the OpenType font specification that enables many different variations of a typeface to be incorporated into a single file, rather than having a separate font file for every width, weight, or style. They let you access all the variations contained in a given font file via CSS and a single {{cssxref("@font-face")}} reference. This article will give you all you need to know to get you started using variable fonts.</p>
 
 <div class="warning">
-<p><strong>Warning</strong>: In order to use variable fonts on your operating system, you need to make sure that it is up to date. For example Linux OSes need the latest Linux Freetype version, and macOS prior to 10.13 does not support variable fonts. If your operating system is not up to date, you will not be able to use variable fonts in web pages or the Firefox Developer Tools.</p>
+<p><strong>Warning</strong>: In order to use variable fonts on your operating system, you need to make sure that it is up to date. For example Linux OSes need the latest Linux Freetype version, and macOS prior to High Sierra (10.13) does not support variable fonts. If your operating system is not up to date, you will not be able to use variable fonts in web pages or the Firefox Developer Tools.</p>
 </div>
 
 <h2 id="Variable_Fonts_what_they_are_and_how_they_differ">Variable Fonts: what they are, and how they differ</h2>


### PR DESCRIPTION
I read the article on https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide

I saw the warning for variable font support 

<img width="726" alt="Screen Shot 2021-02-03 at 10 43 36 AM" src="https://user-images.githubusercontent.com/521705/106771234-be1acc00-660c-11eb-8d77-8b2ffb696a83.png">

I checked my OS version. It is 10.15. So, for a day or so, I thought that variable fonts are not that supported. I had forgotten how apple numbers their OS. I rechecked, and actually High Sierra was 3 years ago. Being more clear with the name might help.