### PR TITLE
Fix String.p.fontsize example in String.p.big doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/big/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/big/index.html
@@ -45,7 +45,7 @@ tags:
 
 console.log(worldString.small());     // &lt;small&gt;Hello, world&lt;/small&gt;
 console.log(worldString.big());       // &lt;big&gt;Hello, world&lt;/big&gt;
-console.log(worldString.fontsize(7)); // &lt;fontsize=7&gt;Hello, world&lt;/fontsize&gt;
+console.log(worldString.fontsize(7)); // &lt;font size=&quot;7&quot;&gt;Hello, world&lt;/font&gt;
 </pre>
 
 <p>With the {{domxref("ElementCSSInlineStyle/style", "element.style")}} object you can get


### PR DESCRIPTION
Output of the example of `String.prototype.fontsize` fn is wrong, also added quotes around the size attribute.

❤️  open source!!