### PR TITLE
Fix typo in GeometryUtils doc

### DIFF
--- a/files/en-us/web/api/geometryutils/index.html
+++ b/files/en-us/web/api/geometryutils/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
-<p>The <code><strong>GeometryUtils</strong></code> interface provides different utility function to retrieve geometry information about {{Glossary("DOM")}} nodes.</p>
+<p>The <code><strong>GeometryUtils</strong></code> interface provides utility methods to retrieve geometry information about {{Glossary("DOM")}} nodes.</p>
 
 <p><code>GeometryUtils</code> is a raw interface and no object of this type can be created; it is implemented by {{domxref("Text")}}, {{domxref("Element")}}, {{domxref("CSSPseudoElement")}}, and {{domxref("Document")}} objects.</p>
 


### PR DESCRIPTION
It should be "functions", plural. But I also changed it to methods because it's more accurate.