### PR TITLE
Fix UK -> US English spelling, "recognize"

### DIFF
--- a/files/en-us/learn/server-side/django/home_page/index.html
+++ b/files/en-us/learn/server-side/django/home_page/index.html
@@ -294,7 +294,7 @@ def index(request):
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>You can easily recognise template variables and template tags (functions) - variables are enclosed in double braces (<code>\{{ num_books }}</code>), and tags are enclosed in single braces with percentage signs (<code>{% extends "base_generic.html" %}</code>).</p>
+  <p>You can easily recognize template variables and template tags (functions) - variables are enclosed in double braces (<code>\{{ num_books }}</code>), and tags are enclosed in single braces with percentage signs (<code>{% extends "base_generic.html" %}</code>).</p>
 </div>
 
 <p>The important thing to note here is that variables are named with the <em>keys</em> that we pass into the <code>context</code> dictionary in the <code>render()</code> function of our view (see sample below). Variables will be replaced with their associated <em>values</em> when the template is rendered.  </p>


### PR DESCRIPTION
recognise -> recognize

https://developer.mozilla.org/en-us/docs/MDN/Guidelines/Writing_style_guide#spelling