### PR TITLE
Fix grammar on arrow functions description page

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
@@ -242,7 +242,7 @@ Object.defineProperty(obj, 'b', {
 <pre class="brush: js notranslate">// ----------------------
 // Traditional Example
 // ----------------------
-// A simplistic object with it's very own "this".
+// A simplistic object with its very own "this".
 var obj = {
     num: 100
 }
@@ -275,7 +275,7 @@ console.log(result(1, 2, 3)) // result 106</pre>
 // Arrow Example
 // ----------------------
 
-// A simplistic object with it's very own "this".
+// A simplistic object with its very own "this".
 var obj = {
     num: 100
 }


### PR DESCRIPTION
Modified the incorrect two forms of "its" (indicating possession), which were erroneously entered as "it's" (meaning "it is").