### PR TITLE
Replace some "var" examples with "let"

### DIFF
--- a/files/en-us/web/api/nodelist/length/index.html
+++ b/files/en-us/web/api/nodelist/length/index.html
@@ -32,12 +32,12 @@ tags:
   iterator in a <code>for</code> loop, as in this example.</p>
 
 <pre class="brush: js">// All the paragraphs in the document
-var items = document.getElementsByTagName("p");
+const items = document.getElementsByTagName("p");
 
 // For each item in the list,
 // append the entire element as a string of HTML
-var gross = "";
-for (var i = 0; i &lt; items.length; i++) {
+let gross = "";
+for (let i = 0; i &lt; items.length; i++) {
   gross += items[i].innerHTML;
 }
 


### PR DESCRIPTION
Fixes #1887 replaced the *var* with *let* or *const*