### PR TITLE
Fix: remove useless <div> tags (part 4)

### DIFF
--- a/files/en-us/web/css/@font-feature-values/index.html
+++ b/files/en-us/web/css/@font-feature-values/index.html
@@ -83,10 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.at-rules.font-feature-values")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_active/index.html
+++ b/files/en-us/web/css/_colon_active/index.html
@@ -116,10 +116,7 @@ form button {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.active")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_defined/index.html
+++ b/files/en-us/web/css/_colon_defined/index.html
@@ -104,10 +104,7 @@ simple-custom:defined {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.defined")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_dir/index.html
+++ b/files/en-us/web/css/_colon_dir/index.html
@@ -97,10 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.dir")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_disabled/index.html
+++ b/files/en-us/web/css/_colon_disabled/index.html
@@ -114,10 +114,7 @@ function toggleBilling() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.disabled")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_first-of-type/index.html
+++ b/files/en-us/web/css/_colon_first-of-type/index.html
@@ -101,10 +101,7 @@ p:first-of-type {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.first-of-type")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_focus/index.html
+++ b/files/en-us/web/css/_colon_focus/index.html
@@ -102,10 +102,7 @@ input:focus {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.focus")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_fullscreen/index.html
+++ b/files/en-us/web/css/_colon_fullscreen/index.html
@@ -78,10 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.fullscreen")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_host/index.html
+++ b/files/en-us/web/css/_colon_host/index.html
@@ -83,10 +83,7 @@ style.textContent = 'span:hover { text-decoration: underline; }' +
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.host")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_hover/index.html
+++ b/files/en-us/web/css/_colon_hover/index.html
@@ -91,10 +91,7 @@ a:hover {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.hover")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_invalid/index.html
+++ b/files/en-us/web/css/_colon_invalid/index.html
@@ -135,10 +135,7 @@ input:required:invalid {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.invalid")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_lang/index.html
+++ b/files/en-us/web/css/_colon_lang/index.html
@@ -88,10 +88,7 @@ p:lang(en) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.lang")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_last-of-type/index.html
+++ b/files/en-us/web/css/_colon_last-of-type/index.html
@@ -100,10 +100,7 @@ p:last-of-type {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.last-of-type")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_link/index.html
+++ b/files/en-us/web/css/_colon_link/index.html
@@ -92,10 +92,7 @@ a:link {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.link")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_nth-child/index.html
+++ b/files/en-us/web/css/_colon_nth-child/index.html
@@ -187,10 +187,7 @@ div em {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.nth-child")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_nth-last-child/index.html
+++ b/files/en-us/web/css/_colon_nth-last-child/index.html
@@ -182,10 +182,7 @@ li:nth-last-child(n+3) ~ li {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.nth-last-child")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_nth-last-of-type/index.html
+++ b/files/en-us/web/css/_colon_nth-last-of-type/index.html
@@ -84,10 +84,7 @@ p:nth-last-of-type(4n) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.nth-last-of-type")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_nth-of-type/index.html
+++ b/files/en-us/web/css/_colon_nth-of-type/index.html
@@ -98,10 +98,7 @@ p.fancy:nth-of-type(1) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.nth-of-type")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_only-of-type/index.html
+++ b/files/en-us/web/css/_colon_only-of-type/index.html
@@ -83,10 +83,7 @@ p:only-of-type {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.only-of-type")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_out-of-range/index.html
+++ b/files/en-us/web/css/_colon_out-of-range/index.html
@@ -102,10 +102,7 @@ input:out-of-range + label::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.out-of-range")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_picture-in-picture/index.html
+++ b/files/en-us/web/css/_colon_picture-in-picture/index.html
@@ -70,10 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.picture-in-picture")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_valid/index.html
+++ b/files/en-us/web/css/_colon_valid/index.html
@@ -114,10 +114,7 @@ input:valid + span::before {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.valid")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_colon_where/index.html
+++ b/files/en-us/web/css/_colon_where/index.html
@@ -147,10 +147,7 @@ footer p:hover {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.where")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_after/index.html
+++ b/files/en-us/web/css/_doublecolon_after/index.html
@@ -162,10 +162,7 @@ span[data-descr]:focus::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.after")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_backdrop/index.html
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.html
@@ -71,10 +71,7 @@ dialog::backdrop {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.backdrop")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_before/index.html
+++ b/files/en-us/web/css/_doublecolon_before/index.html
@@ -216,10 +216,7 @@ li[aria-current='step']::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.before")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_first-letter/index.html
+++ b/files/en-us/web/css/_doublecolon_first-letter/index.html
@@ -152,10 +152,7 @@ h2 + p::first-letter {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.first-letter")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_first-line/index.html
+++ b/files/en-us/web/css/_doublecolon_first-line/index.html
@@ -106,10 +106,7 @@ because it is not a block-level element.&lt;/span&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.first-line")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_grammar-error/index.html
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.html
@@ -73,10 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.grammar-error")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_marker/index.html
+++ b/files/en-us/web/css/_doublecolon_marker/index.html
@@ -87,10 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.marker")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_placeholder/index.html
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.html
@@ -147,10 +147,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.placeholder")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/_doublecolon_spelling-error/index.html
+++ b/files/en-us/web/css/_doublecolon_spelling-error/index.html
@@ -73,10 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.selectors.spelling-error")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/animation-direction/index.html
+++ b/files/en-us/web/css/animation-direction/index.html
@@ -113,10 +113,7 @@ animation-direction: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.animation-direction")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/animation-name/index.html
+++ b/files/en-us/web/css/animation-name/index.html
@@ -107,10 +107,7 @@ animation-name: <a href="/en-US/docs/Web/CSS/unset">unset</a></pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.animation-name")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/counter-reset/index.html
+++ b/files/en-us/web/css/counter-reset/index.html
@@ -100,10 +100,7 @@ counter-reset: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.counter-reset")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/counter-set/index.html
+++ b/files/en-us/web/css/counter-set/index.html
@@ -94,10 +94,7 @@ counter-set: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.counter-set")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/direction/index.html
+++ b/files/en-us/web/css/direction/index.html
@@ -88,10 +88,7 @@ direction: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.direction")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/font-variant/index.html
+++ b/files/en-us/web/css/font-variant/index.html
@@ -121,10 +121,7 @@ p.small {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.font-variant")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/hyphens/index.html
+++ b/files/en-us/web/css/hyphens/index.html
@@ -143,10 +143,7 @@ dd.auto {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.hyphens")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/ime-mode/index.html
+++ b/files/en-us/web/css/ime-mode/index.html
@@ -100,7 +100,4 @@ ime-mode: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.ime-mode")}}</p>
-</div>

--- a/files/en-us/web/css/inherit/index.html
+++ b/files/en-us/web/css/inherit/index.html
@@ -70,10 +70,7 @@ h2 { color: green; }
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.types.global_keywords.inherit")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/integer/index.html
+++ b/files/en-us/web/css/integer/index.html
@@ -82,10 +82,7 @@ _5          Special characters are not allowed.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.types.integer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/line-height/index.html
+++ b/files/en-us/web/css/line-height/index.html
@@ -166,10 +166,7 @@ h1 {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.line-height")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/orphans/index.html
+++ b/files/en-us/web/css/orphans/index.html
@@ -103,10 +103,7 @@ p:first-child {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.orphans")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/outline-color/index.html
+++ b/files/en-us/web/css/outline-color/index.html
@@ -122,10 +122,7 @@ outline-color: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.outline-color")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/perspective-origin/index.html
+++ b/files/en-us/web/css/perspective-origin/index.html
@@ -383,10 +383,7 @@ section {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.perspective-origin")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/resolution/index.html
+++ b/files/en-us/web/css/resolution/index.html
@@ -87,10 +87,7 @@ ten dpi    The number must use digits only.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.types.resolution")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/shape-image-threshold/index.html
+++ b/files/en-us/web/css/shape-image-threshold/index.html
@@ -115,10 +115,7 @@ shape-image-threshold: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.shape-image-threshold")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/shape-margin/index.html
+++ b/files/en-us/web/css/shape-margin/index.html
@@ -110,10 +110,7 @@ of Mars, if he exists, probably knows its truth as we know it.&lt;/section&gt;</
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.shape-margin")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/shape-outside/index.html
+++ b/files/en-us/web/css/shape-outside/index.html
@@ -185,10 +185,7 @@ p {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.shape-outside")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/unset/index.html
+++ b/files/en-us/web/css/unset/index.html
@@ -111,10 +111,7 @@ p {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.types.global_keywords.unset")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/user-select/index.html
+++ b/files/en-us/web/css/user-select/index.html
@@ -138,10 +138,7 @@ user-select: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.user-select")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/widows/index.html
+++ b/files/en-us/web/css/widows/index.html
@@ -109,10 +109,7 @@ p:first-child {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("css.properties.widows")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.html
@@ -72,10 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.AggregateError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@unscopables/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@unscopables/index.html
@@ -65,10 +65,7 @@ Object.keys(Array.prototype[Symbol.unscopables]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Array.@@unscopables")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
@@ -270,10 +270,7 @@ console.log(deleteWords)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Array.filter")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/@@species/index.html
@@ -49,10 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.ArrayBuffer.@@species")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.html
@@ -108,10 +108,7 @@ var bObjProto = new Boolean({});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Boolean")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/columnnumber/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/columnnumber/index.html
@@ -26,10 +26,7 @@ console.log(e.columnNumber) // 0
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error.columnNumber")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/filename/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/filename/index.html
@@ -30,10 +30,7 @@ throw e;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error.fileName")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.html
@@ -208,10 +208,7 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/linenumber/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/linenumber/index.html
@@ -38,10 +38,7 @@ throw e;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error.lineNumber")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/message/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/message/index.html
@@ -40,10 +40,7 @@ throw e;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error.message")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/name/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/name/index.html
@@ -40,10 +40,7 @@ throw e;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error.name")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/error/stack/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/error/stack/index.html
@@ -107,10 +107,7 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Error.stack")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/evalerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/evalerror/index.html
@@ -72,10 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.EvalError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
@@ -222,10 +222,7 @@ console.log(myInstance.constructor);              // logs 'MyConstructor'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Function.apply")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/arguments/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/arguments/index.html
@@ -51,10 +51,7 @@ console.log('returned: ' + g.arguments)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Function.arguments")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/index.html
@@ -94,10 +94,7 @@ console.log(f2());          // 20
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Function")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.html
@@ -62,10 +62,7 @@ console.log((function(a, b = 1, c) {}).length);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Function.length")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/internalerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/internalerror/index.html
@@ -78,10 +78,7 @@ loop(0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.InternalError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@species/index.html
@@ -49,10 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Map.@@species")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.html
@@ -71,10 +71,7 @@ console.log(objectSymbols[0]);     // Symbol(a)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Object.getOwnPropertySymbols")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.html
@@ -117,10 +117,7 @@ new p(); // TypeError is thrown, "p" is not a constructor
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Proxy.handler.construct")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.html
@@ -111,10 +111,7 @@ Object.getOwnPropertyDescriptor(p, 'a'); // TypeError is thrown
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Proxy.handler.getOwnPropertyDescriptor")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.html
@@ -103,10 +103,7 @@ Object.preventExtensions(p); // TypeError is thrown
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Proxy.handler.preventExtensions")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/rangeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/rangeerror/index.html
@@ -111,10 +111,7 @@ catch(error)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RangeError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/referenceerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/referenceerror/index.html
@@ -85,10 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.ReferenceError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.html
@@ -55,10 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.@@species")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/global/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/global/index.html
@@ -62,10 +62,7 @@ console.log(str2);  // Output: examplefoo</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.global")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.html
@@ -51,10 +51,7 @@ console.log(regex.ignoreCase); // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.ignoreCase")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.html
@@ -228,10 +228,7 @@ console.log(/[^.]+/.exec(url)[0].substr(7)) // logs 'xxx'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp")}}</p>
-</div>
 
 <h3 id="Firefox-specific_notes">Firefox-specific notes</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/input/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/input/index.html
@@ -49,10 +49,7 @@ RegExp.$_;            // "hi world!"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.input")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.html
@@ -67,10 +67,7 @@ console.log(re.lastIndex);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.lastIndex")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastmatch/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastmatch/index.html
@@ -49,10 +49,7 @@ RegExp['$&amp;'];     // "hi"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.lastMatch")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastparen/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastparen/index.html
@@ -49,10 +49,7 @@ RegExp['$+'];     // "hi"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.lastParen")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/leftcontext/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/leftcontext/index.html
@@ -49,10 +49,7 @@ RegExp['$`'];       // "hello "
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.leftContext")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.html
@@ -51,10 +51,7 @@ console.log(regex.multiline); // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.multiline")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/n/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/n/index.html
@@ -65,10 +65,7 @@ number; // "24"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.n")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/rightcontext/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/rightcontext/index.html
@@ -49,10 +49,7 @@ RegExp["$'"];       // " world!"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.rightContext")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/source/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/source/index.html
@@ -55,10 +55,7 @@ new RegExp('\n').source === '\\n'; // true, starting with ES5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.source")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.html
@@ -74,10 +74,7 @@ regex2.test('.\nfoo'); // true - index 2 is the beginning of a line
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.sticky")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.html
@@ -52,10 +52,7 @@ console.log(regex.unicode); // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.RegExp.unicode")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@species/index.html
@@ -49,10 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Set.@@species")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.html
@@ -85,10 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.SyntaxError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/@@species/index.html
@@ -51,10 +51,7 @@ Float32Array[Symbol.species]; // function Float32Array()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.TypedArray.@@species")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typeerror/index.html
@@ -93,10 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.TypeError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/urierror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/urierror/index.html
@@ -85,10 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.URIError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/compileerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/compileerror/index.html
@@ -85,10 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.CompileError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/global/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/global/index.html
@@ -92,10 +92,7 @@ WebAssembly.instantiateStreaming(fetch('global.wasm'), { js: { global } })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.Global")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/index.html
@@ -91,10 +91,7 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/instance/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/instance/index.html
@@ -79,10 +79,7 @@ WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.Instance")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/linkerror/index.html
@@ -84,10 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.LinkError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.html
@@ -47,10 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.Memory.buffer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/index.html
@@ -87,10 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.Memory")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/index.html
@@ -79,10 +79,7 @@ onmessage = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.Module")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.html
@@ -84,10 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.RuntimeError")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/index.html
@@ -90,10 +90,7 @@ console.log(tbl.get(1));  // "null"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.WebAssembly.Table")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -426,10 +426,7 @@ const {self, prot} = obj;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.operators.destructuring")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.html
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.html
@@ -288,10 +288,7 @@ assert(obj3.__proto__ === 17)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.operators.object_initializer")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/textlength/index.html
+++ b/files/en-us/web/svg/attribute/textlength/index.html
@@ -34,7 +34,6 @@ tags:
 &lt;/svg&gt;</pre>
 
 <p>{{EmbedLiveSample("topExample", "200", "100")}}</p>
-</div>
 
 <h2 id="Usage_notes">Usage notes</h2>
 
@@ -161,8 +160,6 @@ widthSlider.dispatchEvent(new Event("input"));
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div>
 
 <p>{{Compat("svg.attributes.textLength")}}</p>
 </div>

--- a/files/en-us/web/svg/element/animate/index.html
+++ b/files/en-us/web/svg/element/animate/index.html
@@ -94,7 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("svg.elements.animate")}}</p>
-</div>


### PR DESCRIPTION
This commit removes 112 useless `<div>` tags from allover `files/en-us/web/` folder, all these occurrences look like this:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>

<div>

<p>{{Compat("...")}}</p>
</div>
```
They are replaced with this:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>

<p>{{Compat("...")}}</p>
```