### PR TITLE
Clarify that <acronymn> is deprecated

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.html
+++ b/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.html
@@ -420,7 +420,7 @@ textarea.onkeyup = function(){
 <p>{{EmbedLiveSample('abbreviations-live-sample', '100%', '94px', '', '', 'hide-codepen-jsfiddle')}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: There is another element, {{htmlelement("acronym")}}, which basically does the same thing as <code>&lt;abbr&gt;</code>, and was intended specifically for acronyms rather than abbreviations. This however has fallen into disuse — it wasn't supported in browsers as well as <code>&lt;abbr&gt;</code>, and <code>&lt;abbr&gt;</code> has such a similar function that it was considered pointless to have both. Just use <code>&lt;abbr&gt;</code> instead.</p>
+<p><strong>Note</strong>: Earlier versions of html also included support for the {{htmlelement("acronym")}} element, but it was removed from the HTML spec in favor of using <code>&lt;abbr&gt;</code> to represent both abbreviations and acronyms. <code>&lt;acronym&gt;</code> should not be used.</p>
 </div>
 
 <h3 id="Active_learning_marking_up_an_abbreviation">Active learning: marking up an abbreviation</h3>


### PR DESCRIPTION
The way this note is written feels pre-html5. With <acronym> dropped from the HTML spec, it should be treated like a historical note.
