### PR TITLE
Replaces <tt> in example with <code>

### DIFF
--- a/files/en-us/web/api/document_object_model/introduction/index.html
+++ b/files/en-us/web/api/document_object_model/introduction/index.html
@@ -201,20 +201,20 @@ table.summary = "note: increased border";
 &lt;/head&gt;
 &lt;body&gt;
   &lt;div style="margin: .5in; height: 400px;"&gt;
-    &lt;p&gt;&lt;b&gt;&lt;tt&gt;text&lt;/tt&gt;&lt;/b&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;b&gt;&lt;code&gt;text&lt;/code&gt;&lt;/b&gt;&lt;/p&gt;
     &lt;form&gt;
       &lt;select onChange="setBodyAttr('text',
         this.options[this.selectedIndex].value);"&gt;
         &lt;option value="black"&gt;black&lt;/option&gt;
         &lt;option value="red"&gt;red&lt;/option&gt;
       &lt;/select&gt;
-      &lt;p&gt;&lt;b&gt;&lt;tt&gt;bgColor&lt;/tt&gt;&lt;/b&gt;&lt;/p&gt;
+      &lt;p&gt;&lt;b&gt;&lt;code&gt;bgColor&lt;/code&gt;&lt;/b&gt;&lt;/p&gt;
       &lt;select onChange="setBodyAttr('bgColor',
         this.options[this.selectedIndex].value);"&gt;
         &lt;option value="white"&gt;white&lt;/option&gt;
         &lt;option value="lightgrey"&gt;gray&lt;/option&gt;
       &lt;/select&gt;
-      &lt;p&gt;&lt;b&gt;&lt;tt&gt;link&lt;/tt&gt;&lt;/b&gt;&lt;/p&gt;
+      &lt;p&gt;&lt;b&gt;&lt;code&gt;link&lt;/code&gt;&lt;/b&gt;&lt;/p&gt;
       &lt;select onChange="setBodyAttr('link',
         this.options[this.selectedIndex].value);"&gt;
         &lt;option value="blue"&gt;blue&lt;/option&gt;


### PR DESCRIPTION
`<tt>` is deprecated and obsolete: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt. Replaced with `<code>`.