### PR TITLE
remove unnecessary class=external in learn tree

### DIFF
--- a/files/en-us/learn/css/howto/generated_content/index.html
+++ b/files/en-us/learn/css/howto/generated_content/index.html
@@ -48,9 +48,9 @@ tags:
 
 <p>{{ EmbedLiveSample('Text_content', 600, 30) }}</p>
 
-<p>The character set of a stylesheet is UTF-8 by default, but it can also be specified in the link, in the stylesheet itself, or in other ways. For details, see <a class="external" href="https://www.w3.org/TR/CSS21/syndata.html#q23">4.4 CSS style sheet representation</a> in the CSS Specification.</p>
+<p>The character set of a stylesheet is UTF-8 by default, but it can also be specified in the link, in the stylesheet itself, or in other ways. For details, see <a href="https://www.w3.org/TR/CSS21/syndata.html#q23">4.4 CSS style sheet representation</a> in the CSS Specification.</p>
 
-<p>Individual characters can also be specified by an escape mechanism that uses backslash as the escape character. For example, "\265B" is the chess symbol for a black queen ♛. For details, see <a class="external" href="https://www.w3.org/TR/CSS21/syndata.html#q24">Referring to characters not represented in a character encoding</a> and <a class="external" href="https://www.w3.org/TR/CSS21/syndata.html#q6">Characters and case</a> in the CSS Specification.</p>
+<p>Individual characters can also be specified by an escape mechanism that uses backslash as the escape character. For example, "\265B" is the chess symbol for a black queen ♛. For details, see <a href="https://www.w3.org/TR/CSS21/syndata.html#q24">Referring to characters not represented in a character encoding</a> and <a href="https://www.w3.org/TR/CSS21/syndata.html#q6">Characters and case</a> in the CSS Specification.</p>
 
 <h3 id="Image_content">Image content</h3>
 

--- a/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.html
+++ b/files/en-us/learn/html/howto/author_fast-loading_html_pages/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>Reducing page weight through the elimination of unnecessary whitespace and comments, commonly known as minimization, and by moving inline script and CSS into external files, can improve download performance with minimal need for other changes in the page structure.</p>
 
-<p>Tools such as <a class="external" href="http://www.html-tidy.org">HTML Tidy</a> can automatically strip leading whitespace and extra blank lines from valid HTML source. Other tools can "compress" JavaScript by reformatting the source or by obfuscating the source and replacing long identifiers with shorter versions.</p>
+<p>Tools such as <a href="http://www.html-tidy.org">HTML Tidy</a> can automatically strip leading whitespace and extra blank lines from valid HTML source. Other tools can "compress" JavaScript by reformatting the source or by obfuscating the source and replacing long identifiers with shorter versions.</p>
 
 <h3 id="Minimize_the_number_of_files">Minimize the number of files</h3>
 
@@ -63,10 +63,10 @@ tags:
 <p>More information:</p>
 
 <ol>
- <li><a class="external" href="http://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers">HTTP Conditional Get for RSS Hackers</a></li>
- <li><a class="external" href="http://annevankesteren.nl/archives/2005/05/http-304">HTTP 304: Not Modified</a></li>
- <li><a class="external" href="https://en.wikipedia.org/wiki/HTTP_ETag">HTTP ETag on Wikipedia</a></li>
- <li><a class="external" href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html">Caching in HTTP</a></li>
+ <li><a href="http://fishbowl.pastiche.org/2002/10/21/http_conditional_get_for_rss_hackers">HTTP Conditional Get for RSS Hackers</a></li>
+ <li><a href="http://annevankesteren.nl/archives/2005/05/http-304">HTTP 304: Not Modified</a></li>
+ <li><a href="https://en.wikipedia.org/wiki/HTTP_ETag">HTTP ETag on Wikipedia</a></li>
+ <li><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html">Caching in HTTP</a></li>
 </ol>
 
 <h3 id="Optimally_order_the_components_of_the_page">Optimally order the components of the page</h3>
@@ -85,7 +85,7 @@ tags:
 
 <p>Using valid markup has other advantages. First, browsers will have no need to perform error-correction when parsing the HTML (this is aside from the philosophical issue of whether to allow format variation in user input and then programmatically "correct" or normalize it; or whether, instead, to enforce a strict, no-tolerance input format).</p>
 
