### PR TITLE
Fix: remove useless <div> tags (part 1)

### DIFF
--- a/files/en-us/web/api/abortsignal/abort_event/index.html
+++ b/files/en-us/web/api/abortsignal/abort_event/index.html
@@ -73,10 +73,7 @@ signal.onabort = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AbortSignal.abort_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abstractrange/endoffset/index.html
+++ b/files/en-us/web/api/abstractrange/endoffset/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AbstractRange.endOffset")}}</p>
-</div>

--- a/files/en-us/web/api/abstractrange/startcontainer/index.html
+++ b/files/en-us/web/api/abstractrange/startcontainer/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AbstractRange.startContainer")}}</p>
-</div>

--- a/files/en-us/web/api/abstractrange/startoffset/index.html
+++ b/files/en-us/web/api/abstractrange/startoffset/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AbstractRange.startOffset")}}</p>
-</div>

--- a/files/en-us/web/api/abstractworker/index.html
+++ b/files/en-us/web/api/abstractworker/index.html
@@ -74,10 +74,7 @@ first.onchange = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AbstractWorker")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abstractworker/onerror/index.html
+++ b/files/en-us/web/api/abstractworker/onerror/index.html
@@ -48,10 +48,7 @@ myWorker.onerror = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AbstractWorker.onerror")}}</p>
-</div>
 
 <h3 id="Cross-origin_worker_error_behavior">Cross-origin worker error behavior</h3>
 

--- a/files/en-us/web/api/addresserrors/addressline/index.html
+++ b/files/en-us/web/api/addresserrors/addressline/index.html
@@ -48,7 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.addressLine")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/city/index.html
+++ b/files/en-us/web/api/addresserrors/city/index.html
@@ -47,7 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.city")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/country/index.html
+++ b/files/en-us/web/api/addresserrors/country/index.html
@@ -48,7 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.country")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/dependentlocality/index.html
+++ b/files/en-us/web/api/addresserrors/dependentlocality/index.html
@@ -47,7 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.dependentLocality")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/index.html
+++ b/files/en-us/web/api/addresserrors/index.html
@@ -252,7 +252,4 @@ not-useless gift as a token of our thanks!&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/languagecode/index.html
+++ b/files/en-us/web/api/addresserrors/languagecode/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.languageCode")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/organization/index.html
+++ b/files/en-us/web/api/addresserrors/organization/index.html
@@ -49,7 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.organization")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/phone/index.html
+++ b/files/en-us/web/api/addresserrors/phone/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.phone")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/postalcode/index.html
+++ b/files/en-us/web/api/addresserrors/postalcode/index.html
@@ -51,7 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.postalCode")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/recipient/index.html
+++ b/files/en-us/web/api/addresserrors/recipient/index.html
@@ -47,7 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.recipient")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/region/index.html
+++ b/files/en-us/web/api/addresserrors/region/index.html
@@ -48,7 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.region")}}</p>
-</div>

--- a/files/en-us/web/api/addresserrors/sortingcode/index.html
+++ b/files/en-us/web/api/addresserrors/sortingcode/index.html
@@ -48,7 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AddressErrors.sortingCode")}}</p>
-</div>

