### PR TITLE
Fix anchor link not working

### DIFF
--- a/files/en-us/web/api/element/getattribute/index.html
+++ b/files/en-us/web/api/element/getattribute/index.html
@@ -14,7 +14,7 @@ tags:
 		{{domxref("Element")}} interface returns the value of a specified attribute on the
 		element.</span> If the given attribute does not exist, the value returned will
 	either be <code>null</code> or <code>""</code> (the empty string); see <a
-		href="#Non-existing_attributes">Non-existing attributes</a> for details.</p>
+		href="#non-existing_attributes">Non-existing attributes</a> for details.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -54,7 +54,7 @@ const align = div1.getAttribute('align')
 <p>When called on an HTML element in a DOM flagged as an HTML document,
 	<code>getAttribute()</code> lower-cases its argument before proceeding.</p>
 
-<h3 id="Non-existing_attributes">Non-existing attributes</h3>
+<h3 id="non-existing_attributes">Non-existing attributes</h3>
 
 <p>Essentially all web browsers (Firefox, Internet Explorer, recent versions of Opera,
 	Safari, Konqueror, and iCab, as a non-exhaustive list) return <code>null</code> when


### PR DESCRIPTION
Capitalized anchor link would not work for me.
Reproduced on both Chrome 88.0.4324.96 and Firefox 85.0