### PR TITLE
Fix how to access WorkerNavigator (self.navigator)

### DIFF
--- a/files/en-us/web/api/workernavigator/index.html
+++ b/files/en-us/web/api/workernavigator/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <code><strong>WorkerNavigator</strong></code> interface represents a subset of the {{DOMxRef("Navigator")}} interface allowed to be accessed from a {{DOMxRef("Worker")}}. Such an object is initialized for each worker and is available via the {{DOMxRef("WorkerGlobalScope.navigator")}} property obtained by calling <code>window.self.navigator</code>.</p>
+<p>The <code><strong>WorkerNavigator</strong></code> interface represents a subset of the {{DOMxRef("Navigator")}} interface allowed to be accessed from a {{DOMxRef("Worker")}}. Such an object is initialized for each worker and is available via the {{DOMxRef("WorkerGlobalScope.navigator")}} property obtained by calling <code>self.navigator</code>.</p>
 
 <h2 id="Properties">Properties</h2>
 


### PR DESCRIPTION
Suggesting window.self.navigator is wrong in an especially bad way,
since it works in window contexts but not in workers.