### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/web/svg/attribute/patternunits/index.html
+++ b/files/en-us/web/svg/attribute/patternunits/index.html
@@ -66,7 +66,7 @@ tags:
  <dt><code>userSpaceOnUse</code></dt>
  <dd>This value indicates that all coordinates for the geometry properties refer to the user coordinate system as defined when the pattern was applied.</dd>
  <dt><code>objectBoundingBox</code></dt>
- <dd>This value indicates that all coordinates for the geometry properties represent fractions or percentages of the bounding box of the element to which the mask is applied. A bounding box could be considered the same as if the content of the {{ SVGElement("mask") }} were bound to a "<code>0 0 1 1</code>" {{ SVGAttr("viewbox") }}.</dd>
+ <dd>This value indicates that all coordinates for the geometry properties represent fractions or percentages of the bounding box of the element to which the pattern is applied. A bounding box could be considered the same as if the content of the {{ SVGElement("pattern") }} were bound to a "<code>0 0 1 1</code>" {{ SVGAttr("viewbox") }}.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Replace `mask` (not related to the current document) occurrences by `pattern` (subject of the current document).