### PR TITLE
Make links to CSS Grid &Flexbox a bit more aesthetic

### DIFF
--- a/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.html
@@ -22,8 +22,8 @@ tags:
  <li>Root element of the document (<code>&lt;html&gt;</code>).</li>
  <li>Element with a {{cssxref("position")}} value <code>absolute</code> or <code>relative</code> and {{cssxref("z-index")}} value other than <code>auto</code>.</li>
  <li>Element with a {{cssxref("position")}} value <code>fixed</code> or <code>sticky</code> (sticky for all mobile browsers, but not older desktop).</li>
- <li>Element that is a child of a flex ({{cssxref("CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox")}}) container, with {{cssxref("z-index")}} value other than <code>auto</code>.</li>
- <li>Element that is a child of a grid ({{cssxref("grid")}}) container, with {{cssxref("z-index")}} value other than <code>auto</code>.</li>
+ <li>Element that is a child of a <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">flex</a> container, with {{cssxref("z-index")}} value other than <code>auto</code>.</li>
+ <li>Element that is a child of a {{cssxref("grid")}} container, with {{cssxref("z-index")}} value other than <code>auto</code>.</li>
  <li>Element with a {{cssxref("opacity")}} value less than <code>1</code> (See <a href="https://www.w3.org/TR/css3-color/#transparency">the specification for opacity</a>).</li>
  <li>Element with a {{cssxref("mix-blend-mode")}} value other than <code>normal</code>.</li>
  <li>Element with any of the following properties with value other than <code>none</code>:


### PR DESCRIPTION
Make links to CSS Grid and Flexbox a bit more aesthetic and thus more readable. 
As for now, the wide link inside the list item which refers to the flexbox distracts the user from reading the whole sentence. 
The same goes for the list item with the grid link in it.