### PR TITLE
release note list-style-image

### DIFF
--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -29,6 +29,7 @@ tags:
 
 <ul>
   <li>The {{cssxref(":autofill")}} pseudo-class is now enabled, with <code>-webkit-autofill</code> as an alias. ({{bug(1685675)}}) and ({{bug(1475316)}}). </li>
+  <li>The {{cssxref("list-style-image")}} property now accepts any valid {{cssxref("image")}}. ({{bug(1685078)}}). </li>
 </ul>
 
 <h4 id="Removals_3">Removals</h4>


### PR DESCRIPTION
Adding release notes for `list-style-image` changes in 86: https://bugzilla.mozilla.org/show_bug.cgi?id=1685078