### PR TITLE
Update doc about octal interpretations with no radix of parseInt

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.html
@@ -90,12 +90,6 @@ tags:
     (a zero, followed by lowercase or uppercase X), <code><var>radix</var></code> is
     assumed to be <code>16</code> and the rest of the string is parsed as a hexadecimal
     number.</li>
-  <li>If the input <code>string</code> begins with "<code>0</code>" (a zero),
-    <code><var>radix</var></code> is assumed to be <code>8</code> (octal) or
-    <code>10</code> (decimal). Exactly which radix is chosen is implementation-dependent.
-    ECMAScript 5 clarifies that <code>10</code> (decimal) <em>should</em> be used, but not
-    all browsers support this yet. For this reason, <strong>always specify a
-      <code><var>radix</var></code> when using <code>parseInt</code></strong>.</li>
   <li>If the input <code>string</code> begins with any other value, the radix is
     <code>10</code> (decimal).</li>
 </ol>
@@ -123,11 +117,11 @@ tags:
 
 <h3 id="Octal_interpretations_with_no_radix">Octal interpretations with no radix</h3>
 
-<p>Although discouraged by ECMAScript 3 and forbidden by ECMAScript 5, many
-  implementations interpret a numeric string beginning with a leading <code>0</code> as
-  octal. The following may have an octal result, or it may have a decimal result.
-  <strong>Always specify a <code><var>radix</var></code> to avoid this unreliable
-    behavior.</strong></p>
+<p>Please note that following information doesn't apply to recent implementations as of 2021.</p>
+
+<p>Although discouraged by ECMAScript 3, many ECMAScript 3
+  implementations had interpreted a numeric string beginning with a leading <code>0</code> as
+  octal. The following might have had an octal result, or it might have had a decimal result.</p>
 
 <pre class="brush: js notranslate">parseInt('0e0')  // 0
 parseInt('08')   // 0, because '8' is not an octal digit.
@@ -135,24 +129,11 @@ parseInt('08')   // 0, because '8' is not an octal digit.
 
 <p>The ECMAScript 5 specification of the function <code>parseInt</code> no longer allows
   implementations to treat Strings beginning with a <code>0</code> character as octal
-  values.</p>
+  values. Many implementations have adopted this behavior as of 2021.</p>
 
-<p>ECMAScript 5 states:</p>
-
-<blockquote>
-  <p>The <code>parseInt</code> function produces an integer value dictated by
-    interpretation of the contents of the string argument according to the specified
-    radix. Leading whitespace in string is ignored. If radix is <code>undefined</code> or
-    <code>0</code>, it is assumed to be <code>10</code> except when the number begins with
-    the character pairs <code>0x</code> or <code>0X</code>, in which case a radix of
-    <code>16</code> is assumed.</p>
-</blockquote>
-
-<p>This differs from ECMAScript 3, which merely <em>discouraged</em> (but allowed) octal
-  interpretation.</p>
-
-<p>Many implementations have not adopted this behavior as of 2013. And, because older
-  browsers must be supported, <strong>always specify a radix</strong>.</p>
+<pre class="brush: js notranslate">parseInt('0e0')  // 0
+parseInt('08')   // 8
+</pre>
 
 <h3 id="A_stricter_parse_function">A stricter parse function</h3>
 


### PR DESCRIPTION
Current [parseInt document](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) says:

> Although discouraged by ECMAScript 3 and forbidden by ECMAScript 5, many implementations interpret a numeric string beginning with a leading 0 as octal. The following may have an octal result, or it may have a decimal result. Always specify a radix to avoid this unreliable behavior.

Many implementations have adopted the ECMAScript 5 behavior nowadays. This PR update the document.

References:

* [(ECMAScript 5.1) parseInt specification](https://262.ecma-international.org/5.1/#sec-15.1.2.2)
* [(JavaScriptCore)  Bug 75455 ES5 prohibits parseInt from supporting octal (fixed in 2012)](https://bugs.webkit.org/show_bug.cgi?id=75455)
* [(V8) Issue 1645: parseInt still parsing octal  (fixed in 2012)](https://bugs.chromium.org/p/v8/issues/detail?id=1645)
* [(SpiderMonky) Make parseInt("042") === 42, now that other engines are moving that way  (fixed in 2013)](https://bugzilla.mozilla.org/show_bug.cgi?id=786135)