-<p>Moreover, valid markup allows for the free use of other tools which can <em>pre-process</em> your web pages. For example, <a class="external" href="http://tidy.sourceforge.net/">HTML Tidy</a> can remove whitespace and optional ending tags; however, it will refuse to run on a page with serious markup errors.</p>
+<p>Moreover, valid markup allows for the free use of other tools which can <em>pre-process</em> your web pages. For example, <a href="http://tidy.sourceforge.net/">HTML Tidy</a> can remove whitespace and optional ending tags; however, it will refuse to run on a page with serious markup errors.</p>
 
 <h3 id="Chunk_your_content">Chunk your content</h3>
 
@@ -110,7 +110,7 @@ tags:
 &lt;table&gt;...&lt;/table&gt;
 </pre>
 
-<p>See also: <a class="external" href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout</a> and <a class="external" href="https://www.w3.org/TR/css-grid-1/">CSS Grid Layout</a> specifications.</p>
+<p>See also: <a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout</a> and <a href="https://www.w3.org/TR/css-grid-1/">CSS Grid Layout</a> specifications.</p>
 
 <h3 id="Minify_and_compress_SVG_assets">Minify and compress SVG assets</h3>
 
@@ -186,8 +186,8 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>Book: <a class="external" href="http://www.websiteoptimization.com/">"Speed Up Your Site" by Andy King</a></li>
- <li>The excellent and very complete <a class="external" href="http://developer.yahoo.com/performance/rules.html">Best Practices for Speeding Up Your Web Site</a> (Yahoo!)</li>
+ <li>Book: <a href="http://www.websiteoptimization.com/">"Speed Up Your Site" by Andy King</a></li>
+ <li>The excellent and very complete <a href="http://developer.yahoo.com/performance/rules.html">Best Practices for Speeding Up Your Web Site</a> (Yahoo!)</li>
  <li>Tools for analyzing and optimizing performance: <a href="https://developers.google.com/speed/pagespeed/">Google PageSpeed Tools</a></li>
  <li><a href="/en-US/docs/Tools/Paint_Flashing_Tool">Paint Flashing Tool</a></li>
 </ul>

--- a/files/en-us/learn/server-side/apache_configuration_htaccess/index.html
+++ b/files/en-us/learn/server-side/apache_configuration_htaccess/index.html
@@ -13,11 +13,11 @@ tags:
 
 <p>While this is useful it's important to note that using <code>.htaccess</code> files slows down Apache, so, if you have access to the main server configuration file (which is usually called `httpd.conf`), you should add this logic there under a <code>Directory</code> block.</p>
 
-<p>See <a class="external" href="https://httpd.apache.org/docs/current/howto/htaccess.html">.htaccess</a> in the Apache HTTPD documentation site for more details about what .htaccess files can do.</p>
+<p>See <a href="https://httpd.apache.org/docs/current/howto/htaccess.html">.htaccess</a> in the Apache HTTPD documentation site for more details about what .htaccess files can do.</p>
 
 <p>The remainder of this document will discuss different configuration options you can add to <code>.htaccess</code> and what they do.</p>
 
-<p>Most of the following blocks use the <a class="external" href="https://httpd.apache.org/docs/2.4/mod/core.html#ifmodule">IfModule</a> directive to only execute the instructions inside the block if the corresponding module was properly configured and the server loaded it. This way we save our server from crashing if the module wasn't loaded.</p>
+<p>Most of the following blocks use the <a href="https://httpd.apache.org/docs/2.4/mod/core.html#ifmodule">IfModule</a> directive to only execute the instructions inside the block if the corresponding module was properly configured and the server loaded it. This way we save our server from crashing if the module wasn't loaded.</p>
 
 <h2 id="Redirects">Redirects</h2>
 
@@ -56,7 +56,7 @@ tags:
 
 <h2 id="Cross-origin_resources">Cross-origin resources</h2>
 
-<p>The first set of directives control <a class="external" href="https://www.w3.org/TR/cors/">CORS</a> (Cross-Origin Resource Sharing) access to resources from the server. CORS is an HTTP-header based mechanism that allows a server to indicate the external origins (domain, protocol, or port) which a browser should permit loading of resources.</p>
+<p>The first set of directives control <a href="https://www.w3.org/TR/cors/">CORS</a> (Cross-Origin Resource Sharing) access to resources from the server. CORS is an HTTP-header based mechanism that allows a server to indicate the external origins (domain, protocol, or port) which a browser should permit loading of resources.</p>
 
 <p>For security reasons, browsers restrict cross-origin HTTP requests initiated from scripts. For example, XMLHttpRequest and the Fetch API follow the same-origin policy. A web application using those APIs can only request resources from the same origin the application was loaded from unless the response from other origins includes the appropriate CORS headers.</p>
 
