### PR TITLE
Remove anchor in heading in “Working with the History API” doc

### DIFF
--- a/files/en-us/web/api/history_api/working_with_the_history_api/index.html
+++ b/files/en-us/web/api/history_api/working_with_the_history_api/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>Using {{DOMxRef("History.pushState","pushState()")}} changes the referrer that gets used in the HTTP header for {{domxref("XMLHttpRequest")}} objects created after you change the state. The referrer will be the URL of the document whose window is <code>this</code> at the time of creation of the {{domxref("XMLHttpRequest")}} object.</p>
 
-<h3 id="Example_of_pushState_method_2"><a id="Example_of_pushState_method">Example of pushState() method</a></h3>
+<h3 id="Example_of_pushState_method">Example of pushState() method</h3>
 
 <p>Suppose <code>https://mozilla.org/foo.html</code> executes the following JavaScript:</p>
 


### PR DESCRIPTION
h3 contained an anchor