### PR TITLE
Fix: remove some unnecessary markup

### DIFF
--- a/files/en-us/games/techniques/3d_collision_detection/bounding_volume_collision_detection_with_three.js/index.html
+++ b/files/en-us/games/techniques/3d_collision_detection/bounding_volume_collision_detection_with_three.js/index.html
@@ -124,9 +124,7 @@ THREE.Sphere.prototype.intersectsBox = function (box) {
 
 <p>As an alternative to using raw <code>Box3</code> and <code>Sphere</code> objects, Three.js has a useful object to make handling <strong>bounding boxes easier: <code><a href="https://threejs.org/docs/#api/helpers/BoxHelper">BoxHelper</a></code></strong> (previously <code>BoundingBoxHelper</code>, which has been deprecated). This helper takes a <code>Mesh</code> and calculates a bounding box volume for it (including its child meshes). This results in a new box <code>Mesh</code> representing the bounding box, which shows the bounding box's shape, and can passed to the previously seen <code>setFromObject</code> method in order to have a bounding box matching the <code>Mesh</code>.</p>
 
-<div>
 <p><code>BoxHelper</code> is the <strong>recommended</strong> way to handle 3D collisions with bounding volumes in Three.js. You will miss sphere tests, but the tradeoffs are well worth it.</p>
-</div>
 
 <p>The advantages of using this helper are:</p>
 

--- a/files/en-us/glossary/hpkp/index.html
+++ b/files/en-us/glossary/hpkp/index.html
@@ -7,7 +7,6 @@ tags:
 ---
 <p><strong>HTTP Public Key Pinning</strong> (<strong>HPKP</strong>) is a security feature that tells a web client to associate a specific cryptographic public key with a certain web server to decrease the risk of {{Glossary("MITM")}} attacks with forged certificates.</p>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
@@ -16,4 +15,3 @@ tags:
  <li><a href="https://tools.ietf.org/html/rfc7469">RFC 7469 </a></li>
  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning">HTTP Public Key Pinning</a></li>
 </ul>
-</div>

--- a/files/en-us/glossary/hsts/index.html
+++ b/files/en-us/glossary/hsts/index.html
@@ -9,7 +9,6 @@ tags:
 
 <p>In other words, it tells the browser that changing the protocol from HTTP to HTTPS in a URL  works (and is more secure) and asks the browser to do it for every request.</p>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
@@ -17,4 +16,3 @@ tags:
  <li>OWASP Article: <a href="https://www.owasp.org/index.php/HTTP_Strict_Transport_Security">HTTP Strict Transport Security</a></li>
  <li>Wikipedia: {{interwiki("wikipedia", "HTTP Strict Transport Security")}}</li>
 </ul>
-</div>

--- a/files/en-us/glossary/http/index.html
+++ b/files/en-us/glossary/http/index.html
@@ -15,11 +15,9 @@ tags:
 
 <p>HTTP is textual (all communication is done in plain text) and stateless (no communication is aware of previous communications). This property makes it ideal for humans to read documents (web sites) on the world wide web. However, HTTP can also be used as a basis for {{glossary("REST")}} web services from server to server or {{glossary("AJAX")}} requests within web sites to make them more dynamic.</p>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/HTTP">HTTP on MDN</a></li>
  <li>{{interwiki("wikipedia", "Hypertext Transfer Protocol", "HTTP")}} on Wikipedia</li>
 </ul>
-</div>

--- a/files/en-us/glossary/mitm/index.html
+++ b/files/en-us/glossary/mitm/index.html
@@ -17,7 +17,6 @@ tags:
  <li>Check for HTTPS in your address bar and ensure encryption is in-place before logging in.</li>
 </ul>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
@@ -25,4 +24,3 @@ tags:
  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man-in-the-middle attack</a></li>
  <li>The {{HTTPHeader("Public-Key-Pins")}} header ({{Glossary("HPKP")}}) can significantly decrease the risk of MITM by instructing browsers to require a whitelisted certificate for all subsequent connections to that website.</li>
 </ul>
-</div>

--- a/files/en-us/glossary/navigation_directive/index.html
+++ b/files/en-us/glossary/navigation_directive/index.html
@@ -12,7 +12,6 @@ tags:
 
 <p>See <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#navigation_directives">Navigation directives</a> for a complete list.</p>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
@@ -30,7 +29,6 @@ tags:
  </li>
  <li>{{HTTPHeader("Content-Security-Policy")}}</li>
 </ul>
-</div>
 
 <section id="Quick_links">
 <ol>

--- a/files/en-us/glossary/round_trip_time_(rtt)/index.html
+++ b/files/en-us/glossary/round_trip_time_(rtt)/index.html
@@ -11,7 +11,6 @@ tags:
 ---
 <p><strong>Round Trip Time (RTT)</strong> is the length time it takes for a data packet to be sent to a destination plus the time it takes for an acknowledgment of that packet to be received back at the origin. The RTT between a network and server can be determined by using the <code>ping</code> command.</p>
 
-<div>
 <pre class="brush: unix">$ ping example.com
 PING example.com (216.58.194.174): 56 data bytes
 64 bytes from 216.58.194.174: icmp_seq=0 ttl=55 time=25.050 ms
@@ -24,7 +23,6 @@ PING example.com (216.58.194.174): 56 data bytes
 round-trip min/avg/max/stddev = 23.781/26.828/34.904/4.114 ms</pre>
 
 <p>In the above example, the average round trip time is shown on the final line as 26.8ms.</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/glossary/sri/index.html
+++ b/files/en-us/glossary/sri/index.html
@@ -7,11 +7,9 @@ tags:
 ---
 <p><strong>Subresource Integrity</strong> (SRI) is a security feature that enables browsers to verify that files they fetch (for example, from a {{Glossary("CDN")}}) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched file must match.</p>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/Security/Subresource_Integrity">Subresource Integrity</a></li>
  <li>{{HTTPHeader("Content-Security-Policy")}}: {{CSP("require-sri-for")}}</li>
 </ul>
-</div>

--- a/files/en-us/glossary/tofu/index.html
+++ b/files/en-us/glossary/tofu/index.html
@@ -10,7 +10,6 @@ tags:
 
 <p>TOFU is used in the SSH protocol, in <a href="/en-US/docs/Web/HTTP/Public_Key_Pinning">HTTP Public Key Pinning</a> ({{Glossary("HPKP")}}) where the browsers will accept the first public key returned by the server, and in {{HTTPHeader("Strict-Transport-Security")}}  ({{Glossary("HSTS")}}) where a browser will obey the redirection rule.</p>
 
-<div>
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
@@ -18,4 +17,3 @@ tags:
  <li>{{HTTPHeader("Public-Key-Pins")}}</li>
  <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Trust_on_first_use">TOFU</a></li>
 </ul>
-</div>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.html
@@ -240,11 +240,9 @@ textarea.onkeyup = function(){
 
 <p>Sometimes it makes sense to embed third-party content — like youtube videos and maps — but you can save yourself a lot of headaches if you only embed third-party content when completely necessary. A good rule of thumb for web security is <em>"You can never be too cautious. If you made it, double-check it anyway. If someone else made it, assume it's dangerous until proven otherwise."</em></p>
 
-<div>
 <p>Besides security, you should also be aware of intellectual property issues. Most content is copyrighted, offline and online, even content you might not expect (for example, most images on <a href="https://commons.wikimedia.org/wiki/Main_Page">Wikimedia Commons</a>). Never display content on your webpage unless you own it or the owners have given you written, unequivocal permission. Penalties for copyright infringement are severe. Again, you can never be too cautious.</p>
 
 <p>If the content is licensed, you must obey the license terms. For example, the content on MDN is <a href="/en-US/docs/MDN/About#copyrights_and_licenses">licensed under CC-BY-SA</a>. That means, you must <a href="https://wiki.creativecommons.org/wiki/Best_practices_for_attribution">credit us properly</a> when you quote our content, even if you make substantial changes.</p>
-</div>
 
 <h4 id="Use_HTTPS">Use HTTPS</h4>
 

--- a/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/responsive_images/index.html
@@ -26,9 +26,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
-<div>
 <p class="summary">In this article, we'll learn about the concept of responsive images — images that work well on devices with widely differing screen sizes, resolutions, and other such features — and look at what tools HTML provides to help implement them. This helps to improve performance across different devices. Responsive images are just one part of <a href="/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design">responsive design</a>, a future CSS topic for you to learn.</p>
-</div>
 
 <table class="learn-box nostripe standard-table">
  <tbody>

--- a/files/en-us/learn/javascript/asynchronous/timeouts_and_intervals/index.html
+++ b/files/en-us/learn/javascript/asynchronous/timeouts_and_intervals/index.html
@@ -51,9 +51,7 @@ tags:
 
 <p>The asynchronous code set up by these functions runs on the main thread (after their specified timer has elapsed).</p>
 
-<div>
 <p>It's important to know that you can (and often will) run other code before a <code>setTimeout()</code> call executes, or between iterations of <code>setInterval()</code>. Depending on how processor-intensive these operations are, they can delay your async code even further, as any async code will execute only <em>after</em> the main thread is available. (In other words, when the stack is empty.)  You will learn more on this matter as you progress through this article.</p>
-</div>
 
 <p>In any case, these functions are used for running constant animations and other background processing on a web site or application. In the following sections we will show you how they can be used.</p>
 

--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.html
@@ -110,7 +110,6 @@ tags:
  </li>
 </ol>
 
-<div>
 <p>Note that, as with many things in JavaScript, there are many ways to select an element and store a reference to it in a variable. {{domxref("Document.querySelector()")}} is the recommended modern approach, which is convenient because it allows you to select elements using CSS selectors. The above <code>querySelector()</code> call will match the first {{htmlelement("a")}} element that appears in the document. If you wanted to match and do things to multiple elements, you could use {{domxref("Document.querySelectorAll()")}}, which matches every element in the document that matches the selector, and stores references to them in an <a href="/en-US/docs/Learn/JavaScript/First_steps/Arrays">array</a>-like object called a {{domxref("NodeList")}}.</p>
 
 <p>There are older methods available for grabbing element references, such as:</p>
@@ -121,7 +120,6 @@ tags:
 </ul>
 
 <p>These two work in older browsers than the modern methods like <code>querySelector()</code>, but are not as convenient. Have a look and see what others you can find!</p>
-</div>
 
 <h3 id="Creating_and_placing_new_nodes">Creating and placing new nodes</h3>
 

--- a/files/en-us/learn/javascript/first_steps/what_went_wrong/index.html
+++ b/files/en-us/learn/javascript/first_steps/what_went_wrong/index.html
@@ -240,12 +240,10 @@ tags:
 
 <h2 id="See_also">See also</h2>
 
-<div>
 <ul>
  <li>There are many other types of errors that aren't listed here; we are compiling a reference that explains what they mean in detail — see the <a href="/en-US/docs/Web/JavaScript/Reference/Errors">JavaScript error reference</a>.</li>
  <li>If you come across any errors in your code that you aren't sure how to fix after reading this article, you can get help! Ask for help on the <a href="https://discourse.mozilla.org/c/mdn/learn">MDN Discourse forum Learning category</a>, or in the <a href="https://chat.mozilla.org/#/room/#mdn:mozilla.org">MDN Web Docs room</a> on <a class="external external-icon" href="https://wiki.mozilla.org/Matrix">Matrix</a>. Tell us what your error is, and we'll try to help you. A listing of your code would be useful as well.</li>
 </ul>
-</div>
 
 <p>{{PreviousMenuNext("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps")}}</p>
 

--- a/files/en-us/learn/server-side/express_nodejs/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/index.html
@@ -59,7 +59,6 @@ tags:
 
 <h2 id="Adding_more_tutorials">Adding more tutorials</h2>
 
-<div>
 <p>All existing tutorials are listed above, but if you would like to extend this module, some other interesting topics to cover include:</p>
 
 <ul>
@@ -71,4 +70,3 @@ tags:
 </ul>
 
 <p>An assessment for the module would also make a wonderful addition!</p>
-</div>

--- a/files/en-us/learn/server-side/first_steps/website_security/index.html
+++ b/files/en-us/learn/server-side/first_steps/website_security/index.html
@@ -72,17 +72,13 @@ tags:
 
 <p>The best defense against XSS vulnerabilities is to remove or disable any markup that can potentially contain instructions to run the code. For HTML this includes elements, such as <code>&lt;script&gt;</code>, <code>&lt;object&gt;</code>, <code>&lt;embed&gt;</code>, and <code>&lt;link&gt;</code>.</p>
 
-<div>
 <p>The process of modifying user data so that it can't be used to run scripts or otherwise affect the execution of server code is known as input sanitization. Many web frameworks automatically sanitize user input from HTML forms by default.</p>
-</div>
 
 <h3 id="SQL_injection">SQL injection</h3>
 
 <p>SQL injection vulnerabilities enable malicious users to execute arbitrary SQL code on a database, allowing data to be accessed, modified, or deleted irrespective of the user's permissions. A successful injection attack might spoof identities, create new identities with administration rights, access all data on the server, or destroy/modify the data to make it unusable.</p>
 
-<div>
 <p>SQL injection types include Error-based SQL injection, SQL injection based on boolean errors, and Time-based SQL injection.</p>
-</div>
 
 <p>This vulnerability is present if user input that is passed to an underlying SQL statement can change the meaning of the statement. For example, the following code is intended to list all users with a particular name (<code>userName</code>) that has been supplied from an HTML form:</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.html
@@ -14,11 +14,9 @@ tags:
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div>Open the browser action's popup.</div>
+<p>Open the browser action's popup.</p>
 
-<div>
 <p>You can only call this function from inside the handler for a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions">user action</a>.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.html
@@ -12,13 +12,11 @@ tags:
 ---
 <div>{{AddonSidebar}}</div>
 
-<div>Enables an extension to modify certain global browser settings. Each property of this API is a {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object, providing the ability to modify a particular setting.</div>
+<p>Enables an extension to modify certain global browser settings. Each property of this API is a {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object, providing the ability to modify a particular setting.</p>
 
-<div>Because these are global settings, it's possible for extensions to conflict. See the documentation for <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set">BrowserSetting.set()</a></code> for details of how conflicts are handled.</div>
+<p>Because these are global settings, it's possible for extensions to conflict. See the documentation for <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/set">BrowserSetting.set()</a></code> for details of how conflicts are handled.</p>
 
-<div>
 <p>To use this API you need to have the "browserSettings" <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a>.</p>
-</div>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
@@ -16,8 +16,7 @@ tags:
 
 <div>Fired when a command is executed using its associated keyboard shortcut.</div>
 
-
-<div>The listener is passed the command's name. This matches the name given to the command in its <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands">manifest.json entry</a>.</div>
+<p>The listener is passed the command's name. This matches the name given to the command in its <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands">manifest.json entry</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -64,7 +63,6 @@ browser.commands.onCommand.hasListener(listener)
 <div>Given a manifest.json entry like this:</div>
 
 
-<div>
 <pre class="brush: json line-numbers language-json">&quot;commands&quot;: {
   &quot;toggle-feature&quot;: {
     &quot;suggested_key&quot;: {
@@ -73,9 +71,8 @@ browser.commands.onCommand.hasListener(listener)
     &quot;description&quot;: &quot;Send a 'toggle-feature' event&quot;
   }
 }</pre>
-</div>
 
-<div>You could listen for this particular command like this:</div>
+<p>You could listen for this particular command like this:</p>
 
 
 <div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
@@ -12,9 +12,7 @@ tags:
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div>
 <p>A string that will contain an error message after the {{WebExtAPIRef("webRequest.StreamFilter.onerror", "onerror")}} event has fired.</p>
-</div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.html
@@ -14,11 +14,9 @@ tags:
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div>
 <p>An event handler that will be called repeatedly when response data is available. The handler is passed an <code>event</code> object which contains a <code>data</code> property, which contains a chunk of the response data as an {{domxref("ArrayBuffer")}}.</p>
 
 <p>To decode the data use either {{domxref("TextDecoder")}} or {{domxref("Blob")}}.</p>
-</div>
 
 <h2 id="WebExtension_Examples">WebExtension Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
@@ -12,9 +12,7 @@ tags:
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div>
-<p>An event handler that will be called when the stream is opened and is about to begin delivering data. From this point on, the extension may use filter functions like {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, or {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.</p>
-</div>
+<p><span class="summary">An event handler that will be called when the stream is opened and is about to begin delivering data.</span> From this point on, the extension may use filter functions like {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, or {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.html
@@ -12,9 +12,7 @@ tags:
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div>
-<p>An event handler that will be called when the stream has no more data to deliver. In the event handler you can still call filter functions such as {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, or {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.</p>
-</div>
+<p><span class="summary">An event handler that will be called when the stream has no more data to deliver.</span> In the event handler you can still call filter functions such as {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, or {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.html
@@ -12,8 +12,7 @@ tags:
 ---
 <div>{{AddonSidebar()}}</div>
 
-<div>
-<p>A string that describes the current status of the request. It will be one of the following values:</p>
+<p><span class="summary">A string that describes the current status of the request.</span> It will be one of the following values:</p>
 
 <dl>
  <dt><code>"uninitialized"</code></dt>
@@ -31,7 +30,6 @@ tags:
  <dt><code>"failed"</code></dt>
  <dd> An error has occurred and the filter has been disconnected from the request. The extension can find an error message in {{WebExtAPIRef("webRequest.StreamFilter.error", "error")}}, and may not call any filter functions.</dd>
 </dl>
-</div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/solaris_prerequisites/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/solaris_prerequisites/index.html
@@ -21,10 +21,8 @@ tags:
 </ul>
 
 <pre>$ pfexec pkg install x11/header mercurial header-audio x11/header header-xorg gnu-m4 gnome/gettext cvs gnu-make sunstudio rust
-
 </pre>
 
-<div>
 <ul style="margin-top: 0px; margin-right: 0px; margin-bottom: 1.7em; margin-left: 25px; padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px;">
  <li><code>gcc</code> or <code>gcc-43</code> is required to build <code>js-ctypes</code></li>
  <li><a class="external" href="http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz">autoconf 2.13</a> is necessary if you get source code from hg repo. Download the source tarball, untar it, <code>./configure --program-suffix=-2.13; gmake; pfexec gmake install</code>. Autoconf 2.5x will <strong>not</strong> work. See {{ Bug(104642) }} for details. </li>
@@ -33,7 +31,6 @@ tags:
 </ul>
 
 <h3 id="Build_Environment">Build Environment</h3>
-</div>
 
 <p>Get source code from hg repo or source tarball.</p>
 
@@ -56,7 +53,7 @@ export CXX=[CC | g++]</pre>
 
 <p>You can use a typical <code>.mozconfig</code> file. For current HEAD these mozconfigs are recommended:</p>
 
-<div>For Firefox debug build:</div>
+<p>For Firefox debug build:</p>
 
 <pre>mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-debug
 ac_add_options --enable-application=browser
@@ -71,7 +68,7 @@ ac_add_options --disable-crashreporter
 ac_add_options --disable-verify-mar
 </pre>
 
-<div>For Firefox release build:</div>
+<p>For Firefox release build:</p>
 
 <pre>mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-release
 ac_add_options --enable-application=browser
@@ -85,10 +82,9 @@ ac_add_options --disable-crashreporter
 ac_add_options --disable-verify-mar
 </pre>
 
-<div>For Thunderbird debug build:</div>
+<p>For Thunderbird debug build:</p>
 
-<div>
-<pre style='margin: 0px 0px 1.7em; padding: 10px; border-width: 1px; border-style: solid; border-color: rgb(223, 236, 241); overflow: auto; font: 12px "Courier New", "Andale Mono", monospace; color: rgb(37, 34, 29);'>mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-debug
+<pre>mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-debug
 ac_add_options --enable-application=mail
 ac_add_options --enable-calendar
 ac_add_options --enable-tests
@@ -103,12 +99,10 @@ ac_add_options --disable-static
 ac_add_options --disable-crashreporter
 ac_add_options --disable-verify-mar
 </pre>
-</div>
 
-<div>For Thunderbird release build:</div>
+<p>For Thunderbird release build:</p>
 
-<div>
-<pre style="margin-top: 0px; margin-right: 0px; margin-bottom: 1.7em; margin-left: 0px; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px; border-top-width: 1px; border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-top-style: solid; border-right-style: solid; border-bottom-style: solid; border-left-style: solid; font: normal normal normal 12px/normal 'Courier New', 'Andale Mono', monospace; color: rgb(37, 34, 29);">mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-release
+<pre>mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-release
 ac_add_options --enable-application=mail
 ac_add_options --enable-calendar
 ac_add_options --enable-tests
@@ -122,9 +116,8 @@ ac_add_options --enable-static
 ac_add_options --disable-crashreporter
 ac_add_options --disable-verify-mar
 </pre>
-</div>
 
-<p> Then run <code>gmake -f client.mk</code> to start to build.</p>
+<p>Then run <code>gmake -f client.mk</code> to start to build.</p>
 
 <p>Note that the standard Solaris <code>make</code> tool doesn't work. Use <code>gmake</code> instead. (For OpenSolaris, /usr/gnu/bin/make is gmake.)</p>
 

--- a/files/en-us/mozilla/firefox/releases/34/index.html
+++ b/files/en-us/mozilla/firefox/releases/34/index.html
@@ -5,9 +5,9 @@ tags:
   - Firefox
   - Releases
 ---
-<div>{{FirefoxSidebar}}</div><div>
+<div>{{FirefoxSidebar}}</div>
+
 <p>Firefox 34 was released on December 1st, 2014. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</p>
-</div>
 
 <h2 id="Changes_for_Web_developers">Changes for Web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/35/index.html
+++ b/files/en-us/mozilla/firefox/releases/35/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <div>{{FirefoxSidebar}}</div>
 
-<div><span class="seoSummary">Firefox 35 was released on January 13th, 2015. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</span></div>
+<p><span class="seoSummary">Firefox 35 was released on January 13th, 2015. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</span></p>
 
 <h2 id="Changes_for_Web_developers">Changes for Web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/36/index.html
+++ b/files/en-us/mozilla/firefox/releases/36/index.html
@@ -4,9 +4,9 @@ slug: Mozilla/Firefox/Releases/36
 tags:
   - Firefox
 ---
-<div>{{FirefoxSidebar}}</div><div>
-<div><span class="seoSummary">Firefox 36 was released on February 24th, 2015. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</span></div>
-</div>
+<div>{{FirefoxSidebar}}</div>
+
+<p><span class="seoSummary">Firefox 36 was released on February 24th, 2015. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</span></p>
 
 <h2 id="Changes_for_Web_developers">Changes for Web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/37/index.html
+++ b/files/en-us/mozilla/firefox/releases/37/index.html
@@ -5,7 +5,9 @@ tags:
   - Firefox
   - Release Notes
 ---
-<div>{{FirefoxSidebar}}</div><p>Firefox 37 was released on March 31st, 2015. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</p>
+<div>{{FirefoxSidebar}}</div>
+
+<p><span class="summary">Firefox 37 was released on March 31st, 2015. This article lists key changes that are useful not only for web developers, but also Firefox and Gecko developers as well as add-on developers.</span></p>
 
 <h2 id="Changes_for_Web_developers">Changes for Web developers</h2>
 

--- a/files/en-us/mozilla/projects/nss/nss_developer_tutorial/index.html
+++ b/files/en-us/mozilla/projects/nss/nss_developer_tutorial/index.html
@@ -5,10 +5,6 @@ tags:
   - NSS
   - Tutorial
 ---
-<div title="Page 1">
-<div>
-<div>
-<div>
 <h2 id="NSS_Coding_Style">NSS Coding Style</h2>
 
 <h3 id="Formatting">Formatting</h3>
@@ -46,15 +42,7 @@ else
     action();
 }
 </pre>
-</div>
-</div>
-</div>
-</div>
 
-<div title="Page 2">
-<div>
-<div>
-<div>
 <p>Or:</p>
 
 <pre class="brush: cpp">if (condition)
@@ -107,15 +95,7 @@ else
 <p><strong>goto</strong> can be used, to simplify resource deallocation, before returning from a function.</p>
 
 <p>A data buffer is usually represented as:</p>
-</div>
-</div>
-</div>
-</div>
 
-<div title="Page 3">
-<div>
-<div>
-<div>
 <pre class="brush: cpp">unsigned char *data;
 unsigned int len;</pre>
 
@@ -178,15 +158,7 @@ unsigned int len;</pre>
 <p>Public headers are in the <code>EXPORTS</code> variable.</p>
 
 <p>Private headers,which may be included by files in other directories, are in the <code>PRIVATE_EXPORTS</code> variable.</p>
-</div>
-</div>
-</div>
-</div>
 
-<div title="Page 4">
-<div>
-<div>
-<div>
 <p>Private headers, that are only included by files in the same directory, are not listed in either variable.</p>
 
 <p>Only functions listed in the symbol export lists (<code>nss.def</code>, <code>ssl.def</code>, <code>smime.def</code>, etc.) are truly public functions. Unfortunately, public headers may declare private functions, for historical reasons. The symbol export lists are the authoritative source of public functions.</p>
@@ -210,7 +182,3 @@ unsigned int len;</pre>
 <p>The procedure is documented at <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Updating_NSPR_or_NSS_in_mozilla-central">https://developer.mozilla.org//en-US/docs/Mozilla/Developer_guide/Build_Instructions/Updating_NSPR_or_NSS_in_mozilla-central</a>.</p>
 
 <p>If it is necessary to apply private patches, please document them in <code>&lt;tree&gt;/security/patches/README</code>.</p>
-</div>
-</div>
-</div>
-</div>

--- a/files/en-us/web/guide/audio_and_video_delivery/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/index.html
@@ -471,11 +471,7 @@ lastsource.addEventListener('error', function(ev) {
  <dt><a href="/en-US/Apps/Build/Manipulating_media/Video_player_styling_basics">Video player styling basics</a></dt>
  <dd>With the cross-browser video player put in place in the previous article, this article now looks at providing some basic, responsive styling for the player.</dd>
  <dt><a href="/en-US/Apps/Build/Manipulating_media/Cross-browser_audio_basics">Cross-browser audio basics</a></dt>
- <dd>
- <div>
- <p>This article provides a basic guide to creating an HTML5 audio player that works cross browser, with all the associated attributes, properties and events explained, and a quick guide to custom controls created using the Media API.</p>
- </div>
- </dd>
+ <dd>This article provides a basic guide to creating an HTML5 audio player that works cross browser, with all the associated attributes, properties and events explained, and a quick guide to custom controls created using the Media API.</dd>
  <dt><a href="/en-US/Apps/Build/Manipulating_media/buffering_seeking_time_ranges">Media buffering, seeking, and time ranges</a></dt>
  <dd>Sometimes it's useful to know how much {{ htmlelement("audio") }} or {{ htmlelement("video") }} has downloaded or is playable without delay — a good example of this is the buffered progress bar of an audio or video player. This article discusses how to build a buffer/seek bar using <a href="/en-US/docs/Web/API/TimeRanges">TimeRanges</a>, and other features of the media API.</dd>
  <dt><a href="/en-US/Apps/Build/Manipulating_media/HTML5_playbackRate_explained">HTML5 playbackRate explained</a></dt>

--- a/files/en-us/web/html/element/cite/index.html
+++ b/files/en-us/web/html/element/cite/index.html
@@ -139,11 +139,9 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
 <div class="hidden">The compatibility table in this page is generated from structured data. If you’d like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.cite")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/csp/index.html
+++ b/files/en-us/web/http/csp/index.html
@@ -234,10 +234,7 @@ tags:
   the following policy, disallowing everything but stylesheets from
   <code>cdn.example.com</code>.</p>
 
-<div>
-  <pre
-    class="brush: html notranslate">Content-Security-Policy: default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports</pre>
-</div>
+<pre class="brush: html notranslate">Content-Security-Policy: default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports</pre>
 
 <p>The HTML of <code>signup.html</code> looks like this:</p>
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.html
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The HTTP <strong><code>Content-Security-Policy-Report-Only</code></strong> response header allows web developers to experiment with policies by monitoring (but not enforcing) their effects. These violation reports consist of {{Glossary("JSON")}} documents sent via an HTTP <code>POST</code> request to the specified URI.</p>
+<p><span class="summary">The HTTP <strong><code>Content-Security-Policy-Report-Only</code></strong> response header allows web developers to experiment with policies by monitoring (but not enforcing) their effects. These violation reports consist of {{Glossary("JSON")}} documents sent via an HTTP <code>POST</code> request to the specified URI.</span></p>
 
 <p>For more information, see also this article on <a href="/en-US/docs/Web/HTTP/CSP">Content Security Policy (CSP)</a>.</p>
 
@@ -79,13 +79,11 @@ tags:
 
 <h2 id="Sample_violation_report">Sample violation report</h2>
 
-<div>Let's consider a page located at <code>http://example.com/signup.html</code>. It uses the following policy, disallowing everything but stylesheets from <code>cdn.example.com</code>.</div>
+<p>Let's consider a page located at <code>http://example.com/signup.html</code>. It uses the following policy, disallowing everything but stylesheets from <code>cdn.example.com</code>.</p>
 
-<div>
 <pre class="notranslate">Content-Security-Policy-Report-Only: default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports</pre>
-</div>
 
-<div>The HTML of <code>signup.html</code> looks like this:</div>
+<p>The HTML of <code>signup.html</code> looks like this:</p>
 
 <pre class="brush: html notranslate">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
@@ -98,7 +96,7 @@ tags:
   &lt;/body&gt;
 &lt;/html&gt;</pre>
 
-<div>Can you spot the violation? Stylesheets are only allowed to be loaded from <code>cdn.example.com</code>, yet the website tries to load one from its own origin (<code>http://example.com</code>). A browser capable of enforcing CSP will send the following violation report as a POST request to <code>http://example.com/_/csp-reports</code>, when the document is visited:</div>
+<p>Can you spot the violation? Stylesheets are only allowed to be loaded from <code>cdn.example.com</code>, yet the website tries to load one from its own origin (<code>http://example.com</code>). A browser capable of enforcing CSP will send the following violation report as a POST request to <code>http://example.com/_/csp-reports</code>, when the document is visited:</p>
 
 <pre class="brush: js notranslate">{
   "csp-report": {

--- a/files/en-us/web/javascript/closures/index.html
+++ b/files/en-us/web/javascript/closures/index.html
@@ -11,13 +11,12 @@ tags:
 ---
 <div>{{jsSidebar("Intermediate")}}</div>
 
-<p>A <strong>closure</strong> is the combination of a function bundled together (enclosed) with references to its surrounding state (the <strong>lexical environment</strong>). In other words, a closure gives you access to an outer function’s scope from an inner function. In JavaScript, closures are created every time a function is created, at function creation time.</p>
+<p><span class="summary">A <strong>closure</strong> is the combination of a function bundled together (enclosed) with references to its surrounding state (the <strong>lexical environment</strong>).</span> In other words, a closure gives you access to an outer function’s scope from an inner function. In JavaScript, closures are created every time a function is created, at function creation time.</p>
 
 <h2 id="Lexical_scoping">Lexical scoping</h2>
 
 <p>Consider the following example code:</p>
 
-<div>
 <pre class="brush: js notranslate">function init() {
   var name = 'Mozilla'; // name is a local variable created by init
   function displayName() { // displayName() is the inner function, a closure
@@ -26,7 +25,6 @@ tags:
   displayName();
 }
 init();</pre>
-</div>
 
 <p><code>init()</code> creates a local variable called <code>name</code> and a function called <code>displayName()</code>. The <code>displayName()</code> function is an inner function that is defined inside <code>init()</code> and is available only within the body of the <code>init()</code> function. Note that the <code>displayName()</code> function has no local variables of its own. However, since inner functions have access to the variables of outer functions, <code>displayName()</code> can access the variable <code>name</code> declared in the parent function, <code>init()</code>.</p>
 

--- a/files/en-us/web/javascript/reference/functions/arguments/index.html
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{JSSidebar("Functions")}}</div>
 
-<p><strong><code>arguments</code></strong> is an <code>Array</code>-like object accessible inside <a href="/en-US/docs/Web/JavaScript/Guide/Functions">functions</a> that contains the values of the arguments passed to that function.</p>
+<p></span class="summary"><strong><code>arguments</code></strong> is an <code>Array</code>-like object accessible inside <a href="/en-US/docs/Web/JavaScript/Guide/Functions">functions</a> that contains the values of the arguments passed to that function.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/functions-arguments.html")}}</div>
 
@@ -136,9 +136,7 @@ myConcat('. ', 'sage', 'basil', 'oregano', 'pepper', 'parsley');</pre>
 
 <h3 id="Rest_default_and_destructured_parameters">Rest, default, and destructured parameters</h3>
 
-<div>
 <p>The <code>arguments</code> object can be used in conjunction with <a href="/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters">rest</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters">default</a>, and <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment">destructured</a> parameters.</p>
-</div>
 
 <pre class="brush: js notranslate">function foo(...args) {
   return args;

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
@@ -113,18 +113,16 @@ function (a, b){
   return a + b + chuck;
 }</pre>
 
-<div>And finally, for <strong>named functions</strong> we treat arrow expressions like
-  variables</div>
+<p>And finally, for <strong>named functions</strong> we treat arrow expressions like
+  variables</p>
 
-<div>
-  <pre class="brush: js notranslate">// Traditional Function
+<pre class="brush: js notranslate">// Traditional Function
 function bob (a){
   return a + 100;
 }
 
 // Arrow Function
 let bob = a =&gt; a + 100;</pre>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/functions/set/index.html
+++ b/files/en-us/web/javascript/reference/functions/set/index.html
@@ -42,21 +42,19 @@ tags:
 
 <p>Note the following when working with the <code>set</code> syntax:</p>
 
-<div>
-  <ul>
-    <li>It can have an identifier which is either a number or a string;</li>
-    <li>It must have exactly one parameter (see <a class="external"
-        href="http://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/"
-        rel="external nofollow">Incompatible <abbr
-          title="ECMAScript 5th edition">ES5</abbr> change: literal getter and setter
-        functions must now have exactly zero or one arguments</a> for more information);
-    </li>
-    <li>It must not appear in an object literal with another <code>set</code> or with a
-      data entry for the same property.<br>
-      ( <code>{ set x(v) { }, set x(v) { } }</code> and
-      <code>{ x: ..., set x(v) { } }</code> are forbidden )</li>
-  </ul>
-</div>
+<ul>
+  <li>It can have an identifier which is either a number or a string;</li>
+  <li>It must have exactly one parameter (see <a class="external"
+      href="http://whereswalden.com/2010/08/22/incompatible-es5-change-literal-getter-and-setter-functions-must-now-have-exactly-zero-or-one-arguments/"
+      rel="external nofollow">Incompatible <abbr
+        title="ECMAScript 5th edition">ES5</abbr> change: literal getter and setter
+      functions must now have exactly zero or one arguments</a> for more information);
+  </li>
+  <li>It must not appear in an object literal with another <code>set</code> or with a
+    data entry for the same property.<br>
+    ( <code>{ set x(v) { }, set x(v) { } }</code> and
+    <code>{ x: ..., set x(v) { } }</code> are forbidden )</li>
+</ul>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.html
@@ -51,13 +51,11 @@ arr.forEach(element =&gt; console.log(element));
 
 <p>{{js_property_attributes(1, 0, 0)}}</p>
 
-<div>
 <ul>
  <li><code>Writable</code>: If this attribute set to <code>false</code>, the value of the property cannot be changed.</li>
  <li><code>Configurable</code>: If this attribute set to <code>false</code>, any attempts to delete the property or change its attributes (<code>Writable</code>, <code>Configurable</code>, or <code>Enumerable</code>) will fail.</li>
  <li><code>Enumerable</code>: If this attribute set to <code>true</code>, the property will be iterated over during <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for">for</a> or <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for..in</a> loops.</li>
 </ul>
-</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/displayname/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/displayname/index.html
@@ -76,8 +76,6 @@ console.log(object.someMethod.displayName); // "someMethod (123)"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Function.displayName")}}</p>
 
 <h2 id="See_also">See also</h2>
@@ -85,4 +83,3 @@ console.log(object.someMethod.displayName); // "someMethod (123)"
 <ul>
  <li>{{jsxref("Function.name")}}</li>
 </ul>
-</div>

--- a/files/en-us/web/javascript/reference/global_objects/function/name/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/name/index.html
@@ -217,8 +217,6 @@ o[sym2].name; // ""</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
 <p>{{Compat("javascript.builtins.Function.name")}}</p>
 
 <h2 id="See_also">See also</h2>
@@ -226,4 +224,3 @@ o[sym2].name; // ""</pre>
 <ul>
  <li>{{jsxref("Function")}}</li>
 </ul>
-</div>

--- a/files/en-us/web/javascript/reference/global_objects/function/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/tostring/index.html
@@ -223,10 +223,7 @@ Function("a", "b")</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-    <p>{{Compat("javascript.builtins.Function.toString")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Function.toString")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/parseint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/parseint/index.html
@@ -21,19 +21,17 @@ tags:
 
 <h3 id="Parameters">Parameters</h3>
 
-<div>
-  <dl>
-    <dt><code><var>string</var></code></dt>
-    <dd>The value to parse. If this argument is not a string, then it is converted to one
-      using the <code><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></code>
-      abstract operation. Leading whitespace in this argument is ignored.</dd>
-    <dt><code><var>radix</var></code><var> {{optional_inline}}</var></dt>
-    <dd>An integer between <code>2</code> and <code>36</code> that represents the
-      <em>radix</em> (the base in mathematical numeral systems) of the
-      <code><var>string</var></code>. Be careful—this does <strong><em>not</em></strong>
-      default to <code>10</code>!</dd>
-  </dl>
-</div>
+<dl>
+  <dt><code><var>string</var></code></dt>
+  <dd>The value to parse. If this argument is not a string, then it is converted to one
+    using the <code><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></code>
+    abstract operation. Leading whitespace in this argument is ignored.</dd>
+  <dt><code><var>radix</var></code><var> {{optional_inline}}</var></dt>
+  <dd>An integer between <code>2</code> and <code>36</code> that represents the
+    <em>radix</em> (the base in mathematical numeral systems) of the
+    <code><var>string</var></code>. Be careful—this does <strong><em>not</em></strong>
+    default to <code>10</code>!</dd>
+</dl>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.html
@@ -263,11 +263,9 @@ mime.greet();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
 <div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Object")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/object/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/object/index.html
@@ -75,14 +75,12 @@ console.log(o)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-  <div class="hidden">The compatibility table on this page is generated from structured
-    data. If you'd like to contribute to the data, please check out <a class="external"
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</div>
+<div class="hidden">The compatibility table on this page is generated from structured
+  data. If you'd like to contribute to the data, please check out <a class="external"
+    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+  and send us a pull request.</div>
 
-  <p>{{Compat("javascript.builtins.Object.Object")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Object.Object")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.html
@@ -146,10 +146,7 @@ Object.getPrototypeOf(p); // TypeError: expected same prototype value
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-    <p>{{Compat("javascript.builtins.Proxy.handler.getPrototypeOf")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.Proxy.handler.getPrototypeOf")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/revocable/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/revocable/index.html
@@ -19,16 +19,14 @@ tags:
 
 <h3 id="Parameters">Parameters</h3>
 
-<div>
-  <dl>
-    <dt><code><var>target</var></code></dt>
-    <dd>A target object to wrap with <code>Proxy</code>. It can be any sort of object,
-      including a native array, a function, or even another proxy.</dd>
-    <dt><code><var>handler</var></code></dt>
-    <dd>An object whose properties are functions define the behavior of proxy
-      <code><var>p</var></code> when an operation is performed on it.</dd>
-  </dl>
-</div>
+<dl>
+  <dt><code><var>target</var></code></dt>
+  <dd>A target object to wrap with <code>Proxy</code>. It can be any sort of object,
+    including a native array, a function, or even another proxy.</dd>
+  <dt><code><var>handler</var></code></dt>
+  <dd>An object whose properties are functions define the behavior of proxy
+    <code><var>p</var></code> when an operation is performed on it.</dd>
+</dl>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/rangeerror/rangeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/rangeerror/rangeerror/index.html
@@ -95,10 +95,7 @@ catch(error)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-
-    <p>{{Compat("javascript.builtins.RangeError.RangeError")}}</p>
-</div>
+<p>{{Compat("javascript.builtins.RangeError.RangeError")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -424,43 +424,41 @@ otherwise my code is unreadable."
 
 <h2 id="HTML_wrapper_methods">HTML wrapper methods</h2>
 
-<div>
-  <div class="notecard note">
-    <p><strong>Deprecated. Avoid these methods.</strong></p>
+<div class="notecard note">
+  <p><strong>Deprecated. Avoid these methods.</strong></p>
 
-    <p>They are of limited use, as they provide only a subset of the available HTML tags
-      and attributes.</p>
-  </div>
-
-  <dl>
-    <dt>{{jsxref("String.prototype.anchor()")}}</dt>
-    <dd>{{htmlattrxref("name", "a", "&lt;a name=\"name\"&gt;")}} (hypertext target)</dd>
-    <dt>{{jsxref("String.prototype.big()")}}</dt>
-    <dd>{{HTMLElement("big")}}</dd>
-    <dt>{{jsxref("String.prototype.blink()")}}</dt>
-    <dd>{{HTMLElement("blink")}}</dd>
-    <dt>{{jsxref("String.prototype.bold()")}}</dt>
-    <dd>{{HTMLElement("b")}}</dd>
-    <dt>{{jsxref("String.prototype.fixed()")}}</dt>
-    <dd>{{HTMLElement("tt")}}</dd>
-    <dt>{{jsxref("String.prototype.fontcolor()")}}</dt>
-    <dd>{{htmlattrxref("color", "font", "&lt;font color=\"color\"&gt;")}}</dd>
-    <dt>{{jsxref("String.prototype.fontsize()")}}</dt>
-    <dd>{{htmlattrxref("size", "font", "&lt;font size=\"size\"&gt;")}}</dd>
-    <dt>{{jsxref("String.prototype.italics()")}}</dt>
-    <dd>{{HTMLElement("i")}}</dd>
-    <dt>{{jsxref("String.prototype.link()")}}</dt>
-    <dd>{{htmlattrxref("href", "a", "&lt;a href=\"url\"&gt;")}} (link to URL)</dd>
-    <dt>{{jsxref("String.prototype.small()")}}</dt>
-    <dd>{{HTMLElement("small")}}</dd>
-    <dt>{{jsxref("String.prototype.strike()")}}</dt>
-    <dd>{{HTMLElement("strike")}}</dd>
-    <dt>{{jsxref("String.prototype.sub()")}}</dt>
-    <dd>{{HTMLElement("sub")}}</dd>
-    <dt>{{jsxref("String.prototype.sup()")}}</dt>
-    <dd>{{HTMLElement("sup")}}</dd>
-  </dl>
+  <p>They are of limited use, as they provide only a subset of the available HTML tags
+    and attributes.</p>
 </div>
+
+<dl>
+  <dt>{{jsxref("String.prototype.anchor()")}}</dt>
+  <dd>{{htmlattrxref("name", "a", "&lt;a name=\"name\"&gt;")}} (hypertext target)</dd>
+  <dt>{{jsxref("String.prototype.big()")}}</dt>
+  <dd>{{HTMLElement("big")}}</dd>
+  <dt>{{jsxref("String.prototype.blink()")}}</dt>
+  <dd>{{HTMLElement("blink")}}</dd>
+  <dt>{{jsxref("String.prototype.bold()")}}</dt>
+  <dd>{{HTMLElement("b")}}</dd>
+  <dt>{{jsxref("String.prototype.fixed()")}}</dt>
+  <dd>{{HTMLElement("tt")}}</dd>
+  <dt>{{jsxref("String.prototype.fontcolor()")}}</dt>
+  <dd>{{htmlattrxref("color", "font", "&lt;font color=\"color\"&gt;")}}</dd>
+  <dt>{{jsxref("String.prototype.fontsize()")}}</dt>
+  <dd>{{htmlattrxref("size", "font", "&lt;font size=\"size\"&gt;")}}</dd>
+  <dt>{{jsxref("String.prototype.italics()")}}</dt>
+  <dd>{{HTMLElement("i")}}</dd>
+  <dt>{{jsxref("String.prototype.link()")}}</dt>
+  <dd>{{htmlattrxref("href", "a", "&lt;a href=\"url\"&gt;")}} (link to URL)</dd>
+  <dt>{{jsxref("String.prototype.small()")}}</dt>
+  <dd>{{HTMLElement("small")}}</dd>
+  <dt>{{jsxref("String.prototype.strike()")}}</dt>
+  <dd>{{HTMLElement("strike")}}</dd>
+  <dt>{{jsxref("String.prototype.sub()")}}</dt>
+  <dd>{{HTMLElement("sub")}}</dd>
+  <dt>{{jsxref("String.prototype.sup()")}}</dt>
+  <dd>{{HTMLElement("sup")}}</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.html
@@ -15,7 +15,6 @@ tags:
 
 <h2 id="Description">Description</h2>
 
-<div>
 <p>This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}. The following two examples return same result:</p>
 
 <pre class="brush: js">'abc'.matchAll(/a/);
@@ -25,7 +24,6 @@ tags:
 <p>This method exists for customizing match behavior within {{jsxref("RegExp")}} subclasses.</p>
 
 <p>{{js_property_attributes(0,0,0)}}</p>
-</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/statements/with/index.html
+++ b/files/en-us/web/javascript/reference/statements/with/index.html
@@ -83,25 +83,23 @@ tags:
   especially when used with something other than a plain object. Consider this example:
 </p>
 
-<div>
-  <pre class="brush: js notranslate">function f(foo, values) {
+<pre class="brush: js notranslate">function f(foo, values) {
   with (foo) {
     console.log(values);
   }
 }
 </pre>
 
-  <p>If you call <code>f([1,2,3], obj)</code> in an ECMAScript 5 environment, then the
-    <code>values</code> reference inside the <code>with</code> statement will resolve to
-    <code>obj</code>. However, ECMAScript 2015 introduces a <code>values</code> property
-    on {{jsxref("Array.prototype")}} (so that it will be available on every array). So, in
-    a JavaScript environment that supports ECMAScript 2015, the <code>values</code>
-    reference inside the <code>with</code> statement could resolve to
-    <code>[1,2,3].values</code>. However, in this particular example,
-    {{jsxref("Array.prototype")}} has been defined with <code>values</code> in its
-    {{jsxref("Symbol.unscopables")}} object. If it were not, one can see how this would be
-    a difficult issue to debug.</p>
-</div>
+<p>If you call <code>f([1,2,3], obj)</code> in an ECMAScript 5 environment, then the
+  <code>values</code> reference inside the <code>with</code> statement will resolve to
+  <code>obj</code>. However, ECMAScript 2015 introduces a <code>values</code> property
+  on {{jsxref("Array.prototype")}} (so that it will be available on every array). So, in
+  a JavaScript environment that supports ECMAScript 2015, the <code>values</code>
+  reference inside the <code>with</code> statement could resolve to
+  <code>[1,2,3].values</code>. However, in this particular example,
+  {{jsxref("Array.prototype")}} has been defined with <code>values</code> in its
+  {{jsxref("Symbol.unscopables")}} object. If it were not, one can see how this would be
+  a difficult issue to debug.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/performance/index.html
+++ b/files/en-us/web/performance/index.html
@@ -156,15 +156,9 @@ tags:
  <dt>Performance bottlenecks</dt>
  <dd></dd>
  <dt>Understanding bandwidth</dt>
- <dd>
- <div>
- <div class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr">Bandwidth is the amount of data measured in Megabits(Mb) or Kilobits(Kb) that one can send per second. This article explains the role of bandwidth in media-rich internet applications, how you can measure it, and how you can optimize applications to make the best use of available bandwidth</div>
- </div>
- </dd>
+ <dd>Bandwidth is the amount of data measured in Megabits(Mb) or Kilobits(Kb) that one can send per second. This article explains the role of bandwidth in media-rich internet applications, how you can measure it, and how you can optimize applications to make the best use of available bandwidth</dd>
  <dt>The role of TLS in performance</dt>
- <dd>
- <p>TLS—or HTTPS as we tend to call it—is crucial in creating secure and safe user experiences. While hardware has reduced the negative impacts TLS has had on server performance, it still represents a substantial slice of the time we spend waiting for browsers to connect to servers. This article explains the TLS handshake process, and offers some tips for reducing this time, such as OCSP stapling, HSTS preload headers, and the potential role of resource hints in masking TLS latency for third parties.</p>
- </dd>
+ <dd>TLS—or HTTPS as we tend to call it—is crucial in creating secure and safe user experiences. While hardware has reduced the negative impacts TLS has had on server performance, it still represents a substantial slice of the time we spend waiting for browsers to connect to servers. This article explains the TLS handshake process, and offers some tips for reducing this time, such as OCSP stapling, HSTS preload headers, and the potential role of resource hints in masking TLS latency for third parties.</dd>
  <dt>Reading performance charts</dt>
  <dd>Developer tools provide information on performance, memory, and network requests. Knowing how to read <a href="/en-US/docs/Tools/Performance/Waterfall">waterfall</a> charts, <a href="/en-US/docs/Tools/Performance/Call_Tree">call trees</a>, traces, <a href="/en-US/docs/Tools/Performance/Flame_Chart">flame charts</a> , and <a href="/en-US/docs/Tools/Performance/Allocations">allocations</a> in your browser developer tools will help you understand waterfall and flame charts in other performance tools.</dd>
  <dt>Alternative media formats</dt>

--- a/files/en-us/web/performance/understanding_latency/index.html
+++ b/files/en-us/web/performance/understanding_latency/index.html
@@ -94,7 +94,7 @@ tags:
 
 <p>Also, on the network tab, you can see how long each request took to complete. We can look at how long a 267.5Kb SVG image asset took to download.</p>
 
-<div><img alt="The time it took for a large SVG asset to load." src="https://mdn.mozillademos.org/files/16807/latencymlw.png" style="height: 342px; width: 1311px;"></div>
+<img alt="The time it took for a large SVG asset to load." src="https://mdn.mozillademos.org/files/16807/latencymlw.png">
 
 <p>When a request is in a queue, waiting for a network connection it is considered <strong>blocked</strong>. Blocking happens when there are too many simultaneous connections made to a single server over HTTP. If all connections are in use, the browser can't download more resources until a connection is released, meaning those requests and resources are blocked.</p>
 

--- a/files/en-us/web/web_components/using_shadow_dom/index.html
+++ b/files/en-us/web/web_components/using_shadow_dom/index.html
@@ -194,7 +194,6 @@ customElements.define('popup-info', PopUpInfo);</pre>
                                     security feature — it is the last 3 or 4
                                     numbers on the back of your card.<span class="pl-pds">"</span></span>&gt;</pre>
 
-<div>
 <h3 id="Internal_versus_external_styles">Internal versus external styles</h3>
 
 <p>In the above example we apply style to the Shadow DOM using a {{htmlelement("style")}} element, but it is perfectly possible to do it by referencing an external stylesheet from a {{htmlelement("link")}} element instead.</p>
@@ -219,4 +218,3 @@ shadow.appendChild(linkElem);</pre>
  <li><a href="/en-US/docs/Web/Web_Components/Using_custom_elements">Using custom elements</a></li>
  <li><a href="/en-US/docs/Web/Web_Components/Using_templates_and_slots">Using templates and slots</a></li>
 </ul>
-</div>


### PR DESCRIPTION
This PR removes some unnecessary `<div>`s or replaces them with better alternatives. It touches files all-over `en-us` except for `web/api`.