@@ -78,7 +78,7 @@ tags:
 
 <h3 id="Cross-origin_images">Cross-origin images</h3>
 
-<p>As reported in the <a class="external" href="https://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html">Chromium Blog</a> and documented in <a href="/en-US/docs/Web/HTML/CORS_enabled_image">Allowing cross-origin use of images and canvas</a> can lead to fingerprinting attacks.</p>
+<p>As reported in the <a href="https://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html">Chromium Blog</a> and documented in <a href="/en-US/docs/Web/HTML/CORS_enabled_image">Allowing cross-origin use of images and canvas</a> can lead to fingerprinting attacks.</p>
 
 <p>To mitigate the possibility of these attacks, you should use the <code>crossorigin</code> attribute in the images you request and the code snippet below in your <code>.htaccess</code> to set the CORS header from the server.</p>
 
@@ -91,7 +91,7 @@ tags:
   &lt;/IfModule&gt;
 &lt;/IfModule&gt;</pre>
 
-<p class="brush: bash">Google Chrome's <a class="external" href="https://developers.google.com/fonts/docs/troubleshooting">Google Fonts troubleshooting guide</a> tells us that, while Google Fonts may send the CORS header with every response, some proxy servers may strip it before the browser can use it to render the font.</p>
+<p class="brush: bash">Google Chrome's <a href="https://developers.google.com/fonts/docs/troubleshooting">Google Fonts troubleshooting guide</a> tells us that, while Google Fonts may send the CORS header with every response, some proxy servers may strip it before the browser can use it to render the font.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_headers.c&gt;
   &lt;FilesMatch "\.(eot|otf|tt[cf]|woff2?)$"&gt;
@@ -101,7 +101,7 @@ tags:
 
 <h3 id="Cross-origin_resource_timing">Cross-origin resource timing</h3>
 
-<p>The <a class="external" href="https://www.w3.org/TR/resource-timing/">Resource Timing Level 1</a> specification defines an interface for web applications to access the complete timing information for resources in a document.</p>
+<p>The <a href="https://www.w3.org/TR/resource-timing/">Resource Timing Level 1</a> specification defines an interface for web applications to access the complete timing information for resources in a document.</p>
 
 <p>The <a href="/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin">Timing-Allow-Origin</a> response header specifies origins that are allowed to see values of attributes retrieved via features of the Resource Timing API, which would otherwise be reported as zero due to cross-origin restrictions.</p>
 
@@ -117,7 +117,7 @@ tags:
 
 <p>The error pages are presented as URLs. These URLs can begin with a slash (/) for local web-paths (relative to the DocumentRoot), or be a full URL which the client can resolve.</p>
 
-<p>See the <a class="external" href="https://httpd.apache.org/docs/current/mod/core.html#errordocument">ErrorDocument Directive</a> documentation on the HTTPD documentation site for more information.</p>
+<p>See the <a href="https://httpd.apache.org/docs/current/mod/core.html#errordocument">ErrorDocument Directive</a> documentation on the HTTPD documentation site for more information.</p>
 
 <pre class="brush: bash notranslate">ErrorDocument 500 /errors/500.html
 ErrorDocument 404 /errors/400.html
@@ -138,7 +138,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Media_Types_and_Character_Encodings">Media Types and Character Encodings</h2>
 
-<p>Apache uses <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_mime.html#addtype">mod_mime</a> to assign content metadata to the content selected for an HTTP response by mapping patterns in the URI or filenames to the metadata values.</p>
+<p>Apache uses <a href="https://httpd.apache.org/docs/current/mod/mod_mime.html#addtype">mod_mime</a> to assign content metadata to the content selected for an HTTP response by mapping patterns in the URI or filenames to the metadata values.</p>
 
 <p>For example, the filename extensions of content files often define the content's Internet media type, language, character set, and content-encoding. This information is sent in HTTP messages containing that content and used in content negotiation when selecting alternatives, such that the user's preferences are respected when choosing one of several possible contents to serve.</p>
 
@@ -148,7 +148,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <p>Associates media types with one or more extensions to make sure the resources will be served appropriately.</p>
 
