### PR TITLE
Use 'let' so assignment is not broken

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.html
+++ b/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.html
@@ -175,7 +175,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
 
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
@@ -376,7 +376,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
 
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
@@ -519,7 +519,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
 
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);

--- a/files/en-us/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.html
@@ -301,7 +301,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.html
@@ -158,7 +158,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
 
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.html
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.html
@@ -570,7 +570,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 
@@ -723,7 +723,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.html
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.html
@@ -673,7 +673,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 
@@ -835,7 +835,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 

--- a/files/en-us/learn/javascript/first_steps/arrays/index.html
+++ b/files/en-us/learn/javascript/first_steps/arrays/index.html
@@ -304,7 +304,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 
@@ -503,7 +503,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 

--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.html
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.html
@@ -277,7 +277,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 
@@ -445,7 +445,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 
@@ -626,7 +626,7 @@ textarea.onkeydown = function(e){
 
 function insertAtCaret(text) {
   const scrollPos = textarea.scrollTop;
-  const caretPos = textarea.selectionStart;
+  let caretPos = textarea.selectionStart;
   const front = (textarea.value).substring(0, caretPos);
   const back = (textarea.value).substring(textarea.selectionEnd, textarea.value.length);
 


### PR DESCRIPTION
I didn't test it because I have a problem with a yari dependency (gifsicle).
[Mdn article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Useful_string_methods##fixing_capitalization)
Pressing `tab` in playable code causes :

> Playable_code_2:172 Uncaught TypeError: Assignment to constant variable.
    at insertAtCaret (Playable_code_2:172)
    at HTMLTextAreaElement.textarea.onkeydown (Playable_code_2:157)
