### PR TITLE
Update “Compiling an Existing C Module to WebAssembly” example

### DIFF
--- a/files/en-us/webassembly/existing_c_to_wasm/index.html
+++ b/files/en-us/webassembly/existing_c_to_wasm/index.html
@@ -101,6 +101,10 @@ void destroy_buffer(uint8_t* p) {
   version: Module.cwrap('version', 'number', []),
   create_buffer: Module.cwrap('create_buffer', 'number', ['number', 'number']),
   destroy_buffer: Module.cwrap('destroy_buffer', '', ['number']),
+  encode: Module.cwrap("encode", "", ["number","number","number","number",]),
+  free_result: Module.cwrap("free_result", "", ["number"]),
+  get_result_pointer: Module.cwrap("get_result_pointer", "number", []),
+  get_result_size: Module.cwrap("get_result_size", "number", []),
 };
 
 const image = await loadImage('./image.jpg');
@@ -141,19 +145,6 @@ EMSCRIPTEN_KEEPALIVE
 int get_result_size() {
   return result[1];
 }</pre>
-
-<p>Now add the new functions to the api object. The updated api object will be:</p>
-
-<pre class="brush: js">const api = {
-  version: Module.cwrap('version', 'number', []),
-  create_buffer: Module.cwrap('create_buffer', 'number', ['number', 'number']),
-  destroy_buffer: Module.cwrap('destroy_buffer', '', ['number']),
-  encode: Module.cwrap("encode", "", ["number","number","number","number",]),
-  free_result: Module.cwrap("free_result", "", ["number"]),
-  get_result_pointer: Module.cwrap("get_result_pointer", "number", []),
-  get_result_size: Module.cwrap("get_result_size", "number", []),
-};
-</pre>
 
 <p>Now with all of that in place, you can call the encoding function, grab the pointer and image size, put it in a JavaScript buffer of your own, and release all the wasm buffers allocated in the process:</p>
 

--- a/files/en-us/webassembly/existing_c_to_wasm/index.html
+++ b/files/en-us/webassembly/existing_c_to_wasm/index.html
@@ -142,6 +142,20 @@ int get_result_size() {
   return result[1];
 }</pre>
 
+<p>Now add the new functions to the api object. The updated api object will be:</p>
+
+<pre class="brush: js">const api = {
+  version: Module.cwrap('version', 'number', []),
+  create_buffer: Module.cwrap('create_buffer', 'number', ['number', 'number']),
+  destroy_buffer: Module.cwrap('destroy_buffer', '', ['number']),
+  encode: Module.cwrap("encode", "", ["number","number","number","number",]),
+  free_result: Module.cwrap("free_result", "", ["number"]),
+  get_result_pointer: Module.cwrap("get_result_pointer", "number", []),
+  get_result_size: Module.cwrap("get_result_size", "number", []),
+  destroy_buffer: Module.cwrap("destroy_buffer", "", ["number"]),
+};
+</pre>
+
 <p>Now with all of that in place, you can call the encoding function, grab the pointer and image size, put it in a JavaScript buffer of your own, and release all the wasm buffers allocated in the process:</p>
 
 <pre class="brush: js">api.encode(p, image.width, image.height, 100);

--- a/files/en-us/webassembly/existing_c_to_wasm/index.html
+++ b/files/en-us/webassembly/existing_c_to_wasm/index.html
@@ -152,7 +152,6 @@ int get_result_size() {
   free_result: Module.cwrap("free_result", "", ["number"]),
   get_result_pointer: Module.cwrap("get_result_pointer", "number", []),
   get_result_size: Module.cwrap("get_result_size", "number", []),
-  destroy_buffer: Module.cwrap("destroy_buffer", "", ["number"]),
 };
 </pre>
 


### PR DESCRIPTION
Added encode, free_result, get_result_pointer, get_result_size, destroy_buffer to `api` object.