### PR TITLE
remove unnecessary class=external in web/api tree

### DIFF
--- a/files/en-us/web/api/csskeyframerule/style/index.html
+++ b/files/en-us/web/api/csskeyframerule/style/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p>The read-only <strong><code>CSSKeyframeRule.style</code></strong> property is the {{ domxref("CSSStyleDeclaration") }} interface for the <a class="external" href="https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block">declaration block</a> of the {{ domxref("CSSKeyframeRule") }}.</p>
+<p>The read-only <strong><code>CSSKeyframeRule.style</code></strong> property is the {{ domxref("CSSStyleDeclaration") }} interface for the <a href="https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block">declaration block</a> of the {{ domxref("CSSKeyframeRule") }}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cssstylerule/style/index.html
+++ b/files/en-us/web/api/cssstylerule/style/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
-<p>The read-only <strong><code>style</code></strong> property is the {{ domxref("CSSStyleDeclaration") }} interface for the <a class="external" href="https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block">declaration block</a> of the {{ DOMXref("CSSStyleRule") }}.</p>
+<p>The read-only <strong><code>style</code></strong> property is the {{ domxref("CSSStyleDeclaration") }} interface for the <a href="https://www.w3.org/TR/1998/REC-CSS2-19980512/syndata.html#block">declaration block</a> of the {{ DOMXref("CSSStyleRule") }}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/directoryreadersync/index.html
+++ b/files/en-us/web/api/directoryreadersync/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="About_this_document">About this document</h2>
 
-<p>This document was last updated on March 2, 2012 and follows the <a class="external" href="https://www.w3.org/TR/file-system-api/">W3C Specifications (Working Draft)</a> drafted on April 19, 2011.</p>
+<p>This document was last updated on March 2, 2012 and follows the <a href="https://www.w3.org/TR/file-system-api/">W3C Specifications (Working Draft)</a> drafted on April 19, 2011.</p>
 
 <p>This specification is pretty much abandoned, having failed to reach any substantial traction.</p>
 
@@ -26,7 +26,7 @@ tags:
 
 <h4 id="example">Example</h4>
 
-<p>In the following code snippet from <a class="external" href="http://www.html5rocks.com/en/tutorials/file/filesystem/">HTML5Rocks</a>, we create Web Workers and pass data from it to the main app.</p>
+<p>In the following code snippet from <a href="http://www.html5rocks.com/en/tutorials/file/filesystem/">HTML5Rocks</a>, we create Web Workers and pass data from it to the main app.</p>
 
 <pre class="brush: js">// Taking care of the browser-specific prefixes.
   window.resolveLocalFileSystemURL = window.resolveLocalFileSystemURL ||

--- a/files/en-us/web/api/document/write/index.html
+++ b/files/en-us/web/api/document/write/index.html
@@ -65,7 +65,7 @@ tags:
 &lt;/script&gt;
 </pre>
 
