### PR TITLE
Fix broken 'href' link in “version” doc (#1909)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
@@ -28,7 +28,7 @@ tags:
  </tbody>
 </table>
 
-<p>Version of the extension, formatted as numbers and ASCII characters separated by dots. For the details of the version format, see the <a href="/en-US/docs/Toolkit_version_format">Version format</a> page. </p>
+<p>Version of the extension, formatted as numbers and ASCII characters separated by dots. For the details of the version format, see the <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Toolkit_version_format">Version format</a> page. </p>
 
 <p>You can inspect the <a href="https://github.com/mozilla/addons-linter/blob/master/src/schema/formats.js#L10">add-ons linter code</a> to see how extension versions for Firefox are validated.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
@@ -28,7 +28,7 @@ tags:
  </tbody>
 </table>
 
-<p>Version of the extension, formatted as numbers and ASCII characters separated by dots. For the details of the version format, see the <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Toolkit_version_format">Version format</a> page. </p>
+<p>Version of the extension, formatted as numbers and ASCII characters separated by dots. For the details of the version format, see the <a href="/en-US/docs/Mozilla/Toolkit_version_format">Version format</a> page. </p>
 
 <p>You can inspect the <a href="https://github.com/mozilla/addons-linter/blob/master/src/schema/formats.js#L10">add-ons linter code</a> to see how extension versions for Firefox are validated.</p>
 


### PR DESCRIPTION
Note: @caitmuenster has a possible long-term fix, described in #1959 which may render this PR moot.