### PR TITLE
Fix grammar error in Array.p.find() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p><span class="seoSummary">The <code>find()</code> method returns the value of the first
     element in the provided array that satisfies the provided testing function. If no
-    values satisfies the testing function, {{jsxref("undefined")}} is returned.</span></p>
+    values satisfy the testing function, {{jsxref("undefined")}} is returned.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-find.html","shorter")}}</div>
 


### PR DESCRIPTION
Fixes grammar error: From "If no values satisfies the testing function, undefined is returned." to "If no values satisfy the testing function, undefined is returned."