### PR TITLE
Remove extra call to counter.start() in example in WeakRef doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/weakref/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakref/index.html
@@ -110,7 +110,6 @@ tags:
 }
 
 const counter = new Counter(document.getElementById("counter"));
-counter.start();
 setTimeout(() =&gt; {
   document.getElementById("counter").remove();
 }, 5000);


### PR DESCRIPTION
This call is already made from the constructor, so we don't need to do it from the mainline code.