### PR TITLE
fix more sectioning flaws in popular content

### DIFF
--- a/files/en-us/games/examples/index.html
+++ b/files/en-us/games/examples/index.html
@@ -11,8 +11,6 @@ tags:
 
 <p class="summary"><span class="seoSummary">This page lists a number of impressive web technology demos for you to get inspiration from, and generally have fun with. A testament to what can be done with JavaScript, WebGL, and related technologies.</span> The first two sections list playable games, while the second is a catch-all area to list demos that aren't necessarily interactive/games.</p>
 
-<div class="topicpage-table">
-<div class="section">
 <h2 id="Freedemo_games">Free/demo games</h2>
 
 <dl>
@@ -92,9 +90,7 @@ tags:
  <dt><a href="https://www.solitaireparadise.com/games_list/pyramid_solitaire_ancient_egypt.html">Pyramid Solitaire Ancient Egypt</a></dt>
  <dd>Pyramid solitaire app ported to WebAssembly with Emscripten</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 id="Assorted_demos">Assorted demos</h2>
 
 <dl>
@@ -137,5 +133,3 @@ tags:
  <dt><a href="https://jsfiddle.net/jetienne/rkth90c9/">ThreeJS App Player</a></dt>
  <dd>A player into which you can load and run Three.js examples.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/games/index.html
+++ b/files/en-us/games/index.html
@@ -18,8 +18,6 @@ tags:
 
 <div>{{EmbedGHLiveSample("web-tech-games/index.html", '100%', 820)}}</div>
 
-<div class="topicpage-table">
-<div class="section">
 <h2 id="Develop_web_games">Develop web games</h2>
 
 <p>Welcome to the MDN game development center! In this area of the site, we provide resources for web developers wanting to develop games. You will find many useful tutorials and technique articles in the main menu on the left, so feel free to explore.</p>
@@ -27,9 +25,7 @@ tags:
 <p>We've also included a reference section so you can easily find information about all the most common APIs used in game development.</p>
 
 <div class="note"><strong>Note:</strong> Creating games on the web draws on a number of core web technologies such as HTML, CSS, and JavaScript. The <a href="/en-US/docs/Learn">Learning Area</a> is a good place to go to get started with the basics.</div>
-</div>
 
-<div class="section">
 <h2 id="Port_native_games_to_the_Web">Port native games to the Web</h2>
 
 <p>If you are a native developer (for example writing games in C++), and you are interested in how you can port your games over to the Web, you should learn more about our <a href="https://kripken.github.io/emscripten-site/index.html">Emscripten</a> tool — this is an LLVM to JavaScript compiler, which takes LLVM bytecode (e.g. generated from C/C++ using Clang, or from another language) and compiles that into <a href="/en-US/docs/Games/Tools/asm.js">asm.js</a>, which can be run on the Web.</p>
@@ -41,21 +37,13 @@ tags:
  <li><a href="https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html">Download and Install</a> for installing the toolchain.</li>
  <li><a href="https://kripken.github.io/emscripten-site/docs/getting_started/Tutorial.html">Emscripten Tutorial</a> for a tutorial to teach you how to get started.</li>
 </ul>
-</div>
-</div>
 
-<div class="topicpage-table">
-<div class="section">
 <h2 id="Examples">Examples</h2>
 
 <p>For a list of web game examples, see our <a href="/en-US/docs/Games/Examples">examples page</a>. Also, check out <a href="https://games.mozilla.org/">games.mozilla.org</a> for more useful resources!</p>
-</div>
-</div>
 
 <h2 id="See_also">See also</h2>
 
-<div class="topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="http://buildnewgames.com/">Build New Games</a></dt>
  <dd>A collaborative site featuring a large number of open web game development tutorials. Has not been very active recently, but still holds some nice resources.</dd>
@@ -68,9 +56,7 @@ tags:
  <dt><a href="http://www.html5gamedevs.com/">HTML5 Game Devs Forum</a></dt>
  <dd>Forums for developers, framework creators, and publishers. Ask questions, get feedback and help others.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><a href="http://html5gameengine.com/">HTML5 Game Engine</a></dt>
  <dd>List of the most popular HTML5 game frameworks along with their rating, features and samples.</dd>
@@ -85,8 +71,6 @@ tags:
  <dt><a href="https://hacks.mozilla.org/category/games/">Mozilla Hacks Blog</a></dt>
  <dd>Games category on the Mozilla Hacks blog containing interesting gamedev related articles.</dd>
 </dl>
-</div>
-</div>
 
 <h2 id="See_also_2">See also</h2>
 

--- a/files/en-us/games/introduction_to_html5_game_development/index.html
+++ b/files/en-us/games/introduction_to_html5_game_development/index.html
@@ -9,7 +9,6 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>
 <h2 id="Advantages">Advantages</h2>
 
 <ol>
@@ -23,7 +22,6 @@ tags:
 </ol>
 
 <h2 id="Web_Technologies">Web Technologies</h2>
-</div>
 
 <table class="standard-table">
  <thead>
@@ -64,7 +62,6 @@ tags:
  </tbody>
 </table>
 
-<div class="twocolumns">
 <dl>
  <dt><a href="/en-US/docs/Web/API/Fullscreen_API">Full Screen API</a></dt>
  <dd>Full screen gameplay.</dd>
@@ -98,4 +95,3 @@ tags:
  <dt><a href="/en-US/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a> and <a href="/en-US/docs/DOM/File_API">File API</a></dt>
  <dd>Send and receive any kind of data you want from a Web server like downloading new game levels and artwork to transmitting non-real-time game status information back and forth.</dd>
 </dl>
