### PR TITLE
[web/css/text-transform] Add lang attribute in uppercase (Greek vowels) example

### DIFF
--- a/files/en-us/web/css/text-transform/index.html
+++ b/files/en-us/web/css/text-transform/index.html
@@ -215,7 +215,7 @@ strong { float: right; }</pre>
   &lt;strong&gt;Θα πάμε στο "Θεϊκό φαΐ" ή στη "Νεράιδα"&lt;/strong&gt;
 &lt;/p&gt;
 &lt;p&gt;text-transform: uppercase
-  &lt;strong&gt;&lt;span&gt;Θα πάμε στο "Θεϊκό φαΐ" ή στη "Νεράιδα"&lt;/span&gt;&lt;/strong&gt;
+  &lt;strong&gt;&lt;span lang="el"&gt;Θα πάμε στο "Θεϊκό φαΐ" ή στη "Νεράιδα"&lt;/span&gt;&lt;/strong&gt;
 &lt;/p&gt;</pre>
 
 <pre class="brush: css notranslate">span {


### PR DESCRIPTION
The language attribute `lang="el"` is missing from the example. The text transform works properly when the language is specified. It does not work in most browsers otherwise.