-<div class="note"><strong>Note</strong>: <code>document.write()</code> and {{domxref("document.writeln")}} <a href="/en-US/docs/Archive/Web/Writing_JavaScript_for_HTML">do not work in XHTML documents</a> (you'll get an "Operation is not supported" [<code>NS_ERROR_DOM_NOT_SUPPORTED_ERR</code>] error in the error console). This happens when opening a local file with the .xhtml file extension or for any document served with an <code>application/xhtml+xml</code> {{Glossary("MIME type")}}. More information is available in the <a class="external" href="https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite">W3C XHTML FAQ</a>.</div>
+<div class="note"><strong>Note</strong>: <code>document.write()</code> and {{domxref("document.writeln")}} <a href="/en-US/docs/Archive/Web/Writing_JavaScript_for_HTML">do not work in XHTML documents</a> (you'll get an "Operation is not supported" [<code>NS_ERROR_DOM_NOT_SUPPORTED_ERR</code>] error in the error console). This happens when opening a local file with the .xhtml file extension or for any document served with an <code>application/xhtml+xml</code> {{Glossary("MIME type")}}. More information is available in the <a href="https://www.w3.org/MarkUp/2004/xhtml-faq#docwrite">W3C XHTML FAQ</a>.</div>
 
 <div class="note"><strong>Note</strong>: Using <code>document.write()</code> in <a href="/en-US/docs/Web/HTML/Element/script#attr-defer">deferred</a> or <a href="/en-US/docs/Web/HTML/Element/script#attr-async">asynchronous</a> scripts will be ignored and you'll get a message like "A call to <code>document.write()</code> from an asynchronously-loaded external script was ignored" in the error console.</div>
 

--- a/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.html
+++ b/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{draft}}</p>
 
-<p>This page describes how to use the <a class="external" href="https://www.w3.org/TR/DOM-Level-3-Core">DOM Core</a> API in JavaScript to create and modify DOM objects. It applies to all Gecko-based applications (such as Firefox) both in privileged (extensions) and unprivileged (web pages) code.</p>
+<p>This page describes how to use the <a href="https://www.w3.org/TR/DOM-Level-3-Core">DOM Core</a> API in JavaScript to create and modify DOM objects. It applies to all Gecko-based applications (such as Firefox) both in privileged (extensions) and unprivileged (web pages) code.</p>
 
 <h3 id="Dynamically_creating_a_DOM_tree">Dynamically creating a DOM tree</h3>
 

--- a/files/en-us/web/api/document_object_model/introduction/index.html
+++ b/files/en-us/web/api/document_object_model/introduction/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>A Web page is a document. This document can be either displayed in the browser window or as the HTML source. But it is the same document in both cases. The Document Object Model (DOM) represents that same document so it can be manipulated. The DOM is an object-oriented representation of the web page, which can be modified with a scripting language such as JavaScript.</p>
 
-<p>The <a class="external" href="https://www.w3.org/DOM/">W3C DOM</a> and <a class="external" href="https://dom.spec.whatwg.org">WHATWG DOM</a> standards are implemented in most modern browsers. Many browsers extend the standard, so care must be exercised when using them on the web where documents may be accessed by various browsers with different DOMs.</p>
+<p>The <a href="https://www.w3.org/DOM/">W3C DOM</a> and <a href="https://dom.spec.whatwg.org">WHATWG DOM</a> standards are implemented in most modern browsers. Many browsers extend the standard, so care must be exercised when using them on the web where documents may be accessed by various browsers with different DOMs.</p>
 
 <p>For example, the standard DOM specifies that the <code>querySelectorAll</code> method in the code below must return a list of all the <code>&lt;p&gt;</code> elements in the document:</p>
 

--- a/files/en-us/web/api/document_object_model/locating_dom_elements_using_selectors/index.html
+++ b/files/en-us/web/api/document_object_model/locating_dom_elements_using_selectors/index.html
@@ -40,7 +40,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a class="external" href="https://www.w3.org/TR/selectors-api/">Selectors API</a></li>
+ <li><a href="https://www.w3.org/TR/selectors-api/">Selectors API</a></li>
  <li>{{domxref("Element.querySelector()")}}</li>
  <li>{{domxref("Element.querySelectorAll()")}}</li>
  <li>{{domxref("Document.querySelector()")}}</li>

--- a/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.html
+++ b/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.html
@@ -34,7 +34,7 @@ tags:
 
 <h2 id="What_does_the_DOM_Level_1_Core_let_me_do.3F">What does the DOM Level 1 Core let me do?</h2>
 
-<p>The W3C DOM Level 1 Core allows you to change a DOM tree in <em>any way you want</em>. This implies the ability to create any HTML or XML document from scratch, or to change any contents of a given HTML or XML document. The easiest way for web page authors to edit the DOM of a document is to use JavaScript to access the <code>document</code> property of the global object. This <code>document</code> object implements the <a class="external" href="https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#i-Document">Document interface</a> from the W3C's DOM Level 1 spec.</p>
+<p>The W3C DOM Level 1 Core allows you to change a DOM tree in <em>any way you want</em>. This implies the ability to create any HTML or XML document from scratch, or to change any contents of a given HTML or XML document. The easiest way for web page authors to edit the DOM of a document is to use JavaScript to access the <code>document</code> property of the global object. This <code>document</code> object implements the <a href="https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#i-Document">Document interface</a> from the W3C's DOM Level 1 spec.</p>
 
 <h2 id="A_simple_example">A simple example</h2>
 
@@ -82,13 +82,13 @@ tags:
 
 <p>Now that you are familiar with the basic concepts of the DOM, you may want to learn about the <a href="/en-US/docs/Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces">DOM Level 1 fundamental methods</a>.</p>
 
-<p>See also the <a class="external" href="https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html">DOM Level 1 Core specification</a> from the W3C. It's a reasonably clear spec, although it is formal. The main thing that's useful to authors is the description of the different DOM objects and all their properties and methods. Also see our <a href="/en-US/docs/Web/API/Document_Object_Model">other DOM documentation</a>.</p>
+<p>See also the <a href="https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html">DOM Level 1 Core specification</a> from the W3C. It's a reasonably clear spec, although it is formal. The main thing that's useful to authors is the description of the different DOM objects and all their properties and methods. Also see our <a href="/en-US/docs/Web/API/Document_Object_Model">other DOM documentation</a>.</p>
 
 <div class="originaldocinfo">
 <p><strong>Original Document Information</strong></p>
 
 <ul>
  <li>Author(s): L. David Baron &lt;dbaron at dbaron dot org&gt;</li>
- <li>Copyright Information: © 1998-2005 by individual mozilla.org contributors; content available under a <a class="external" href="https://www.mozilla.org/foundation/licensing/website-content.html">Creative Commons license</a></li>
+ <li>Copyright Information: © 1998-2005 by individual mozilla.org contributors; content available under a <a href="https://www.mozilla.org/foundation/licensing/website-content.html">Creative Commons license</a></li>
 </ul>
 </div>

--- a/files/en-us/web/api/element/gesturechange_event/index.html
+++ b/files/en-us/web/api/element/gesturechange_event/index.html
@@ -58,5 +58,5 @@ tags:
    <li><code><a href="/en-US/docs/Web/API/Element/gestureend_event">gestureend</a></code></li>
   </ul>
  </li>
- <li><a class="external" href="https://developer.apple.com/library/iad/documentation/UserExperience/Reference/GestureEventClassReference/index.html">GestureEventClassReference at the Safari Developer Library</a></li>
+ <li><a href="https://developer.apple.com/library/iad/documentation/UserExperience/Reference/GestureEventClassReference/index.html">GestureEventClassReference at the Safari Developer Library</a></li>
 </ul>

--- a/files/en-us/web/api/element/gestureend_event/index.html
+++ b/files/en-us/web/api/element/gestureend_event/index.html
@@ -58,5 +58,5 @@ tags:
    <li><code><a href="/en-US/docs/Web/API/Element/gesturechange_event">gesturechange</a></code></li>
   </ul>
  </li>
- <li><a class="external" href="https://developer.apple.com/library/iad/documentation/UserExperience/Reference/GestureEventClassReference/index.html">GestureEventClassReference at the Safari Developer Library</a></li>
+ <li><a href="https://developer.apple.com/library/iad/documentation/UserExperience/Reference/GestureEventClassReference/index.html">GestureEventClassReference at the Safari Developer Library</a></li>
 </ul>

--- a/files/en-us/web/api/element/gesturestart_event/index.html
+++ b/files/en-us/web/api/element/gesturestart_event/index.html
@@ -58,5 +58,5 @@ tags:
    <li><code><a href="/en-US/docs/Web/API/Element/gestureend_event">gestureend</a></code></li>
   </ul>
  </li>
- <li><a class="external" href="https://developer.apple.com/library/iad/documentation/UserExperience/Reference/GestureEventClassReference/index.html">GestureEventClassReference at the Safari Developer Library</a></li>
+ <li><a href="https://developer.apple.com/library/iad/documentation/UserExperience/Reference/GestureEventClassReference/index.html">GestureEventClassReference at the Safari Developer Library</a></li>
 </ul>

--- a/files/en-us/web/api/element/getattributenodens/index.html
+++ b/files/en-us/web/api/element/getattributenodens/index.html
@@ -22,7 +22,7 @@ tags:
  <li><code>nodeName</code> is a string specifying the name of the attribute.</li>
 </ul>
 
-<p><span class="comment">== Example == TBD The example needs to be fixed pre&gt; // html: &lt;div id="top" /&gt; t = document.getElementById("top"); specialNode = t.getAttributeNodeNS( "<a class="external" href="https://www.mozilla.org/ns/specialspace">http://www.mozilla.org/ns/specialspace</a>", "id"); // iNode.value = "full-top" &lt;/pre</span></p>
+<p><span class="comment">== Example == TBD The example needs to be fixed pre&gt; // html: &lt;div id="top" /&gt; t = document.getElementById("top"); specialNode = t.getAttributeNodeNS( "<a href="https://www.mozilla.org/ns/specialspace">http://www.mozilla.org/ns/specialspace</a>", "id"); // iNode.value = "full-top" &lt;/pre</span></p>
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/api/element/namespaceuri/index.html
+++ b/files/en-us/web/api/element/namespaceuri/index.html
@@ -44,7 +44,7 @@ tags:
 
 <p>In Firefox 3.5 and earlier, the namespace URI for HTML elements in HTML documents is
   <code>null</code>. In later versions, in compliance with HTML5, it is
-  <code><a class="external" href="https://www.w3.org/1999/xhtml">http://www.w3.org/1999/xhtml</a></code>
+  <code><a href="https://www.w3.org/1999/xhtml">http://www.w3.org/1999/xhtml</a></code>
   as in XHTML. {{gecko_minversion_inline("1.9.2")}}</p>
 
 <p>You can create an element with the specified <code>namespaceURI</code> using the DOM

--- a/files/en-us/web/api/fileentrysync/index.html
+++ b/files/en-us/web/api/fileentrysync/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="About_this_document">About this document</h2>
 
-<p>This document was last updated on March 2, 2012 and follows the <a class="external" href="https://www.w3.org/TR/file-system-api/">W3C Specifications (Working Draft)</a> drafted on April 19, 2011.</p>
+<p>This document was last updated on March 2, 2012 and follows the <a href="https://www.w3.org/TR/file-system-api/">W3C Specifications (Working Draft)</a> drafted on April 19, 2011.</p>
 
 <p>This specification is more or less abandoned as it didn't get significant traction among browser makers.</p>
 

--- a/files/en-us/web/api/fileerror/index.html
+++ b/files/en-us/web/api/fileerror/index.html
@@ -16,7 +16,7 @@ tags:
 <p><strong>Note:</strong> This interface is obsolete per the latest specification. Use the new DOM4 {{domxref("DOMError")}} interface instead.</p>
 </div>
 
-<p>In the <a href="/en-US/docs/Web/API/File_System_API/Introduction">File System API</a>, a <code>FileError</code> represents error conditions that you might encounter while accessing the file system using the asynchronous API. It extends the <code>FileError</code> interface described in <a class="external" href="http://dev.w3.org/2009/dap/file-system/pub/FileSystem/#bib-FILE-WRITER">File Writer</a> and adds several new error codes.</p>
+<p>In the <a href="/en-US/docs/Web/API/File_System_API/Introduction">File System API</a>, a <code>FileError</code> represents error conditions that you might encounter while accessing the file system using the asynchronous API. It extends the <code>FileError</code> interface described in <a href="http://dev.w3.org/2009/dap/file-system/pub/FileSystem/#bib-FILE-WRITER">File Writer</a> and adds several new error codes.</p>
 
 <p><code>FileError</code> objects are passed to error callbacks. The objects have a code that shows the type of error that occurred.</p>
 
@@ -102,7 +102,7 @@ tags:
   <tr>
    <td><code><a>QUOTA_EXCEEDED_ERR</a></code></td>
    <td>10</td>
-   <td>Either there's not enough remaining storage space or the storage quota was reached and the user declined to give more space to the database. To ask for more storage, see <a class="external" href="http://code.google.com/chrome/whitepapers/storage.html">Managing HTML5 Offline Storage</a>.</td>
+   <td>Either there's not enough remaining storage space or the storage quota was reached and the user declined to give more space to the database. To ask for more storage, see <a href="http://code.google.com/chrome/whitepapers/storage.html">Managing HTML5 Offline Storage</a>.</td>
   </tr>
   <tr>
    <td><code><a>SECURITY_ERR</a></code></td>

--- a/files/en-us/web/api/filesystementrysync/index.html
+++ b/files/en-us/web/api/filesystementrysync/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p>The <code>FileSystemEntrySync</code> interface includes methods that you would expect for manipulating files and directories, but it also include a really handy method for getting a URL of the entry: <code><a href="#tourl">toURL()</a></code>. It also introduces a new URL scheme: <code>filesystem:</code>.</p>
 
-<p>You can use the <code>filesystem:</code> scheme on Google Chrome to see all the files and folders that are stored in the origin of your app. Just use <code>filesystem:</code> scheme for the root directory of the origin of the app. For example, if your app is in <code><a class="external" href="http://ww.html5rocks.com">http://ww.html5rocks.com</a></code>, open <code>filesystem:<a class="external" href="http://www.html5rocks.com/temporary/">http://www.html5rocks.com/temporary/</a></code> in a tab. Chrome shows a read-only list of all the files and folders stored the origin of your app.</p>
+<p>You can use the <code>filesystem:</code> scheme on Google Chrome to see all the files and folders that are stored in the origin of your app. Just use <code>filesystem:</code> scheme for the root directory of the origin of the app. For example, if your app is in <code><a href="http://ww.html5rocks.com">http://ww.html5rocks.com</a></code>, open <code>filesystem:<a href="http://www.html5rocks.com/temporary/">http://www.html5rocks.com/temporary/</a></code> in a tab. Chrome shows a read-only list of all the files and folders stored the origin of your app.</p>
 
 <h2 id="Method_overview">Method overview</h2>
 
@@ -280,7 +280,7 @@ tags:
 
 <h3 id="toURL">toURL()</h3>
 
-<p>Returns a URL that can be used to identify this entry. It exposes a new URL scheme—<code>filesystem:</code>—that you can use to fill <code>src</code> or <code>href </code>attributes. For example, if you wanted to display an image and have its <a class="external" href="/en-US/docs/DOM/File_API/File_System_API/FileEntry">fileEntry</a>, calling <code>toURL()</code> gives you the image file's file system URL. You get something like: <code>filesystem:<a class="external" href="http://example.com/temporary/lolcat.png">http://example.com/temporary/lolcat.png</a>.</code></p>
+<p>Returns a URL that can be used to identify this entry. It exposes a new URL scheme—<code>filesystem:</code>—that you can use to fill <code>src</code> or <code>href </code>attributes. For example, if you wanted to display an image and have its <a href="/en-US/docs/DOM/File_API/File_System_API/FileEntry">fileEntry</a>, calling <code>toURL()</code> gives you the image file's file system URL. You get something like: <code>filesystem:<a href="http://example.com/temporary/lolcat.png">http://example.com/temporary/lolcat.png</a>.</code></p>
 
 <p>The file system URL does not expire. Because the method describes a location on disk, the URL is valid for as long as that location exists. You can delete the file and recreate it, and it's all good. </p>
 

--- a/files/en-us/web/api/globaleventhandlers/oninput/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninput/index.html
@@ -99,7 +99,7 @@ function handleInput(e) {
   <li>Mathias Bynens suggests <a class="external"
       href="http://mathiasbynens.be/notes/oninput">binding to both input and keydown</a>
   </li>
-  <li><a class="external" href="http://help.dottoro.com/ljhxklln.php">oninput event |
+  <li><a href="http://help.dottoro.com/ljhxklln.php">oninput event |
       dottoro</a> has notes about bugginess in IE9</li>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=312094">Bug 312094 - Add
       support for &lt;select oninput&gt;</a></li>

--- a/files/en-us/web/api/htmlvideoelement/index.html
+++ b/files/en-us/web/api/htmlvideoelement/index.html
@@ -119,6 +119,6 @@ tags:
 
 <ul>
  <li>HTML element implementing this interface: {{HTMLElement("video")}}.</li>
- <li><a class="external" href="http://people.mozilla.org/~cpearce/paint-stats-demo.html">Demo of video paint statistics</a></li>
+ <li><a href="http://people.mozilla.org/~cpearce/paint-stats-demo.html">Demo of video paint statistics</a></li>
  <li><a href="/en-US/docs/Web/HTML/Supported_media_formats">Supported media formats</a></li>
 </ul>

--- a/files/en-us/web/api/idbcursor/index.html
+++ b/files/en-us/web/api/idbcursor/index.html
@@ -129,5 +129,5 @@ tags:
  <li>Setting a range of keys: {{domxref("IDBKeyRange")}}</li>
  <li>Retrieving and making changes to your data: {{domxref("IDBObjectStore")}}</li>
  <li>Using cursors: {{domxref("IDBCursor")}}</li>
- <li>Reference example: <a class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
+ <li>Reference example: <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
 </ul>

--- a/files/en-us/web/api/idbenvironment/index.html
+++ b/files/en-us/web/api/idbenvironment/index.html
@@ -59,5 +59,5 @@ function openDB() {
  <li>Setting a range of keys: {{domxref("IDBKeyRange")}}</li>
  <li>Retrieving and making changes to your data: {{domxref("IDBObjectStore")}}</li>
  <li>Using cursors: {{domxref("IDBCursor")}}</li>
- <li>Reference example: <a class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
+ <li>Reference example: <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
 </ul>

--- a/files/en-us/web/api/idblocaleawarekeyrange/index.html
+++ b/files/en-us/web/api/idblocaleawarekeyrange/index.html
@@ -74,5 +74,5 @@ tags:
  <li>Setting a range of keys: {{domxref("IDBKeyRange")}}</li>
  <li>Retrieving and making changes to your data: {{domxref("IDBObjectStore")}}</li>
  <li>Using cursors: {{domxref("IDBCursor")}}</li>
- <li>Reference example: <a class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
+ <li>Reference example: <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
 </ul>

--- a/files/en-us/web/api/idbobjectstore/index.html
+++ b/files/en-us/web/api/idbobjectstore/index.html
@@ -35,7 +35,7 @@ tags:
 
 <dl>
  <dt>{{domxref("IDBObjectStore.add()")}}</dt>
- <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a <a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/multipage/common-dom-interfaces.html#structured-clone">structured clone</a> of the <code>value</code>, and stores the cloned value in the object store. This is for adding new records to an object store.</dd>
+ <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a <a href="https://www.whatwg.org/specs/web-apps/current-work/multipage/common-dom-interfaces.html#structured-clone">structured clone</a> of the <code>value</code>, and stores the cloned value in the object store. This is for adding new records to an object store.</dd>
  <dt>{{domxref("IDBObjectStore.clear()")}}</dt>
  <dd>Creates and immediately returns an {{domxref("IDBRequest")}} object, and clears this object store in a separate thread. This is for deleting all current records out of an object store.</dd>
  <dt>{{domxref("IDBObjectStore.count()")}}</dt>
@@ -61,7 +61,7 @@ tags:
  <dt>{{domxref("IDBObjectStore.openKeyCursor()")}}<span style="line-height: 1.5;"> </span></dt>
  <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, returns a new {{domxref("IDBCursor")}}. Used for iterating through an object store with a key.</dd>
  <dt>{{domxref("IDBObjectStore.put()")}}</dt>
- <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a <a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/multipage/common-dom-interfaces.html#structured-clone">structured clone</a> of the <code>value</code>, and stores the cloned value in the object store. This is for updating existing records in an object store when the transaction's mode is <code>readwrite</code>.</dd>
+ <dd>Returns an {{domxref("IDBRequest")}} object, and, in a separate thread, creates a <a href="https://www.whatwg.org/specs/web-apps/current-work/multipage/common-dom-interfaces.html#structured-clone">structured clone</a> of the <code>value</code>, and stores the cloned value in the object store. This is for updating existing records in an object store when the transaction's mode is <code>readwrite</code>.</dd>
 </dl>
 
 <h2 id="Example">Example</h2>
@@ -167,5 +167,5 @@ objectStoreRequest.onsuccess = function(event) {
  <li>Setting a range of keys: {{domxref("IDBKeyRange")}}</li>
  <li>Retrieving and making changes to your data: {{domxref("IDBObjectStore")}}</li>
  <li>Using cursors: {{domxref("IDBCursor")}}</li>
- <li>Reference example: <a class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
+ <li>Reference example: <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
 </ul>

--- a/files/en-us/web/api/idbversionchangeevent/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/index.html
@@ -54,7 +54,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>In the following code snippet, we make a request to open a database, and include handlers for the success and error cases. Upon a version change (after an <code>upgradedneeded</code> event), the <code>success</code> event will implement the <code>IDBVersionChangeEvent</code> interface. For a full working example, see our <a class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> app (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
+<p>In the following code snippet, we make a request to open a database, and include handlers for the success and error cases. Upon a version change (after an <code>upgradedneeded</code> event), the <code>success</code> event will implement the <code>IDBVersionChangeEvent</code> interface. For a full working example, see our <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> app (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
 
 <pre class="brush:js">var note = document.querySelector("ul");
 
@@ -118,5 +118,5 @@ DBOpenRequest.onsuccess = function(event) {
  <li>Retrieving and making changes to your data: {{domxref("IDBObjectStore")}}</li>
  <li>Using cursors: {{domxref("IDBCursor")}}</li>
  <li><a href="/en-US/docs/Web/API/IDBDatabase/onversionchange">IDBDatabase.onversionchange</a></li>
- <li>Reference example: <a class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
+ <li>Reference example: <a href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</li>
 </ul>

--- a/files/en-us/web/api/idbversionchangeevent/newversion/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/newversion/index.html
@@ -36,7 +36,7 @@ tags:
 <p>In the following code snippet, we make a request to open a database, and include
   handlers for the success and error cases. These events are fired via the custom
   <code>IDBVersionChangeEvent</code> interface. For a full working example, see our <a
-    class="external" href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do
+    href="https://github.com/mdn/to-do-notifications/tree/gh-pages">To-do
     Notifications</a> app (<a class="external"
     href="https://mdn.github.io/to-do-notifications/">view example live</a>.)</p>
 

--- a/files/en-us/web/api/indexeddb_api/basic_concepts_behind_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/basic_concepts_behind_indexeddb/index.html
@@ -28,7 +28,7 @@ tags:
 
 <h2 id="Overview_of_IndexedDB">Overview of IndexedDB</h2>
 
-<p>IndexedDB lets you store and retrieve objects that are indexed with a "key." All changes that you make to the database happen within transactions. Like most web storage solutions, IndexedDB follows a <a class="external" href="https://www.w3.org/Security/wiki/Same_Origin_Policy">same-origin policy</a>. So while you can access stored data within a domain, you cannot access data across different domains.</p>
+<p>IndexedDB lets you store and retrieve objects that are indexed with a "key." All changes that you make to the database happen within transactions. Like most web storage solutions, IndexedDB follows a <a href="https://www.w3.org/Security/wiki/Same_Origin_Policy">same-origin policy</a>. So while you can access stored data within a domain, you cannot access data across different domains.</p>
 
 <p>IndexedDB is an <a href="/en-US/docs/IndexedDB#Asynchronous_API">asynchronous</a> API that can be used in most contexts, including <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>. It used to include a <a href="/en-US/docs/IndexedDB#Synchronous_API">synchronous</a> version also, for use in web workers, but this was removed from the spec due to lack of interest by the web community.</p>
 
@@ -59,15 +59,15 @@ tags:
  <li>
   <p><strong>IndexedDB is object-oriented.</strong> IndexedDB is not a relational database with tables representing collections of rows and columns. This important and fundamental difference affects the way you design and build your applications.</p>
 
-  <p>In a traditional relational data store, you would have a table that stores a collection of rows of data and columns of named types of data. IndexedDB, on the other hand, requires you to create an object store for a type of data and persist JavaScript objects to that store. Each object store can have a collection of indexes that makes it efficient to query and iterate across. If you are not familiar with object-oriented database management systems, read the <a class="external" href="https://en.wikipedia.org/wiki/Object_database">Wikipedia article on object database</a>.</p>
+  <p>In a traditional relational data store, you would have a table that stores a collection of rows of data and columns of named types of data. IndexedDB, on the other hand, requires you to create an object store for a type of data and persist JavaScript objects to that store. Each object store can have a collection of indexes that makes it efficient to query and iterate across. If you are not familiar with object-oriented database management systems, read the <a href="https://en.wikipedia.org/wiki/Object_database">Wikipedia article on object database</a>.</p>
  </li>
  <li>
-  <p><strong>IndexedDB does not use Structured Query Language (<abbr>SQL</abbr>).</strong> It uses queries on an index that produces a cursor, which you use to iterate across the result set. If you are not familiar with NoSQL systems, read the <a class="external" href="https://en.wikipedia.org/wiki/NoSQL">Wikipedia article on NoSQL</a>.</p>
+  <p><strong>IndexedDB does not use Structured Query Language (<abbr>SQL</abbr>).</strong> It uses queries on an index that produces a cursor, which you use to iterate across the result set. If you are not familiar with NoSQL systems, read the <a href="https://en.wikipedia.org/wiki/NoSQL">Wikipedia article on NoSQL</a>.</p>
  </li>
  <li>
   <p><a name="origin"><strong>IndexedDB adheres to a same-origin policy</strong></a>. An origin is the domain, application layer protocol, and port of a URL of the document where the script is being executed. Each origin has its own associated set of databases. Every database has a name that identifies it within an origin.</p>
 
-  <p>The security boundary imposed on IndexedDB prevents applications from accessing data with a different origin. For example, while an app or a page in <a class="external" href="http://www.example.com/app/">http://www.example.com/app/</a> can retrieve data from <a class="external" href="http://www.example.com/dir/">http://www.example.com/dir/</a>, because they have the same origin, it cannot retrieve data from <a class="external" href="http://www.example.com:8080/dir/">http://www.example.com:8080/dir/</a> (different port) or <a class="link-https" href="https://www.example.com/dir/">https://www.example.com/dir/</a> (different protocol), because they have different origins.</p>
+  <p>The security boundary imposed on IndexedDB prevents applications from accessing data with a different origin. For example, while an app or a page in <a href="http://www.example.com/app/">http://www.example.com/app/</a> can retrieve data from <a href="http://www.example.com/dir/">http://www.example.com/dir/</a>, because they have the same origin, it cannot retrieve data from <a href="http://www.example.com:8080/dir/">http://www.example.com:8080/dir/</a> (different port) or <a class="link-https" href="https://www.example.com/dir/">https://www.example.com/dir/</a> (different protocol), because they have different origins.</p>
 
   <div class="note"><strong>Note</strong>: Third party window content (e.g. {{htmlelement("iframe")}} content) can access the IndexedDB store for the origin it is embedded into, unless the browser is set to <a href="https://support.mozilla.org/en-US/kb/disable-third-party-cookies">never accept third party cookies</a> (see {{bug("1147821")}}.)</div>
  </li>
@@ -109,7 +109,7 @@ tags:
  </dd>
  <dt><a name="gloss_version">version</a></dt>
  <dd>When a database is first created, its version is the integer 1. Each database has one version at a time; a database can't exist in multiple versions at once. The only way to change the version is by opening it with a greater version than the current one. This will start a <a href="/en-US/docs/Web/API/IDBVersionChangeRequest"><code>versionchange</code></a> <em>transaction</em> and fire an <a href="/en-US/docs/Web/Reference/Events/upgradeneeded_indexedDB"><code>upgradeneeded</code></a> event. The only place where the schema of the database can be updated is inside the handler of that event.</dd>
- <dd>Note: This definition describes the <a class="external" href="http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">most recent specification</a>, which is only implemented in up-to-date browsers. Old browsers implemented the now deprecated and removed <a href="/en-US/docs/IndexedDB/IDBDatabase#setVersion()"><code>IDBDatabase.setVersion()</code></a> method.</dd>
+ <dd>Note: This definition describes the <a href="http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">most recent specification</a>, which is only implemented in up-to-date browsers. Old browsers implemented the now deprecated and removed <a href="/en-US/docs/IndexedDB/IDBDatabase#setVersion()"><code>IDBDatabase.setVersion()</code></a> method.</dd>
  <dt><a name="gloss_database_connection">database connection</a></dt>
  <dd>An operation created by opening a <em><a href="#gloss_database">database</a></em>. A given database can have multiple connections at the same time.</dd>
  <dt><a name="gloss_transaction">transaction</a></dt>
@@ -161,7 +161,7 @@ tags:
 
  <p>When an object or array is stored, the properties and values in that object or array can also be anything that is a valid value.</p>
 
- <p><a href="/en-US/docs/DOM/Blob">Blobs</a> and files can be stored, cf. <a class="external" href="http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">specification</a> {{ fx_minversion_inline("11") }}.</p>
+ <p><a href="/en-US/docs/DOM/Blob">Blobs</a> and files can be stored, cf. <a href="http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html">specification</a> {{ fx_minversion_inline("11") }}.</p>
  </dd>
 </dl>
 
@@ -212,5 +212,5 @@ tags:
  <li><a href="https://www.w3.org/TR/IndexedDB/"><span style="direction: ltr;">Indexed Database API Specification</span></a></li>
  <li><a href="/en-US/docs/IndexedDB">IndexedDB API Reference</a></li>
  <li><a href="/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB">Using IndexedDB</a></li>
- <li><a class="external" href="https://msdn.microsoft.com/en-us/scriptjunkie/gg679063.aspx">IndexedDB — The Store in Your Browser</a></li>
+ <li><a href="https://msdn.microsoft.com/en-us/scriptjunkie/gg679063.aspx">IndexedDB — The Store in Your Browser</a></li>
 </ul>

--- a/files/en-us/web/api/indexeddb_api/index.html
+++ b/files/en-us/web/api/indexeddb_api/index.html
@@ -31,7 +31,7 @@ tags:
 </ul>
 
 <div class="note">
-<p><strong>Note</strong>: Like most web storage solutions, IndexedDB follows a <a class="external" href="https://www.w3.org/Security/wiki/Same_Origin_Policy">same-origin policy</a>. So while you can access stored data within a domain, you cannot access data across different domains.</p>
+<p><strong>Note</strong>: Like most web storage solutions, IndexedDB follows a <a href="https://www.w3.org/Security/wiki/Same_Origin_Policy">same-origin policy</a>. So while you can access stored data within a domain, you cannot access data across different domains.</p>
 </div>
 
 <h3 id="Synchronous_and_asynchronous">Synchronous and asynchronous</h3>
@@ -117,9 +117,9 @@ tags:
 <h2 id="Examples">Examples</h2>
 
 <ul>
- <li><a class="external" href="https://marco-c.github.io/eLibri/">eLibri:</a> A powerful library and eBook reader application, written by Marco Castelluccio, winner of the IndexedDB Mozilla DevDerby.</li>
- <li><a class="external" href="https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a class="external" href="https://mdn.github.io/to-do-notifications/">view example live</a>): The reference application for the examples in the reference docs.</li>
- <li><a class="external" href="https://hacks.mozilla.org/2012/02/storing-images-and-files-in-indexeddb/">Storing images and files in IndexedDB</a></li>
+ <li><a href="https://marco-c.github.io/eLibri/">eLibri:</a> A powerful library and eBook reader application, written by Marco Castelluccio, winner of the IndexedDB Mozilla DevDerby.</li>
+ <li><a href="https://github.com/chrisdavidmills/to-do-notifications/tree/gh-pages">To-do Notifications</a> (<a href="https://mdn.github.io/to-do-notifications/">view example live</a>): The reference application for the examples in the reference docs.</li>
+ <li><a href="https://hacks.mozilla.org/2012/02/storing-images-and-files-in-indexeddb/">Storing images and files in IndexedDB</a></li>
 </ul>
 
 <h2 id="Specifications">Specifications</h2>
@@ -149,8 +149,8 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a class="external" href="https://localforage.github.io/localForage/">localForage</a>: A Polyfill providing a simple name:value syntax for client-side data storage, which uses IndexedDB in the background, but falls back to WebSQL and then localStorage in browsers that don't support IndexedDB.</li>
- <li><a class="external" href="https://dexie.org/">Dexie.js</a>: A wrapper for IndexedDB that allows much faster code development via nice, simple syntax.</li>
+ <li><a href="https://localforage.github.io/localForage/">localForage</a>: A Polyfill providing a simple name:value syntax for client-side data storage, which uses IndexedDB in the background, but falls back to WebSQL and then localStorage in browsers that don't support IndexedDB.</li>
+ <li><a href="https://dexie.org/">Dexie.js</a>: A wrapper for IndexedDB that allows much faster code development via nice, simple syntax.</li>
  <li><a href="https://github.com/erikolson186/zangodb">ZangoDB</a>: A MongoDB-like interface for IndexedDB that supports most of the familiar filtering, projection, sorting, updating and aggregation features of MongoDB.</li>
  <li><a href="https://jsstore.net/">JsStore</a>: An IndexedDB wrapper with SQL like syntax.</li>
  <li><a href="https://github.com/mWater/minimongo">MiniMongo</a>: A client-side in-memory mongodb backed by localstorage with server sync over http. MiniMongo is used by MeteorJS.</li>

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.html
@@ -1320,7 +1320,7 @@ input {
 
 <ul>
  <li><a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API Reference</a></li>
- <li><a class="external" href="https://www.w3.org/TR/IndexedDB/">Indexed Database API Specification</a></li>
+ <li><a href="https://www.w3.org/TR/IndexedDB/">Indexed Database API Specification</a></li>
  <li>IndexedDB <a class="link-https" href="https://searchfox.org/mozilla-central/search?q=dom%2FindexedDB%2F.*%5C.idl&path=&case=false&regexp=true">interface files</a> in the Firefox source code</li>
 </ul>
 
@@ -1328,7 +1328,7 @@ input {
 
 <ul>
  <li><a href="http://www.html5rocks.com/en/tutorials/indexeddb/uidatabinding/">Databinding UI Elements with IndexedDB</a></li>
- <li><a class="external" href="https://msdn.microsoft.com/en-us/scriptjunkie/gg679063.aspx">IndexedDB — The Store in Your Browser</a></li>
+ <li><a href="https://msdn.microsoft.com/en-us/scriptjunkie/gg679063.aspx">IndexedDB — The Store in Your Browser</a></li>
 </ul>
 
 <h3 id="Libraries">Libraries</h3>

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -42,7 +42,7 @@ navigator.webkitPersistentStorage.requestQuota (
 
 <p>Your user must grant your app permission to store data locally before your app can use persistent storage. Once your user grants it, you don't need to call <code>requestQuota()</code> again. Subsequent calls are a noop.</p>
 
-<p>Another API, the Quota Management API, lets you query an origin's current quota usage and allocation using <code>window.webkitPersistentStorage.queryUsageAndQuota()</code>. To learn more, see this <a href="http://stackoverflow.com/a/29662985/89484">StackOverflow Answer</a>. (An older version of the API is described at <a class="external" href="https://developer.chrome.com/apps/offline_storage?csw=1">Managing HTML5 Offline Storage</a>.)</p>
+<p>Another API, the Quota Management API, lets you query an origin's current quota usage and allocation using <code>window.webkitPersistentStorage.queryUsageAndQuota()</code>. To learn more, see this <a href="http://stackoverflow.com/a/29662985/89484">StackOverflow Answer</a>. (An older version of the API is described at <a href="https://developer.chrome.com/apps/offline_storage?csw=1">Managing HTML5 Offline Storage</a>.)</p>
 
 <h3 id="Working_within_a_single_origin">Working within a single origin</h3>
 

--- a/files/en-us/web/api/navigatoronline/online_and_offline_events/index.html
+++ b/files/en-us/web/api/navigatoronline/online_and_offline_events/index.html
@@ -10,7 +10,7 @@ tags:
   - Offline web applications
   - Web Development
 ---
-<p>Some browsers implement <a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/#offline">Online/Offline events</a> from the <a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/">WHATWG Web Applications 1.0 specification</a>.</p>
+<p>Some browsers implement <a href="https://www.whatwg.org/specs/web-apps/current-work/#offline">Online/Offline events</a> from the <a href="https://www.whatwg.org/specs/web-apps/current-work/">WHATWG Web Applications 1.0 specification</a>.</p>
 
 <h2 id="Overview">Overview</h2>
 
@@ -23,7 +23,7 @@ tags:
 
 <p>It is this process that online/offline events help to simplify.</p>
 
-<p>Unfortunately, these events aren't fully reliable. If you need greater reliability, or if the API isn't implemented in the browser, you can use other signals to detect if you are offline including using service workers and <a class="external" href="http://www.html5rocks.com/en/mobile/workingoffthegrid.html#toc-xml-http-request">responses from XMLHttpRequest</a>.</p>
+<p>Unfortunately, these events aren't fully reliable. If you need greater reliability, or if the API isn't implemented in the browser, you can use other signals to detect if you are offline including using service workers and <a href="http://www.html5rocks.com/en/mobile/workingoffthegrid.html#toc-xml-http-request">responses from XMLHttpRequest</a>.</p>
 
 <h2 id="API">API</h2>
 
@@ -113,13 +113,13 @@ tags:
 
 <h2 id="Notes">Notes</h2>
 
-<p>If the API isn't implemented in the browser, you can use other signals to detect if you are offline including using service workers and <a class="external" href="http://www.html5rocks.com/en/mobile/workingoffthegrid.html#toc-xml-http-request">responses from XMLHttpRequest</a>.</p>
+<p>If the API isn't implemented in the browser, you can use other signals to detect if you are offline including using service workers and <a href="http://www.html5rocks.com/en/mobile/workingoffthegrid.html#toc-xml-http-request">responses from XMLHttpRequest</a>.</p>
 
 <h2 id="References">References</h2>
 
 <ul>
- <li><a class="external" href="https://www.whatwg.org/specs/web-apps/current-work/#offline">'Online/Offline events' section from the WHATWG Web Applications 1.0 Specification</a></li>
+ <li><a href="https://www.whatwg.org/specs/web-apps/current-work/#offline">'Online/Offline events' section from the WHATWG Web Applications 1.0 Specification</a></li>
  <li><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=336359">The bug tracking online/offline events implementation in Firefox</a> and a <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=336682">follow-up</a></li>
  <li><a class="link-https" href="https://bugzilla.mozilla.org/attachment.cgi?id=220609">A simple test case</a></li>
- <li><a class="external" href="http://ejohn.org/blog/offline-events/">An explanation of Online/Offline events</a></li>
+ <li><a href="http://ejohn.org/blog/offline-events/">An explanation of Online/Offline events</a></li>
 </ul>

--- a/files/en-us/web/api/svganimatedangle/index.html
+++ b/files/en-us/web/api/svganimatedangle/index.html
@@ -38,7 +38,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedAngle">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedAngle">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedboolean/index.html
+++ b/files/en-us/web/api/svganimatedboolean/index.html
@@ -37,7 +37,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedBoolean">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedBoolean">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedinteger/index.html
+++ b/files/en-us/web/api/svganimatedinteger/index.html
@@ -39,7 +39,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedInteger">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedInteger">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedlength/index.html
+++ b/files/en-us/web/api/svganimatedlength/index.html
@@ -36,7 +36,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedLength">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedLength">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedlengthlist/index.html
+++ b/files/en-us/web/api/svganimatedlengthlist/index.html
@@ -38,7 +38,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedLengthList">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedLengthList">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedpreserveaspectratio/index.html
+++ b/files/en-us/web/api/svganimatedpreserveaspectratio/index.html
@@ -37,7 +37,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/coords.html#InterfaceSVGAnimatedPreserveAspectRatio">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/coords.html#InterfaceSVGAnimatedPreserveAspectRatio">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedrect/index.html
+++ b/files/en-us/web/api/svganimatedrect/index.html
@@ -36,7 +36,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedRect">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGAnimatedRect">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svganimatedtransformlist/index.html
+++ b/files/en-us/web/api/svganimatedtransformlist/index.html
@@ -37,7 +37,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG/coords.html#InterfaceSVGAnimatedTransformList">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG/coords.html#InterfaceSVGAnimatedTransformList">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/svgnumberlist/index.html
+++ b/files/en-us/web/api/svgnumberlist/index.html
@@ -53,7 +53,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Normative document</th>
-   <td><a class="external" href="https://www.w3.org/TR/SVG/types.html#InterfaceSVGNumberList">SVG 1.1 (2nd Edition)</a></td>
+   <td><a href="https://www.w3.org/TR/SVG/types.html#InterfaceSVGNumberList">SVG 1.1 (2nd Edition)</a></td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/texttrack/cuechange_event/index.html
+++ b/files/en-us/web/api/texttrack/cuechange_event/index.html
@@ -93,7 +93,7 @@ textTrackElem.oncuechange = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.TextTrack.cuechange_event")}}</p>
 

--- a/files/en-us/web/api/timeranges/index.html
+++ b/files/en-us/web/api/timeranges/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>A <code>TimeRanges</code> object includes one or more ranges of time, each specified by a starting and ending time offset. You reference each time range by using the <code>start()</code> and <code>end()</code> methods, passing the index number of the time range you want to retrieve.</p>
 
-<p>The term "<a class="external" href="https://www.w3.org/TR/html52/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a>" indicates that ranges in such an object are ordered, don't overlap, aren't empty, and don't touch (adjacent ranges are folded into one bigger range).</p>
+<p>The term "<a href="https://www.w3.org/TR/html52/semantics-embedded-content.html#normalized-timeranges-object">normalized TimeRanges object</a>" indicates that ranges in such an object are ordered, don't overlap, aren't empty, and don't touch (adjacent ranges are folded into one bigger range).</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/userdatahandler/index.html
+++ b/files/en-us/web/api/userdatahandler/index.html
@@ -76,7 +76,7 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<p><a class="external" href="https://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler">DOM Level 3 Core: UserDataHandler</a></p>
+<p><a href="https://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler">DOM Level 3 Core: UserDataHandler</a></p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/web_authentication_api/index.html
+++ b/files/en-us/web/api/web_authentication_api/index.html
@@ -193,8 +193,8 @@ navigator.credentials.create(createCredentialDefaultArgs)
 </pre>
 
 <ul>
- <li><a class="external" href="https://webauthn.bin.coffee/">Mozilla Demo</a> website and its <a href="https://github.com/jcjones/webauthn.bin.coffee">source code</a>.</li>
- <li><a class="external" href="http://webauthndemo.appspot.com/">Google Demo</a> website and its <a href="https://github.com/google/webauthndemo">source code</a>.</li>
+ <li><a href="https://webauthn.bin.coffee/">Mozilla Demo</a> website and its <a href="https://github.com/jcjones/webauthn.bin.coffee">source code</a>.</li>
+ <li><a href="http://webauthndemo.appspot.com/">Google Demo</a> website and its <a href="https://github.com/google/webauthndemo">source code</a>.</li>
  <li><a href="https://webauthn.org">webauthn.org</a> and its <a href="https://github.com/apowers313/webauthn-simple-app">client source code</a> and <a href="https://github.com/apowers313/fido2-lib">server source code</a></li>
 </ul>
 

--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.html
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.html
@@ -309,8 +309,8 @@ function loadShader(gl, type, source) {
 
 <ul>
  <li><a href="https://webglfundamentals.org/webgl/lessons/webgl-2d-matrices.html">Matrices</a> on WebGLFundamentals</li>
- <li><a class="external" href="http://mathworld.wolfram.com/Matrix.html">Matrices</a> on Wolfram MathWorld</li>
- <li><a class="external" href="https://en.wikipedia.org/wiki/Matrix_(mathematics)">Matrix</a> on Wikipedia</li>
+ <li><a href="http://mathworld.wolfram.com/Matrix.html">Matrices</a> on Wolfram MathWorld</li>
+ <li><a href="https://en.wikipedia.org/wiki/Matrix_(mathematics)">Matrix</a> on Wikipedia</li>
 </ul>
 
 <p>{{PreviousNext("Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL", "Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL")}}</p>

--- a/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <div>{{WebGLSidebar("Tutorial")}} {{Next("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context")}}</div>
 
-<p><span class="seoSummary"><a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> enables web content to use an API based on <a class="external" href="http://www.khronos.org/opengles/">OpenGL ES</a> 2.0 to perform 2D and 3D rendering in an HTML <a class="internal" href="/en-US/docs/Web/API/Canvas_API"><code>canvas</code></a> in browsers that support it without the use of plug-ins.</span> WebGL programs consist of control code written in JavaScript and shader code (GLSL) that is executed on a computer's Graphics Processing Unit (GPU). WebGL elements can be mixed with other HTML elements and composited with other parts of the page or page background.</p>
+<p><span class="seoSummary"><a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> enables web content to use an API based on <a href="http://www.khronos.org/opengles/">OpenGL ES</a> 2.0 to perform 2D and 3D rendering in an HTML <a class="internal" href="/en-US/docs/Web/API/Canvas_API"><code>canvas</code></a> in browsers that support it without the use of plug-ins.</span> WebGL programs consist of control code written in JavaScript and shader code (GLSL) that is executed on a computer's Graphics Processing Unit (GPU). WebGL elements can be mixed with other HTML elements and composited with other parts of the page or page background.</p>
 
 <p>This article will introduce you to the basics of using WebGL. It's assumed that you already have an understanding of the mathematics involved in 3D graphics, and this article doesn't pretend to try to teach you 3D graphics concepts itself.</p>
 

--- a/files/en-us/web/api/webgl_api/tutorial/index.html
+++ b/files/en-us/web/api/webgl_api/tutorial/index.html
@@ -10,7 +10,7 @@ tags:
 <div>{{WebGLSidebar}}</div>
 
 <div class="summary">
-<p><a class="external" href="http://www.khronos.org/webgl/">WebGL</a> enables web content to use an API based on <a class="external" href="http://www.khronos.org/opengles/">OpenGL ES</a> 2.0 to perform 3D rendering in an HTML {{HTMLElement("canvas")}} in browsers that support it without the use of plug-ins. WebGL programs consist of control code written in JavaScript and special effects code (shader code) that is executed on a computer's Graphics Processing Unit (GPU). WebGL elements can be mixed with other HTML elements and composited with other parts of the page or page background.</p>
+<p><a href="http://www.khronos.org/webgl/">WebGL</a> enables web content to use an API based on <a href="http://www.khronos.org/opengles/">OpenGL ES</a> 2.0 to perform 3D rendering in an HTML {{HTMLElement("canvas")}} in browsers that support it without the use of plug-ins. WebGL programs consist of control code written in JavaScript and special effects code (shader code) that is executed on a computer's Graphics Processing Unit (GPU). WebGL elements can be mixed with other HTML elements and composited with other parts of the page or page background.</p>
 </div>
 
 <p><span class="seoSummary">This tutorial describes how to use the <code>&lt;canvas&gt;</code> element to draw WebGL graphics, starting with the basics. The examples provided should give you some clear ideas of what you can do with WebGL and will provide code snippets that may get you started in building your own content.</span></p>

--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.html
@@ -25,7 +25,7 @@ tags:
 
 <h2 id="Simulating_lighting_and_shading_in_3D">Simulating lighting and shading in 3D</h2>
 
-<p>Although going into detail about the theory behind simulated lighting in 3D graphics is far beyond the scope of this article, it's helpful to know a bit about how it works. Instead of discussing it in depth here, take a look at the article on <a class="external" href="https://en.wikipedia.org/wiki/Phong_shading">Phong shading</a> at Wikipedia, which provides a good overview of the most commonly used lighting model or if you'd like to see a WebGL based explanation <a href="https://webglfundamentals.org/webgl/lessons/webgl-3d-lighting-point.html">see this artcle</a>.</p>
+<p>Although going into detail about the theory behind simulated lighting in 3D graphics is far beyond the scope of this article, it's helpful to know a bit about how it works. Instead of discussing it in depth here, take a look at the article on <a href="https://en.wikipedia.org/wiki/Phong_shading">Phong shading</a> at Wikipedia, which provides a good overview of the most commonly used lighting model or if you'd like to see a WebGL based explanation <a href="https://webglfundamentals.org/webgl/lessons/webgl-3d-lighting-point.html">see this artcle</a>.</p>
 
 <p>There are three basic types of lighting:</p>
 

--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.html
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.html
@@ -269,7 +269,7 @@ function drawScene(gl, programInfo, buffers, texture, deltaTime) {
 
 <p>Because WebGL now requires textures to be loaded from secure contexts, you can't use textures loaded from <code>file:///</code> URLs in WebGL. That means that you'll need a secure web server to test and deploy your code. For local testing, see our guide <a href="/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server">How do you set up a local testing server?</a> for help.</p>
 
-<p>See this <a class="external" href="http://hacks.mozilla.org/2011/11/using-cors-to-load-webgl-textures-from-cross-domain-images/">hacks.mozilla.org article</a> for an explanation of how to use CORS-approved images as WebGL textures, with <a class="external" href="http://people.mozilla.org/~bjacob/webgltexture-cors-js.html">a self-contained example</a>.</p>
+<p>See this <a href="http://hacks.mozilla.org/2011/11/using-cors-to-load-webgl-textures-from-cross-domain-images/">hacks.mozilla.org article</a> for an explanation of how to use CORS-approved images as WebGL textures, with <a href="http://people.mozilla.org/~bjacob/webgltexture-cors-js.html">a self-contained example</a>.</p>
 
 <div class="note">
 <p><strong>Note:</strong> CORS support for WebGL textures and the <code>crossOrigin</code> attribute for image elements is implemented in {{Gecko("8.0")}}.</p>

--- a/files/en-us/web/api/webgl_api/using_extensions/index.html
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <div>{{WebGLSidebar}}</div>
 
-<p>WebGL, like its sister APIs (OpenGL and OpenGL ES), supports extensions. A complete list of extensions is available in the <a class="external" href="http://www.khronos.org/registry/webgl/extensions/">khronos webgl extension registry</a>.</p>
+<p>WebGL, like its sister APIs (OpenGL and OpenGL ES), supports extensions. A complete list of extensions is available in the <a href="http://www.khronos.org/registry/webgl/extensions/">khronos webgl extension registry</a>.</p>
 
 <div class="note"><strong>Note:</strong> In WebGL, unlike in other GL APIs, extensions are only available if explicitly requested.</div>
 

--- a/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.html
+++ b/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="The_HTML">The HTML</h2>
 
-<p>First, let's take a quick look at the <a class="external" href="https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel/index.html" rel="noopener">HTML that's needed</a>. There's nothing incredibly complicated here. First, we have a couple of buttons for establishing and closing the connection:</p>
+<p>First, let's take a quick look at the <a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel/index.html" rel="noopener">HTML that's needed</a>. There's nothing incredibly complicated here. First, we have a couple of buttons for establishing and closing the connection:</p>
 
 <pre class="brush: html notranslate">&lt;button id="connectButton" name="connectButton" class="buttonleft"&gt;
   Connect
@@ -45,7 +45,7 @@ tags:
 
 <h2 id="The_JavaScript_code">The JavaScript code</h2>
 
-<p>While you can just <a class="external" href="https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel/main.js" rel="noopener">look at the code itself on GitHub</a>, below we'll review the parts of the code that do the heavy lifting.</p>
+<p>While you can just <a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel/main.js" rel="noopener">look at the code itself on GitHub</a>, below we'll review the parts of the code that do the heavy lifting.</p>
 
 <p>The WebRTC API makes heavy use of {{jsxref("Promise")}}s. They make it very easy to chain the steps of the connection process together; if you haven't already read up on this functionality of <a href="/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla">ECMAScript 2015</a>, you should read up on them. Similarly, this example uses <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a> to simplify syntax.</p>
 

--- a/files/en-us/web/api/webrtc_api/taking_still_photos/index.html
+++ b/files/en-us/web/api/webrtc_api/taking_still_photos/index.html
@@ -20,11 +20,11 @@ tags:
 
 <p><img alt="WebRTC-based image capture app — on the left we have a video stream taken from a webcam and a take photo button, on the right we have the still image output from taking the photo" src="https://mdn.mozillademos.org/files/10281/web-rtc-demo.png" style="display: block; height: 252px; margin: 0px auto; width: 677px;"></p>
 
-<p>You can also jump straight to the <a class="external" href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill" rel="noopener">code on Github</a> if you like.</p>
+<p>You can also jump straight to the <a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill" rel="noopener">code on Github</a> if you like.</p>
 
 <h2 id="The_HTML_markup">The HTML markup</h2>
 
-<p><a class="external" href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill/index.html" rel="noopener">Our HTML interface</a> has two main operational sections: the stream and capture panel and the presentation panel. Each of these is presented side-by-side in its own {{HTMLElement("div")}} to facilitate styling and control.</p>
+<p><a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill/index.html" rel="noopener">Our HTML interface</a> has two main operational sections: the stream and capture panel and the presentation panel. Each of these is presented side-by-side in its own {{HTMLElement("div")}} to facilitate styling and control.</p>
 
 <p>The first panel on the left contains two components: a {{HTMLElement("video")}} element, which will receive the stream from WebRTC, and a {{HTMLElement("button")}} the user clicks to capture a video frame.</p>
 
@@ -49,7 +49,7 @@ tags:
 
 <h2 id="The_JavaScript_code"><span style="font-size: 30px;">The JavaScript code</span></h2>
 
-<p>Now let's take a look at the <a class="external" href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill/capture.js" rel="noopener">JavaScript code</a>. We'll break it up into a few bite-sized pieces to make it easier to explain.</p>
+<p>Now let's take a look at the <a href="https://github.com/mdn/samples-server/tree/master/s/webrtc-capturestill/capture.js" rel="noopener">JavaScript code</a>. We'll break it up into a few bite-sized pieces to make it easier to explain.</p>
 
 <h3 id="Initialization">Initialization</h3>
 

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -186,6 +186,6 @@ tags:
    <li><a href="/en-US/docs/Web/API/Fetch_API" title="Fetch API">Fetch API</a></li>
   </ul>
  </li>
- <li><a class="external" href="http://www.html5rocks.com/en/tutorials/file/xhr2/">HTML5 Rocks — New Tricks in XMLHttpRequest2</a></li>
+ <li><a href="http://www.html5rocks.com/en/tutorials/file/xhr2/">HTML5 Rocks — New Tricks in XMLHttpRequest2</a></li>
  <li>Feature-Policy directive {{httpheader("Feature-Policy/sync-xhr", "sync-xhr")}}</li>
 </ul>


### PR DESCRIPTION
The `class="external"` gets automatically injected at build-time anyway so no need to manually set it in the raw sources. 
Besides, this'll make more sense as we move towards something Markdown'ish. 

Note! I capped this to the first 50 files to make the PR slightly less huge. 