### PR TITLE
Fixing links on media overview page

### DIFF
--- a/files/en-us/web/media/index.html
+++ b/files/en-us/web/media/index.html
@@ -12,8 +12,6 @@ tags:
 
 <p><span class="seoSummary">Over the years, the Web's ability to present, create, and manage audio, video, and other media has grown at an increasing pace. Today, there are a large number of APIs available, as well as HTML elements, DOM interfaces, and other features that make it possible to not only perform these tasks, but use media in tandem with other technologies to do truly remarkable things. This article lists the various APIs with links to documentation you may find helpful in mastering them.</span></p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Documentation" id="References">References</h2>
 
 <h3 id="HTML">HTML</h3>
@@ -26,7 +24,7 @@ tags:
  <dt>{{HTMLElement("video")}}</dt>
  <dd>The <code>&lt;video&gt;</code> element is an endpoint for video content in a Web context. It can be used to present video files, or as a destination for streamed video content. <code>&lt;video&gt;</code> can also be used as a way to link media APIs with other HTML and DOM technologies, including {{HTMLElement("canvas")}} (for frame grabbing and manipulation), for example. Accessible from JavaScript as {{domxref("HTMLVideoElement")}} objects.</dd>
  <dt>{{HTMLElement("track")}}</dt>
- <dd>The HTML <code>&lt;track&gt;</code> element can be placed within an {{HTMLElement("audio")}} or {{HTMLElement("video")}} element to provide a reference to a <a href="/en-US/docs/Web/API/Web_Video_Text_Tracks_Format">WebVTT</a> format subtitle or caption track to be used when playing the media. Accessible from JavaScript as {{domxref("HTMLTrackElement")}} objects.</dd>
+ <dd>The HTML <code>&lt;track&gt;</code> element can be placed within an {{HTMLElement("audio")}} or {{HTMLElement("video")}} element to provide a reference to a <a href="/en-US/docs/Web/API/WebVTT_API">WebVTT</a> format subtitle or caption track to be used when playing the media. Accessible from JavaScript as {{domxref("HTMLTrackElement")}} objects.</dd>
  <dt>{{HTMLElement("source")}}</dt>
  <dd>The HTML <code>&lt;source&gt;</code> element is used within an {{HTMLElement("audio")}} or {{HTMLElement("video")}} element to specify source media to present. Multiple sources can be used to provide the media in different formats, sizes, or resolutions. Accessible from JavaScript as {{domxref("HTMLSourceElement")}} objects.</dd>
 </dl>
@@ -45,17 +43,13 @@ tags:
  <dt><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></dt>
  <dd>WebRTC (Web Real-Time Communication) makes it possible to stream live audio and video, as well as transfer arbitrary data, between two peers over the Internet, without requiring an intermediary.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 class="Documentation" id="Guides">Guides</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Web/Media/Overview">Overview of media technology on the web</a></dt>
- <dd>A general look at the open Web technologies and APIs that provide support for audio and video playback, manipulation, and recording. If you're not sure which API you should use, this is the place to start.</dd>
  <dt><a href="/en-US/docs/Web/Media/HTML_media">Using audio and video in HTML</a></dt>
  <dd>A guide to using the HTML <code>&lt;audio&gt;</code> and <code>&lt;video&gt;</code> elements.</dd>
- <dt><a href="/en-US/docs/Web/Media/Accessibility">Accessibility guide for media in web design</a></dt>
+ <dt><a href="/en-US/docs/Learn/Accessibility/Multimedia">Accessible multimedia</a></dt>
  <dd>In this guide, we cover ways web designers and developers can create content that is accessible to people with different capabilities. This ranges from using the {{htmlattrxref("alt", "img")}} attribute on {{HTMLElement("img")}} elements to captions to tagging media for screen readers.</dd>
  <dt><a href="/en-US/docs/Web/Media/Formats">Guide to media types and formats on the web</a></dt>
  <dd>A guide to the file types and codecs available for images, audio, and video media on the web. This includes recommendations for what formats to use for what kinds of content, best practices including how to provide fallbacks and how to prioritize media types, and also includes general browser support information for each media container and codec.</dd>
@@ -63,10 +57,8 @@ tags:
  <dd>A guide which covers how to stream audio and video, as well as techniques and technologies you can take advantage of to ensure the best possible quality and/or performance of your streams.</dd>
  <dt><a href="/en-US/docs/Web/Media/Autoplay_guide">Autoplay guide for media and Web Audio APIs</a></dt>
  <dd>Unexpected automatic playback of media or audio can be an unwelcome surprise to users. While autoplay serves a purpose, it should be used carefully. To give users control over this, many browsers now provide forms of autoplay blocking. This article is a guide to autoplay, with tips on when and how to use it and how to work with browsers to handle autoplay blocking gracefully.</dd>
- <dt><a href="/en-US/docs/Web/Media/3D_audio">Positional audio in a 3D environment</a></dt>
+ <dt><a href="/en-US/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics">Web Audio spatialization basics</a></dt>
  <dd>In 3D environments, which may either be 3D scenes rendered to the screen or a mixed reality experience experienced using a headset, it's important for audio to be performed so that it sounds like it's coming from the direction of its source. This guide covers how to accomplish this.</dd>
- <dt><a href="/en-US/docs/Web/Media/3D_video">Playing video in a 3D environment</a></dt>
- <dd>In this guide, we examine how to play video into a 3D scene. This technique can be used in both standard <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> applications presented on a flat computer screen, or in a <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a>-generated virtual or augmented reality environment.</dd>
 </dl>
 
 <h2 id="Other_topics">Other topics</h2>
@@ -78,10 +70,8 @@ tags:
  <dd>The Canvas API lets you draw into an {{HTMLElement("canvas")}}, manipulating and changing the contents of an image. This can be used with media in many ways, including by setting a <code>&lt;canvas&gt;</code> element as the destination for video playback or camera capture so that you can capture and manipulate video frames.</dd>
  <dt><a href="/en-US/docs/Web/API/WebGL_API">WebGL</a></dt>
  <dd>WebGL provides an OpenGL ES compatible API on top of the existing Canvas API, making it possible to do powerful 3D graphics on the Web. Through a canvas, this can be used to add 3D imagery to media content.</dd>
- <dt><a href="/en-US/docs/Web/API/WebXR_API">WebXR</a></dt>
+ <dt><a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a></dt>
  <dd>WebXR, which has replaced the now-obsolete WebVR API, is a technology that provides support for creating virtual reality (VR) and augmented reality (AR) content. The mixed reality content can then be displayed on the device's screen or using goggles or a headset.</dd>
  <dt><a href="/en-US/docs/Web/API/WebVR_API">WebVR</a> {{deprecated_inline}}</dt>
  <dd>The Web Virtual Reality API supports virtual reality (VR) devices such as the Oculus Rift or the HTC Vive, making it possible for developers to translate position and movement of the user into movement within a 3D scene which is then presented on the device. WebVR has been replaced by WebXR, and is due to be removed from browsers soon.</dd>
 </dl>
-</div>
-</div>


### PR DESCRIPTION
Either removing or pointing to correct url

This fixes https://github.com/mdn/content/issues/1812