### PR TITLE
XMLHttpRequest: add note not supported in service workers

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -67,7 +67,7 @@ tags:
  <dt id="xmlhttprequest-timeout">{{domxref("XMLHttpRequest.timeout")}}</dt>
  <dd>Is an <code>unsigned long</code> representing the number of milliseconds a request can take before automatically being terminated.</dd>
  <dt id="xmlhttprequesteventtarget-ontimeout">{{domxref("XMLHttpRequestEventTarget.ontimeout")}}</dt>
- <dd>Is an {{domxref("EventHandler")}} that is called whenever the request times out. {{gecko_minversion_inline("12.0")}}</dd>
+ <dd>Is an {{domxref("EventHandler")}} that is called whenever the request times out. </dd>
  <dt id="xmlhttprequest-upload">{{domxref("XMLHttpRequest.upload")}} {{readonlyinline}}</dt>
  <dd>Is an {{domxref("XMLHttpRequestUpload")}}, representing the upload process.</dd>
  <dt id="xmlhttprequest-withcredentials">{{domxref("XMLHttpRequest.withCredentials")}}</dt>
@@ -85,7 +85,7 @@ tags:
  <dd>Is a boolean. If true, the same origin policy will not be enforced on the request.</dd>
  <dt>{{domxref("XMLHttpRequest.mozBackgroundRequest")}}</dt>
  <dd>Is a boolean. It indicates whether or not the object represents a background service request.</dd>
- <dt>{{domxref("XMLHttpRequest.mozResponseArrayBuffer")}}{{gecko_minversion_inline("2.0")}} {{obsolete_inline("6")}} {{ReadOnlyInline}}</dt>
+ <dt>{{domxref("XMLHttpRequest.mozResponseArrayBuffer")}} {{obsolete_inline("6")}} {{ReadOnlyInline}}</dt>
  <dd>{{jsxref("ArrayBuffer")}}. The response to the request, as a JavaScript typed array.</dd>
  <dt>{{domxref("XMLHttpRequest.multipart")}}{{obsolete_inline("22")}}</dt>
  <dd><strong>This Gecko-only feature, a boolean, was removed in Firefox/Gecko 22.</strong> Please use <a href="/en-US/docs/Web/API/Server-sent_events">Server-Sent Events</a>, <a href="/en-US/docs/Web/API/WebSockets_API">Web Sockets</a>, or <code>responseText</code> from progress events instead.</dd>

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -16,19 +16,24 @@ tags:
 
 <p><span class="seoSummary"><code>XMLHttpRequest</code> (XHR) objects are used to interact with servers. You can retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just part of a page without disrupting what the user is doing.</span> <code>XMLHttpRequest</code> is used heavily in {{Glossary("AJAX")}} programming.</p>
 
