### PR TITLE
Cross link to simple getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ document: `title`, `slug`, and [`tags`](https://developer.mozilla.org/en-US/docs
 
 If you just want to make a simple change to a single file, like fixing a typo,
 the GitHub UI is the simplest way to do that. For example, if you've found
-a typo within the [JavaScript landing page](files/en-us/web/javascript/index.html),
-you can sign into GitHub, go to <https://github.com/mdn/content>, navigate to
+a typo within the [JavaScript landing page](https://developer.mozilla.org/en-US/docs/Web/JavaScript),
+you can sign into GitHub, go to <https://github.com/mdn/content>, navigate to the source file
 `files/en-us/web/javascript/index.html`, and then click on the edit
-(pencil) button. From there the GitHub UI will take your hand and
+(pencil) button. 
+
+> **Tip:** Click the **Source on GitHub** link in the footer of any MDN page to jump to its source file on GitHub.
+
+From there the GitHub UI will take your hand and
 [walk you through the rest](https://docs.github.com/en/free-pro-team@latest/github/managing-files-in-a-repository/editing-files-in-your-repository),
 like automatically creating a
 [fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo)
@@ -134,8 +138,9 @@ and branch to commit your changes to, as well as helping you reach the
 ultimate goal, a [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
 Your pull request represents the work you want to be reviewed,
 hopefully approved, and then merged into the `main` branch of this repository.
-**See the [pull request etiquette section](#pull-request-etiquette) for more details**
-**on creating and handling pull requests successfully.**
+
+> **Note:** See the [pull request etiquette section](#pull-request-etiquette) for more details
+on creating and handling pull requests successfully.
 
 If you're not certain of the changes that you want to make, get in touch
 with us first!

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ The following is a set of guidelines for contributing to the
 [content of MDN Web Docs](https://github.com/mdn/content), which is
 hosted within the [MDN Organization](https://github.com/mdn) on GitHub.
 
+> **Note:** Just want to find a task and jump in?
+  See [Getting started on MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Getting_started) 
+  for an overview of how to join, and [Contributing to MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute)
+  for a filtered list of tasks.
+
 <!-- You can quickly regenerate this TOC by running:
   npx markdown-toc@1.2.0 --bullets='-' --no-firsth1 README.md -->
 
@@ -32,8 +37,8 @@ hosted within the [MDN Organization](https://github.com/mdn) on GitHub.
 
 ## Code of Conduct
 
-Everyone participating in this project is expected to follow
-[our Code of Conduct](CODE_OF_CONDUCT.md).
+Everyone participating in this project is expected to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -623,10 +628,10 @@ you can follow the below steps to unarchive it:
 directory into the appropriate place inside this repo, and update the
 page's meta data (like `slug`) if needed.
 
-Note: To archive a currently-non-archived page, you need to follow the
+> **Note:** To archive a currently-non-archived page, you need to follow the
 above procedure, but move the page in question the opposite way between repos.
 
-Note: You can have an archived page with non-archived pages below it in the
+> **Note:** You can have an archived page with non-archived pages below it in the
 hierarchy, and vice-versa. To achive this you need to have the same directory
 structure in both the `content` and `archive-content` repos. Whether a page
 is non-archived or archived depends on which repo its `index.html` file is

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to the
 hosted within the [MDN Organization](https://github.com/mdn) on GitHub.
 
 > **Note:** Just want to find a task and jump in?
-  See [Getting started on MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Getting_started) 
+  See [Getting started on MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Getting_started)
   for an overview of how to join, and [Contributing to MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute)
   for a filtered list of tasks.
 
@@ -124,11 +124,12 @@ document: `title`, `slug`, and [`tags`](https://developer.mozilla.org/en-US/docs
 If you just want to make a simple change to a single file, like fixing a typo,
 the GitHub UI is the simplest way to do that. For example, if you've found
 a typo within the [JavaScript landing page](https://developer.mozilla.org/en-US/docs/Web/JavaScript),
-you can sign into GitHub, go to <https://github.com/mdn/content>, navigate to the source file
-`files/en-us/web/javascript/index.html`, and then click on the edit
-(pencil) button. 
+you can sign into GitHub, go to <https://github.com/mdn/content>,
+navigate to the source file `files/en-us/web/javascript/index.html`,
+and then click on the edit (pencil) button.
 
-> **Tip:** Click the **Source on GitHub** link in the footer of any MDN page to jump to its source file on GitHub.
+> **Tip:** Click the **Source on GitHub** link in the footer of any MDN page
+  to jump to its source file on GitHub.
 
 From there the GitHub UI will take your hand and
 [walk you through the rest](https://docs.github.com/en/free-pro-team@latest/github/managing-files-in-a-repository/editing-files-in-your-repository),
@@ -139,8 +140,8 @@ ultimate goal, a [pull request](https://docs.github.com/en/free-pro-team@latest/
 Your pull request represents the work you want to be reviewed,
 hopefully approved, and then merged into the `main` branch of this repository.
 
-> **Note:** See the [pull request etiquette section](#pull-request-etiquette) for more details
-on creating and handling pull requests successfully.
+> **Note:** See the [pull request etiquette section](#pull-request-etiquette)
+  for more details on creating and handling pull requests successfully.
 
 If you're not certain of the changes that you want to make, get in touch
 with us first!
@@ -636,7 +637,7 @@ page's meta data (like `slug`) if needed.
 > **Note:** To archive a currently-non-archived page, you need to follow the
 above procedure, but move the page in question the opposite way between repos.
 
-> **Note:** You can have an archived page with non-archived pages below it in the
+**Note:** You can have an archived page with non-archived pages below it in the
 hierarchy, and vice-versa. To achive this you need to have the same directory
 structure in both the `content` and `archive-content` repos. Whether a page
 is non-archived or archived depends on which repo its `index.html` file is

--- a/files/en-us/mdn/contribute/index.html
+++ b/files/en-us/mdn/contribute/index.html
@@ -10,7 +10,10 @@ tags:
 
 <p>MDN Web Docs needs your help! We have a large number of typos to fix, examples to write, bugs to fix, people to talk to, and more, and the number is growing as more people start using the site. This page outlines what you can do to help.</p>
 
-<p>If you haven't contributed to MDN previously, the <a href="/en-US/docs/MDN/Contribute/Getting_started">Getting Started</a> guide can help you pick a task to jump in and help with.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>If you haven't contributed to MDN previously, the <a href="/en-US/docs/MDN/Contribute/Getting_started">Getting Started</a> guide explains the process in four simple steps. Good news, you're already on step 3: "Finding out how you can help"!</p>
+</div>
 
 <h2 id="What_can_I_do_to_help">What can I do to help?</h2>
 


### PR DESCRIPTION
This does a couple of things around contributing/getting started.
1. It updates README.md to link to the MDN getting started and contributing. This adds info on how you find the right tasks to work on, which was missing.
2. It updates README.md to better highlight notes, tips etc., which are currently invisible. 

   > **Note:** It does so using this syntax:
   > ```
   >  > **Note:** It does so using this syntax.
   > ```
2. Adds a tip that you can navigate to source from the link in the MDN page footer (which is actually the easiest way to find the page)

This follows on from https://github.com/mdn/content/issues/1856