-<p>Servers should use text/javascript for JavaScript resources as indicated in the <a class="external" href="https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages">HTML specification</a></p>
+<p>Servers should use text/javascript for JavaScript resources as indicated in the <a href="https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages">HTML specification</a></p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_expires.c&gt;
   # Data interchange
@@ -212,7 +212,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <p>Every piece of content on the web has a character set. Most, if not all, the content is UTF-8 Unicode.</p>
 
-<p>Use <a class="external" href="https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
+<p>Use <a href="https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
 ">AddDefaultCharset</a> to serve all resources labeled as <code>text/html</code> or <code>text/plain</code> with the <code>UTF-8</code> charset.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_mime.c&gt;
@@ -221,7 +221,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Set_the_charset_for_specific_media_types">Set the charset for specific media types</h2>
 
-<p>Serve the following file types with the <code>charset</code> parameter set to `UTF-8` using the <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_mime.html#addcharset">AddCharset</a> directive available in <code>mod_mime</code>.</p>
+<p>Serve the following file types with the <code>charset</code> parameter set to `UTF-8` using the <a href="https://httpd.apache.org/docs/current/mod/mod_mime.html#addcharset">AddCharset</a> directive available in <code>mod_mime</code>.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_mime.c&gt;
   AddCharset utf-8 .appcache \
@@ -246,7 +246,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Mod_rewrite_and_the_RewriteEngine_directives">Mod_rewrite and the RewriteEngine directives</h2>
 
-<p><a class="external" href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html">mod_rewrite</a> provides a way to modify incoming URL requests, dynamically, based on regular expression rules. This allows you to map arbitrary URLs onto your internal URL structure in any way you like.</p>
+<p><a href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html">mod_rewrite</a> provides a way to modify incoming URL requests, dynamically, based on regular expression rules. This allows you to map arbitrary URLs onto your internal URL structure in any way you like.</p>
 
 <p>It supports an unlimited number of rules and an unlimited number of attached rule conditions for each rule to provide a really flexible and powerful URL manipulation mechanism. The URL manipulations can depend on various tests: server variables, environment variables, HTTP headers, time stamps, external database lookups, and various other external programs or handlers, can be used to achieve granular URL matching.</p>
 
@@ -257,13 +257,13 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 <p>The required steps are:</p>
 
 <ol>
- <li>Turn on the rewrite engine (this is necessary in order for the <code>RewriteRule</code> directives to work) as documented in the <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html#RewriteEngine">RewriteEngine</a> documentation</li>
- <li>Enable the <code>FollowSymLinks</code> option if it isn't already. See <a class="external" href="https://httpd.apache.org/docs/current/mod/core.html#options">Core Options</a> documentation</li>
- <li>If your web host doesn't allow the <code>FollowSymlinks</code> option, you need to comment it out or remove it, and then uncomment the <code>Options +SymLinksIfOwnerMatch</code> line, but be aware of the <a class="external" href="https://httpd.apache.org/docs/current/misc/perf-tuning.html#symlinks">performance impact</a>
+ <li>Turn on the rewrite engine (this is necessary in order for the <code>RewriteRule</code> directives to work) as documented in the <a href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html#RewriteEngine">RewriteEngine</a> documentation</li>
+ <li>Enable the <code>FollowSymLinks</code> option if it isn't already. See <a href="https://httpd.apache.org/docs/current/mod/core.html#options">Core Options</a> documentation</li>
+ <li>If your web host doesn't allow the <code>FollowSymlinks</code> option, you need to comment it out or remove it, and then uncomment the <code>Options +SymLinksIfOwnerMatch</code> line, but be aware of the <a href="https://httpd.apache.org/docs/current/misc/perf-tuning.html#symlinks">performance impact</a>
   <ul>
    <li>Some cloud hosting services will require you set <code>RewriteBase</code></li>
-   <li>See <a class="external" href="https://www.rackspace.com/knowledge_center/frequently-asked-question/why-is-modrewrite-not-working-on-my-site">Rackspace FAQ</a> and the <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritebase">HTTPD documentation</a></li>
-   <li>Depending on how your server is set up, you may also need to use the <code><a class="external" href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriteoptions">RewriteOptions</a></code> directive to enable some options for the rewrite engine</li>
+   <li>See <a href="https://www.rackspace.com/knowledge_center/frequently-asked-question/why-is-modrewrite-not-working-on-my-site">Rackspace FAQ</a> and the <a href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritebase">HTTPD documentation</a></li>
+   <li>Depending on how your server is set up, you may also need to use the <code><a href="https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriteoptions">RewriteOptions</a></code> directive to enable some options for the rewrite engine</li>
   </ul>
  </li>
 </ol>
