### PR TITLE
remove unnecessary class=external in web/css tree

### DIFF
--- a/files/en-us/web/css/-moz-user-focus/index.html
+++ b/files/en-us/web/css/-moz-user-focus/index.html
@@ -76,7 +76,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Not part of any standard. A similar property, <code>user-focus</code>, was proposed in <a class="external" href="https://www.w3.org/TR/2000/WD-css3-userint-20000216">early drafts of a predecessor of the CSS3 UI specification</a>, but was rejected by the working group.</p>
+<p>Not part of any standard. A similar property, <code>user-focus</code>, was proposed in <a href="https://www.w3.org/TR/2000/WD-css3-userint-20000216">early drafts of a predecessor of the CSS3 UI specification</a>, but was rejected by the working group.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/css/-moz-user-input/index.html
+++ b/files/en-us/web/css/-moz-user-input/index.html
@@ -28,7 +28,7 @@ tags:
 <p>For elements that normally take user input, such as a {{HTMLElement("textarea")}}, the initial value of <code>-moz-user-input</code> is <code>enabled</code>.</p>
 
 <div class="note">
-<p><strong>Note:</strong> <code>-moz-user-input</code> was one of the proposals leading to the proposed CSS 3 {{cssxref("user-input")}} property, which has not yet reached Candidate Recommendation (call for implementations). A similar property, <code>user-focus</code>, was proposed in <a class="external" href="https://www.w3.org/TR/2000/WD-css3-userint-20000216">early drafts of a predecessor of the CSS3 UI specification</a>, but was rejected by the working group.</p>
+<p><strong>Note:</strong> <code>-moz-user-input</code> was one of the proposals leading to the proposed CSS 3 {{cssxref("user-input")}} property, which has not yet reached Candidate Recommendation (call for implementations). A similar property, <code>user-focus</code>, was proposed in <a href="https://www.w3.org/TR/2000/WD-css3-userint-20000216">early drafts of a predecessor of the CSS3 UI specification</a>, but was rejected by the working group.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/css/-webkit-box-reflect/index.html
+++ b/files/en-us/web/css/-webkit-box-reflect/index.html
@@ -66,7 +66,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>The Apple <a class="external" href="http://developer.apple.com/library/safari/documentation/appleapplications/reference/safaricssref/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-SW16">documentation</a>.</li>
+ <li>The Apple <a href="http://developer.apple.com/library/safari/documentation/appleapplications/reference/safaricssref/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-SW16">documentation</a>.</li>
  <li>The Webkit <a href="https://www.webkit.org/blog/182/css-reflections/">specification</a>.</li>
- <li>Lea Verou's article on reflection using <a class="external" href="http://lea.verou.me/2011/06/css-reflections-for-firefox-with-moz-element-and-svg-masks/">CSS features on the standard track</a>.</li>
+ <li>Lea Verou's article on reflection using <a href="http://lea.verou.me/2011/06/css-reflections-for-firefox-with-moz-element-and-svg-masks/">CSS features on the standard track</a>.</li>
 </ul>

--- a/files/en-us/web/css/@document/index.html
+++ b/files/en-us/web/css/@document/index.html
@@ -79,5 +79,5 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a class="external" href="http://lists.w3.org/Archives/Public/www-style/2004Aug/0135">Per-site user style sheet rules</a> on the www-style mailing list.</li>
+ <li><a href="http://lists.w3.org/Archives/Public/www-style/2004Aug/0135">Per-site user style sheet rules</a> on the www-style mailing list.</li>
 </ul>

--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -196,11 +196,11 @@ tags:
 <ul>
  <li><a href="/en-US/docs/WOFF">About WOFF</a></li>
  <li><a href="https://everythingfonts.com/font-face">Everythingfonts font-face generator</a></li>
- <li><a class="external" href="http://www.fontsquirrel.com/fontface/generator">FontSquirrel @font-face generator</a></li>
- <li><a class="external" href="http://hacks.mozilla.org/2009/06/beautiful-fonts-with-font-face/">Beautiful fonts with @font-face</a></li>
- <li><a class="external" href="http://openfontlibrary.org/">Open Font Library</a></li>
- <li><a class="external" href="https://caniuse.com/woff">When can I use WOFF?</a></li>
- <li><a class="external" href="https://caniuse.com/svg-fonts">When can I use SVG Fonts?</a></li>
+ <li><a href="http://www.fontsquirrel.com/fontface/generator">FontSquirrel @font-face generator</a></li>
+ <li><a href="http://hacks.mozilla.org/2009/06/beautiful-fonts-with-font-face/">Beautiful fonts with @font-face</a></li>
+ <li><a href="http://openfontlibrary.org/">Open Font Library</a></li>
+ <li><a href="https://caniuse.com/woff">When can I use WOFF?</a></li>
+ <li><a href="https://caniuse.com/svg-fonts">When can I use SVG Fonts?</a></li>
  <li><a href="https://coolfont.org">Free Fancy Cool Fonts</a></li>
  <li><a href="https://nicknames.name/">Best Nicknames</a></li>
 </ul>

--- a/files/en-us/web/css/@keyframes/index.html
+++ b/files/en-us/web/css/@keyframes/index.html
@@ -135,7 +135,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.at-rules.keyframes")}}</p>
 

--- a/files/en-us/web/css/@media/-webkit-transform-3d/index.html
+++ b/files/en-us/web/css/@media/-webkit-transform-3d/index.html
@@ -66,7 +66,7 @@ tags:
    <td>Initial standardization</td>
   </tr>
   <tr>
-   <td><a class="external" href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3">Safari CSS Reference<br>
+   <td><a href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3">Safari CSS Reference<br>
     <small lang="en-US">'media query extensions' in that document.</small></a></td>
    <td>Non-standard unofficial documentation</td>
    <td>Initial documentation</td>

--- a/files/en-us/web/css/@property/index.html
+++ b/files/en-us/web/css/@property/index.html
@@ -75,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.at-rules.property")}}</p>
 

