### PR TITLE
Add another keyboard shortcut for opening DevTools on MacOS

### DIFF
--- a/files/en-us/tools/index.html
+++ b/files/en-us/tools/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="The_Core_Tools">The Core Tools</h2>
 
-<p>You can open the Firefox Developer Tools from the menu by selecting <em>Tools</em> &gt; <em>Web Developer</em> &gt; <em>Toggle Tools</em> or use the keyboard shortcut  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> or <kbd>F12</kbd> on Windows and Linux, or <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd> on macOS.</p>
+<p>You can open the Firefox Developer Tools from the menu by selecting <em>Tools</em> &gt; <em>Web Developer</em> &gt; <em>Toggle Tools</em> or use the keyboard shortcut  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> or <kbd>F12</kbd> on Windows and Linux, or <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd> or <kbd>Fn</kbd> + <kbd>F12</kbd> on macOS.</p>
 
 <p>The ellipsis menu on the right-hand side of Developer Tools contains several commands that let you perform actions or change tool settings.</p>
 


### PR DESCRIPTION
Fn+F12 works for opening DevTools on MacOS.