### PR TITLE
Update using_readable_streams

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_streams/index.html
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.html
@@ -253,6 +253,7 @@ return pump();</pre>
 <pre class="brush: js">function readStream() {
   const reader = stream.getReader();
   let charsReceived = 0;
+  let result = '';
 
   // read() returns a promise that resolves
   // when a value has been received


### PR DESCRIPTION
A variable was used in the function readStream() example that was not declared like other variables within the example.