-<p>{{InheritanceDiagram(650, 150)}}</p>
+<p>{{InheritanceDiagram(650, 70)}}</p>
 
 <p>Despite its name, <code>XMLHttpRequest</code> can be used to retrieve any type of data, not just XML.</p>
 
 <p>If your communication needs to involve receiving event data or message data from a server, consider using <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> through the {{domxref("EventSource")}} interface. For full-duplex communication, <a href="/en-US/docs/Web/API/WebSockets_API">WebSockets</a> may be a better choice.</p>
 
 <p>{{AvailableInWorkers}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Not supported in service workers.</p>
+</div>
+
 
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
  <dt>{{domxref("XMLHttpRequest.XMLHttpRequest", "XMLHttpRequest()")}}</dt>
- <dd>The constructor initializes an XMLHttpRequest. It must be called before any other method calls.</dd>
+ <dd>The constructor initializes an <code>XMLHttpRequest</code>. It must be called before any other method calls.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>
@@ -54,8 +59,9 @@ tags:
  <dd>Returns an <code>unsigned short</code> with the status of the response of the request.</dd>
  <dt id="xmlhttprequest-statustext">{{domxref("XMLHttpRequest.statusText")}} {{readonlyinline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the response string returned by the HTTP server. Unlike {{domxref("XMLHttpRequest.status")}}, this includes the entire text of the response message ("<code>200 OK</code>", for example).
- <div class="note">
- <p><strong>Note:</strong> According to the HTTP/2 specification (<a href="https://http2.github.io/http2-spec/#rfc.section.8.1.2.4">8.1.2.4</a> <a href="https://http2.github.io/http2-spec/#HttpResponse">Response Pseudo-Header Fields</a>), HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.</p>
+ <div class="notecard note">
+   <h4>Note</h4>
+    <p>According to the HTTP/2 specification (<a href="https://http2.github.io/http2-spec/#rfc.section.8.1.2.4">8.1.2.4</a> <a href="https://http2.github.io/http2-spec/#HttpResponse">Response Pseudo-Header Fields</a>), HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.</p>
  </div>
  </dd>
  <dt id="xmlhttprequest-timeout">{{domxref("XMLHttpRequest.timeout")}}</dt>
@@ -120,7 +126,8 @@ tags:
  <div class="warning"><strong>Warning:</strong> This method must <em>not</em> be called from JavaScript.</div>
  </dd>
  <dt>{{domxref("XMLHttpRequest.openRequest()")}}</dt>
- <dd>Initializes a request. This method is to be used from native code; to initialize a request from JavaScript code, use <a class="internal" href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIXMLHttpRequest#open()"><code>open()</code></a> instead. See the documentation for <code>open()</code>.</dd>
+ <dd>Initializes a request. This method is to be used from native code; to initialize a request from JavaScript code, 
+   use <a class="internal" href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIXMLHttpRequest#open()"><code>open()</code></a> instead. See the documentation for <code>open()</code>.</dd>
  <dt>{{domxref("XMLHttpRequest.sendAsBinary()")}}{{deprecated_inline()}}</dt>
  <dd>A variant of the <code>send()</code> method that sends binary data.</dd>
 </dl>
@@ -180,7 +187,7 @@ tags:
  <li>{{domxref("XMLSerializer")}}: Serializing a DOM tree into XML</li>
  <li>MDN tutorials covering <code>XMLHttpRequest</code>:
   <ul>
-   <li><a href="/en-US/docs/AJAX/Getting_Started">Ajax — Getting Started</a></li>
+   <li><a href="/en-US/docs/Web/Guide/AJAX/Getting_Started">Ajax — Getting Started</a></li>
    <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest">Using XMLHttpRequest</a></li>
    <li><a href="/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest">HTML in XMLHttpRequest</a></li>
    <li><a href="/en-US/docs/Web/API/Fetch_API" title="Fetch API">Fetch API</a></li>

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -71,14 +71,14 @@ tags:
  <dt id="xmlhttprequest-upload">{{domxref("XMLHttpRequest.upload")}} {{readonlyinline}}</dt>
  <dd>Is an {{domxref("XMLHttpRequestUpload")}}, representing the upload process.</dd>
  <dt id="xmlhttprequest-withcredentials">{{domxref("XMLHttpRequest.withCredentials")}}</dt>
- <dd>Is a {{domxref("Boolean")}} that indicates whether or not cross-site <code>Access-Control</code> requests should be made using credentials such as cookies or authorization headers.</dd>
+ <dd>Is a {{jsxref("Boolean")}} that indicates whether or not cross-site <code>Access-Control</code> requests should be made using credentials such as cookies or authorization headers.</dd>
 </dl>
 
 <h3 id="Non-standard_properties">Non-standard properties</h3>
 
 <dl>
  <dt>{{domxref("XMLHttpRequest.channel")}}{{ReadOnlyInline}}</dt>
- <dd>Is a {{Interface("nsIChannel")}}. The channel used by the object when performing the request.</dd>
+ <dd>The channel used by the object when performing the request.</dd>
  <dt>{{domxref("XMLHttpRequest.mozAnon")}}{{ReadOnlyInline}}</dt>
  <dd>Is a boolean. If true, the request will be sent without cookie and authentication headers.</dd>
  <dt>{{domxref("XMLHttpRequest.mozSystem")}}{{ReadOnlyInline}}</dt>
@@ -127,7 +127,7 @@ tags:
  </dd>
  <dt>{{domxref("XMLHttpRequest.openRequest()")}}</dt>
  <dd>Initializes a request. This method is to be used from native code; to initialize a request from JavaScript code, 
-   use <a class="internal" href="/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIXMLHttpRequest#open()"><code>open()</code></a> instead. See the documentation for <code>open()</code>.</dd>
+   use {{domxref("XMLHttpRequest.open()")}} instead.</dd>
  <dt>{{domxref("XMLHttpRequest.sendAsBinary()")}}{{deprecated_inline()}}</dt>
  <dd>A variant of the <code>send()</code> method that sends binary data.</dd>
 </dl>


### PR DESCRIPTION
Not supported in service workers. While this is now going to be clear in the BCD (see https://github.com/mdn/browser-compat-data/pull/8853) at the top of the page you have "Available in web workers" - so adding this note makes it clear that it is not available in "all web workers".

Also fixes flaws. Fixes #1515

@peterbe Not sure what is happening with the AvailableInWorker macro going forward, but if this still exists, would be great if this could have ability to add replacement or appendable text.