--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -62,10 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.AnalyserNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/fftsize/index.html
+++ b/files/en-us/web/api/analysernode/fftsize/index.html
@@ -99,10 +99,7 @@ function draw() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.fftSize")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/frequencybincount/index.html
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.html
@@ -85,10 +85,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.frequencyBinCount")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.html
@@ -106,10 +106,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.getByteFrequencyData")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.html
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.html
@@ -102,10 +102,7 @@ draw();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.getByteTimeDomainData")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
@@ -133,10 +133,7 @@ draw();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.getFloatFrequencyData")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.html
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.html
@@ -110,10 +110,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.getFloatTimeDomainData")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/index.html
@@ -169,10 +169,7 @@ draw();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.html
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.html
@@ -88,10 +88,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.maxDecibels")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/mindecibels/index.html
+++ b/files/en-us/web/api/analysernode/mindecibels/index.html
@@ -91,10 +91,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.minDecibels")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.html
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.html
@@ -96,10 +96,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AnalyserNode.smoothingTimeConstant")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/animation/index.html
+++ b/files/en-us/web/api/animation/animation/index.html
@@ -52,10 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.Animation")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/cancel/index.html
+++ b/files/en-us/web/api/animation/cancel/index.html
@@ -54,10 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.cancel")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/commitstyles/index.html
+++ b/files/en-us/web/api/animation/commitstyles/index.html
@@ -60,10 +60,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.commitStyles")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/currenttime/index.html
+++ b/files/en-us/web/api/animation/currenttime/index.html
@@ -78,10 +78,7 @@ animation.currentTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.currentTime")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/effect/index.html
+++ b/files/en-us/web/api/animation/effect/index.html
@@ -44,10 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.effect")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/finish/index.html
+++ b/files/en-us/web/api/animation/finish/index.html
@@ -80,10 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.finish")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/finished/index.html
+++ b/files/en-us/web/api/animation/finished/index.html
@@ -63,10 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.finished")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/id/index.html
+++ b/files/en-us/web/api/animation/id/index.html
@@ -50,10 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.id")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/oncancel/index.html
+++ b/files/en-us/web/api/animation/oncancel/index.html
@@ -57,10 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.oncancel")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/onremove/index.html
+++ b/files/en-us/web/api/animation/onremove/index.html
@@ -71,10 +71,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.onremove")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/pause/index.html
+++ b/files/en-us/web/api/animation/pause/index.html
@@ -88,10 +88,7 @@ bottle.addEventListener("mouseup", stopPlayingAlice, false);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.pause")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/pending/index.html
+++ b/files/en-us/web/api/animation/pending/index.html
@@ -42,10 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.pending")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/persist/index.html
+++ b/files/en-us/web/api/animation/persist/index.html
@@ -74,10 +74,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.persist")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/play/index.html
+++ b/files/en-us/web/api/animation/play/index.html
@@ -82,10 +82,7 @@ cake.addEventListener("touchstart", growAlice, false);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.play")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/playbackrate/index.html
+++ b/files/en-us/web/api/animation/playbackrate/index.html
@@ -100,10 +100,7 @@ document.addEventListener("touchstart", goFaster);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.playbackRate")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/playstate/index.html
+++ b/files/en-us/web/api/animation/playstate/index.html
@@ -91,10 +91,7 @@ tears.forEach(function(el) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.playState")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/ready/index.html
+++ b/files/en-us/web/api/animation/ready/index.html
@@ -65,10 +65,7 @@ animation.play();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.ready")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/replacestate/index.html
+++ b/files/en-us/web/api/animation/replacestate/index.html
@@ -75,10 +75,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.replaceState")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/reverse/index.html
+++ b/files/en-us/web/api/animation/reverse/index.html
@@ -71,10 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.reverse")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/starttime/index.html
+++ b/files/en-us/web/api/animation/starttime/index.html
@@ -97,10 +97,7 @@ animation.startTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.startTime")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/timeline/index.html
+++ b/files/en-us/web/api/animation/timeline/index.html
@@ -51,10 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Animation.timeline")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.html
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.html
@@ -91,10 +91,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioBuffer.getChannelData")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/index.html
+++ b/files/en-us/web/api/audiobuffer/index.html
@@ -100,10 +100,7 @@ source.start();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioBuffer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/index.html
@@ -135,10 +135,7 @@ source.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioBufferSourceNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/close/index.html
+++ b/files/en-us/web/api/audiocontext/close/index.html
@@ -61,10 +61,7 @@ await audioCtx.close();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioContext.close")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/createmediaelementsource/index.html
+++ b/files/en-us/web/api/audiocontext/createmediaelementsource/index.html
@@ -101,10 +101,7 @@ gainNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioContext.createMediaElementSource")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.html
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.html
@@ -108,10 +108,7 @@ var destination = audioCtx.createMediaStreamDestination();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioContext.createMediaStreamDestination")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/index.html
+++ b/files/en-us/web/api/audiocontext/index.html
@@ -92,10 +92,7 @@ var finish = audioCtx.destination;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioContext")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/suspend/index.html
+++ b/files/en-us/web/api/audiocontext/suspend/index.html
@@ -62,10 +62,7 @@ audioCtx.suspend().then(function() { ... });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioContext.suspend")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiodestinationnode/index.html
+++ b/files/en-us/web/api/audiodestinationnode/index.html
@@ -84,10 +84,7 @@ gainNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioDestinationNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.html
+++ b/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.html
@@ -60,10 +60,7 @@ gainNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioDestinationNode.maxChannelCount")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.html
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.html
@@ -37,10 +37,7 @@ myListener.dopplerFactor = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.dopplerFactor")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.html
+++ b/files/en-us/web/api/audiolistener/forwardx/index.html
@@ -52,10 +52,7 @@ myListener.forwardX.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.forwardX")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardy/index.html
+++ b/files/en-us/web/api/audiolistener/forwardy/index.html
@@ -52,10 +52,7 @@ myListener.forwardY.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.forwardY")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/index.html
+++ b/files/en-us/web/api/audiolistener/index.html
@@ -101,10 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/positionx/index.html
+++ b/files/en-us/web/api/audiolistener/positionx/index.html
@@ -52,10 +52,7 @@ myListener.positionX.value = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.positionX")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/positiony/index.html
+++ b/files/en-us/web/api/audiolistener/positiony/index.html
@@ -52,10 +52,7 @@ myListener.positionY.value = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.positionY")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/positionz/index.html
+++ b/files/en-us/web/api/audiolistener/positionz/index.html
@@ -52,10 +52,7 @@ myListener.positionZ.value = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.positionZ")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/setorientation/index.html
+++ b/files/en-us/web/api/audiolistener/setorientation/index.html
@@ -58,10 +58,7 @@ myListener.setOrientation(0,0,-1,0,1,0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.setOrientation")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/setposition/index.html
+++ b/files/en-us/web/api/audiolistener/setposition/index.html
@@ -65,10 +65,7 @@ myListener.setPosition(1,1,1);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.setPosition")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/upx/index.html
+++ b/files/en-us/web/api/audiolistener/upx/index.html
@@ -52,10 +52,7 @@ myListener.upX.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.upX")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/upy/index.html
+++ b/files/en-us/web/api/audiolistener/upy/index.html
@@ -51,10 +51,7 @@ myListener.upY.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.upY")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/upz/index.html
+++ b/files/en-us/web/api/audiolistener/upz/index.html
@@ -52,10 +52,7 @@ myListener.upZ.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioListener.upZ")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/channelcount/index.html
+++ b/files/en-us/web/api/audionode/channelcount/index.html
@@ -64,10 +64,7 @@ oscillator.channelCount;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioNode.channelCount")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/channelcountmode/index.html
+++ b/files/en-us/web/api/audionode/channelcountmode/index.html
@@ -89,10 +89,7 @@ oscillator.channelCountMode = 'explicit';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioNode.channelCountMode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/channelinterpretation/index.html
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.html
@@ -61,10 +61,7 @@ oscillator.channelInterpretation = 'discrete';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioNode.channelInterpretation")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/disconnect/index.html
+++ b/files/en-us/web/api/audionode/disconnect/index.html
@@ -89,10 +89,7 @@ gainNode.disconnect();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioNode.disconnect")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/index.html
+++ b/files/en-us/web/api/audionode/index.html
@@ -136,10 +136,7 @@ oscillator.channelCount;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/index.html
+++ b/files/en-us/web/api/audioparam/index.html
@@ -96,10 +96,7 @@ compressor.release.setValueAtTime(0.25, audioCtx.currentTime);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioParam")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioprocessingevent/index.html
+++ b/files/en-us/web/api/audioprocessingevent/index.html
@@ -77,10 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioProcessingEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioscheduledsourcenode/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/index.html
@@ -65,10 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioScheduledSourceNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworklet/index.html
+++ b/files/en-us/web/api/audioworklet/index.html
@@ -57,10 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioWorklet")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletglobalscope/index.html
+++ b/files/en-us/web/api/audioworkletglobalscope/index.html
@@ -101,10 +101,7 @@ testNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioWorkletGlobalScope")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletnode/index.html
+++ b/files/en-us/web/api/audioworkletnode/index.html
@@ -96,10 +96,7 @@ whiteNoiseNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioWorkletNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/index.html
@@ -115,10 +115,7 @@ whiteNoiseNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.AudioWorkletProcessor")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/background_tasks_api/index.html
+++ b/files/en-us/web/api/background_tasks_api/index.html
@@ -502,10 +502,7 @@ document.getElementById("startButton").addEventListener("click", decodeTechnoStu
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Window.requestIdleCallback")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/index.html
+++ b/files/en-us/web/api/baseaudiocontext/index.html
@@ -123,10 +123,7 @@ const finish = audioContext.destination;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BaseAudioContext")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/basiccardrequest/index.html
+++ b/files/en-us/web/api/basiccardrequest/index.html
@@ -135,7 +135,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BasicCardRequest")}}</p>
-</div>

--- a/files/en-us/web/api/basiccardresponse/index.html
+++ b/files/en-us/web/api/basiccardresponse/index.html
@@ -114,7 +114,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BasicCardResponse")}}</p>
-</div>

--- a/files/en-us/web/api/beforeunloadevent/index.html
+++ b/files/en-us/web/api/beforeunloadevent/index.html
@@ -74,10 +74,7 @@ window.addEventListener("beforeunload", function( event ) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BeforeUnloadEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/detune/index.html
+++ b/files/en-us/web/api/biquadfilternode/detune/index.html
@@ -80,10 +80,7 @@ biquadFilter.detune.value = 100;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BiquadFilterNode.detune")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/frequency/index.html
+++ b/files/en-us/web/api/biquadfilternode/frequency/index.html
@@ -80,10 +80,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BiquadFilterNode.frequency")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/gain/index.html
+++ b/files/en-us/web/api/biquadfilternode/gain/index.html
@@ -83,10 +83,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BiquadFilterNode.gain")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/index.html
@@ -170,10 +170,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BiquadFilterNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/q/index.html
+++ b/files/en-us/web/api/biquadfilternode/q/index.html
@@ -85,10 +85,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BiquadFilterNode.Q")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/type/index.html
+++ b/files/en-us/web/api/biquadfilternode/type/index.html
@@ -145,10 +145,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BiquadFilterNode.type")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
@@ -75,7 +75,4 @@ if (characteristic.properties.notify) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BluetoothCharacteristicProperties")}}</p>
-</div>

--- a/files/en-us/web/api/budgetservice/index.html
+++ b/files/en-us/web/api/budgetservice/index.html
@@ -29,7 +29,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.BudgetService")}}</p>
-</div>

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.html
@@ -68,7 +68,4 @@ var size = queueingStrategy.size(chunk);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ByteLengthQueuingStrategy")}}</p>
-</div>

--- a/files/en-us/web/api/cache/add/index.html
+++ b/files/en-us/web/api/cache/add/index.html
@@ -99,10 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Cache.add")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/index.html
+++ b/files/en-us/web/api/cache/index.html
@@ -175,10 +175,7 @@ self.addEventListener('fetch', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Cache")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/index.html
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/index.html
@@ -56,10 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CanvasCaptureMediaStreamTrack")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvaspattern/index.html
+++ b/files/en-us/web/api/canvaspattern/index.html
@@ -47,10 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CanvasPattern")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.html
@@ -403,10 +403,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CanvasRenderingContext2D")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/index.html
@@ -81,10 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ChannelMergerNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/index.html
@@ -82,10 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ChannelSplitterNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/client/frametype/index.html
+++ b/files/en-us/web/api/client/frametype/index.html
@@ -44,7 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Client.frameType")}}</p>
-</div>

--- a/files/en-us/web/api/client/id/index.html
+++ b/files/en-us/web/api/client/id/index.html
@@ -44,7 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Client.id")}}</p>
-</div>

--- a/files/en-us/web/api/clients/index.html
+++ b/files/en-us/web/api/clients/index.html
@@ -84,10 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Clients")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/index.html
@@ -116,10 +116,7 @@ gainNode3.connect(context.destination);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ConstantSourceNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/convolvernode/buffer/index.html
+++ b/files/en-us/web/api/convolvernode/buffer/index.html
@@ -79,10 +79,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ConvolverNode.buffer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/index.html
@@ -112,10 +112,7 @@ reverb.connect(audioCtx.destination);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ConvolverNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/index.html
@@ -70,7 +70,4 @@ var size = queueingStrategy.size();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CountQueuingStrategy")}}</p>
-</div>

--- a/files/en-us/web/api/credentialscontainer/index.html
+++ b/files/en-us/web/api/credentialscontainer/index.html
@@ -64,7 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CredentialsContainer")}}</p>
-</div>

--- a/files/en-us/web/api/crypto/index.html
+++ b/files/en-us/web/api/crypto/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Crypto")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/index.html
+++ b/files/en-us/web/api/csscounterstylerule/index.html
@@ -71,10 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CSSCounterStyleRule")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -179,10 +179,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CSSPrimitiveValue")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssrule/index.html
+++ b/files/en-us/web/api/cssrule/index.html
@@ -97,10 +97,7 @@ console.log(myRules);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CSSRule")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -67,10 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CSSValue")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvaluelist/index.html
+++ b/files/en-us/web/api/cssvaluelist/index.html
@@ -54,10 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.CSSValueList")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.html
@@ -115,10 +115,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DedicatedWorkerGlobalScope")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/delaynode/delaytime/index.html
+++ b/files/en-us/web/api/delaynode/delaytime/index.html
@@ -55,10 +55,7 @@ myDelay.delayTime.value = 3.0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DelayNode.delayTime")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/index.html
@@ -85,10 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DelayNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/index.html
@@ -44,7 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DeviceMotionEventRotationRate")}}</p>
-</div>

--- a/files/en-us/web/api/directoryentrysync/index.html
+++ b/files/en-us/web/api/directoryentrysync/index.html
@@ -371,10 +371,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DirectoryEntrySync")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/index.html
@@ -49,10 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DisplayMediaStreamConstraints")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domhighrestimestamp/index.html
+++ b/files/en-us/web/api/domhighrestimestamp/index.html
@@ -113,10 +113,7 @@ let elapsedTime = performance.now() - startTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMHighResTimestamp")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domquad/index.html
+++ b/files/en-us/web/api/domquad/index.html
@@ -59,7 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMQuad")}}</p>
-</div>

--- a/files/en-us/web/api/domrectreadonly/bottom/index.html
+++ b/files/en-us/web/api/domrectreadonly/bottom/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.bottom")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/height/index.html
+++ b/files/en-us/web/api/domrectreadonly/height/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.height")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/index.html
+++ b/files/en-us/web/api/domrectreadonly/index.html
@@ -72,10 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/left/index.html
+++ b/files/en-us/web/api/domrectreadonly/left/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.left")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/right/index.html
+++ b/files/en-us/web/api/domrectreadonly/right/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.right")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/top/index.html
+++ b/files/en-us/web/api/domrectreadonly/top/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.top")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/width/index.html
+++ b/files/en-us/web/api/domrectreadonly/width/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.width")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/x/index.html
+++ b/files/en-us/web/api/domrectreadonly/x/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.x")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/y/index.html
+++ b/files/en-us/web/api/domrectreadonly/y/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DOMRectReadOnly.y")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/doublerange/index.html
+++ b/files/en-us/web/api/doublerange/index.html
@@ -47,10 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DoubleRange")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.html
@@ -55,10 +55,7 @@ compressor.attack.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode.attack")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/index.html
@@ -94,10 +94,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.html
@@ -58,10 +58,7 @@ compressor.knee.value = 40;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode.knee")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.html
@@ -57,10 +57,7 @@ compressor.ratio.value = 12;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode.ratio")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/reduction/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/reduction/index.html
@@ -50,10 +50,7 @@ var myReduction = compressor.reduction;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode.reduction")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/release/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.html
@@ -55,10 +55,7 @@ compressor.release.value = 0.25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode.release")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.html
@@ -57,10 +57,7 @@ compressor.threshold.value = -50;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.DynamicsCompressorNode.threshold")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/eventsource/index.html
+++ b/files/en-us/web/api/eventsource/index.html
@@ -147,10 +147,7 @@ evtSource.onmessage = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.EventSource")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/eventtarget/index.html
+++ b/files/en-us/web/api/eventtarget/index.html
@@ -120,10 +120,7 @@ EventTarget.prototype.dispatchEvent = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.EventTarget")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/extendableevent/index.html
+++ b/files/en-us/web/api/extendableevent/index.html
@@ -110,10 +110,7 @@ self.addEventListener('install', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ExtendableEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/extendablemessageevent/index.html
+++ b/files/en-us/web/api/extendablemessageevent/index.html
@@ -92,10 +92,7 @@ addEventListener('message', event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ExtendableMessageEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/index.html
+++ b/files/en-us/web/api/fetchevent/index.html
@@ -97,10 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FetchEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/lastmodifieddate/index.html
+++ b/files/en-us/web/api/file/lastmodifieddate/index.html
@@ -65,10 +65,7 @@ someFile.lastModifiedDate.getTime();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.File.lastModifiedDate")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/index.html
+++ b/files/en-us/web/api/filereadersync/index.html
@@ -51,10 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FileReaderSync")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
@@ -64,10 +64,7 @@ slug: Web/API/FileReaderSync/readAsArrayBuffer
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FileReaderSync.readAsArrayBuffer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.html
@@ -50,10 +50,7 @@ readAsBinaryString(<em>Blob</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FileReaderSync.readAsBinaryString")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.html
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.html
@@ -46,10 +46,7 @@ readAsDataURL(<em>Blob</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FileReaderSync.readAsDataURL")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readastext/index.html
+++ b/files/en-us/web/api/filereadersync/readastext/index.html
@@ -50,10 +50,7 @@ readAsText(<em>Blob</em>, <em>encoding</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FileReaderSync.readAsText")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/index.html
+++ b/files/en-us/web/api/filesystementry/index.html
@@ -107,10 +107,7 @@ window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, function(fs) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FileSystemEntry")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fontfaceset/index.html
+++ b/files/en-us/web/api/fontfaceset/index.html
@@ -68,7 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FontFaceSet")}}</p>
-</div>

--- a/files/en-us/web/api/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/index.html
@@ -49,7 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.FontFaceSetLoadEvent")}}</p>
-</div>

--- a/files/en-us/web/api/gainnode/gain/index.html
+++ b/files/en-us/web/api/gainnode/gain/index.html
@@ -53,10 +53,7 @@ gainNode.gain.value = 0.5;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.GainNode.gain")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -84,10 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.GainNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -255,10 +255,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.GlobalEventHandlers")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/html_dom_api/index.html
+++ b/files/en-us/web/api/html_dom_api/index.html
@@ -469,10 +469,7 @@ nameField.addEventListener("input", event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlanchorelement/index.html
+++ b/files/en-us/web/api/htmlanchorelement/index.html
@@ -131,10 +131,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLAnchorElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -55,10 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLBaseFontElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlbrelement/index.html
+++ b/files/en-us/web/api/htmlbrelement/index.html
@@ -50,10 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLBRElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/index.html
@@ -92,10 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLCanvasElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextcreationerror_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextcreationerror_event/index.html
@@ -64,10 +64,7 @@ var gl = canvas.getContext('webgl');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLCanvasElement.webglcontextcreationerror_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.html
@@ -67,10 +67,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLCanvasElement.webglcontextlost_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.html
@@ -67,10 +67,7 @@ gl.getExtension('WEBGL_lose_context').restoreContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLCanvasElement.webglcontextrestored_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmldataelement/index.html
+++ b/files/en-us/web/api/htmldataelement/index.html
@@ -52,10 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLDataElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmldetailselement/index.html
+++ b/files/en-us/web/api/htmldetailselement/index.html
@@ -56,10 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLDetailsElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlfontelement/index.html
+++ b/files/en-us/web/api/htmlfontelement/index.html
@@ -35,10 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLFontElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlformelement/formdata_event/index.html
+++ b/files/en-us/web/api/htmlformelement/formdata_event/index.html
@@ -105,10 +105,7 @@ formElem.addEventListener('formdata', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLFormElement.formdata_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlformelement/reset_event/index.html
+++ b/files/en-us/web/api/htmlformelement/reset_event/index.html
@@ -97,10 +97,7 @@ form.addEventListener('reset', logReset);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLFormElement.reset_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.html
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.html
@@ -107,10 +107,7 @@ form.addEventListener('submit', logSubmit);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLFormElement.submit_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlhrelement/index.html
+++ b/files/en-us/web/api/htmlhrelement/index.html
@@ -75,10 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLHRElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmliframeelement/index.html
+++ b/files/en-us/web/api/htmliframeelement/index.html
@@ -99,10 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLIFrameElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmlimageelement/index.html
+++ b/files/en-us/web/api/htmlimageelement/index.html
@@ -168,10 +168,7 @@ alert(document.images[0].src);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLImageElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmllabelelement/index.html
+++ b/files/en-us/web/api/htmllabelelement/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLLabelElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmllegendelement/index.html
+++ b/files/en-us/web/api/htmllegendelement/index.html
@@ -73,10 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLLegendElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmllielement/index.html
+++ b/files/en-us/web/api/htmllielement/index.html
@@ -65,10 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLLIElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmllinkelement/index.html
+++ b/files/en-us/web/api/htmllinkelement/index.html
@@ -109,10 +109,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLLinkElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmltablecellelement/index.html
+++ b/files/en-us/web/api/htmltablecellelement/index.html
@@ -120,10 +120,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLTableCellElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmltablecolelement/index.html
+++ b/files/en-us/web/api/htmltablecolelement/index.html
@@ -76,10 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLTableColElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmltablesectionelement/index.html
+++ b/files/en-us/web/api/htmltablesectionelement/index.html
@@ -75,10 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLTableSectionElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/htmltimeelement/index.html
+++ b/files/en-us/web/api/htmltimeelement/index.html
@@ -55,10 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.HTMLTimeElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/index.html
+++ b/files/en-us/web/api/idbcursor/index.html
@@ -118,10 +118,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBCursor")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursorwithvalue/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/index.html
@@ -83,10 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBCursorWithValue")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbenvironment/index.html
+++ b/files/en-us/web/api/idbenvironment/index.html
@@ -48,10 +48,7 @@ function openDB() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBEnvironment")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbfactory/index.html
+++ b/files/en-us/web/api/idbfactory/index.html
@@ -78,10 +78,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBFactory")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/isautolocale/index.html
+++ b/files/en-us/web/api/idbindex/isautolocale/index.html
@@ -66,10 +66,7 @@ console.log(myIndex.isAutoLocale);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBIndex.isAutoLocale")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/locale/index.html
+++ b/files/en-us/web/api/idbindex/locale/index.html
@@ -66,10 +66,7 @@ console.log(myIndex.locale);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBIndex.locale")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/index.html
+++ b/files/en-us/web/api/idbkeyrange/index.html
@@ -171,10 +171,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBKeyRange")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idblocaleawarekeyrange/index.html
+++ b/files/en-us/web/api/idblocaleawarekeyrange/index.html
@@ -63,10 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBLocaleAwareKeyRange")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/index.html
+++ b/files/en-us/web/api/idbobjectstore/index.html
@@ -156,10 +156,7 @@ objectStoreRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBObjectStore")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbopendbrequest/index.html
+++ b/files/en-us/web/api/idbopendbrequest/index.html
@@ -115,10 +115,7 @@ DBOpenRequest.onupgradeneeded = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBOpenDBRequest")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/index.html
+++ b/files/en-us/web/api/idbtransaction/index.html
@@ -223,10 +223,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IDBTransaction")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idledeadline/index.html
+++ b/files/en-us/web/api/idledeadline/index.html
@@ -57,10 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IdleDeadline")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/iirfilternode/index.html
+++ b/files/en-us/web/api/iirfilternode/index.html
@@ -99,10 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.IIRFilterNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagebitmaprenderingcontext/index.html
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/index.html
@@ -43,10 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ImageBitmapRenderingContext")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagedata/index.html
+++ b/files/en-us/web/api/imagedata/index.html
@@ -52,10 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ImageData")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/installevent/index.html
+++ b/files/en-us/web/api/installevent/index.html
@@ -79,10 +79,7 @@ console.log('Handling install event. Resources to pre-fetch:', urlsToPrefetch);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.InstallEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/installevent/installevent/index.html
+++ b/files/en-us/web/api/installevent/installevent/index.html
@@ -34,10 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.InstallEvent.InstallEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/index.html
@@ -94,10 +94,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaDeviceInfo")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadevices/index.html
+++ b/files/en-us/web/api/mediadevices/index.html
@@ -112,10 +112,7 @@ function errorMsg(msg, error) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaDevices")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.html
@@ -78,10 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaElementAudioSourceNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediakeymessageevent/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/index.html
@@ -60,7 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeyMessageEvent")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeys/index.html
+++ b/files/en-us/web/api/mediakeys/index.html
@@ -52,7 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeys")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeysession/index.html
+++ b/files/en-us/web/api/mediakeysession/index.html
@@ -78,7 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeySession")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.html
+++ b/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.html
@@ -33,7 +33,4 @@ slug: Web/API/MediaKeySession/onkeystatuseschange
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeySession.onkeystatuseschange")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeysession/remove/index.html
+++ b/files/en-us/web/api/mediakeysession/remove/index.html
@@ -38,7 +38,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeySession.remove")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeystatusmap/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/index.html
@@ -57,7 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeyStatusMap")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeysystemaccess/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/index.html
@@ -52,7 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeySystemAccess")}}</p>
-</div>

--- a/files/en-us/web/api/mediakeysystemconfiguration/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/index.html
@@ -51,7 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaKeySystemConfiguration")}}</p>
-</div>

--- a/files/en-us/web/api/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/index.html
@@ -74,7 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaMetadata")}}</p>
-</div>

--- a/files/en-us/web/api/mediasessionactiondetails/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/index.html
@@ -88,7 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaSessionActionDetails")}}</p>
-</div>

--- a/files/en-us/web/api/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/index.html
@@ -139,10 +139,7 @@ function fetchAB (url, cb) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaSource")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
@@ -84,10 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaStreamAudioDestinationNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
@@ -52,10 +52,7 @@ var myStream = destination.stream;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaStreamAudioDestinationNode.stream")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.html
@@ -112,10 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaStreamAudioSourceNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
@@ -65,10 +65,7 @@ slug: Web/API/MediaStreamTrackAudioSourceNode
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaStreamTrackAudioSourceNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/index.html
@@ -170,10 +170,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaTrackConstraints")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/merchantvalidationevent/complete/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/complete/index.html
@@ -62,10 +62,7 @@ function getValidationData(url) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MerchantValidationEvent.complete")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/merchantvalidationevent/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/index.html
@@ -46,7 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MerchantValidationEvent")}}</p>
-</div>

--- a/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.html
@@ -55,10 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MerchantValidationEvent.MerchantValidationEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messagechannel/index.html
+++ b/files/en-us/web/api/messagechannel/index.html
@@ -83,10 +83,7 @@ function onMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MessageChannel")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/index.html
+++ b/files/en-us/web/api/messageport/index.html
@@ -100,10 +100,7 @@ function onMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MessagePort")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/metadata/index.html
+++ b/files/en-us/web/api/metadata/index.html
@@ -52,10 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Metadata")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/midiaccess/index.html
+++ b/files/en-us/web/api/midiaccess/index.html
@@ -64,7 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MIDIAccess")}}</p>
-</div>

--- a/files/en-us/web/api/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/index.html
@@ -49,7 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MIDIConnectionEvent")}}</p>
-</div>

--- a/files/en-us/web/api/midiinput/index.html
+++ b/files/en-us/web/api/midiinput/index.html
@@ -44,7 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MIDIInput")}}</p>
-</div>

--- a/files/en-us/web/api/midiinputmap/index.html
+++ b/files/en-us/web/api/midiinputmap/index.html
@@ -27,7 +27,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MIDIInputMap")}}</p>
-</div>

--- a/files/en-us/web/api/midioutputmap/index.html
+++ b/files/en-us/web/api/midioutputmap/index.html
@@ -27,7 +27,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MIDIOutputMap")}}</p>
-</div>

--- a/files/en-us/web/api/mimetype/index.html
+++ b/files/en-us/web/api/mimetype/index.html
@@ -43,7 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MimeType")}}</p>
-</div>

--- a/files/en-us/web/api/mimetypearray/index.html
+++ b/files/en-us/web/api/mimetypearray/index.html
@@ -61,7 +61,4 @@ if (typeof flashPlugin === "undefined") {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MimeTypeArray")}}</p>
-</div>

--- a/files/en-us/web/api/mutationobserverinit/index.html
+++ b/files/en-us/web/api/mutationobserverinit/index.html
@@ -61,7 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MutationObserverInit")}}</p>
-</div>

--- a/files/en-us/web/api/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/index.html
@@ -93,7 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.NotificationEvent")}}</p>
-</div>

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.html
@@ -56,10 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OfflineAudioCompletionEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/index.html
@@ -151,10 +151,7 @@ getData();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OfflineAudioContext")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/oncomplete/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/oncomplete/index.html
@@ -50,10 +50,7 @@ offlineAudioCtx.oncomplete = function() { ... }</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OfflineAudioContext.oncomplete")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/index.html
+++ b/files/en-us/web/api/offscreencanvas/index.html
@@ -130,10 +130,7 @@ worker.postMessage({canvas: offscreen}, [offscreen]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OffscreenCanvas")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/detune/index.html
+++ b/files/en-us/web/api/oscillatornode/detune/index.html
@@ -62,10 +62,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OscillatorNode.detune")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/frequency/index.html
+++ b/files/en-us/web/api/oscillatornode/frequency/index.html
@@ -61,10 +61,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OscillatorNode.frequency")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -115,10 +115,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OscillatorNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/onended/index.html
+++ b/files/en-us/web/api/oscillatornode/onended/index.html
@@ -62,10 +62,7 @@ oscillator.onended = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.OscillatorNode.onended")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/coneinnerangle/index.html
+++ b/files/en-us/web/api/pannernode/coneinnerangle/index.html
@@ -50,10 +50,7 @@ panner.coneInnerAngle = 360;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.coneInnerAngle")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/coneouterangle/index.html
+++ b/files/en-us/web/api/pannernode/coneouterangle/index.html
@@ -51,10 +51,7 @@ panner.coneOuterAngle = 0;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.coneOuterAngle")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/coneoutergain/index.html
+++ b/files/en-us/web/api/pannernode/coneoutergain/index.html
@@ -58,10 +58,7 @@ panner.coneOuterGain = 0;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.coneOuterGain")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/distancemodel/index.html
+++ b/files/en-us/web/api/pannernode/distancemodel/index.html
@@ -61,10 +61,7 @@ panner.distanceModel = 'inverse';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.distanceModel")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/index.html
@@ -125,10 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/maxdistance/index.html
+++ b/files/en-us/web/api/pannernode/maxdistance/index.html
@@ -57,10 +57,7 @@ panner.maxDistance = 10000;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.maxDistance")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/panningmodel/index.html
+++ b/files/en-us/web/api/pannernode/panningmodel/index.html
@@ -55,10 +55,7 @@ panner.panningModel = 'HRTF';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.panningModel")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/refdistance/index.html
+++ b/files/en-us/web/api/pannernode/refdistance/index.html
@@ -95,10 +95,7 @@ scheduleTestTone(7, context.currentTime + NOTE_LENGTH * 2);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.refDistance")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/rollofffactor/index.html
+++ b/files/en-us/web/api/pannernode/rollofffactor/index.html
@@ -107,10 +107,7 @@ scheduleTestTone(0.1, context.currentTime + NOTE_LENGTH * 2);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.rolloffFactor")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/setorientation/index.html
+++ b/files/en-us/web/api/pannernode/setorientation/index.html
@@ -63,10 +63,7 @@ panner.setOrientation(1,0,0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.setOrientation")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/setposition/index.html
+++ b/files/en-us/web/api/pannernode/setposition/index.html
@@ -61,10 +61,7 @@ panner.setPosition(0,0,0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.setPosition")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/setvelocity/index.html
+++ b/files/en-us/web/api/pannernode/setvelocity/index.html
@@ -51,10 +51,7 @@ panner.setVelocity(0,0,17);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PannerNode.setVelocity")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/index.html
@@ -85,7 +85,4 @@ navigator.credentials.store(cred)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PasswordCredential")}}</p>
-</div>

--- a/files/en-us/web/api/path2d/index.html
+++ b/files/en-us/web/api/path2d/index.html
@@ -65,10 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Path2D")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/payererrors/index.html
+++ b/files/en-us/web/api/payererrors/index.html
@@ -53,7 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PayerErrors")}}</p>
-</div>

--- a/files/en-us/web/api/paymentaddress/index.html
+++ b/files/en-us/web/api/paymentaddress/index.html
@@ -143,7 +143,4 @@ doPaymentRequest();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentAddress")}}</p>
-</div>

--- a/files/en-us/web/api/paymentcurrencyamount/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/index.html
@@ -59,7 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentCurrencyAmount")}}</p>
-</div>

--- a/files/en-us/web/api/paymentdetailsbase/index.html
+++ b/files/en-us/web/api/paymentdetailsbase/index.html
@@ -58,7 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentDetailsBase")}}</p>
-</div>

--- a/files/en-us/web/api/paymentdetailsupdate/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/index.html
@@ -56,8 +56,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentDetailsUpdate")}}</p>
-</div>
 

--- a/files/en-us/web/api/paymentitem/index.html
+++ b/files/en-us/web/api/paymentitem/index.html
@@ -45,10 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentItem")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentmethodchangeevent/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/index.html
@@ -57,7 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentMethodChangeEvent")}}</p>
-</div>

--- a/files/en-us/web/api/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/index.html
@@ -85,7 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentRequest")}}</p>
-</div>

--- a/files/en-us/web/api/paymentresponse/index.html
+++ b/files/en-us/web/api/paymentresponse/index.html
@@ -73,7 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentResponse")}}</p>
-</div>

--- a/files/en-us/web/api/paymentvalidationerrors/index.html
+++ b/files/en-us/web/api/paymentvalidationerrors/index.html
@@ -57,10 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PaymentValidationErrors")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/index.html
+++ b/files/en-us/web/api/performance/index.html
@@ -130,7 +130,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Performance")}}</p>
-</div>

--- a/files/en-us/web/api/performanceentry/index.html
+++ b/files/en-us/web/api/performanceentry/index.html
@@ -141,7 +141,4 @@ function print_PerformanceEntry(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PerformanceEntry")}}</p>
-</div>

--- a/files/en-us/web/api/performanceframetiming/index.html
+++ b/files/en-us/web/api/performanceframetiming/index.html
@@ -60,10 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PerformanceFrameTiming")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/index.html
@@ -61,10 +61,7 @@ observer2.observe({entryTypes: ["measure"]});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PerformanceObserver")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/index.html
+++ b/files/en-us/web/api/performancetiming/index.html
@@ -105,10 +105,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PerformanceTiming")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/index.html
@@ -58,10 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PeriodicWave")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/permissions/query/index.html
+++ b/files/en-us/web/api/permissions/query/index.html
@@ -88,7 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Permissions.query")}}</p>
-</div>

--- a/files/en-us/web/api/photocapabilities/index.html
+++ b/files/en-us/web/api/photocapabilities/index.html
@@ -79,7 +79,4 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PhotoCapabilities")}}</p>
-</div>

--- a/files/en-us/web/api/plugin/index.html
+++ b/files/en-us/web/api/plugin/index.html
@@ -58,7 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Plugin")}}</p>
-</div>

--- a/files/en-us/web/api/pushevent/data/index.html
+++ b/files/en-us/web/api/pushevent/data/index.html
@@ -72,7 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushEvent.data")}}</p>
-</div>

--- a/files/en-us/web/api/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/index.html
@@ -86,10 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushmanager/index.html
+++ b/files/en-us/web/api/pushmanager/index.html
@@ -96,10 +96,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushManager")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
@@ -54,7 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushMessageData.arrayBuffer")}}</p>
-</div>

--- a/files/en-us/web/api/pushmessagedata/blob/index.html
+++ b/files/en-us/web/api/pushmessagedata/blob/index.html
@@ -54,7 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushMessageData.blob")}}</p>
-</div>

--- a/files/en-us/web/api/pushmessagedata/index.html
+++ b/files/en-us/web/api/pushmessagedata/index.html
@@ -68,7 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushMessageData")}}</p>
-</div>

--- a/files/en-us/web/api/pushmessagedata/json/index.html
+++ b/files/en-us/web/api/pushmessagedata/json/index.html
@@ -54,7 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushMessageData.json")}}</p>
-</div>

--- a/files/en-us/web/api/pushmessagedata/text/index.html
+++ b/files/en-us/web/api/pushmessagedata/text/index.html
@@ -55,7 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushMessageData.text")}}</p>
-</div>

--- a/files/en-us/web/api/pushregistrationmanager/index.html
+++ b/files/en-us/web/api/pushregistrationmanager/index.html
@@ -30,7 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushRegistrationManager")}}</p>
-</div>

--- a/files/en-us/web/api/pushsubscription/index.html
+++ b/files/en-us/web/api/pushsubscription/index.html
@@ -72,10 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.PushSubscription")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -124,10 +124,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ReadableStream")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/readablestreambyobrequest/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/index.html
@@ -59,7 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ReadableStreamBYOBRequest")}}</p>
-</div>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.html
@@ -92,7 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ReadableStreamDefaultController")}}</p>
-</div>

--- a/files/en-us/web/api/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.html
@@ -92,7 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ReadableStreamDefaultReader")}}</p>
-</div>

--- a/files/en-us/web/api/rtccertificate/index.html
+++ b/files/en-us/web/api/rtccertificate/index.html
@@ -39,7 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCCertificate")}}</p>
-</div>

--- a/files/en-us/web/api/rtcconfiguration/index.html
+++ b/files/en-us/web/api/rtcconfiguration/index.html
@@ -83,7 +83,4 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCConfiguration")}}</p>
-</div>

--- a/files/en-us/web/api/rtcdtmfsender/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/index.html
@@ -71,10 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCDTMFSender")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/index.html
@@ -98,7 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceCandidate")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicecandidateinit/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/index.html
@@ -49,7 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceCandidateInit")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicecandidatetype/index.html
+++ b/files/en-us/web/api/rtcicecandidatetype/index.html
@@ -58,7 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceCandidateType")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicecomponent/index.html
+++ b/files/en-us/web/api/rtcicecomponent/index.html
@@ -52,7 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceComponent")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicegathererstate/index.html
+++ b/files/en-us/web/api/rtcicegathererstate/index.html
@@ -49,7 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceGathererState")}}</p>
-</div>

--- a/files/en-us/web/api/rtciceprotocol/index.html
+++ b/files/en-us/web/api/rtciceprotocol/index.html
@@ -51,7 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceProtocol")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicerole/index.html
+++ b/files/en-us/web/api/rtcicerole/index.html
@@ -52,7 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceRole")}}</p>
-</div>

--- a/files/en-us/web/api/rtciceserver/index.html
+++ b/files/en-us/web/api/rtciceserver/index.html
@@ -64,10 +64,7 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceServer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetcpcandidatetype/index.html
+++ b/files/en-us/web/api/rtcicetcpcandidatetype/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceTcpCandidateType")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicetransport/index.html
+++ b/files/en-us/web/api/rtcicetransport/index.html
@@ -88,7 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceTransport")}}</p>
-</div>

--- a/files/en-us/web/api/rtcicetransportstate/index.html
+++ b/files/en-us/web/api/rtcicetransportstate/index.html
@@ -80,7 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIceRole")}}</p>
-</div>

--- a/files/en-us/web/api/rtcidentityassertion/index.html
+++ b/files/en-us/web/api/rtcidentityassertion/index.html
@@ -42,7 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCIdentityAssertion")}}</p>
-</div>

--- a/files/en-us/web/api/rtcnetworktype/index.html
+++ b/files/en-us/web/api/rtcnetworktype/index.html
@@ -69,7 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCNetworkType")}}</p>
-</div>

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.html
@@ -83,7 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCPeerConnection.icecandidateerror_event")}}</p>
-</div>

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.html
@@ -72,7 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCPeerConnectionIceErrorEvent")}}</p>
-</div>

--- a/files/en-us/web/api/rtcrtpcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.html
@@ -77,7 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpCapabilities")}}</p>
-</div>

--- a/files/en-us/web/api/rtcrtpcodeccapability/index.html
+++ b/files/en-us/web/api/rtcrtpcodeccapability/index.html
@@ -59,7 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpCodecCapability")}}</p>
-</div>

--- a/files/en-us/web/api/rtcrtpcontributingsource/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpContributingSource")}}</p>
-</div>

--- a/files/en-us/web/api/rtcrtpsender/index.html
+++ b/files/en-us/web/api/rtcrtpsender/index.html
@@ -82,10 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpSender")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpsynchronizationsource/index.html
+++ b/files/en-us/web/api/rtcrtpsynchronizationsource/index.html
@@ -50,7 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpSynchronizationSource")}}</p>
-</div>

--- a/files/en-us/web/api/rtcrtptransceiver/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpTransceiver")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiverdirection/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverdirection/index.html
@@ -79,10 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpTransceiverDirection")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiverinit/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverinit/index.html
@@ -47,10 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.RTCRtpTransceiverInit")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/screen_capture_api/index.html
+++ b/files/en-us/web/api/screen_capture_api/index.html
@@ -116,10 +116,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.MediaDevices.getDisplayMedia")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.html
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.html
@@ -53,10 +53,7 @@ console.log(scriptNode.bufferSize);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ScriptProcessorNode.bufferSize")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/index.html
+++ b/files/en-us/web/api/scriptprocessornode/index.html
@@ -96,10 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ScriptProcessorNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
+++ b/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
@@ -49,10 +49,7 @@ scriptNode.onaudioprocess = function() { ... }</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ScriptProcessorNode.onaudioprocess")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/securitypolicyviolationevent/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/index.html
@@ -83,10 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SecurityPolicyViolationEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworker/index.html
+++ b/files/en-us/web/api/serviceworker/index.html
@@ -95,10 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorker")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/index.html
@@ -109,10 +109,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerContainer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkercontainer/message_event/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/message_event/index.html
@@ -73,10 +73,7 @@ navigator.serviceWorker.addEventListener('message', (message) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerContainer.message_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/message_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/message_event/index.html
@@ -83,10 +83,7 @@ addEventListener('message', event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.message_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/oninstall/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/oninstall/index.html
@@ -60,10 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.oninstall")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/onnotificationclick/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onnotificationclick/index.html
@@ -66,7 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.onnotificationclick")}}</p>
-</div>

--- a/files/en-us/web/api/serviceworkerglobalscope/registration/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/registration/index.html
@@ -44,10 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.registration")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.html
@@ -61,10 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.skipWaiting")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkermessageevent/index.html
+++ b/files/en-us/web/api/serviceworkermessageevent/index.html
@@ -71,10 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.ServiceWorkerMessageEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/sourcebuffer/index.html
+++ b/files/en-us/web/api/sourcebuffer/index.html
@@ -143,10 +143,7 @@ function fetchAB (url, cb) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SourceBuffer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/sourcebufferlist/index.html
+++ b/files/en-us/web/api/sourcebufferlist/index.html
@@ -68,10 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SourceBufferList")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechgrammar/index.html
+++ b/files/en-us/web/api/speechgrammar/index.html
@@ -64,10 +64,7 @@ console.log(speechRecognitionList[0].weight); // should return 1 - the same as t
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechGrammar")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/audiostart_event/index.html
+++ b/files/en-us/web/api/speechrecognition/audiostart_event/index.html
@@ -71,10 +71,7 @@ recognition.addEventListener('audiostart', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.audiostart_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/end_event/index.html
+++ b/files/en-us/web/api/speechrecognition/end_event/index.html
@@ -68,10 +68,7 @@ recognition.addEventListener('end', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.end_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/error_event/index.html
+++ b/files/en-us/web/api/speechrecognition/error_event/index.html
@@ -68,10 +68,7 @@ recognition.addEventListener('error', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.error_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/nomatch_event/index.html
+++ b/files/en-us/web/api/speechrecognition/nomatch_event/index.html
@@ -68,10 +68,7 @@ recognition.addEventListener('nomatch', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.nomatch_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/result_event/index.html
+++ b/files/en-us/web/api/speechrecognition/result_event/index.html
@@ -73,10 +73,7 @@ recognition.addEventListener('result', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.result_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/soundend_event/index.html
+++ b/files/en-us/web/api/speechrecognition/soundend_event/index.html
@@ -68,10 +68,7 @@ recognition.addEventListener('soundend', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.soundend_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/soundstart_event/index.html
+++ b/files/en-us/web/api/speechrecognition/soundstart_event/index.html
@@ -66,10 +66,7 @@ recognition.addEventListener('soundstart', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.soundstart_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/speechend_event/index.html
+++ b/files/en-us/web/api/speechrecognition/speechend_event/index.html
@@ -66,10 +66,7 @@ recognition.addEventListener('speechend', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.speechend_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/speechstart_event/index.html
+++ b/files/en-us/web/api/speechrecognition/speechstart_event/index.html
@@ -68,10 +68,7 @@ recognition.addEventListener('speechstart', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.speechstart_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognition/start_event/index.html
+++ b/files/en-us/web/api/speechrecognition/start_event/index.html
@@ -66,10 +66,7 @@ recognition.addEventListener('start', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognition.start_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechrecognitionalternative/index.html
+++ b/files/en-us/web/api/speechrecognitionalternative/index.html
@@ -61,10 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognitionAlternative")}}</p>
-</div>
 
 <h3 id="Firefox_OS_permissions">Firefox OS permissions</h3>
 

--- a/files/en-us/web/api/speechrecognitionerror/index.html
+++ b/files/en-us/web/api/speechrecognitionerror/index.html
@@ -41,10 +41,7 @@ recognition.onerror = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognitionError")}}</p>
-</div>
 
 <h3 id="Firefox_OS_permissions">Firefox OS permissions</h3>
 

--- a/files/en-us/web/api/speechrecognitionerrorevent/index.html
+++ b/files/en-us/web/api/speechrecognitionerrorevent/index.html
@@ -45,10 +45,7 @@ recognition.onerror = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognitionErrorEvent")}}</p>
-</div>
 
 <h3 id="Firefox_OS_permissions">Firefox OS permissions</h3>
 

--- a/files/en-us/web/api/speechrecognitionevent/index.html
+++ b/files/en-us/web/api/speechrecognitionevent/index.html
@@ -67,10 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognitionEvent")}}</p>
-</div>
 
 <h3 id="Firefox_OS_permissions">Firefox OS permissions</h3>
 

--- a/files/en-us/web/api/speechrecognitionresult/index.html
+++ b/files/en-us/web/api/speechrecognitionresult/index.html
@@ -68,10 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognitionResult")}}</p>
-</div>
 
 <h3 id="Firefox_OS_permissions">Firefox OS permissions</h3>
 

--- a/files/en-us/web/api/speechrecognitionresultlist/index.html
+++ b/files/en-us/web/api/speechrecognitionresultlist/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechRecognitionResultList")}}</p>
-</div>
 
 <h3 id="Firefox_OS_permissions">Firefox OS permissions</h3>
 

--- a/files/en-us/web/api/speechsynthesis/index.html
+++ b/files/en-us/web/api/speechsynthesis/index.html
@@ -137,10 +137,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesis")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.html
+++ b/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.html
@@ -81,10 +81,7 @@ synth.addEventListener('voiceschanged', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesis.voiceschanged_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/index.html
+++ b/files/en-us/web/api/speechsynthesiserrorevent/index.html
@@ -79,10 +79,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisErrorEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisevent/index.html
+++ b/files/en-us/web/api/speechsynthesisevent/index.html
@@ -65,10 +65,7 @@ utterThis.onboundary = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisEvent")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/boundary_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/boundary_event/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisUtterance.boundary_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/error_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/error_event/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisUtterance.error_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/index.html
@@ -117,10 +117,7 @@ inputForm.onsubmit = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisUtterance")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/mark_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/mark_event/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisUtterance.mark_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/resume_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/resume_event/index.html
@@ -64,10 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisUtterance.resume_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/speechsynthesisutterance/start_event/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/start_event/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SpeechSynthesisUtterance.start_event")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/index.html
@@ -87,10 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.StereoPannerNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/stereopannernode/pan/index.html
+++ b/files/en-us/web/api/stereopannernode/pan/index.html
@@ -53,10 +53,7 @@ panNode.pan.value = -0.5;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.StereoPannerNode.pan")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/svgtextelement/index.html
+++ b/files/en-us/web/api/svgtextelement/index.html
@@ -46,10 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SVGTextElement")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/syncevent/index.html
+++ b/files/en-us/web/api/syncevent/index.html
@@ -46,7 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SyncEvent")}}</p>
-</div>

--- a/files/en-us/web/api/syncmanager/index.html
+++ b/files/en-us/web/api/syncmanager/index.html
@@ -45,7 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.SyncManager")}}</p>
-</div>

--- a/files/en-us/web/api/taskattributiontiming/index.html
+++ b/files/en-us/web/api/taskattributiontiming/index.html
@@ -47,7 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TaskAttributionTiming")}}</p>
-</div>

--- a/files/en-us/web/api/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/index.html
@@ -96,10 +96,7 @@ console.log(win1251decoder.decode(bytes)); // Привет, мир!
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TextDecoder")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textencoder/index.html
+++ b/files/en-us/web/api/textencoder/index.html
@@ -136,10 +136,7 @@ console.log(view); // Uint8Array(3) [226, 130, 172]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TextEncoder")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/index.html
+++ b/files/en-us/web/api/textmetrics/index.html
@@ -121,10 +121,7 @@ console.log(Math.abs(textMetrics.actualBoundingBoxLeft) +
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TextMetrics")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/touch/index.html
+++ b/files/en-us/web/api/touch/index.html
@@ -96,10 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Touch")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefault/index.html
+++ b/files/en-us/web/api/trackdefault/index.html
@@ -42,10 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TrackDefault")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefault/trackdefault/index.html
+++ b/files/en-us/web/api/trackdefault/trackdefault/index.html
@@ -64,10 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TrackDefault.TrackDefault")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transferable/index.html
+++ b/files/en-us/web/api/transferable/index.html
@@ -54,10 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Transferable")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/index.html
@@ -152,10 +152,7 @@ responses.reduce(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.TransformStream")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url_api/index.html
+++ b/files/en-us/web/api/url_api/index.html
@@ -121,10 +121,7 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.URL")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/index.html
+++ b/files/en-us/web/api/videoplaybackquality/index.html
@@ -65,10 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.VideoPlaybackQuality")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/waveshapernode/curve/index.html
+++ b/files/en-us/web/api/waveshapernode/curve/index.html
@@ -55,10 +55,7 @@ distortion.curve = myCurveDataArray; // myCurveDataArray is a Float32Array
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WaveShaperNode.curve")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/index.html
@@ -86,10 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WaveShaperNode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/waveshapernode/oversample/index.html
+++ b/files/en-us/web/api/waveshapernode/oversample/index.html
@@ -75,10 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WaveShaperNode.oversample")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/web_bluetooth_api/index.html
+++ b/files/en-us/web/api/web_bluetooth_api/index.html
@@ -54,7 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Bluetooth")}}</p>
-</div>

--- a/files/en-us/web/api/web_nfc_api/index.html
+++ b/files/en-us/web/api/web_nfc_api/index.html
@@ -44,7 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.NDEFReader")}}</p>
-</div>

--- a/files/en-us/web/api/websocket/index.html
+++ b/files/en-us/web/api/websocket/index.html
@@ -137,10 +137,7 @@ socket.addEventListener('message', function (event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WebSocket")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/window/customelements/index.html
+++ b/files/en-us/web/api/window/customelements/index.html
@@ -58,7 +58,4 @@ customElementRegistry.define('my-custom-element', MyCustomElement);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Window.customElements")}}</p>
-</div>

--- a/files/en-us/web/api/windowclient/index.html
+++ b/files/en-us/web/api/windowclient/index.html
@@ -79,10 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WindowClient")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/worklet/index.html
+++ b/files/en-us/web/api/worklet/index.html
@@ -84,10 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.Worklet")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/index.html
@@ -136,10 +136,7 @@ sendMessage("Hello, world.", writableStream);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WritableStream")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/index.html
@@ -68,7 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.WritableStreamDefaultController")}}</p>
-</div>

--- a/files/en-us/web/api/xmlserializer/index.html
+++ b/files/en-us/web/api/xmlserializer/index.html
@@ -85,10 +85,7 @@ document.body.insertAdjacentHTML('afterbegin', inp_xmls);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("api.XMLSerializer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
MDN content has over 2000 useless `<div>` tags (which do not have any attributes nor group any content together). To simplify the review, I'll split the 2000 changes into smaller chunks. This commit removes 389 such tags from `files/en-us/web/api/` folder, all these occurrences look like this:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>

<div>

<p>{{Compat("...")}}</p>
</div>
```
They are replaced with this:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>

<p>{{Compat("...")}}</p>
```