@@ -278,7 +278,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h3 id="Forcing_https">Forcing https</h3>
 
-<p>These Rewrite rules will redirect from the <code>http://</code> insecure version to the <code>https://</code> secure version of the URL as described in the <a class="external" href="https://wiki.apache.org/httpd/RewriteHTTPToHTTPS">Apache HTTPD wiki</a>.</p>
+<p>These Rewrite rules will redirect from the <code>http://</code> insecure version to the <code>https://</code> secure version of the URL as described in the <a href="https://wiki.apache.org/httpd/RewriteHTTPToHTTPS">Apache HTTPD wiki</a>.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_rewrite.c&gt;
   RewriteEngine On
@@ -301,7 +301,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <p>These directives will rewrite <code>www.example.com</code> to <code>example.com</code>.</p>
 
-<p>You should not duplicate content in multiple origins (with and without www);This can cause SEO problems (duplicate content), and therefore, you should choose one of the alternatives and redirect the other one. You should also use <a class="external" href="https://www.semrush.com/blog/canonical-url-guide/">Canonical URLs</a> to indicate which URL should search engines crawl (if they support the feature).</p>
+<p>You should not duplicate content in multiple origins (with and without www);This can cause SEO problems (duplicate content), and therefore, you should choose one of the alternatives and redirect the other one. You should also use <a href="https://www.semrush.com/blog/canonical-url-guide/">Canonical URLs</a> to indicate which URL should search engines crawl (if they support the feature).</p>
 
 <p>Set <code>%{ENV:PROTO}</code> variable, to allow rewrites to redirect with the appropriate schema automatically (http or https).</p>
 
@@ -322,7 +322,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <p>These rules will insert <code>www.</code> at the beginning of a URL. It's important to note that you should never make the same content available under two different URLs.</p>
 
-<p>This can cause SEO problems (duplicate content), and therefore, you should choose one of the alternatives and redirect the other one. For search engines that support them you should use <a class="external" href="https://www.semrush.com/blog/canonical-url-guide/">Canonical URLs</a> to indicate which URL should search engines crawl.</p>
+<p>This can cause SEO problems (duplicate content), and therefore, you should choose one of the alternatives and redirect the other one. For search engines that support them you should use <a href="https://www.semrush.com/blog/canonical-url-guide/">Canonical URLs</a> to indicate which URL should search engines crawl.</p>
 
 <p>Set <code>%{ENV:PROTO}</code> variable, to allow rewrites to redirect with the appropriate schema automatically (http or https).</p>
 
@@ -347,9 +347,9 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Frame_Options">Frame Options</h2>
 
-<p>The example below sends the <code>X-Frame-Options</code> response header with DENY as the value, informing browsers not to display the content of the web page in any frame to protect the website against <a class="external" href="https://www.owasp.org/index.php/Clickjacking">clickjacking</a>.</p>
+<p>The example below sends the <code>X-Frame-Options</code> response header with DENY as the value, informing browsers not to display the content of the web page in any frame to protect the website against <a href="https://www.owasp.org/index.php/Clickjacking">clickjacking</a>.</p>
 
-<p>This might not be the best setting for everyone. You should read about <a class="external" href="https://tools.ietf.org/html/rfc7034#section-2.1">the other two possible values for the <code>X-Frame-Options</code> header</a>: <code>SAMEORIGIN</code> and <code>ALLOW-FROM</code>.</p>
+<p>This might not be the best setting for everyone. You should read about <a href="https://tools.ietf.org/html/rfc7034#section-2.1">the other two possible values for the <code>X-Frame-Options</code> header</a>: <code>SAMEORIGIN</code> and <code>ALLOW-FROM</code>.</p>
 
 <p>While you could send the <code>X-Frame-Options</code> header for all of your website's pages, this has the potential downside that it forbids even any framing of your content (e.g.: when users visit your website using a Google Image Search results page).</p>
 
@@ -361,13 +361,13 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Content_Security_Policy_CSP">Content Security Policy (CSP)</h2>
 