--- a/files/en-us/web/css/_colon_lang/index.html
+++ b/files/en-us/web/css/_colon_lang/index.html
@@ -96,5 +96,5 @@ p:lang(en) {
  <li>Language-related pseudo-classes: {{cssxref(":lang")}}, {{cssxref(":dir")}}</li>
  <li>HTML {{htmlattrxref("lang")}} attribute</li>
  <li>HTML {{htmlattrxref("translate")}} attribute</li>
- <li><a class="external" href="https://tools.ietf.org/html/bcp47">BCP 47 - Tags for Identifying Languages</a></li>
+ <li><a href="https://tools.ietf.org/html/bcp47">BCP 47 - Tags for Identifying Languages</a></li>
 </ul>

--- a/files/en-us/web/css/_colon_last-child/index.html
+++ b/files/en-us/web/css/_colon_last-child/index.html
@@ -114,7 +114,7 @@ ul li:last-child {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.selectors.last-child")}}</p>
 

--- a/files/en-us/web/css/_colon_scope/index.html
+++ b/files/en-us/web/css/_colon_scope/index.html
@@ -106,7 +106,7 @@ document.getElementById('results').innerHTML = Array.prototype.map.call(selected
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.selectors.scope")}}</p>
 

--- a/files/en-us/web/css/_doublecolon_selection/index.html
+++ b/files/en-us/web/css/_doublecolon_selection/index.html
@@ -114,7 +114,7 @@ p::selection {
 </table>
 
 <div class="note">
-<p><strong>Note:</strong> <code>::selection</code> was in drafts of CSS Selectors Level 3, but it was removed in the Candidate Recommendation phase because its was under-specified (especially with nested elements) and interoperability wasn't achieved <a class="external" href="http://lists.w3.org/Archives/Public/www-style/2008Oct/0268.html">(based on discussion in the W3C Style mailing list)</a>. It returned in <a href="http://dev.w3.org/csswg/css-pseudo-4/">Pseudo-Elements Level 4</a>.</p>
+<p><strong>Note:</strong> <code>::selection</code> was in drafts of CSS Selectors Level 3, but it was removed in the Candidate Recommendation phase because its was under-specified (especially with nested elements) and interoperability wasn't achieved <a href="http://lists.w3.org/Archives/Public/www-style/2008Oct/0268.html">(based on discussion in the W3C Style mailing list)</a>. It returned in <a href="http://dev.w3.org/csswg/css-pseudo-4/">Pseudo-Elements Level 4</a>.</p>
 </div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/css/angle/index.html
+++ b/files/en-us/web/css/angle/index.html
@@ -26,11 +26,11 @@ tags:
 
 <dl>
  <dt><code><a id="deg">deg</a></code></dt>
- <dd>Represents an angle in <a class="external" href="https://en.wikipedia.org/wiki/Degree_%28angle%29">degrees</a>. One full circle is <code>360deg</code>. Examples: <code>0deg</code>, <code>90deg</code>, <code>14.23deg</code>.</dd>
+ <dd>Represents an angle in <a href="https://en.wikipedia.org/wiki/Degree_%28angle%29">degrees</a>. One full circle is <code>360deg</code>. Examples: <code>0deg</code>, <code>90deg</code>, <code>14.23deg</code>.</dd>
  <dt id="grad"><code>grad</code></dt>
- <dd>Represents an angle in <a class="external" href="https://en.wikipedia.org/wiki/Gradian">gradians</a>. One full circle is <code>400grad</code>. Examples: <code>0grad</code>, <code>100grad</code>, <code>38.8grad</code>.</dd>
+ <dd>Represents an angle in <a href="https://en.wikipedia.org/wiki/Gradian">gradians</a>. One full circle is <code>400grad</code>. Examples: <code>0grad</code>, <code>100grad</code>, <code>38.8grad</code>.</dd>
  <dt id="rad"><code>rad</code></dt>
- <dd>Represents an angle in <a class="external" href="https://en.wikipedia.org/wiki/Radian">radians</a>. One full circle is 2π radians which approximates to <code>6.2832rad</code>. <code>1rad</code> is 180/π degrees. Examples: <code>0rad</code>, <code>1.0708rad</code>, <code>6.2832rad</code>.</dd>
+ <dd>Represents an angle in <a href="https://en.wikipedia.org/wiki/Radian">radians</a>. One full circle is 2π radians which approximates to <code>6.2832rad</code>. <code>1rad</code> is 180/π degrees. Examples: <code>0rad</code>, <code>1.0708rad</code>, <code>6.2832rad</code>.</dd>
  <dt id="turn"><code>turn</code></dt>
  <dd>Represents an angle in a number of turns. One full circle is <code>1turn</code>. Examples: <code>0turn</code>, <code>0.25turn</code>, <code>1.2turn</code>.</dd>
 </dl>

--- a/files/en-us/web/css/appearance/index.html
+++ b/files/en-us/web/css/appearance/index.html
@@ -1984,6 +1984,6 @@ div{ color: black;
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a class="external" href="https://www.w3.org/TR/2004/CR-css3-ui-20040511/#appearance">Definition of <code>appearance</code> in CSS 3 Basic User Interface</a> (Candidate Recommendation from 2004-05-11).</li>
-	<li><a class="external" href="http://wiki.csswg.org/spec/css4-ui#dropped-css3-features">Dropped CSS3 features from the UI spec.4</a></li>
+	<li><a href="https://www.w3.org/TR/2004/CR-css3-ui-20040511/#appearance">Definition of <code>appearance</code> in CSS 3 Basic User Interface</a> (Candidate Recommendation from 2004-05-11).</li>
+	<li><a href="http://wiki.csswg.org/spec/css4-ui#dropped-css3-features">Dropped CSS3 features from the UI spec.4</a></li>
 </ul>

--- a/files/en-us/web/css/border-bottom/index.html
+++ b/files/en-us/web/css/border-bottom/index.html
@@ -123,7 +123,7 @@ border-bottom: medium dashed blue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.border-bottom")}}</p>
 

--- a/files/en-us/web/css/border-left/index.html
+++ b/files/en-us/web/css/border-left/index.html
@@ -123,7 +123,7 @@ border-left: medium dashed blue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.border-left")}}</p>
 

--- a/files/en-us/web/css/border-right/index.html
+++ b/files/en-us/web/css/border-right/index.html
@@ -123,7 +123,7 @@ border-right: medium dashed green;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.border-right")}}</p>
 

--- a/files/en-us/web/css/border-top/index.html
+++ b/files/en-us/web/css/border-top/index.html
@@ -123,7 +123,7 @@ border-top: medium dashed green;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.border-top")}}</p>
 

--- a/files/en-us/web/css/color-adjust/index.html
+++ b/files/en-us/web/css/color-adjust/index.html
@@ -111,7 +111,7 @@ color-adjust: exact;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.color-adjust")}}</p>
 

--- a/files/en-us/web/css/color-scheme/index.html
+++ b/files/en-us/web/css/color-scheme/index.html
@@ -80,7 +80,7 @@ color-scheme: light dark;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.color-scheme")}}</p>
 

--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -17,14 +17,14 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>&lt;color&gt;</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Types">data type</a> represents a color in the <a class="external" href="https://en.wikipedia.org/wiki/SRGB">sRGB color space</a>. A <code>&lt;color&gt;</code> may also include an <a class="external" href="https://en.wikipedia.org/wiki/Alpha_compositing">alpha-channel</a> <em>transparency value</em>, indicating how the color should <a class="external" href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending">composite</a> with its background.</p>
+<p>The <strong><code>&lt;color&gt;</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Types">data type</a> represents a color in the <a href="https://en.wikipedia.org/wiki/SRGB">sRGB color space</a>. A <code>&lt;color&gt;</code> may also include an <a href="https://en.wikipedia.org/wiki/Alpha_compositing">alpha-channel</a> <em>transparency value</em>, indicating how the color should <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/masking.html#SimpleAlphaBlending">composite</a> with its background.</p>
 
 <p>A <code>&lt;color&gt;</code> can be defined in any of the following ways:</p>
 
 <ul>
  <li>Using a keyword (such as <code>blue</code> or <code>transparent</code>)</li>
- <li>Using the <a class="external" href="https://en.wikipedia.org/wiki/RGB_color_model#Geometric_representation">RGB cubic-coordinate</a> system (via the #-hexadecimal or the <code>rgb()</code> and <code>rgba()</code> functional notations)</li>
- <li>Using the <a class="external" href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSL cylindrical-coordinate</a> system (via the <code>hsl()</code> and <code>hsla()</code> functional notations)</li>
+ <li>Using the <a href="https://en.wikipedia.org/wiki/RGB_color_model#Geometric_representation">RGB cubic-coordinate</a> system (via the #-hexadecimal or the <code>rgb()</code> and <code>rgba()</code> functional notations)</li>
+ <li>Using the <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSL cylindrical-coordinate</a> system (via the <code>hsl()</code> and <code>hsla()</code> functional notations)</li>
 </ul>
 
 <div class="note">
@@ -36,7 +36,7 @@ tags:
 <p>The <code>&lt;color&gt;</code> data type is specified using one of the options listed below.</p>
 
 <div class="note">
-<p><strong>Note:</strong> Although <code>&lt;color&gt;</code> values are precisely defined, their actual appearance may vary (sometimes significantly) from device to device. This is because most devices are not calibrated, and some browsers do not support output devices' <a class="external" href="https://en.wikipedia.org/wiki/ICC_profile">color profiles</a>.</p>
+<p><strong>Note:</strong> Although <code>&lt;color&gt;</code> values are precisely defined, their actual appearance may vary (sometimes significantly) from device to device. This is because most devices are not calibrated, and some browsers do not support output devices' <a href="https://en.wikipedia.org/wiki/ICC_profile">color profiles</a>.</p>
 </div>
 
 <h3 id="Color_keywords">Color keywords</h3>
@@ -69,7 +69,7 @@ tags:
 <p><strong>Note:</strong> The list of accepted keywords has undergone many changes during the evolution of CSS:</p>
 
 <ul>
- <li>CSS Level 1 only included 16 basic colors, called the <em>VGA colors</em> as they were taken from the set of displayable colors on <a class="external" href="https://en.wikipedia.org/wiki/VGA">VGA</a> graphics cards.</li>
+ <li>CSS Level 1 only included 16 basic colors, called the <em>VGA colors</em> as they were taken from the set of displayable colors on <a href="https://en.wikipedia.org/wiki/VGA">VGA</a> graphics cards.</li>
  <li>CSS Level 2 added the <code>orange</code> keyword.</li>
  <li>Although various colors not in the specification (mostly adapted from the X11 colors list) were supported by early browsers, it wasn't until SVG 1.0 and CSS Colors Level 3 that they were formally defined. They are called the <em>extended color keywords</em>, the <em>X11 colors</em>, or the <em>SVG colors</em>.</li>
  <li>CSS Colors Level 4 added the <code>rebeccapurple</code> keyword <a href="https://codepen.io/trezy/post/honoring-a-great-man">to honor web pioneer Eric Meyer</a>.</li>
@@ -1223,11 +1223,11 @@ tags:
 
 <h2 id="Interpolation">Interpolation</h2>
 
-<p>In animations and <a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">gradients</a>, <code>&lt;color&gt;</code> values are interpolated on each of their red, green, and blue components. Each component is interpolated as a real, floating-point number. Note that interpolation of colors happens in the <a class="external" href="https://www.gimp.org/docs/plug-in/appendix-alpha.html">alpha-premultiplied sRGBA color space</a> to prevent unexpected gray colors from appearing. In animations, the interpolation's speed is determined by the <a href="/en-US/docs/Web/CSS/single-transition-timing-function">timing function</a>.</p>
+<p>In animations and <a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">gradients</a>, <code>&lt;color&gt;</code> values are interpolated on each of their red, green, and blue components. Each component is interpolated as a real, floating-point number. Note that interpolation of colors happens in the <a href="https://www.gimp.org/docs/plug-in/appendix-alpha.html">alpha-premultiplied sRGBA color space</a> to prevent unexpected gray colors from appearing. In animations, the interpolation's speed is determined by the <a href="/en-US/docs/Web/CSS/single-transition-timing-function">timing function</a>.</p>
 
 <h2 id="Accessibility_considerations">Accessibility considerations</h2>
 
-<p>Some people have difficulty distinguishing colors. The <a class="external" href="https://www.w3.org/TR/WCAG/#visual-audio-contrast">WCAG 2.0</a> recommendation strongly advises against using color as the only means of conveying a specific message, action, or result. See <a href="/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color contrast</a> for more information.</p>
+<p>Some people have difficulty distinguishing colors. The <a href="https://www.w3.org/TR/WCAG/#visual-audio-contrast">WCAG 2.0</a> recommendation strongly advises against using color as the only means of conveying a specific message, action, or result. See <a href="/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#Color_and_color_contrast">Color and color contrast</a> for more information.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/css/css_animations/detecting_css_animation_support/index.html
+++ b/files/en-us/web/css/css_animations/detecting_css_animation_support/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>CSS animations make it possible to do creative animations of content using nothing but CSS. However, there are likely to be times when this feature isn't available, and you may wish to handle that case by using JavaScript code to simulate a similar effect. This article, based on <a class="external" href="http://hacks.mozilla.org/2011/09/detecting-and-generating-css-animations-in-javascript/">this blog post</a> by Chris Heilmann, demonstrates a technique for doing this.</p>
+<p>CSS animations make it possible to do creative animations of content using nothing but CSS. However, there are likely to be times when this feature isn't available, and you may wish to handle that case by using JavaScript code to simulate a similar effect. This article, based on <a href="http://hacks.mozilla.org/2011/09/detecting-and-generating-css-animations-in-javascript/">this blog post</a> by Chris Heilmann, demonstrates a technique for doing this.</p>
 
 <h2 id="Testing_for_CSS_animation_support">Testing for CSS animation support</h2>
 

--- a/files/en-us/web/css/css_columns/using_multi-column_layouts/index.html
+++ b/files/en-us/web/css/css_columns/using_multi-column_layouts/index.html
@@ -94,7 +94,7 @@ tags:
 
 <p>{{EmbedLiveSample("column_width", "100%")}}</p>
 
-<p>The exact details are described in <a class="external" href="https://www.w3.org/TR/css3-multicol/">the CSS3 specification</a>.</p>
+<p>The exact details are described in <a href="https://www.w3.org/TR/css3-multicol/">the CSS3 specification</a>.</p>
 
 <p>In a multi-column block, content is automatically flowed from one column into the next as needed. All HTML, CSS and DOM functionality is supported within columns, as are editing and printing.</p>
 

--- a/files/en-us/web/css/css_display/index.html
+++ b/files/en-us/web/css/css_display/index.html
@@ -110,6 +110,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.display", 10)}}</p>

--- a/files/en-us/web/css/css_images/using_css_gradients/index.html
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.html
@@ -791,7 +791,7 @@ tags:
  <li>Gradient functions: {{cssxref("linear-gradient")}}, {{cssxref("radial-gradient")}}, {{cssxref("conic-gradient")}}, {{cssxref("repeating-linear-gradient")}}, {{cssxref("repeating-radial-gradient")}}, {{cssxref("repeating-conic-gradient")}}</li>
  <li>Gradient-related CSS data types: {{cssxref("&lt;gradient&gt;")}}, {{cssxref("&lt;image&gt;")}}</li>
  <li>Gradient-related CSS properties: {{cssxref("background")}}, {{cssxref("background-image")}}</li>
- <li><a class="external" href="http://lea.verou.me/css3patterns/">CSS Gradients Patterns Gallery, by Lea Verou</a></li>
- <li><a class="external" href="http://standardista.com/cssgradients">CSS3 Gradients Library, by Estelle Weyl</a></li>
+ <li><a href="http://lea.verou.me/css3patterns/">CSS Gradients Patterns Gallery, by Lea Verou</a></li>
+ <li><a href="http://standardista.com/cssgradients">CSS3 Gradients Library, by Estelle Weyl</a></li>
  <li><a href="https://cssgenerator.org/gradient-css-generator.html">Gradient CSS Generator</a></li>
 </ul>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.html
@@ -157,7 +157,7 @@ b {
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: November 3, 2014</li>
 </ul>
 </div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/index.html
@@ -17,11 +17,11 @@ tags:
 <p><em>In CSS 2.1, each box has a position in three dimensions. In addition to their horizontal and vertical positions, boxes lie along a "z-axis" and are formatted one on top of the other. Z-axis positions are particularly relevant when boxes overlap visually.</em></p>
 </blockquote>
 
-<p>(from <a class="external" href="https://www.w3.org/TR/CSS21/visuren.html#z-index">CSS 2.1 Section 9.9.1 - Layered presentation</a>)</p>
+<p>(from <a href="https://www.w3.org/TR/CSS21/visuren.html#z-index">CSS 2.1 Section 9.9.1 - Layered presentation</a>)</p>
 
 <p>This means that CSS style rules allow you to position boxes on layers in addition to the normal rendering layer (layer 0). The Z position of each layer is expressed as an integer representing the stacking order for rendering. Greater numbers mean closer to the observer. Z position can be controlled with the CSS <code>z-index</code> property.</p>
 
-<p>Using <code>z-index</code> appears extremely easy: a single property, assigned a single integer number, with an easy-to-understand behavior. However, when <code>z-index</code> is applied to complex hierarchies of HTML elements, its behavior can be hard to understand or predict. This is due to complex stacking rules. In fact a dedicated section has been reserved in the CSS specification <a class="external" href="https://www.w3.org/TR/CSS21/zindex.html">CSS-2.1 Appendix E</a> to explain these rules better.</p>
+<p>Using <code>z-index</code> appears extremely easy: a single property, assigned a single integer number, with an easy-to-understand behavior. However, when <code>z-index</code> is applied to complex hierarchies of HTML elements, its behavior can be hard to understand or predict. This is due to complex stacking rules. In fact a dedicated section has been reserved in the CSS specification <a href="https://www.w3.org/TR/CSS21/zindex.html">CSS-2.1 Appendix E</a> to explain these rules better.</p>
 
 <p>This article will try to explain those rules, with some simplification and several examples.</p>
 
@@ -40,7 +40,7 @@ tags:
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: July 9, 2005</li>
 </ul>
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.html
@@ -144,7 +144,7 @@ b {
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: November 3, 2014</li>
 </ul>
 </div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.html
@@ -131,7 +131,7 @@ tags:
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: July 9, 2005</li>
 </ul>
 </div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.html
@@ -135,7 +135,7 @@ span.bold { font-weight: bold; }
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: July 9, 2005</li>
 </ul>
 </div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.html
@@ -182,7 +182,7 @@ div.lev3 {
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: July 9, 2005</li>
 </ul>
 </div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
@@ -120,7 +120,7 @@ div {
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: November 3, 2014</li>
 </ul>
 </div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.html
@@ -234,7 +234,7 @@ h1 {
 
 <ul>
  <li>Author(s): Paolo Lombardi</li>
- <li>This article is the English translation of an article I wrote in Italian for <a class="external" href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a class="external" href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
+ <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: July 9, 2005</li>
 </ul>
 </div>

--- a/files/en-us/web/css/custom-ident/index.html
+++ b/files/en-us/web/css/custom-ident/index.html
@@ -15,7 +15,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The syntax of <code>&lt;custom-ident&gt;</code> is similar to CSS identifiers (such as property names), except that it is <a class="external" href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. It consists of one or more characters, where characters can be any of the following:</p>
+<p>The syntax of <code>&lt;custom-ident&gt;</code> is similar to CSS identifiers (such as property names), except that it is <a href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. It consists of one or more characters, where characters can be any of the following:</p>
 
 <ul>
  <li>any alphabetical character (<code>A</code> to <code>Z</code>, or <code>a</code> to <code>z</code>),</li>
@@ -23,10 +23,10 @@ tags:
  <li>a hyphen (<code>-</code>),</li>
  <li>an underscore (<code>_</code>),</li>
  <li>an escaped character (preceded by a backslash, <code>\</code>),</li>
- <li>a <a class="external" href="https://en.wikipedia.org/wiki/Unicode">Unicode</a> character (in the format of a backslash, <code>\</code>, followed by one to six hexadecimal digits, representing its Unicode code point)</li>
+ <li>a <a href="https://en.wikipedia.org/wiki/Unicode">Unicode</a> character (in the format of a backslash, <code>\</code>, followed by one to six hexadecimal digits, representing its Unicode code point)</li>
 </ul>
 
-<p>Note that <code>id1</code>, <code>Id1</code>, <code>iD1</code> and <code>ID1</code> are all different identifiers as they are <a class="external" href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. On the other hand, as there are several ways to escape a character, <code>toto\?</code> and <code>toto\3F</code> are the same identifiers.</p>
+<p>Note that <code>id1</code>, <code>Id1</code>, <code>iD1</code> and <code>ID1</code> are all different identifiers as they are <a href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. On the other hand, as there are several ways to escape a character, <code>toto\?</code> and <code>toto\3F</code> are the same identifiers.</p>
 
 <h3 id="Forbidden_values">Forbidden values</h3>
 

--- a/files/en-us/web/css/display-box/index.html
+++ b/files/en-us/web/css/display-box/index.html
@@ -32,8 +32,8 @@ tags:
 <p>Current implementations in most browsers will remove from the <a href="/en-US/docs/Learn/Accessibility/What_is_accessibility#Accessibility_APIs">accessibility tree</a> any element with a <code>display</code> value of <code>contents</code>. This will cause the element — and in some browser versions, its descendant elements — to no longer be announced by screen reading technology. This is incorrect behavior according to the <a href="https://drafts.csswg.org/css-display/#the-display-properties">CSSWG specification</a>.</p>
 
 <ul>
- <li><a class="external" href="https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents">More accessible markup with display: contents | Hidde de Vries</a></li>
- <li><a class="external" href="http://adrianroselli.com/2018/05/display-contents-is-not-a-css-reset.html">Display: Contents Is Not a CSS Reset | Adrian Roselli</a></li>
+ <li><a href="https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents">More accessible markup with display: contents | Hidde de Vries</a></li>
+ <li><a href="http://adrianroselli.com/2018/05/display-contents-is-not-a-css-reset.html">Display: Contents Is Not a CSS Reset | Adrian Roselli</a></li>
 </ul>
 
 <h2 id="Examples">Examples</h2>
@@ -104,7 +104,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <h3 id="Support_of_contents">Support of contents</h3>
 

--- a/files/en-us/web/css/display-internal/index.html
+++ b/files/en-us/web/css/display-internal/index.html
@@ -101,7 +101,7 @@ label, input {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <h3 id="Support_of_table_values">Support of table values</h3>
 

--- a/files/en-us/web/css/display-legacy/index.html
+++ b/files/en-us/web/css/display-legacy/index.html
@@ -88,7 +88,7 @@ Not a flex item
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <h3 id="Support_of_inline-block">Support of inline-block</h3>
 

--- a/files/en-us/web/css/display-listitem/index.html
+++ b/files/en-us/web/css/display-listitem/index.html
@@ -62,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <h3 id="Support_of_list-item">Support of <code>list-item</code></h3>
 

--- a/files/en-us/web/css/display-outside/index.html
+++ b/files/en-us/web/css/display-outside/index.html
@@ -71,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.display.display-outside", 10)}}</p>
 

--- a/files/en-us/web/css/display/index.html
+++ b/files/en-us/web/css/display/index.html
@@ -158,15 +158,15 @@ display: unset;
 
 <p>Using a <code>display</code> value of <code>none</code> on an element will remove it from the <a href="/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis">accessibility tree</a>. This will cause the element and all its descendant elements to no longer be announced by screen reading technology.</p>
 
-<p>If you want to visually hide the element, a more accessible alternative is to use <a class="external" href="https://gomakethings.com/hidden-content-for-better-a11y/#hiding-the-link">a combination of properties</a> to remove it visually from the screen but keep it parsable by assistive technology such as screen readers.</p>
+<p>If you want to visually hide the element, a more accessible alternative is to use <a href="https://gomakethings.com/hidden-content-for-better-a11y/#hiding-the-link">a combination of properties</a> to remove it visually from the screen but keep it parsable by assistive technology such as screen readers.</p>
 
 <h3 id="display_contents">display: contents</h3>
 
 <p>Current implementations in most browsers will remove from the <a href="/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis">accessibility tree</a> any element with a <code>display</code> value of <code>contents</code> (but descendants will remain). This will cause the element itself to no longer be announced by screen reading technology. This is incorrect behavior according to the <a href="https://drafts.csswg.org/css-display/#valdef-display-contents">CSS specification</a>.</p>
 
 <ul>
- <li><a class="external" href="https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents">More accessible markup with display: contents | Hidde de Vries</a></li>
- <li><a class="external" href="http://adrianroselli.com/2018/05/display-contents-is-not-a-css-reset.html">Display: Contents Is Not a CSS Reset | Adrian Roselli</a></li>
+ <li><a href="https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents">More accessible markup with display: contents | Hidde de Vries</a></li>
+ <li><a href="http://adrianroselli.com/2018/05/display-contents-is-not-a-css-reset.html">Display: Contents Is Not a CSS Reset | Adrian Roselli</a></li>
 </ul>
 
 <h3 id="Tables">Tables</h3>
@@ -174,10 +174,10 @@ display: unset;
 <p>Changing the <code>display</code> value of a {{HTMLElement("table")}} element to <code>block</code>, <code>grid</code>, or <code>flex</code> will alter its representation in the <a href="/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis">accessibility tree</a>. This will cause the table to no longer be announced properly by screen reading technology.</p>
 
 <ul>
- <li><a class="external" href="https://developer.paciellogroup.com/blog/2018/03/short-note-on-what-css-display-properties-do-to-table-semantics/">Short note on what CSS display properties do to table semantics — The Paciello Group</a></li>
- <li><a class="external" href="https://gomakethings.com/hidden-content-for-better-a11y/">Hidden content for better a11y | Go Make Things</a></li>
+ <li><a href="https://developer.paciellogroup.com/blog/2018/03/short-note-on-what-css-display-properties-do-to-table-semantics/">Short note on what CSS display properties do to table semantics — The Paciello Group</a></li>
+ <li><a href="https://gomakethings.com/hidden-content-for-better-a11y/">Hidden content for better a11y | Go Make Things</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.3_%e2%80%94_create_content_that_can_be_presented_in_different_ways">MDN Understanding WCAG, Guideline 1.3 explanations</a></li>
- <li><a class="external" href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html">Understanding Success Criterion 1.3.1 | W3C Understanding WCAG 2.0</a></li>
+ <li><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html">Understanding Success Criterion 1.3.1 | W3C Understanding WCAG 2.0</a></li>
 </ul>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -326,7 +326,7 @@ updateDisplay();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.display", 10)}}</p>
 

--- a/files/en-us/web/css/display/two-value_syntax_of_display/index.html
+++ b/files/en-us/web/css/display/two-value_syntax_of_display/index.html
@@ -150,7 +150,7 @@ tags:
 
 <p>As demonstrated above, there is not a lot of advantage in using the two-value version right now; if you did your page would only work in Firefox! Other browsers do not yet implement the two-value versions. Therefore <code>display: block flex</code> will only get you flex layout in Firefox, and will be ignored as invalid in Chrome. You can see current support in the compat data for the two-value syntax:</p>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.display.multi-keyword_values", 10)}}</p>
 

--- a/files/en-us/web/css/filter/index.html
+++ b/files/en-us/web/css/filter/index.html
@@ -1136,5 +1136,5 @@ img {
  <li><a class="internal" href="/en-US/docs/Web/SVG/Applying_SVG_effects_to_HTML_content">Applying SVG effects to HTML content</a></li>
  <li>The {{cssxref("mask")}} property</li>
  <li><a class="internal" href="/en-US/docs/Web/SVG">SVG</a></li>
- <li><a class="external" href="http://www.html5rocks.com/en/tutorials/filters/understanding-css/">Understanding CSS filters</a>, HTML5Rocks! article</li>
+ <li><a href="http://www.html5rocks.com/en/tutorials/filters/understanding-css/">Understanding CSS filters</a>, HTML5Rocks! article</li>
 </ul>

--- a/files/en-us/web/css/flex-direction/index.html
+++ b/files/en-us/web/css/flex-direction/index.html
@@ -143,7 +143,7 @@ flex-direction: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.flex-direction")}}</p>
 

--- a/files/en-us/web/css/flex-grow/index.html
+++ b/files/en-us/web/css/flex-grow/index.html
@@ -120,7 +120,7 @@ flex-grow: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.flex-grow")}}</p>
 

--- a/files/en-us/web/css/flex-shrink/index.html
+++ b/files/en-us/web/css/flex-shrink/index.html
@@ -114,7 +114,7 @@ flex-shrink: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.flex-shrink")}}</p>
 

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -281,7 +281,7 @@ flex.addEventListener("click", function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.flex")}}</p>
 

--- a/files/en-us/web/css/float/index.html
+++ b/files/en-us/web/css/float/index.html
@@ -214,7 +214,7 @@ div {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.float")}}</p>
 

--- a/files/en-us/web/css/font-optical-sizing/index.html
+++ b/files/en-us/web/css/font-optical-sizing/index.html
@@ -102,7 +102,7 @@ p {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.font-optical-sizing")}}</p>
 

--- a/files/en-us/web/css/font-size/index.html
+++ b/files/en-us/web/css/font-size/index.html
@@ -233,7 +233,7 @@ span {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.font-size")}}</p>
 

--- a/files/en-us/web/css/font-style/index.html
+++ b/files/en-us/web/css/font-style/index.html
@@ -222,7 +222,7 @@ update();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.font-style")}}</p>
 

--- a/files/en-us/web/css/font-weight/index.html
+++ b/files/en-us/web/css/font-weight/index.html
@@ -390,7 +390,7 @@ span {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.font-weight")}}</p>
 

--- a/files/en-us/web/css/forced-color-adjust/index.html
+++ b/files/en-us/web/css/forced-color-adjust/index.html
@@ -112,7 +112,7 @@ forced-color-adjust: none;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.forced-color-adjust")}}</p>
 

--- a/files/en-us/web/css/frequency/index.html
+++ b/files/en-us/web/css/frequency/index.html
@@ -26,7 +26,7 @@ tags:
 </dl>
 
 <div class="note">
-<p><strong>Note:</strong> Although the number <code>0</code> is always the same regardless of unit, the unit may not be omitted. In other words, <code>0</code> is invalid and does not represent <code>0Hz</code> or <code>0kHz</code>. Though the units are case-insensitive, it is good practice to use a capital "H" for <code>Hz</code> and <code>kHz</code>, as specified in the <a class="external" href="https://en.wikipedia.org/wiki/International_System_of_Units">SI</a>.</p>
+<p><strong>Note:</strong> Although the number <code>0</code> is always the same regardless of unit, the unit may not be omitted. In other words, <code>0</code> is invalid and does not represent <code>0Hz</code> or <code>0kHz</code>. Though the units are case-insensitive, it is good practice to use a capital "H" for <code>Hz</code> and <code>kHz</code>, as specified in the <a href="https://en.wikipedia.org/wiki/International_System_of_Units">SI</a>.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>
@@ -65,7 +65,7 @@ tags:
 </table>
 
 <div class="note">
-<p><strong>Note:</strong> This data type was initially introduced in <a class="external" href="https://www.w3.org/TR/CSS2/aural.html#q19.0">CSS Level 2</a> for the now-obsolete <a href="/en-US/docs/Web/CSS/@media/aural">aural</a> <a href="/en-US/docs/Web/CSS/@media#Media_types">media type</a>, where it was used to define the pitch of the voice. However, the <code>&lt;frequency&gt;</code> data type has been reintroduced in CSS3, though no CSS property is using it at the moment.</p>
+<p><strong>Note:</strong> This data type was initially introduced in <a href="https://www.w3.org/TR/CSS2/aural.html#q19.0">CSS Level 2</a> for the now-obsolete <a href="/en-US/docs/Web/CSS/@media/aural">aural</a> <a href="/en-US/docs/Web/CSS/@media#Media_types">media type</a>, where it was used to define the pitch of the voice. However, the <code>&lt;frequency&gt;</code> data type has been reintroduced in CSS3, though no CSS property is using it at the moment.</p>
 </div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/css/ident/index.html
+++ b/files/en-us/web/css/ident/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The syntax of <code>&lt;custom-ident&gt;</code> is similar to CSS identifiers (such as property names), except that it is <a class="external" href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. It consists of one or more characters, where characters can be any of the following:</p>
+<p>The syntax of <code>&lt;custom-ident&gt;</code> is similar to CSS identifiers (such as property names), except that it is <a href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. It consists of one or more characters, where characters can be any of the following:</p>
 
 <ul>
  <li>any alphabetical character (<code>A</code> to <code>Z</code>, or <code>a</code> to <code>z</code>),</li>
@@ -25,10 +25,10 @@ tags:
  <li>a hyphen (<code>-</code>),</li>
  <li>an underscore (<code>_</code>),</li>
  <li>an escaped character (preceded by a backslash, <code>\</code>),</li>
- <li>a <a class="external" href="https://en.wikipedia.org/wiki/Unicode">Unicode</a> character (in the format of a backslash, <code>\</code>, followed by one to six hexadecimal digits, representing its Unicode code point)</li>
+ <li>a <a href="https://en.wikipedia.org/wiki/Unicode">Unicode</a> character (in the format of a backslash, <code>\</code>, followed by one to six hexadecimal digits, representing its Unicode code point)</li>
 </ul>
 
-<p>Note that <code>id1</code>, <code>Id1</code>, <code>iD1</code> and <code>ID1</code> are all different identifiers as they are <a class="external" href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. On the other hand, as there are several ways to escape a character, <code>toto\?</code> and <code>toto\3F</code> are the same identifiers.</p>
+<p>Note that <code>id1</code>, <code>Id1</code>, <code>iD1</code> and <code>ID1</code> are all different identifiers as they are <a href="https://en.wikipedia.org/wiki/Case_sensitivity">case-sensitive</a>. On the other hand, as there are several ways to escape a character, <code>toto\?</code> and <code>toto\3F</code> are the same identifiers.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/css/index.html
+++ b/files/en-us/web/css/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p class="summary"><span class="seoSummary"><strong>Cascading Style Sheets</strong> (<strong>CSS</strong>) is a <a href="/en-US/docs/Web/API/StyleSheet">stylesheet</a> language used to describe the presentation of a document written in <a href="/en-US/docs/Web/HTML" title="HyperText Markup Language">HTML</a></span> or <a href="/en-US/docs/Web/XML/XML_introduction">XML</a> (including XML dialects such as <a href="/en-US/docs/Web/SVG">SVG</a>, <a href="/en-US/docs/Web/MathML">MathML</a> or {{Glossary("XHTML")}}). CSS describes how elements should be rendered on screen, on paper, in speech, or on other media.</p>
 
-<p>CSS is among the core languages of the <strong>open web</strong> and is standardized across Web browsers according to <a class="external" href="http://w3.org/Style/CSS/#specs">W3C specifications</a>. Previously, development of various parts of CSS specification was done synchronously, which allowed versioning of the latest recommendations. You might have heard about CSS1, CSS2.1, CSS3. However, CSS4 has never become an official version.</p>
+<p>CSS is among the core languages of the <strong>open web</strong> and is standardized across Web browsers according to <a href="http://w3.org/Style/CSS/#specs">W3C specifications</a>. Previously, development of various parts of CSS specification was done synchronously, which allowed versioning of the latest recommendations. You might have heard about CSS1, CSS2.1, CSS3. However, CSS4 has never become an official version.</p>
 
 <p>From CSS3, the scope of the specification increased significantly and the progress on different CSS modules started to differ so much, that it became more effective to <a href="https://www.w3.org/Style/CSS/current-work">develop and release recommendations separately per module</a>. Instead of versioning the CSS specification, W3C now periodically takes a snapshot of <a href="https://www.w3.org/TR/css/">the latest stable state of the CSS specification</a>.</p>
 
@@ -96,7 +96,7 @@ tags:
 <h2 class="Tools" id="Tools_for_CSS_development">Tools for CSS development</h2>
 
 <ul>
- <li>You can use the <a class="external" href="https://jigsaw.w3.org/css-validator/">W3C CSS Validation Service</a> to check if your CSS is valid. This is an invaluable debugging tool.</li>
+ <li>You can use the <a href="https://jigsaw.w3.org/css-validator/">W3C CSS Validation Service</a> to check if your CSS is valid. This is an invaluable debugging tool.</li>
  <li><a href="/en-US/docs/Tools">Firefox Developer Tools</a> lets you view and edit a page's live CSS via the <a href="/en-US/docs/Tools/Page_Inspector">Inspector</a> and <a href="/en-US/docs/Tools/Style_Editor">Style Editor</a> tools.</li>
  <li>The <a class="link-https" href="https://addons.mozilla.org/en-US/firefox/addon/web-developer/">Web Developer extension</a> for Firefox lets you track and edit live CSS on watched sites.</li>
  <li>The Web community has created various other <a href="/en-US/docs/Web/CSS/Tools">miscellaneous CSS tools</a> for you to use.</li>

--- a/files/en-us/web/css/inset-block-end/index.html
+++ b/files/en-us/web/css/inset-block-end/index.html
@@ -94,7 +94,7 @@ inset-block-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.inset-block-end")}}</p>
 

--- a/files/en-us/web/css/inset-block-start/index.html
+++ b/files/en-us/web/css/inset-block-start/index.html
@@ -92,7 +92,7 @@ inset-block-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.inset-block-start")}}</p>
 

--- a/files/en-us/web/css/inset-inline-end/index.html
+++ b/files/en-us/web/css/inset-inline-end/index.html
@@ -97,7 +97,7 @@ inset-inline-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.inset-inline-end")}}</p>
 

--- a/files/en-us/web/css/inset-inline-start/index.html
+++ b/files/en-us/web/css/inset-inline-start/index.html
@@ -96,7 +96,7 @@ inset-inline-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.inset-inline-start")}}</p>
 

--- a/files/en-us/web/css/max-height/index.html
+++ b/files/en-us/web/css/max-height/index.html
@@ -118,7 +118,7 @@ form { max-height: none; }
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.max-height")}}</p>
 

--- a/files/en-us/web/css/max-width/index.html
+++ b/files/en-us/web/css/max-width/index.html
@@ -144,7 +144,7 @@ max-width: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.max-width")}}</p>
 

--- a/files/en-us/web/css/pointer-events/index.html
+++ b/files/en-us/web/css/pointer-events/index.html
@@ -144,7 +144,7 @@ pointer-events: unset;
  </tbody>
 </table>
 
-<p>Its extension to HTML elements, though present in early drafts of CSS Basic User Interface Module Level 3, has been pushed to its <a class="external" href="http://wiki.csswg.org/spec/css4-ui#pointer-events">level 4</a>.</p>
+<p>Its extension to HTML elements, though present in early drafts of CSS Basic User Interface Module Level 3, has been pushed to its <a href="http://wiki.csswg.org/spec/css4-ui#pointer-events">level 4</a>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
@@ -155,6 +155,6 @@ pointer-events: unset;
 <ul>
  <li>The SVG attribute {{SVGAttr("pointer-events")}}</li>
  <li>The SVG attribute {{SVGAttr("visibility")}}</li>
- <li><a class="external" href="http://webkit.org/specs/PointerEventsProperty.html">WebKit Specs PointerEventsProperty</a> extended for use in (X)HTML content</li>
+ <li><a href="http://webkit.org/specs/PointerEventsProperty.html">WebKit Specs PointerEventsProperty</a> extended for use in (X)HTML content</li>
  <li>{{cssxref("user-select")}} - controls whether the user can select text</li>
 </ul>

--- a/files/en-us/web/css/privacy_and_the__colon_visited_selector/index.html
+++ b/files/en-us/web/css/privacy_and_the__colon_visited_selector/index.html
@@ -68,7 +68,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a class="external" href="http://hacks.mozilla.org/2010/03/privacy-related-changes-coming-to-css-vistited/">privacy-related changes coming to CSS :visited</a> on Mozilla Hacks</li>
- <li><a class="external" href="http://blog.mozilla.com/security/2010/03/31/plugging-the-css-history-leak/">Plugging the CSS History Leak</a> on the Mozilla Security Blog</li>
- <li><a class="external" href="http://dbaron.org/mozilla/visited-privacy">Preventing attacks on a user's history through CSS :visited selectors</a></li>
+ <li><a href="http://hacks.mozilla.org/2010/03/privacy-related-changes-coming-to-css-vistited/">privacy-related changes coming to CSS :visited</a> on Mozilla Hacks</li>
+ <li><a href="http://blog.mozilla.com/security/2010/03/31/plugging-the-css-history-leak/">Plugging the CSS History Leak</a> on the Mozilla Security Blog</li>
+ <li><a href="http://dbaron.org/mozilla/visited-privacy">Preventing attacks on a user's history through CSS :visited selectors</a></li>
 </ul>

--- a/files/en-us/web/css/scaling_of_svg_backgrounds/index.html
+++ b/files/en-us/web/css/scaling_of_svg_backgrounds/index.html
@@ -330,5 +330,5 @@ background-size: 150px auto;
 
 <ul>
 	<li>{{cssxref("background-size")}}</li>
-	<li>Blog post: <a class="external" href="http://whereswalden.com/2011/10/21/properly-resizing-vector-image-backgrounds/">Properly resizing vector image backgrounds</a></li>
+	<li>Blog post: <a href="http://whereswalden.com/2011/10/21/properly-resizing-vector-image-backgrounds/">Properly resizing vector image backgrounds</a></li>
 </ul>

--- a/files/en-us/web/css/scrollbar-color/index.html
+++ b/files/en-us/web/css/scrollbar-color/index.html
@@ -122,7 +122,7 @@ scrollbar-color: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <div>{{Compat("css.properties.scrollbar-color")}}</div>
 

--- a/files/en-us/web/css/scrollbar-width/index.html
+++ b/files/en-us/web/css/scrollbar-width/index.html
@@ -68,7 +68,7 @@ scrollbar-width: unset;
  <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#Guideline_2.1_%E2%80%94_Keyboard_Accessible_Make_all_functionality_available_from_a_keyboard">MDN Understanding WCAG, Guideline 2.1 explanations</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#Guideline_2.5_Input_Modalities_Make_it_easier_for_users_to_operate_functionality_through_various_inputs_beyond_keyboard.s/">MDN Understanding WCAG, Guideline 2.5 explanations</a></li>
  <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard">Understanding Success Criterion 2.1.1 | W3C Understanding WCAG 2.1</a></li>
- <li><a class="external" href="https://www.w3.org/WAI/WCAG21/Understanding/target-size.html" rel="noopener">Understanding Success Criterion 2.5.5 | W3C Understanding WCAG 2.1</a></li>
+ <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size.html" rel="noopener">Understanding Success Criterion 2.5.5 | W3C Understanding WCAG 2.1</a></li>
 </ul>
 
 <h2 id="Formal_definition">Formal definition</h2>

--- a/files/en-us/web/css/specificity/index.html
+++ b/files/en-us/web/css/specificity/index.html
@@ -341,6 +341,6 @@ h1 {
 
 <ul>
  <li>Specificity Calculator: An interactive website to test and understand your own CSS rules - <a href="https://specificity.keegan.st/">https://specificity.keegan.st/</a></li>
- <li>CSS3 Selectors Specificity - <a class="external" href="https://www.w3.org/TR/selectors/#specificity">http://www.w3.org/TR/selectors/#specificity</a></li>
+ <li>CSS3 Selectors Specificity - <a href="https://www.w3.org/TR/selectors/#specificity">http://www.w3.org/TR/selectors/#specificity</a></li>
  <li>{{CSS_Key_Concepts}}</li>
 </ul>

--- a/files/en-us/web/css/string/index.html
+++ b/files/en-us/web/css/string/index.html
@@ -15,9 +15,9 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<p>The <code>&lt;string&gt;</code> data type is composed of any number of <a class="external" href="https://en.wikipedia.org/wiki/Unicode">Unicode</a> characters surrounded by either double (<code>"</code>) or single (<code>'</code>) quotes.</p>
+<p>The <code>&lt;string&gt;</code> data type is composed of any number of <a href="https://en.wikipedia.org/wiki/Unicode">Unicode</a> characters surrounded by either double (<code>"</code>) or single (<code>'</code>) quotes.</p>
 
-<p>Most characters can be represented literally. All characters can also be represented with their respective <a class="external" href="https://en.wikipedia.org/wiki/Unicode#Code_point_planes_and_blocks">Unicode code points</a> in hexadecimal, in which case they are preceded by a backslash (<code>\</code>). For example, <code>\22</code> represents a double quote, <code>\27</code> a single quote (<code>'</code>), and <code>\A9</code> the copyright symbol (<code>©</code>).</p>
+<p>Most characters can be represented literally. All characters can also be represented with their respective <a href="https://en.wikipedia.org/wiki/Unicode#Code_point_planes_and_blocks">Unicode code points</a> in hexadecimal, in which case they are preceded by a backslash (<code>\</code>). For example, <code>\22</code> represents a double quote, <code>\27</code> a single quote (<code>'</code>), and <code>\A9</code> the copyright symbol (<code>©</code>).</p>
 
 <p>Importantly, certain characters which would otherwise be invalid can be escaped with a backslash. These include double quotes when used inside a double-quoted string, single quotes when used inside a single-quoted string, and the backslash itself. For example, <code>\\</code> will create a single backslash.</p>
 

--- a/files/en-us/web/css/tab-size/index.html
+++ b/files/en-us/web/css/tab-size/index.html
@@ -114,5 +114,5 @@ tab-size: unset;
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a class="external" href="https://lists.w3.org/Archives/Public/www-style/2008Dec/0009.html"><cite>Controlling size of a tab character (U+0009)</cite></a>, an email by Anne van Kesteren to the CSSWG.</li>
+ <li><a href="https://lists.w3.org/Archives/Public/www-style/2008Dec/0009.html"><cite>Controlling size of a tab character (U+0009)</cite></a>, an email by Anne van Kesteren to the CSSWG.</li>
 </ul>

--- a/files/en-us/web/css/text-shadow/index.html
+++ b/files/en-us/web/css/text-shadow/index.html
@@ -119,7 +119,7 @@ text-shadow: unset;
   <tr>
    <td>{{SpecName('CSS3 Text Decoration', '#text-shadow-property', 'text-shadow')}}</td>
    <td>{{Spec2('CSS3 Text Decoration')}}</td>
-   <td>The CSS property <code>text-shadow</code> was <a class="external" href="https://www.w3.org/TR/2008/REC-CSS2-20080411/text.html#text-shadow-props">improperly defined in CSS2</a> and dropped in CSS2 (Level 1). The CSS Text Module Level 3 spec refined the syntax. Later it was moved to <a href="https://www.w3.org/TR/css-text-decor-3/">CSS Text Decoration Module Level 3</a>.</td>
+   <td>The CSS property <code>text-shadow</code> was <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/text.html#text-shadow-props">improperly defined in CSS2</a> and dropped in CSS2 (Level 1). The CSS Text Module Level 3 spec refined the syntax. Later it was moved to <a href="https://www.w3.org/TR/css-text-decor-3/">CSS Text Decoration Module Level 3</a>.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/css/text-size-adjust/index.html
+++ b/files/en-us/web/css/text-size-adjust/index.html
@@ -92,6 +92,6 @@ text-size-adjust: unset;
 
 <ul>
  <li><a class="link-https" href="https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW16">Apple's documentation</a></li>
- <li><a class="external" href="http://dbaron.org/log/20111126-font-inflation">Gecko's behavior description</a>, by L. David Baron</li>
- <li><a class="external" href="https://msdn.microsoft.com/library/windows/apps/ff462082(v=vs.105).aspx#BKMK_AdjustingTextSizewithCustomCSS">Microsoft's documentation</a></li>
+ <li><a href="http://dbaron.org/log/20111126-font-inflation">Gecko's behavior description</a>, by L. David Baron</li>
+ <li><a href="https://msdn.microsoft.com/library/windows/apps/ff462082(v=vs.105).aspx#BKMK_AdjustingTextSizewithCustomCSS">Microsoft's documentation</a></li>
 </ul>

--- a/files/en-us/web/css/transform-function/index.html
+++ b/files/en-us/web/css/transform-function/index.html
@@ -120,7 +120,7 @@ tags:
 <p>However, one major transformation is not linear, and therefore must be special-cased when using this notation: translation. The translation vector <code>(tx, ty)</code> must be expressed separately, as two additional parameters.</p>
 
 <div class="note">
-<p><strong>Note:</strong> Though trickier than Cartesian coordinates, <a class="external" href="https://en.wikipedia.org/wiki/Homogeneous_coordinates">homogeneous coordinates</a> in <a class="external" href="https://en.wikipedia.org/wiki/Projective_geometry">projective geometry</a> lead to 3×3 transformation matrices, and can express translations as linear functions.</p>
+<p><strong>Note:</strong> Though trickier than Cartesian coordinates, <a href="https://en.wikipedia.org/wiki/Homogeneous_coordinates">homogeneous coordinates</a> in <a href="https://en.wikipedia.org/wiki/Projective_geometry">projective geometry</a> lead to 3×3 transformation matrices, and can express translations as linear functions.</p>
 </div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/css/transform-function/scalex()/index.html
+++ b/files/en-us/web/css/transform-function/scalex()/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>It modifies the abscissa of each element point by a constant factor, except when the scale factor is 1, in which case
   the function is the identity transform. The scaling is not isotropic, and the angles of the element are not conserved.
-  <code>scaleX(-1)</code> defines an <a class="external" href="https://en.wikipedia.org/wiki/Axial_symmetry">axial
+  <code>scaleX(-1)</code> defines an <a href="https://en.wikipedia.org/wiki/Axial_symmetry">axial
     symmetry</a>, with a vertical axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
   property).
 </p>

--- a/files/en-us/web/css/transform-function/scaley()/index.html
+++ b/files/en-us/web/css/transform-function/scaley()/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>It modifies the ordinate of each element point by a constant factor, except when the scale factor is 1, in which case
   the function is the identity transform. The scaling is not isotropic, and the angles of the element are not conserved.
-  <code>scaleY(-1)</code> defines an <a class="external" href="https://en.wikipedia.org/wiki/Axial_symmetry">axial
+  <code>scaleY(-1)</code> defines an <a href="https://en.wikipedia.org/wiki/Axial_symmetry">axial
     symmetry</a>, with a horizontal axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
   property).
 </p>

--- a/files/en-us/web/css/transform-function/scalez()/index.html
+++ b/files/en-us/web/css/transform-function/scalez()/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>This scaling transformation modifies the z-coordinate of each element point by a constant factor, except when the
   scale factor is 1, in which case the function is the identity transform. The scaling is not isotropic, and the angles
-  of the element are not conserved. <code>scaleZ(-1)</code> defines an <a class="external"
+  of the element are not conserved. <code>scaleZ(-1)</code> defines an <a
     href="https://en.wikipedia.org/wiki/Axial_symmetry">axial symmetry</a>, with the z-axis passing through the origin
   (as specified by the {{cssxref("transform-origin")}} property).</p>
 

--- a/files/en-us/web/css/used_value/index.html
+++ b/files/en-us/web/css/used_value/index.html
@@ -83,7 +83,7 @@ window.addEventListener('resize', updateAllUsedWidths);
 
 <h2 id="Difference_from_computed_value">Difference from computed value</h2>
 
-<p>CSS 2.0 defined only <em>computed value</em> as the last step in a property's calculation. Then, CSS 2.1 introduced the distinct definition of used value. An element could then explicitly inherit a width/height of a parent, whose computed value is a percentage. For CSS properties that don't depend on layout (e.g., <code>display</code>, <code>font-size</code>, or <code>line-height</code>), the computed values and used values are the same. The following are the CSS 2.1 properties that do depend on layout, so they have a different computed value and used value: (taken from <a class="external" href="https://www.w3.org/TR/CSS2/changes.html#q21.36">CSS 2.1 Changes: Specified, computed, and actual values</a>):</p>
+<p>CSS 2.0 defined only <em>computed value</em> as the last step in a property's calculation. Then, CSS 2.1 introduced the distinct definition of used value. An element could then explicitly inherit a width/height of a parent, whose computed value is a percentage. For CSS properties that don't depend on layout (e.g., <code>display</code>, <code>font-size</code>, or <code>line-height</code>), the computed values and used values are the same. The following are the CSS 2.1 properties that do depend on layout, so they have a different computed value and used value: (taken from <a href="https://www.w3.org/TR/CSS2/changes.html#q21.36">CSS 2.1 Changes: Specified, computed, and actual values</a>):</p>
 
 <ul>
  <li><code>background-position</code></li>

--- a/files/en-us/web/css/user-modify/index.html
+++ b/files/en-us/web/css/user-modify/index.html
@@ -72,7 +72,7 @@ user-modify: unset;
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>Not part of any standard. A similar property, <code>user-focus</code>, was proposed in <a class="external" href="https://www.w3.org/TR/2000/WD-css3-userint-20000216">early drafts of a predecessor of the CSS3 UI specification</a>, but was rejected by the working group.</p>
+<p>Not part of any standard. A similar property, <code>user-focus</code>, was proposed in <a href="https://www.w3.org/TR/2000/WD-css3-userint-20000216">early drafts of a predecessor of the CSS3 UI specification</a>, but was rejected by the working group.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
The `class="external"` gets automatically injected at build-time anyway so no need to manually set it in the raw sources. 
Besides, this'll make more sense as we move towards something Markdown'ish. 