-</div>

--- a/files/en-us/games/techniques/webrtc_data_channels/index.html
+++ b/files/en-us/games/techniques/webrtc_data_channels/index.html
@@ -32,7 +32,6 @@ tags:
 <p><strong>Note:</strong> We will continue to add content here soon; there are some organizational issues to sort out.</p>
 </div>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
@@ -41,4 +40,3 @@ tags:
  <li>Other Contributors: Robert Nyman</li>
  <li>Copyright Information: Alan Kligman, 2013</li>
 </ul>
-</div>

--- a/files/en-us/learn/accessibility/css_and_javascript/index.html
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.html
@@ -355,7 +355,6 @@ imgThumb.onblur = hideImg;</pre>
 
 <div>{{PreviousMenuNext("Learn/Accessibility/HTML","Learn/Accessibility/WAI-ARIA_basics", "Learn/Accessibility")}}</div>
 
-<div>
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
@@ -367,4 +366,3 @@ imgThumb.onblur = hideImg;</pre>
  <li><a href="/en-US/docs/Learn/Accessibility/Mobile">Mobile accessibility</a></li>
  <li><a href="/en-US/docs/Learn/Accessibility/Accessibility_troubleshooting">Accessibility troubleshooting</a></li>
 </ul>
-</div>

--- a/files/en-us/learn/accessibility/mobile/index.html
+++ b/files/en-us/learn/accessibility/mobile/index.html
@@ -307,7 +307,6 @@ panel.ontouchend = stopMove;</pre>
 
 <div>{{PreviousMenuNext("Learn/Accessibility/Multimedia","Learn/Accessibility/Accessibility_troubleshooting", "Learn/Accessibility")}}</div>
 
-<div>
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
@@ -319,4 +318,3 @@ panel.ontouchend = stopMove;</pre>
  <li><a href="/en-US/docs/Learn/Accessibility/Mobile">Mobile accessibility</a></li>
  <li><a href="/en-US/docs/Learn/Accessibility/Accessibility_troubleshooting">Accessibility troubleshooting</a></li>
 </ul>
-</div>

--- a/files/en-us/learn/css/css_layout/flexbox/index.html
+++ b/files/en-us/learn/css/css_layout/flexbox/index.html
@@ -330,7 +330,6 @@ article:nth-of-type(3) {
 
 <div>{{PreviousMenuNext("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout")}}</div>
 
-<div>
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
@@ -347,4 +346,3 @@ article:nth-of-type(3) {
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers">Supporting older browsers</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension">Fundamental layout comprehension assessment</a></li>
 </ul>
-</div>

--- a/files/en-us/learn/html/tables/basics/index.html
+++ b/files/en-us/learn/html/tables/basics/index.html
@@ -562,7 +562,6 @@ tags:
 
 <div>{{NextMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}</div>
 
-<div>
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
@@ -570,4 +569,3 @@ tags:
  <li><a href="/en-US/docs/Learn/HTML/Tables/Advanced">HTML table advanced features and accessibility</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Tables/Structuring_planet_data">Structuring planet data</a></li>
 </ul>
-</div>

--- a/files/en-us/learn/javascript/client-side_web_apis/fetching_data/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/fetching_data/index.html
@@ -373,7 +373,6 @@ myFetch.then(function(response) {
 
 <div>{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Manipulating_documents", "Learn/JavaScript/Client-side_web_APIs/Third_party_APIs", "Learn/JavaScript/Client-side_web_APIs")}}</div>
 
-<div>
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
@@ -385,4 +384,3 @@ myFetch.then(function(response) {
  <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs">Video and audio APIs</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage">Client-side storage</a></li>
 </ul>
-</div>

--- a/files/en-us/web/accessibility/aria/index.html
+++ b/files/en-us/web/accessibility/aria/index.html
@@ -54,8 +54,6 @@ function updateProgress(percentComplete) {
 
 <p>It is also important to test your authored ARIA with actual assistive technology. Much as how browser emulators and simulators are not an effective solution for testing full support, proxy assistive technology solutions aren't sufficient to fully guarantee functionality.</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Documentation" id="Tutorials">Tutorials</h2>
 
 <dl>
@@ -86,9 +84,7 @@ function updateProgress(percentComplete) {
  <dt><a class="external" href="http://www.freedomscientific.com/Training/Surfs-up/AriaLiveRegions.htm">Using ARIA Live Regions to announce content changes</a></dt>
  <dd>A quick summary of live regions, by the makers of JAWS screen reader software. Live regions are also supported by NVDA with Firefox, and VoiceOver with Safari.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 class="Tools" id="References">References</h2>
 
 <dl>
@@ -116,8 +112,6 @@ function updateProgress(percentComplete) {
 <h2 id="Filing_Bugs">Filing Bugs</h2>
 
 <p><a href="/en-US/docs/Web/Accessibility/ARIA/How_to_file_ARIA-related_bugs">File ARIA bugs on browsers, screen readers, and JavaScript libraries.</a></p>
-</div>
-</div>
 
 <h2 id="Related_Topics">Related topics</h2>
 


### PR DESCRIPTION
What's actually quite nice about this is that it'll become easier to move to Markdown once all of these are rooted out. 

Also, the browser will render these pages faster now because it can do it as a stream if the block tags aren't wrapping multiple other block tags, otherwise, the browser can't "dump to display" as it's going through. 