-<p><a class="external" href="https://content-security-policy.com/">CSP (Content Security Policy)</a> mitigates the risk of cross-site scripting and other content-injection attacks by setting a `Content Security Policy` which whitelists trusted sources of content for your website.</p>
+<p><a href="https://content-security-policy.com/">CSP (Content Security Policy)</a> mitigates the risk of cross-site scripting and other content-injection attacks by setting a `Content Security Policy` which whitelists trusted sources of content for your website.</p>
 
 <p>There is no policy that fits all websites, the example below is meant as guidelines for you to modify for your site.</p>
 
 <p>The example policy below:</p>
 
-<p>To make your CSP implementation easier, you can use an online <a class="external" href="https://report-uri.com/home/generate/">CSP header generator</a>. You should also use a <a class="external" href="https://csp-evaluator.withgoogle.com">validator</a> to make sure your header does what you want it to do.</p>
+<p>To make your CSP implementation easier, you can use an online <a href="https://report-uri.com/home/generate/">CSP header generator</a>. You should also use a <a href="https://csp-evaluator.withgoogle.com">validator</a> to make sure your header does what you want it to do.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_headers.c&gt;
   Content-Security-Policy "default-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" "expr=%{CONTENT_TYPE} =~ m#text\/(html|javascript)|application\/pdf|xml#i"
@@ -385,7 +385,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <p>In Macintosh and Linux systems, files that begin with a period are hidden from view but not from access if you know their name and location. These types of files usually contain user preferences or the preserved state of a utility, and can include rather private places like, for example, the <code>.git</code> or <code>.svn</code> directories.</p>
 
-<p>The <code>.well-known/</code> directory represents <a class="external" href="https://tools.ietf.org/html/rfc5785">the standard (RFC 5785)</a> path prefix for "well-known locations" (e.g.: <code>/.well-known/manifest.json</code>, <code>/.well-known/keybase.txt</code>), and therefore, access to its visible content should not be blocked.</p>
+<p>The <code>.well-known/</code> directory represents <a href="https://tools.ietf.org/html/rfc5785">the standard (RFC 5785)</a> path prefix for "well-known locations" (e.g.: <code>/.well-known/manifest.json</code>, <code>/.well-known/keybase.txt</code>), and therefore, access to its visible content should not be blocked.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_rewrite.c&gt;
     RewriteEngine On
@@ -470,8 +470,8 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 <p>Use services like the ones below to check your Referrer Policy:</p>
 
 <ul>
- <li><a class="external" href="https://securityheaders.com/">securityheaders.com</a></li>
- <li><a class="external" href="https://observatory.mozilla.org/">Mozilla Observatory</a></li>
+ <li><a href="https://securityheaders.com/">securityheaders.com</a></li>
+ <li><a href="https://observatory.mozilla.org/">Mozilla Observatory</a></li>
 </ul>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_headers.c&gt;
@@ -480,11 +480,11 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Disable_TRACE_HTTP_Method">Disable TRACE HTTP Method</h2>
 
-<p>The <a href="/en-US/docs/Web/HTTP/Methods/TRACE">TRACE</a> method, while seemingly harmless, can be successfully leveraged in some scenarios to steal legitimate users' credentials. See <a class="external" href="https://www.owasp.org/index.php/Cross_Site_Tracing">A Cross-Site Tracing (XST) attack</a> and <a class="external" href="https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)">OWASP Web Security Testing Guide</a></p>
+<p>The <a href="/en-US/docs/Web/HTTP/Methods/TRACE">TRACE</a> method, while seemingly harmless, can be successfully leveraged in some scenarios to steal legitimate users' credentials. See <a href="https://www.owasp.org/index.php/Cross_Site_Tracing">A Cross-Site Tracing (XST) attack</a> and <a href="https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)">OWASP Web Security Testing Guide</a></p>
 
 <p>Modern browsers now prevent TRACE requests made via JavaScript, however, other ways of sending TRACE requests with browsers have been discovered, such as using Java.</p>
 
-<p>If you have access to the main server configuration file, use the <code><a class="external" href="https://httpd.apache.org/docs/current/mod/core.html#traceenable">TraceEnable</a></code> directive instead.</p>
+<p>If you have access to the main server configuration file, use the <code><a href="https://httpd.apache.org/docs/current/mod/core.html#traceenable">TraceEnable</a></code> directive instead.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_rewrite.c&gt;
   RewriteEngine On
@@ -509,7 +509,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Remove_Apache-generated_Server_Information_Footer">Remove Apache-generated Server Information Footer</h2>
 
