### PR TITLE
mask-image - moving the example

### DIFF
--- a/files/en-us/web/css/mask-image/index.html
+++ b/files/en-us/web/css/mask-image/index.html
@@ -7,7 +7,7 @@ tags:
   - CSS Property
   - Experimental
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 ---
 <div>{{CSSRef}}</div>
 
@@ -40,7 +40,7 @@ mask-image: unset;
  <dt><code>none</code></dt>
  <dd>This keyword is interpreted as a transparent black image layer.</dd>
  <dt><code>&lt;mask-source&gt;</code></dt>
- <dd>A {{cssxref("&lt;url&gt;")}} reference to a {{SVGElement("mask")}} or to a CSS image.</dd>
+ <dd>A {{cssxref("url()","url()")}} reference to a {{SVGElement("mask")}} or to a CSS image.</dd>
  <dt>{{cssxref("&lt;image&gt;")}}</dt>
  <dd>An image value used as mask image layer.</dd>
 </dl>
@@ -57,23 +57,7 @@ mask-image: unset;
 
 <h3 id="Setting_a_mask_image_with_a_URL">Setting a mask image with a URL</h3>
 
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html notranslate">&lt;div id="masked"&gt;&lt;/div&gt;</pre>
-
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css notranslate">#masked {
-  width: 100px;
-  height: 100px;
-  background-color: #8cffa0;
-  -webkit-mask-image: url(https://mdn.mozillademos.org/files/12676/star.svg);
-  mask-image: url(https://mdn.mozillademos.org/files/12676/star.svg);
-}</pre>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample('Setting_a_mask_image_with_a_URL', '100px', '100px', '', '', 'hide-codepen-jsfiddle')}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-image.html", '100%', 560)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes #2115 

Another example which was not loading due to CORS, moved to the CSS examples repo.