### PR TITLE
Cache/CacheStorage secure contexts

### DIFF
--- a/files/en-us/web/api/cache/index.html
+++ b/files/en-us/web/api/cache/index.html
@@ -21,15 +21,18 @@ tags:
 
 <p>You are also responsible for periodically purging cache entries. Each browser has a hard limit on the amount of cache storage that a given origin can use. Cache quota usage estimates are available via the {{domxref("StorageEstimate")}} API. The browser does its best to manage disk space, but it may delete the Cache storage for an origin. The browser will generally delete all of the data for an origin or none of the data for an origin. Make sure to version caches by name and use the caches only from the version of the script that they can safely operate on. See <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#deleting_old_caches">Deleting old caches</a> for more information.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The key matching algorithm depends on the <a href="https://www.fastly.com/blog/best-practices-for-using-the-vary-header">VARY header</a> in the value. So matching a new key requires looking at both key and value for entries in the Cache.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The key matching algorithm depends on the <a href="https://www.fastly.com/blog/best-practices-for-using-the-vary-header">VARY header</a> in the value. So matching a new key requires looking at both key and value for entries in the Cache.</p>
 </div>
 
-<div class="note">
-<p><strong>Note:</strong> The caching API doesn't honor HTTP caching headers.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The caching API doesn't honor HTTP caching headers.</p>
 </div>
 
 <p>{{AvailableInWorkers}}</p>
+<p>{{securecontext_header}}</p>
 
 <h2 id="Methods">Methods</h2>
 
@@ -62,9 +65,12 @@ tags:
 
 <p>In the code example, <code>caches</code> is a property of the {{domxref("ServiceWorkerGlobalScope")}}. It holds the <code>CacheStorage</code> object, by which it can access the {{domxref("CacheStorage")}} interface. This is an implementation of the {{domxref("WindowOrWorkerGlobalScope")}} mixin.</p>
 
-<div class="note"><strong>Note:</strong> In Chrome, visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below the registered service worker to view logging statements for the various actions the <code><a href="https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js">service-worker.js</a></code> script is performing.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>In Chrome, visit <code>chrome://inspect/#service-workers</code> and click on the "inspect" link below the registered service worker to view logging statements for the various actions the <code><a href="https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js">service-worker.js</a></code> script is performing.</p>
+</div>
 
-<pre class="brush: js notranslate">var CACHE_VERSION = 1;
+<pre class="brush: js">var CACHE_VERSION = 1;
 var CURRENT_CACHES = {
   font: 'font-cache-v' + CACHE_VERSION
 };

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -18,7 +18,10 @@ tags:
 
 <ul>
  <li>Provides a master directory of all the named caches that can be accessed by a {{domxref("ServiceWorker")}} or other type of worker or {{domxref("window")}} scope (you’re not limited to only using it with service workers, even though the {{SpecName('Service Workers')}} spec defines it).
-  <div class="note"><strong>Note</strong>: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">Chrome and Safari only expose `CacheStorage` to the windowed context over HTTPS</a>. {{domxref("WindowOrWorkerGlobalScope/caches", "WorkerGlobalScope.caches")}} will be undefined unless an SSL certificate is configured.</div>
+  <div class="notecard note">
+    <h4>Note</h4>
+    <p><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1026063">Chrome and Safari only expose `CacheStorage` to the windowed context over HTTPS</a>. {{domxref("WindowOrWorkerGlobalScope/caches", "WorkerGlobalScope.caches")}} will be undefined unless an SSL certificate is configured.</p>
+  </div>
  </li>
  <li>Maintains a mapping of string names to corresponding {{domxref("Cache")}} objects.</li>
 </ul>
@@ -29,9 +32,13 @@ tags:
 
 <p>You can access <code>CacheStorage</code> through the global {{domxref("WindowOrWorkerGlobalScope.caches", "caches")}} property.</p>
 
-<div class="note"><strong>Note</strong>: CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing, you can get around this by checking the "Enable Service Workers over HTTP (when toolbox is open)" option in the Firefox Devtools options/gear menu.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>{{domxref("CacheStorage.match()")}} is a convenience method. Equivalent functionality to match a cache entry can be implemented by returning an array of cache names from {{domxref("CacheStorage.keys()")}}, opening each cache with {{domxref("CacheStorage.open()")}}, and matching the one you want with {{domxref("Cache.match()")}}.</p>
+</div>
 
