### PR TITLE
Fix: remove word 'obsolete' from some titles

### DIFF
--- a/files/en-us/web/html/element/bgsound/index.html
+++ b/files/en-us/web/html/element/bgsound/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<bgsound>: The Background Sound element (obsolete)'
+title: '<bgsound>: The Background Sound element'
 slug: Web/HTML/Element/bgsound
 tags:
   - Audio

--- a/files/en-us/web/html/element/blink/index.html
+++ b/files/en-us/web/html/element/blink/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<blink>: The Blinking Text element (obsolete)'
+title: '<blink>: The Blinking Text element'
 slug: Web/HTML/Element/blink
 tags:
   - Blink

--- a/files/en-us/web/html/element/center/index.html
+++ b/files/en-us/web/html/element/center/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<center>: The Centered Text element (obsolete)'
+title: '<center>: The Centered Text element'
 slug: Web/HTML/Element/center
 tags:
   - Element

--- a/files/en-us/web/html/element/content/index.html
+++ b/files/en-us/web/html/element/content/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<content>: The Shadow DOM Content Placeholder element (obsolete)'
+title: '<content>: The Shadow DOM Content Placeholder element'
 slug: Web/HTML/Element/content
 tags:
   - Content

--- a/files/en-us/web/html/element/dir/index.html
+++ b/files/en-us/web/html/element/dir/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<dir>: The Directory element (obsolete)'
+title: '<dir>: The Directory element'
 slug: Web/HTML/Element/dir
 tags:
   - Directory

--- a/files/en-us/web/html/element/image/index.html
+++ b/files/en-us/web/html/element/image/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<image>: The obsolete Image element'
+title: '<image>: The Image element'
 slug: Web/HTML/Element/image
 tags:
   - Element

--- a/files/en-us/web/html/element/marquee/index.html
+++ b/files/en-us/web/html/element/marquee/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<marquee>: The Marquee element (Obsolete)'
+title: '<marquee>: The Marquee element'
 slug: Web/HTML/Element/marquee
 tags:
   - Element

--- a/files/en-us/web/html/element/multicol/index.html
+++ b/files/en-us/web/html/element/multicol/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<multicol>: The HTML Multi-Column Layout element (Obsolete)'
+title: '<multicol>: The HTML Multi-Column Layout element'
 slug: Web/HTML/Element/multicol
 tags:
   - Element

--- a/files/en-us/web/html/element/nextid/index.html
+++ b/files/en-us/web/html/element/nextid/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<nextid>: The NeXT ID element (Obsolete)'
+title: '<nextid>: The NeXT ID element'
 slug: Web/HTML/Element/nextid
 tags:
   - Element

--- a/files/en-us/web/html/element/nobr/index.html
+++ b/files/en-us/web/html/element/nobr/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<nobr>: The Non-Breaking Text element (obsolete)'
+title: '<nobr>: The Non-Breaking Text element'
 slug: Web/HTML/Element/nobr
 tags:
   - Element

--- a/files/en-us/web/html/element/noembed/index.html
+++ b/files/en-us/web/html/element/noembed/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<noembed>: The Embed Fallback element (Obsolete)'
+title: '<noembed>: The Embed Fallback element'
 slug: Web/HTML/Element/noembed
 tags:
   - Element

--- a/files/en-us/web/html/element/shadow/index.html
+++ b/files/en-us/web/html/element/shadow/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<shadow>: The obsolete Shadow Root element'
+title: '<shadow>: The Shadow Root element'
 slug: Web/HTML/Element/shadow
 tags:
   - Deprecated

--- a/files/en-us/web/html/element/tt/index.html
+++ b/files/en-us/web/html/element/tt/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<tt>: The Teletype Text element (obsolete)'
+title: '<tt>: The Teletype Text element'
 slug: Web/HTML/Element/tt
 tags:
   - Element


### PR DESCRIPTION
A while ago, MDN writers decided to [remove word "obsolete" from MDN](https://github.com/mdn/browser-compat-data/issues/4519#issuecomment-513689917). Also, this removal does not lead to information loss, since deprecated and non-standard status of an API is conveyed via `{{deprecated_header}}` macros in the documents.