### PR TITLE
Adding a page for the ::target-text pseudo

### DIFF
--- a/files/en-us/web/css/_doublecolon_target-text/index.html
+++ b/files/en-us/web/css/_doublecolon_target-text/index.html
@@ -1,0 +1,63 @@
+---
+title: '::target-text'
+slug: 'Web/CSS/::target-text'
+tags:
+  - '::target-text'
+  - CSS
+  - Pseudo-element
+  - Reference
+  - Selector
+  - Web
+---
+<div>{{CSSRef}}{{SeeCompatTable}}</div>
+
+<p>The <strong><code>::target-text</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-elements">pseudo-element</a> represents the text that has been scrolled to if the browser supports scroll-to-text fragments. It allows authors to choose how to highlight that section of text.</p>
+
+<pre class="brush: css no-line-numbers">::target-text {
+  background-color: pink;
+}</pre>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css notranslate">{{csssyntax}}</pre>
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Highlighting_scroll-to-text">Highlighting scroll-to-text</h3>
+
+<pre class="brush: css no-line-numbers">::target-text {
+  background-color: rebeccapurple;
+  color: white;
+  font-weight: bold;
+}</pre>
+
+<p>To see this CSS in action follow the link to <a href="https://mdn.github.io/css-examples/target-text/index.html#:~:text=From%20the%20foregoing%20remarks%20we%20may%20gather%20an%20idea%20of%20the%20importance">scroll-to-text demo</a>.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+    <td>{{SpecName('CSS4 Pseudo-Elements', '#selectordef-target-text', '::target-text')}}</td>
+    <td>{{Spec2('CSS4 Pseudo-Elements')}}</td>
+    <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.selectors.target-text")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="https://web.dev/text-fragments/">Text fragments</a></li>
+</ul>

--- a/files/en-us/web/css/pseudo-elements/index.html
+++ b/files/en-us/web/css/pseudo-elements/index.html
@@ -86,6 +86,12 @@ p::first-line {
  <li>{{CSSxRef("::slotted", "::slotted()")}}</li>
  <li>{{CSSxRef("::spelling-error")}} {{Experimental_Inline}}</li>
 </ul>
+
+<span>T</span>
+
+<ul>
+ <li>{{CSSxRef("::target-text")}} {{Experimental_Inline}}</li>
+</ul>
 </div>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
The `::target-text` pseudo is in Chrome 89. I have submitted PRs for the other data and BCD, this adds the page.

https://www.chromestatus.com/feature/5689463273422848

This is not a candidate for a live example, I have added a page of content in the css-examples repo to demonstrate how it works.