-<div class="note"><strong>Note</strong>: {{domxref("CacheStorage.match()")}} is a convenience method. Equivalent functionality to match a cache entry can be implemented by returning an array of cache names from {{domxref("CacheStorage.keys()")}}, opening each cache with {{domxref("CacheStorage.open()")}}, and matching the one you want with {{domxref("Cache.match()")}}.</div>
+<p>{{AvailableInWorkers}}</p>
+<p>{{securecontext_header}}</p>
 
 <h2 id="Methods">Methods</h2>
 

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -34,6 +34,11 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
+  <p>CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing, you can get around this by checking the "Enable Service Workers over HTTP (when toolbox is open)" option in the Firefox Devtools options/gear menu.</p>
+</div>
+
+<div class="notecard note">
+  <h4>Note</h4>
   <p>{{domxref("CacheStorage.match()")}} is a convenience method. Equivalent functionality to match a cache entry can be implemented by returning an array of cache names from {{domxref("CacheStorage.keys()")}}, opening each cache with {{domxref("CacheStorage.open()")}}, and matching the one you want with {{domxref("Cache.match()")}}.</p>
 </div>
 

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -34,7 +34,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing, you can get around this by checking the "Enable Service Workers over HTTP (when toolbox is open)" option in the Firefox Devtools options/gear menu.</p>
+  <p>CacheStorage always rejects with a <code>SecurityError</code> on untrusted origins (i.e. those that aren't using HTTPS, although this definition will likely become more complex in the future.) When testing on Firefox, you can get around this by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
 </div>
 
 <div class="notecard note">

--- a/files/en-us/web/api/service_worker_api/index.html
+++ b/files/en-us/web/api/service_worker_api/index.html
@@ -22,12 +22,20 @@ tags:
 
 <p>Service workers only run over HTTPS, for security reasons. Having modified network requests, wide open to <em>man in the middle</em> attacks would be really bad. In Firefox, Service Worker APIs are also hidden and cannot be used when the user is in <a href="https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history">private browsing mode</a>.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Unlike previous attempts in this area such as <a href="http://alistapart.com/article/application-cache-is-a-douchebag">AppCache</a>, service workers don't make assumptions about what you are trying to do, but then break when those assumptions are not exactly right. Instead, service workers give you much more granular control.</p>
+
+<div class="notecard note">
+  <h4>Tip</h4>
+  <p>On Firefox, for testing you can run service workers over HTTP (insecurely) by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
 </div>
 
-<div class="note">
-<p><strong>Note</strong>: Service workers make heavy use of <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, as generally they will wait for responses to come through, after which they will respond with a success or failure action. The promises architecture is ideal for this.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Unlike previous attempts in this area such as <a href="http://alistapart.com/article/application-cache-is-a-douchebag">AppCache</a>, service workers don't make assumptions about what you are trying to do, but then break when those assumptions are not exactly right. Instead, service workers give you much more granular control.</p>
+</div>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Service workers make heavy use of <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, as generally they will wait for responses to come through, after which they will respond with a success or failure action. The promises architecture is ideal for this.</p>
 </div>
 
 <h3 id="Registration">Registration</h3>
@@ -65,11 +73,12 @@ tags:
 
 <p>Your service worker can respond to requests using the {{DOMxRef("FetchEvent")}} event. You can modify the response to these requests in any way you want, using the {{DOMxRef("FetchEvent.respondWith()")}} method.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Because <code>install</code>/<code>activate</code> events could take a while to complete, the service worker spec provides a {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} method. Once it is called on <code>install</code> or <code>activate</code> events with a promise, functional events such as <code>fetch</code> and <code>push</code> will wait until the promise is successfully resolved.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Because <code>install</code>/<code>activate</code> events could take a while to complete, the service worker spec provides a {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} method. Once it is called on <code>install</code> or <code>activate</code> events with a promise, functional events such as <code>fetch</code> and <code>push</code> will wait until the promise is successfully resolved.</p>
 </div>
 
-<p>For a complete tutorial to show how to build up your first basic example, read <a href="/en-US/docs/Web/API/ServiceWorker_API/Using_Service_Workers">Using Service Workers</a>.</p>
+<p>For a complete tutorial to show how to build up your first basic example, read <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using Service Workers</a>.</p>
 
 <h2 id="Other_use_case_ideas">Other use case ideas</h2>
 
@@ -164,7 +173,7 @@ tags:
 
 <ul>
  <li><a href="https://serviceworke.rs">ServiceWorker Cookbook</a></li>
- <li><a href="/en-US/docs/Web/API/ServiceWorker_API/Using_Service_Workers">Using Service Workers</a></li>
+ <li><a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using Service Workers</a></li>
  <li><a href="https://github.com/mdn/sw-test">Service workers basic code example</a></li>
  <li><a href="https://jakearchibald.github.io/isserviceworkerready/">Is ServiceWorker ready?</a></li>
  <li>{{jsxref("Promise")}}</li>

--- a/files/en-us/web/api/service_worker_api/index.html
+++ b/files/en-us/web/api/service_worker_api/index.html
@@ -25,7 +25,7 @@ tags:
 
 <div class="notecard note">
   <h4>Tip</h4>
-  <p>On Firefox, for testing you can run service workers over HTTP (insecurely) by checking the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
+  <p>On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the <strong>Enable Service Workers over HTTP (when toolbox is open)</strong> option in the Firefox Devtools options/gear menu.</p>
 </div>
 
 <div class="notecard note">


### PR DESCRIPTION
This adds secure context header to `Cache` and `CacheStorage` docs and also fixes flaws. 