-<p>Prevent Apache from adding a trailing footer line containing information about the server to the server-generated documents (e.g.: error messages, directory listings, etc.). See <a class="external" href="https://httpd.apache.org/docs/current/mod/core.html#serversignature"> ServerSignature Directive</a> for more information on what the server signature provides and the <a class="external" href="https://httpd.apache.org/docs/current/mod/core.html#servertokens">ServerTokens Directive</a> for information about configuring the information provided in the signature.</p>
+<p>Prevent Apache from adding a trailing footer line containing information about the server to the server-generated documents (e.g.: error messages, directory listings, etc.). See <a href="https://httpd.apache.org/docs/current/mod/core.html#serversignature"> ServerSignature Directive</a> for more information on what the server signature provides and the <a href="https://httpd.apache.org/docs/current/mod/core.html#servertokens">ServerTokens Directive</a> for information about configuring the information provided in the signature.</p>
 
 <pre class="brush: bash notranslate">ServerSignature Off
 </pre>
@@ -529,7 +529,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Compress_media_types">Compress media types</h2>
 
-<p>Compress all output labeled with one of the following media types using the <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_filter.html#addoutputfilterbytype">AddOutputFilterByType Directive</a>.</p>
+<p>Compress all output labeled with one of the following media types using the <a href="https://httpd.apache.org/docs/current/mod/mod_filter.html#addoutputfilterbytype">AddOutputFilterByType Directive</a>.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_deflate.c&gt;
   &lt;IfModule mod_filter.c&gt;
@@ -574,7 +574,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Map_extensions_to_media_types">Map extensions to media types</h2>
 
-<p>Map the following filename extensions to the specified encoding type using <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_mime.html#addencoding">AddEncoding</a> so Apache can serve the file types with the appropriate <code>Content-Encoding</code> response header (this will NOT make Apache compress them!). If these files types would be served without an appropriate <code>Content-Encoding</code> response header, client applications (e.g.: browsers) wouldn't know that they first need to uncompress the response, and thus, wouldn't be able to understand the content.</p>
+<p>Map the following filename extensions to the specified encoding type using <a href="https://httpd.apache.org/docs/current/mod/mod_mime.html#addencoding">AddEncoding</a> so Apache can serve the file types with the appropriate <code>Content-Encoding</code> response header (this will NOT make Apache compress them!). If these files types would be served without an appropriate <code>Content-Encoding</code> response header, client applications (e.g.: browsers) wouldn't know that they first need to uncompress the response, and thus, wouldn't be able to understand the content.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_deflate.c&gt;
   &lt;IfModule mod_mime.c&gt;
@@ -584,7 +584,7 @@ ErrorDocument 403 "Sorry, can't allow you access today"
 
 <h2 id="Cache_expiration">Cache expiration</h2>
 
-<p>Serve resources with a far-future expiration date using the <a class="external" href="https://httpd.apache.org/docs/current/mod/mod_expires.html">mod_expires</a> module, and <a href="/en-US/docs/Web/HTTP/Headers/Cache-Control">Cache-Control</a> and <a href="/en-US/docs/Web/HTTP/Headers/Expires">Expires</a> headers.</p>
+<p>Serve resources with a far-future expiration date using the <a href="https://httpd.apache.org/docs/current/mod/mod_expires.html">mod_expires</a> module, and <a href="/en-US/docs/Web/HTTP/Headers/Cache-Control">Cache-Control</a> and <a href="/en-US/docs/Web/HTTP/Headers/Expires">Expires</a> headers.</p>
 
 <pre class="brush: bash notranslate">&lt;IfModule mod_expires.c&gt;
     ExpiresActive on

--- a/files/en-us/learn/server-side/configuring_server_mime_types/index.html
+++ b/files/en-us/learn/server-side/configuring_server_mime_types/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>Versions of the Apache Web Server <strong>before 2.2.7</strong> were configured to report a MIME type of <code>text/plain</code> or <code>application/octet-stream</code> for unknown content types. Modern versions of Apache report <code>none</code> for files with unknown content types.</p>
 
-<p><a class="external" href="https://nginx.org/">Nginx</a> will report <code>text/plain</code> if you don't define a default content type.</p>
+<p><a href="https://nginx.org/">Nginx</a> will report <code>text/plain</code> if you don't define a default content type.</p>
 
 <p>As new content types are invented or added to web servers, web administrators may fail to add the new MIME types to their web server's configuration. This is a major source of problems for users of browsers that respect the MIME types reported by web servers and applications.</p>
 
