### PR TITLE
Fix: remove useless <div> tags (part 3)

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arguments/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/functions/arguments/@@iterator/index.html
@@ -53,10 +53,7 @@ f('w', 'y', 'k', 'o', 'p');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.functions.arguments.@@iterator")}}</p>
-</div>
+<p>{{Compat("javascript.functions.arguments.@@iterator")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
@@ -530,10 +530,7 @@ setTimeout( () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.functions.arrow_functions")}}</p>
-</div>
+<p>{{Compat("javascript.functions.arrow_functions")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.html
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.html
@@ -253,10 +253,7 @@ f()  // 6</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.functions.default_parameters")}}</p>
-</div>
+<p>{{Compat("javascript.functions.default_parameters")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.html
@@ -57,10 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.AggregateError.AggregateError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.AggregateError.AggregateError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@species/index.html
@@ -66,10 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.@@species")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.@@species")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
@@ -144,10 +144,7 @@ console.log(numbers);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.concat")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.concat")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.html
@@ -179,10 +179,7 @@ i32a.copyWithin(0, 2)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.copyWithin")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.copyWithin")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/entries/index.html
@@ -71,10 +71,7 @@ for (let e of iterator) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.entries")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.entries")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.html
@@ -264,10 +264,7 @@ arr.every( (elem, index, arr) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.every")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.every")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -255,10 +255,7 @@ array.find(function(value, index) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.find")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.find")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
@@ -209,10 +209,7 @@ console.log(fruits[index]); // blueberries
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.findIndex")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.findIndex")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.html
@@ -164,10 +164,7 @@ arr5.flat();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.flat")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.flat")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.html
@@ -153,10 +153,7 @@ a.flatMap( (n) =&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.flatMap")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.flatMap")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -401,10 +401,7 @@ flatten(nested) // [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.forEach")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.forEach")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -150,10 +150,7 @@ arr.includes('a', -2)   // false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.includes")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.includes")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.html
@@ -226,10 +226,7 @@ if (!Array.prototype.indexOf) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.indexOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.indexOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/isarray/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/isarray/index.html
@@ -115,10 +115,7 @@ arr instanceof Array; // false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.isArray")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.isArray")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/keys/index.html
@@ -60,10 +60,7 @@ console.log(denseKeys);  // [0, 1, 2]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.keys")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.keys")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.html
@@ -159,10 +159,7 @@ if (!Array.prototype.lastIndexOf) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.lastIndexOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.lastIndexOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.html
@@ -404,10 +404,7 @@ let filteredNumbers = numbers.map(function(num, index) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.map")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.map")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.html
@@ -103,10 +103,7 @@ Array.of(undefined); // [undefined]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.of")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.of")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
@@ -95,10 +95,7 @@ console.log(popped); // 'sturgeon'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.pop")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.pop")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.html
@@ -142,10 +142,7 @@ console.log(obj.length)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.push")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.push")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -633,10 +633,7 @@ multiply24(10) // 240
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.reduce")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.reduce")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
@@ -373,10 +373,7 @@ console.log(compose(inc, double)(2)); // 5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.reduceRight")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.reduceRight")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
@@ -93,10 +93,7 @@ console.log(a); // {0: 3, 1: 2, 2: 1, length: 3}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.reverse")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.reverse")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
@@ -99,10 +99,7 @@ while( (i = names.shift()) !== undefined ) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.shift")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.shift")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.html
@@ -222,10 +222,7 @@ getBoolean('true');  // true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.some")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.some")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
@@ -291,10 +291,7 @@ var result = mapped.map(function(el){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.sort")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.sort")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -170,10 +170,7 @@ let removed = myFish.splice(2)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.splice")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.splice")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.html
@@ -176,10 +176,7 @@ prices.toLocaleString('ja-JP', { style: 'currency', currency: 'JPY' });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.toLocaleString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.toLocaleString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/tostring/index.html
@@ -67,10 +67,7 @@ console.log(array1.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.html
@@ -103,10 +103,7 @@ arr.unshift([-7, -6], [-5])  // the new array length is 8
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.unshift")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.unshift")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.html
@@ -114,10 +114,7 @@ iterator.next().value;        //  "n"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Array.values")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Array.values")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/asyncfunction/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/asyncfunction/index.html
@@ -105,10 +105,7 @@ a(10, 20).then(v =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.AsyncFunction")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.AsyncFunction")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.html
@@ -62,10 +62,7 @@ var bObjProto = new Boolean({});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Boolean.Boolean")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Boolean.Boolean")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/tosource/index.html
@@ -42,10 +42,7 @@ Boolean.toSource()</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Boolean.toSource")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Boolean.toSource")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/tostring/index.html
@@ -64,10 +64,7 @@ var myVar = flag.toString();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Boolean.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Boolean.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/valueof/index.html
@@ -55,10 +55,7 @@ myVar = x.valueOf(); // assigns false to myVar
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Boolean.valueOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Boolean.valueOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/error/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/error/index.html
@@ -63,10 +63,7 @@ const y = new Error('I was constructed via the "new" keyword!')</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Error.Error")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Error.Error")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/tosource/index.html
@@ -51,10 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Error.toSource")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Error.toSource")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/tostring/index.html
@@ -94,10 +94,7 @@ console.log(e5.toString()); // 'hello'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Error.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Error.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/evalerror/evalerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/evalerror/evalerror/index.html
@@ -68,10 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.EvalError.EvalError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.EvalError.EvalError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
@@ -430,10 +430,7 @@ if (!Function.prototype.bind) (function(){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Function.bind")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Function.bind")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/function/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/function/index.html
@@ -96,10 +96,7 @@ adder(2, 6);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Function.Function")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Function.Function")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/tosource/index.html
@@ -60,10 +60,7 @@ hello.toSource();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Function.toSource")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Function.toSource")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/generator/next/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/next/index.html
@@ -137,10 +137,7 @@ g.next(2);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Generator.next")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Generator.next")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/generator/return/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/return/index.html
@@ -88,10 +88,7 @@ g.return(1); // { value: 1, done: true }
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Generator.return")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Generator.return")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/generator/throw/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/throw/index.html
@@ -93,10 +93,7 @@ g.throw(new Error('Something went wrong'));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Generator.throw")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Generator.throw")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.html
@@ -95,10 +95,7 @@ console.log(iterator.next().value); // 20
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.GeneratorFunction")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.GeneratorFunction")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/internalerror/internalerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/internalerror/internalerror/index.html
@@ -42,10 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.InternalError.InternalError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.InternalError.InternalError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/json/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/json/index.html
@@ -176,10 +176,7 @@ eval(code)        // throws a SyntaxError in old engines
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.JSON")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.JSON")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.html
@@ -437,10 +437,7 @@ console.log(restoredSession);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.JSON.stringify")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.JSON.stringify")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definegetter__/index.html
@@ -89,10 +89,7 @@ console.log(o.gimmeFive); // 5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.defineGetter")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.defineGetter")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/__definesetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__definesetter__/index.html
@@ -103,10 +103,7 @@ console.log(o.anotherValue); // 5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.defineSetter")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.defineSetter")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupgetter__/index.html
@@ -77,10 +77,7 @@ Object.getOwnPropertyDescriptor(obj, "foo").get;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.lookupGetter")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.lookupGetter")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/__lookupsetter__/index.html
@@ -76,10 +76,7 @@ Object.getOwnPropertyDescriptor(obj, 'foo').set;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.lookupSetter")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.lookupSetter")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.html
@@ -428,10 +428,7 @@ o2 = Object.create({p: 42}) */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.create")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.create")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.html
@@ -154,10 +154,7 @@ Object.entries(obj).forEach(([key, value]) =&gt; console.log(`${key}: ${value}`)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.entries")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.entries")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.html
@@ -111,10 +111,7 @@ subclass.prototype = Object.create(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.getOwnPropertyDescriptors")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.getOwnPropertyDescriptors")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.html
@@ -95,10 +95,7 @@ Object.isExtensible(1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.isExtensible")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.isExtensible")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.html
@@ -159,10 +159,7 @@ Object.isFrozen(1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.isFrozen")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.isFrozen")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.html
@@ -114,10 +114,7 @@ console.log(Object.prototype.isPrototypeOf(baz)); // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.isPrototypeOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.isPrototypeOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.html
@@ -122,10 +122,7 @@ Object.isSealed(1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.isSealed")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.isSealed")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.html
@@ -132,10 +132,7 @@ Object.preventExtensions(1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.preventExtensions")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.preventExtensions")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/propertyisenumerable/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/propertyisenumerable/index.html
@@ -133,10 +133,7 @@ o.propertyIsEnumerable('firstMethod'); // returns false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.propertyIsEnumerable")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.propertyIsEnumerable")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.html
@@ -228,10 +228,7 @@ george(); // 'Hello guys!!'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.setPrototypeOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.setPrototypeOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/tosource/index.html
@@ -128,10 +128,7 @@ theDog = new Dog('Gabby', 'Lab', 'chocolate', 'female');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.toSource")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.toSource")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.html
@@ -194,10 +194,7 @@ Object.prototype.toString.call(new Date()); // [object prototype polluted]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/values/index.html
@@ -88,10 +88,7 @@ console.log(Object.values('foo')); // ['f', 'o', 'o']
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Object.values")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.values")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.html
@@ -106,10 +106,7 @@ console.log(p(1, 2, 3)); // "called: 1, 2, 3"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.apply")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.apply")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.html
@@ -145,10 +145,7 @@ Object.defineProperty(p, 'name', {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.defineProperty")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.defineProperty")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.html
@@ -123,10 +123,7 @@ console.log(result)    // false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.deleteProperty")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.deleteProperty")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.html
@@ -132,10 +132,7 @@ p.a; // TypeError is thrown
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.get")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.get")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.html
@@ -123,10 +123,7 @@ const p = new Proxy(obj, {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.has")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.has")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.html
@@ -114,10 +114,7 @@ Object.isExtensible(p); // TypeError is thrown
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.isExtensible")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.isExtensible")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.html
@@ -123,10 +123,7 @@ console.log(Object.getOwnPropertyNames(p));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.ownKeys")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.ownKeys")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.html
@@ -139,10 +139,7 @@ console.log(p.a);       // 10
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.set")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.set")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.html
@@ -138,10 +138,7 @@ Reflect.setPrototypeOf(p2, newProto); // throws new Error("custom error")</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.Proxy.handler.setPrototypeOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.setPrototypeOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/referenceerror/referenceerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/referenceerror/referenceerror/index.html
@@ -78,10 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.ReferenceError.ReferenceError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.ReferenceError.ReferenceError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.html
@@ -102,10 +102,7 @@ console.log(result.group(3)); // 02
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.@@match")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.@@match")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.html
@@ -121,10 +121,7 @@ console.log(newstr); // ###34567</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.@@replace")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.@@replace")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.html
@@ -106,10 +106,7 @@ console.log(result); // 3
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.@@search")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.@@search")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.html
@@ -104,10 +104,7 @@ console.log(result); // ["(2016)", "(01)", "(02)"]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.@@split")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.@@split")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/compile/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/compile/index.html
@@ -79,10 +79,7 @@ regexObj.compile('new foo', 'g');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.compile")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.compile")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -214,10 +214,7 @@ console.log(matches[1]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.exec")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.exec")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
@@ -131,10 +131,7 @@ new RegExp('ab+c', 'i') // constructor
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.RegExp")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.RegExp")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/tosource/index.html
@@ -49,10 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.toSource")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.toSource")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/tostring/index.html
@@ -82,10 +82,7 @@ new RegExp('\n').toString() === '/\\n/'; // true, starting with ES5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.RegExp.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RegExp.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.html
@@ -78,10 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.SyntaxError.SyntaxError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.SyntaxError.SyntaxError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/@@iterator/index.html
@@ -66,10 +66,7 @@ console.log(eArr.next().value); // 50
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.@@iterator")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.@@iterator")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.html
@@ -68,10 +68,7 @@ console.log(eArr.next().value); // [4, 50]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.entries")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.entries")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.html
@@ -119,10 +119,7 @@ new Uint8Array([12, 54, 18, 130, 44]).every(elem =&gt; elem &gt;= 10); // true</
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.every")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.every")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.html
@@ -102,10 +102,7 @@ if (!Uint8Array.prototype.fill) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.fill")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.fill")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.html
@@ -126,10 +126,7 @@ new Uint8Array([12, 5, 8, 130, 44]).filter(isBigEnough);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.filter")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.filter")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.html
@@ -126,10 +126,7 @@ console.log(uint8.find(isPrime)); // 5</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.find")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.find")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.html
@@ -163,10 +163,7 @@ console.log(uint16.findIndex(isPrime)); // 2
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.findIndex")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.findIndex")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/foreach/index.html
@@ -119,10 +119,7 @@ new Uint8Array([0, 1, 2, 3]).forEach(logArrayElements);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.forEach")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.forEach")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.html
@@ -88,10 +88,7 @@ if (!Uint8Array.prototype.join) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.join")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.join")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.html
@@ -74,10 +74,7 @@ console.log(eArr.next().value); // 4
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.keys")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.keys")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.html
@@ -134,10 +134,7 @@ const doubles = numbers.map(function(num) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.map")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.map")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.html
@@ -102,10 +102,7 @@ Int16Array.of(undefined);    // Int16Array [ 0 ]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.of")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.of")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.html
@@ -115,10 +115,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.reduce")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.reduce")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduceright/index.html
@@ -108,10 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.reduceRight")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.reduceRight")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
@@ -113,10 +113,7 @@ uint8.slice(0,1); // Uint8Array [ 1 ]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.slice")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.slice")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/some/index.html
@@ -128,10 +128,7 @@ new Uint8Array([12, 5, 8, 1, 4]).some(elem =&gt; elem &gt; 10); // true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.some")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.some")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tolocalestring/index.html
@@ -77,10 +77,7 @@ uint.toLocaleString('ja-JP', { style: 'currency', currency: 'JPY' });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.toLocaleString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.toLocaleString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.html
@@ -75,10 +75,7 @@ numbers.toString(); // "[object Uint8Array]"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.html
@@ -112,10 +112,7 @@ iterator.next().value;        //  "n"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypedArray.values")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypedArray.values")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typeerror/typeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typeerror/typeerror/index.html
@@ -79,10 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.TypeError.TypeError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.TypeError.TypeError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/urierror/urierror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/urierror/urierror/index.html
@@ -78,10 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.URIError.URIError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.URIError.URIError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/compile/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/compile/index.html
@@ -88,10 +88,7 @@ fetch('simple.wasm').then(response =&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.compile")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.compile")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/compileerror/compileerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/compileerror/compileerror/index.html
@@ -70,10 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.CompileError.CompileError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.CompileError.CompileError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/compilestreaming/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/compilestreaming/index.html
@@ -95,10 +95,7 @@ WebAssembly.compileStreaming(fetch('simple.wasm'))
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.compileStreaming")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.compileStreaming")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/global/global/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/global/global/index.html
@@ -109,10 +109,7 @@ WebAssembly.instantiateStreaming(fetch('global.wasm'), { js: { global } })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Global.Global")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Global.Global")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instance/exports/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instance/exports/index.html
@@ -66,10 +66,7 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Instance.exports")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Instance.exports")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instance/instance/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instance/instance/index.html
@@ -94,10 +94,7 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Instance.Instance")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Instance.Instance")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.html
@@ -113,10 +113,7 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.instantiateStreaming")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.instantiateStreaming")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/linkerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/linkerror/index.html
@@ -70,10 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.LinkError.LinkError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.LinkError.LinkError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/grow/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/grow/index.html
@@ -71,10 +71,7 @@ console.log(memory.buffer.byteLength / bytesPerPage);  // "2"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Memory.grow")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Memory.grow")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.html
@@ -126,10 +126,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Memory.Memory")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Memory.Memory")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.html
@@ -111,10 +111,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Module.customSections")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Module.customSections")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/exports/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/exports/index.html
@@ -107,10 +107,7 @@ onmessage = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Module.exports")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Module.exports")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/imports/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/imports/index.html
@@ -78,10 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Module.imports")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Module.imports")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/module/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/module/index.html
@@ -86,10 +86,7 @@ fetch('simple.wasm').then(response =&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Module.Module")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Module.Module")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.html
@@ -71,10 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.RuntimeError.RuntimeError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.RuntimeError.RuntimeError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/get/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/get/index.html
@@ -81,10 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Table.get")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Table.get")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/grow/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/grow/index.html
@@ -71,10 +71,7 @@ console.log(table.length);   // "3"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Table.grow")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Table.grow")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/length/index.html
@@ -55,10 +55,7 @@ console.log(table.length);   // "3"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Table.length")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Table.length")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/table/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/table/index.html
@@ -110,10 +110,7 @@ console.log(tbl.get(1));  // "null"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.Table.Table")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.Table.Table")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/validate/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/validate/index.html
@@ -79,10 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.builtins.WebAssembly.validate")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.WebAssembly.validate")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/operators/async_function/index.html
+++ b/files/en-us/web/javascript/reference/operators/async_function/index.html
@@ -91,10 +91,7 @@ add(10).then(v =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.operators.async_function_expression")}}</p>
-</div>
+<p>{{Compat("javascript.operators.async_function_expression")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/operators/await/index.html
+++ b/files/en-us/web/javascript/reference/operators/await/index.html
@@ -158,10 +158,7 @@ export default await colors;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.operators.await")}}</p>
-</div>
+<p>{{Compat("javascript.operators.await")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.html
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.html
@@ -239,10 +239,7 @@ console.log(customerCity); // Unknown city</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.operators.optional_chaining")}}</p>
-</div>
+<p>{{Compat("javascript.operators.optional_chaining")}}</p>
 
 <h3 id="Implementation_Progress">Implementation Progress</h3>
 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.html
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.html
@@ -354,10 +354,7 @@ setTimeout(parallel, 10000) // truly parallel: after 1 second, logs "fast", then
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.statements.async_function")}}</p>
-</div>
+<p>{{Compat("javascript.statements.async_function")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/statements/function_star_/index.html
+++ b/files/en-us/web/javascript/reference/statements/function_star_/index.html
@@ -254,10 +254,7 @@ for(let power of powers(2)){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.statements.generator_function")}}</p>
-</div>
+<p>{{Compat("javascript.statements.generator_function")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/template_literals/index.html
+++ b/files/en-us/web/javascript/reference/template_literals/index.html
@@ -290,10 +290,7 @@ latex`\unicode`
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.grammar.template_literals")}}</p>
-</div>
+<p>{{Compat("javascript.grammar.template_literals")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.html
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.html
@@ -178,10 +178,7 @@ JSON.parse('{"foo" : 1 }');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-  <p>{{Compat("javascript.grammar.trailing_commas")}}</p>
-</div>
+<p>{{Compat("javascript.grammar.trailing_commas")}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
MDN content has over 1500 useless `<div>` tags (which do not have any attributes nor group any content together). To simplify the review, I'll split the 1500 changes into smaller chunks. This commit removes 138 such tags from `files/en-us/web/javascript/` folder, all these occurrences look like this:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>

<div>

  <p>{{Compat("api.Animation.onfinish")}}</p>
</div>
```
They are replaced with this:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>

<p>{{Compat("...")}}</p>
```