### PR TITLE
Remove unclear "other reasons"

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.html
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.html
@@ -42,7 +42,7 @@ tags:
 <pre class="brush: html notranslate">&lt;p&gt;My cat is very grumpy&lt;/p&gt;</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Tags in HTML are case-insensitive. This means they can be written in uppercase or lowercase. For example, a {{htmlelement("title")}} tag could be written as <code>&lt;title&gt;</code>, <code>&lt;TITLE&gt;</code>, <code>&lt;Title&gt;</code>, <code>&lt;TiTlE&gt;</code>, etc., and it will work. However, it is best practice to write all tags in lowercase for consistency, readability, and other reasons.</p>
+<p><strong>Note</strong>: Tags in HTML are case-insensitive. This means they can be written in uppercase or lowercase. For example, a {{htmlelement("title")}} tag could be written as <code>&lt;title&gt;</code>, <code>&lt;TITLE&gt;</code>, <code>&lt;Title&gt;</code>, <code>&lt;TiTlE&gt;</code>, etc., and it will work. However, it is best practice to write all tags in lowercase for consistency, and readability.</p>
 </div>
 
 <h2 id="Anatomy_of_an_HTML_element">Anatomy of an HTML element</h2>

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.html
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.html
@@ -42,7 +42,7 @@ tags:
 <pre class="brush: html notranslate">&lt;p&gt;My cat is very grumpy&lt;/p&gt;</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Tags in HTML are case-insensitive. This means they can be written in uppercase or lowercase. For example, a {{htmlelement("title")}} tag could be written as <code>&lt;title&gt;</code>, <code>&lt;TITLE&gt;</code>, <code>&lt;Title&gt;</code>, <code>&lt;TiTlE&gt;</code>, etc., and it will work. However, it is best practice to write all tags in lowercase for consistency, and readability.</p>
+<p><strong>Note</strong>: Tags in HTML are case-insensitive. This means they can be written in uppercase or lowercase. For example, a {{htmlelement("title")}} tag could be written as <code>&lt;title&gt;</code>, <code>&lt;TITLE&gt;</code>, <code>&lt;Title&gt;</code>, <code>&lt;TiTlE&gt;</code>, etc., and it will work. However, it is best practice to write all tags in lowercase for consistency and readability.</p>
 </div>
 
 <h2 id="Anatomy_of_an_HTML_element">Anatomy of an HTML element</h2>


### PR DESCRIPTION
If there are other reasons, I recommend they be linked, or explicitly defined.
The "other reasons" had me doing some curious web searching, but nothing I found felt compelling enough that I felt it should be added here.
Consequently, this PR suggests removing those words.