@@ -76,8 +76,8 @@ tags:
 
 <ul>
  <li>If your content was created using commercial software, read the vendor's documentation to see what MIME types should be reported for the application.</li>
- <li>Look in IANA's <a class="external" href="https://www.iana.org/assignments/media-types/index.html">MIME Media Types registry</a>, which contains information on all registered MIME types.</li>
- <li>Search for the file extension in <a class="external" href="https://filext.com/">FILExt</a> or the <a class="external" href="https://www.file-extensions.org/">File extensions reference</a> to see what MIME types are associated with that extension. Pay close attention as the application may have multiple MIME types that differ by only one letter.</li>
+ <li>Look in IANA's <a href="https://www.iana.org/assignments/media-types/index.html">MIME Media Types registry</a>, which contains information on all registered MIME types.</li>
+ <li>Search for the file extension in <a href="https://filext.com/">FILExt</a> or the <a href="https://www.file-extensions.org/">File extensions reference</a> to see what MIME types are associated with that extension. Pay close attention as the application may have multiple MIME types that differ by only one letter.</li>
 </ul>
 
 <h2 id="How_to_check_the_MIME_type_of_received_content">How to check the MIME type of received content</h2>
@@ -101,7 +101,7 @@ tags:
  </li>
 </ul>
 
-<p><a class="external" href="https://www.iana.org/">IANA</a> keeps a list of registered <a class="external" href="https://www.iana.org/assignments/media-types/index.html">MIME Media Types</a>. The <a class="external" href="https://www.w3.org/Protocols/HTTP/1.1/spec.html">HTTP specification</a> defines a superset of MIME types, which is used to describe the media types used on the web.</p>
+<p><a href="https://www.iana.org/">IANA</a> keeps a list of registered <a href="https://www.iana.org/assignments/media-types/index.html">MIME Media Types</a>. The <a href="https://www.w3.org/Protocols/HTTP/1.1/spec.html">HTTP specification</a> defines a superset of MIME types, which is used to describe the media types used on the web.</p>
 
 <h2 id="How_to_set_up_your_server_to_send_the_correct_MIME_types">How to set up your server to send the correct MIME types</h2>
 
@@ -117,12 +117,12 @@ tags:
 
 <ul>
  <li><a href="/en-US/Incorrect_MIME_Type_for_CSS_Files">Incorrect MIME Type for CSS Files</a></li>
- <li><a class="external" href="https://www.iana.org/assignments/media-types/index.html">IANA | MIME Media Types</a></li>
- <li><a class="external" href="https://www.w3.org/Protocols/HTTP/1.1/spec.html">Hypertext Transfer Protocol — HTTP/1.1</a></li>
+ <li><a href="https://www.iana.org/assignments/media-types/index.html">IANA | MIME Media Types</a></li>
+ <li><a href="https://www.w3.org/Protocols/HTTP/1.1/spec.html">Hypertext Transfer Protocol — HTTP/1.1</a></li>
  <li><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME types (IANA media types)</a></li>
- <li><a class="external" href="https://www.digitalocean.com/community/tutorials/apache-vs-nginx-practical-considerations">Apache vs Nginx: Practical Considerations</a></li>
- <li><a class="external" href="https://barryvanveen.nl/blog/56-migrate-apache-htaccess-to-nginx-server-block">Migrate Apache .htaccess to NGINX server block</a></li>
- <li><a class="external" href="https://support.microsoft.com/default.aspx?sd=msdn&amp;scid=kb;en-us;293336">Microsoft - 293336 - INFO: WebCast: MIME Type Handling in Microsoft Internet Explorer</a></li>
+ <li><a href="https://www.digitalocean.com/community/tutorials/apache-vs-nginx-practical-considerations">Apache vs Nginx: Practical Considerations</a></li>
+ <li><a href="https://barryvanveen.nl/blog/56-migrate-apache-htaccess-to-nginx-server-block">Migrate Apache .htaccess to NGINX server block</a></li>
+ <li><a href="https://support.microsoft.com/default.aspx?sd=msdn&amp;scid=kb;en-us;293336">Microsoft - 293336 - INFO: WebCast: MIME Type Handling in Microsoft Internet Explorer</a></li>
 </ul>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}</p>


### PR DESCRIPTION
The `class="external"` gets automatically injected at build-time anyway so no need to manually set it in the raw sources. 
Besides, this'll make more sense as we move towards something Markdown'ish. 