### PR TITLE
Remove charArg/repeatArg and extract modifierListArg parameters

### DIFF
--- a/files/en-us/web/api/keyboardevent/initkeyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/initkeyboardevent/index.html
@@ -35,17 +35,16 @@ tags:
   <dd>Whether or not the event can be canceled.</dd>
   <dt><em><code>viewArg</code></em></dt>
   <dd>The {{domxref("WindowProxy")}} it is associated to.</dd>
-  <dt><em><code>charArg</code></em></dt>
-  <dd>The value of the char attribute.</dd>
   <dt><em><code>keyArg</code></em></dt>
   <dd>The value of the key attribute.</dd>
   <dt><em><code>locationArg</code></em></dt>
   <dd>The value of the location attribute.</dd>
-  <dt><em><code>modifiersListArg</code></em></dt>
-  <dd>A whitespace-delineated list of modifier keys that should be considered to be active
-    on the event's key. For example, specifying "Control Shift" indicates that the user
-    was holding down the Control and Shift keys when pressing the key described by the
-    event.</dd>
-  <dt><em><code>repeatArg</code></em></dt>
-  <dd>The value of the repeat attribute.</dd>
+  <dt><em><code>ctrlKey</code></em></dt>
+  <dd>Whether the Control key modifier is active.</dd>
+  <dt><em><code>altKey</code></em></dt>
+  <dd>Whether the Alt key modifier is active.</dd>
+  <dt><em><code>shiftKey</code></em></dt>
+  <dd>Whether the Shift key modifier is active.</dd>
+  <dt><em><code>metaKey</code></em></dt>
+  <dd>Whether the Meta key modifier is active.</dd>
 </dl>


### PR DESCRIPTION
While this method is already deprecated, the current Mozilla implementation introduced in https://bugzilla.mozilla.org/show_bug.cgi?id=1387828 and the spec at https://www.w3.org/TR/uievents/#idl-interface-KeyboardEvent-initializers has different parameters.

This fixes https://github.com/mdn/content/issues/2183