### PR TITLE
fixing broken TOC links

### DIFF
--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.html
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.html
@@ -32,33 +32,33 @@ slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs
   <h3>Table of Contents</h3>
   <ol>
     <li>
-      <a href="Setup">Setup</a>
+      <a href="Build_a_phone_with_peerjs/Setup">Setup</a>
     </li>
     <li>
-      <a href="Connect_peers">Connect Peers</a>
+      <a href="Build_a_phone_with_peerjs/Connect_peers">Connect Peers</a>
       <ol type="i">
         <li>
-          <a href="Connect_peers/Get_microphone_permission">Get Microphone Permission</a>
+          <a href="Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission">Get Microphone Permission</a>
         </li>
         <li>
-          <a href="Connect_peers/Show_hide_html">Showing and hiding HTML</a>
+          <a href="Build_a_phone_with_peerjs/Connect_peers/Show_hide_html">Showing and hiding HTML</a>
         </li>
         <li>
-          <a href="Connect_peers/Create_a_peer_connection">Create a Peer Connection</a>
+          <a href="Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection">Create a Peer Connection</a>
         </li>
         <li>
-          <a href="Connect_peers/Creating_a_call">Creating a Call</a>
+          <a href="Build_a_phone_with_peerjs/Connect_peers/Creating_a_call">Creating a Call</a>
         </li>
         <li>
-          <a href="Connect_peers/Answer_a_call">Answer a Call</a>
+          <a href="Build_a_phone_with_peerjs/Connect_peers/Answer_a_call">Answer a Call</a>
         </li>
         <li>
-          <a href="Connect_peers/End_a_call">End a Call</a>
+          <a href="Build_a_phone_with_peerjs/Connect_peers/End_a_call">End a Call</a>
         </li>
       </ol>
     </li>
     <li>
-      <a href="Deployment_and_further_reading">Deployment and Further Reading</a>
+      <a href="Build_a_phone_with_peerjs/Deployment_and_further_reading">Deployment and Further Reading</a>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
The links in the TOC at the bottom of https://developer.mozilla.org/en-US/docs/web/api/webrtc_api/build_a_phone_with_peerjs were broken, so I've fixed them.