### PR TITLE
Subedit fixing content bugs

### DIFF
--- a/files/en-us/mdn/contribute/fixing_mdn_content_bugs/index.html
+++ b/files/en-us/mdn/contribute/fixing_mdn_content_bugs/index.html
@@ -8,11 +8,18 @@ tags:
 ---
 <p>{{MDNSidebar}}</p>
 
-<p>Our <a href="https://github.com/mdn/content/issues">content repo</a> is where people submit issues to report problems found with MDN docs (You'll also find a lot of content bugs still to fix in the older <a href="https://github.com/mdn/sprints/issues">sprints repo</a>, which will eventually be shut down). We get a lot of content bugs, and any help you can give in fixing them would be much appreciated.</p>
+<p>Problems with MDN docs are reported as <a href="https://github.com/mdn/content/issues">content repo issues</a> (and there are still some open issues in the legacy <a href="https://github.com/mdn/sprints/issues">sprints repo</a>). This article helps you find the <em>best</em> issues to work on, based on your expertise and how much time you have available, and outlines the main steps to fixing them.</p>
+
+<div class="notecard note">
+  <p>We get a lot of content bugs — any help you can give in fixing them is very much appreciated!</p>
+</div>
+
 
 <h2 id="What_do_we_need_help_with">What do we need help with?</h2>
 
-<p>To help you choose what content issues to work on, we've split them up using GitHub labels into different timings so you'll be able to find something to work on in the time you have available.</p>
+<p>To help you choose what content issues to work on, we've sorted them using GitHub labels.</p>
+  
+<p>The labels below help you find tasks based on how much time you have available.</p>
 
 <table class="standard-table">
  <thead>
@@ -97,6 +104,8 @@ tags:
  </tbody>
 </table>
 
+
+
 <h2 id="How_can_you_benefit">How can you benefit?</h2>
 
 <ul>
@@ -116,7 +125,6 @@ tags:
 
 <ol>
  <li>First of all, sign up for a <a href="https://github.com/join">GitHub account</a>, if you don’t already have one — you'll need this to communicate on the GitHub issues.</li>
- <li>Sign up for an MDN account, if you don’t already have one, as explained in <a href="/en-US/docs/MDN/Contribute/Getting_started#step_1_create_an_account_on_mdn">Create an account on MDN</a>. You can authenticate it using your GitHub account, and you'll need this to update MDN content as required to fix the issues you sign up for.</li>
  <li>Next, choose one or more topic areas you’d like to help with. Use the list above to get more information to help you make your selection. If you are not sure what a good choice would be, ask for help in the <a href="https://chat.mozilla.org/#/room/#mdn:mozilla.org">MDN Web Docs chat room</a> on <a href="https://wiki.mozilla.org/Matrix">Matrix</a>. </li>
 </ol>
 
@@ -130,5 +138,5 @@ tags:
 </ol>
 
 <div class="notecard note">
-<p><strong>Note</strong>: When choosing and working on an issue, you might find our <a href="/en-US/docs/MDN/Contribute/GitHub_best_practices">GitHub best practices</a> useful.</p>
+<p><strong>Note</strong>: When choosing and working on an issue, you might also find our <a href="/en-US/docs/MDN/Contribute/GitHub_best_practices">GitHub best practices</a> and <a href="/en-US/docs/MDN/Contribute/Getting_started">Getting started on MDN</a> useful</p>
 </div>

--- a/files/en-us/mdn/contribute/fixing_mdn_content_bugs/index.html
+++ b/files/en-us/mdn/contribute/fixing_mdn_content_bugs/index.html
@@ -11,6 +11,7 @@ tags:
 <p>Problems with MDN docs are reported as <a href="https://github.com/mdn/content/issues">content repo issues</a> (and there are still some open issues in the legacy <a href="https://github.com/mdn/sprints/issues">sprints repo</a>). This article helps you find the <em>best</em> issues to work on, based on your expertise and how much time you have available, and outlines the main steps to fixing them.</p>
 
 <div class="notecard note">
+  <h2>Note</h2>
   <p>We get a lot of content bugs — any help you can give in fixing them is very much appreciated!</p>
 </div>
 
@@ -138,5 +139,5 @@ tags:
 </ol>
 
 <div class="notecard note">
-<p><strong>Note</strong>: When choosing and working on an issue, you might also find our <a href="/en-US/docs/MDN/Contribute/GitHub_best_practices">GitHub best practices</a> and <a href="/en-US/docs/MDN/Contribute/Getting_started">Getting started on MDN</a> useful</p>
+<p><strong>Note</strong>: When choosing and working on an issue, you might also find our <a href="/en-US/docs/MDN/Contribute/GitHub_best_practices">GitHub best practices</a> and <a href="/en-US/docs/MDN/Contribute/Getting_started">Getting started on MDN</a> guides useful.</p>
 </div>


### PR DESCRIPTION
@chrisdavidmills This is my first step in addressing the concerns here: https://github.com/mdn/content/issues/1856#issuecomment-770657255

Does two things. 
- Minor readability improvement. 
- Removes the instruction to create a (no longer existing) MDN account.

My concern is the one raised by @Ryuno-Ki [here](https://github.com/mdn/content/issues/1856#issuecomment-770658731) - discoverability. I think we need this to be more visible. It is probably not the "complete solution" but it will certainly help some developers find these docs if we create a CONTRIBUTING.md in the root of content. Any objection/do you want to do that?