### PR TITLE
Syntax guide - update re multiple line syntax blocks

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -236,7 +236,7 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 
 <h4 id="Inline_code_formatting">Inline code formatting</h4>
 
-<p>Use the "Code" button (labeled with two angle brackets "<strong>&lt;&gt;</strong>") to apply inline code-style formatting to function names, variable names, and method names. (This uses the {{HTMLElement("code")}} element). For example: "the <code class="js plain">frenchText()</code> function".</p>
+<p>Use the {{HTMLElement("code")}} tags to mark up function names, variable names, and method names. For example: "the <code>frenchText()</code> function".</p>
 
 <p><strong>Method names should be followed by a pair of parentheses.</strong> For example, <code>doSomethingUseful()</code>. The parentheses help differentiate methods from other code terms.</p>
 

--- a/files/en-us/mdn/structures/syntax_sections/index.html
+++ b/files/en-us/mdn/structures/syntax_sections/index.html
@@ -16,11 +16,20 @@ tags:
 
 <h2 id="API_reference_syntax">API reference syntax</h2>
 
-<p>Syntax sections for API reference pages are written manually, and they differ depending on which page type includes them. Yet, all have things in common. In each case the section is titled "Syntax", and included at the top of the reference page, just below the introductory material.</p>
+<p>Syntax sections for API reference pages are written manually, and may differ slightly based on feature being documented.
+  The section starts with a heading (typically {{HTMLElement("H2")}}) named "Syntax", and must be included at the top of the reference page (just below the introductory material).
+  Below the heading is a code block showing the feature's exact syntax, styled using the <code>brush: [markup-language]</code> class.</p>
 
-<p>In addition, each syntax section starts with a "code" block showing the feature's exact syntax, styled using the <code>brush: [syntax] notranslate</code> class:</p>
+<p>The example below shows the source code for a typical Syntax section (for a JavaScript function):</p>
 
-<pre class="brush: js">A syntax block example</pre>
+<pre class="brush: html">
+  &lt;h2 id="Syntax"&gt;Syntax&lt;/h2&gt;
+
+  &lt;pre class="brush: js"&gt;slice()
+  slice(start)
+  slice(start, end)
+  &lt;/pre&gt;
+</pre>
 
 <h3 id="General_style_rules">General style rules</h3>
 
@@ -31,7 +40,7 @@ tags:
  <li>
   <p>All programmer-specified content in a syntax block should be italicized using the {{HTMLElement("var")}} element:</p>
 
-  <pre class="brush: js"><var>responseStr</var> = <var>element</var>.querySelector(<var>selector</var>);</pre>
+  <pre class="brush: js"><var>responseStr</var> = <var>element</var>.querySelector(<var>selector</var>);</pre> 
 
   <p>Here, <code>responseStr</code> is the return value (a variable named by the developer), <code>element</code> is a placeholder for the variable referencing an {{DOMxRef("Element")}} object, and <code>selector</code> is the placeholder for an input parameter to the method.</p>
  </li>
@@ -41,41 +50,51 @@ tags:
 
 <h4 id="Syntax_block">Syntax block</h4>
 
-<p>Start with a syntax block, like this (see the {{DOMxRef("IntersectionObserver.IntersectionObserver", "IntersectionObserver constructor")}} page):</p>
+<p>Start with a syntax block, like this (from the {{DOMxRef("IntersectionObserver.IntersectionObserver", "IntersectionObserver constructor")}} page):</p>
 
-<pre class="brush: js">var <var>observer</var> = new IntersectionObserver(<var>callback</var>, <var>options</var>);</pre>
+<pre class="brush: js">new IntersectionObserver(<var>callback</var>, <var>options</var>);</pre>
 
-<p>or this (see {{DOMxRef("WindowOrWorkerGlobalScope.fetch")}}):</p>
+<p>or this (from {{DOMxRef("WindowOrWorkerGlobalScope.fetch")}}):</p>
 
 <pre class="brush: js"><var>promiseResponse</var> = fetch(<var>input</var>, <var>init</var>);</pre>
 
-<p>Sometimes syntax is written using formal syntax notation, for example see the following on {{jsxref("Array.prototype.slice()")}}:</p>
+<h5 id="Multiple_lines">Multiple lines/Optional parameters</h5>
 
-<pre class="brush: js">arr.slice([begin[, end]])</pre>
+<p>Methods that can be used in many different different ways should be expanded out into multiple lines, showing all possible variations.</p>
 
-<p>The square brackets mean that the enclosed parameter is optional.</p>
+<p>Each option should be on its own line, omitting both per-option comments and assignment. For example, {{jsxref("Array.prototype.slice()")}} has two optional parameters, and would be documented as shown below:</p>
+<pre class="brush: js">Array slice()
+Array slice(<var>begin</var>)
+Array slice(<var>begin</var>, <var>end</var>)</pre>
 
-<h5 id="Multiple_lines">Multiple lines</h5>
+<p>Similarly, for {{DOMxRef("CanvasRenderingContext2D.drawImage")}}:</p>
 
-<p>Sometimes you'll want to include multiple lines, because the method can be used in different forms. For example, see this example ({{DOMxRef("CanvasRenderingContext2D.drawImage")}}):</p>
+<pre class="brush: js">drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>);
+drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>);
+drawImage(<var>image</var>, <var>sx</var>, <var>sy</var>, <var>sWidth</var>, <var>sHeight</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>);</pre>
 
-<pre class="brush: js">void <var>ctx</var>.drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>);
-void <var>ctx</var>.drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>);
-void <var>ctx</var>.drawImage(<var>image</var>, <var>sx</var>, <var>sy</var>, <var>sWidth</var>, <var>sHeight</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>);</pre>
-
-<p>The <code>slice()</code> syntax example could be rewritten like so, to show all possible variations and make it arguably easier to understand:</p>
-
-<pre class="brush: js"><var>arr</var>.slice()<var>
-arr</var>.slice(<var>begin</var>)
-<var>arr</var>.slice(<var>begin</var>, <var>end</var>)</pre>
-
-<p>Another good multiple line example is found on the {{jsxref("Date")}} constructor page, which has many quite different possibilities for its parameters:</p>
+<p>Similarly for the {{jsxref("Date")}} constructor:</p>
 
 <pre class="brush: js">new Date();
 new Date(<var>value</var>);
 new Date(<var>dateString</var>);
-new Date(<var>year</var>, <var>monthIndex</var> [, <var>day</var> [, <var>hours</var> [, <var>minutes</var> [, <var>seconds</var> [, <var>milliseconds</var>]]]]]);
+new Date(<var>year</var>, <var>monthIndex</var>);
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>);
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>);
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>);
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>, <var>seconds</var>, <var>milliseconds</var>);
 </pre>
+
+<h5 id="Formal_syntax">Formal syntax</h5>
+
+<p>Formal syntax notation (using <a href="https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form">BNF</a>) should not be used in the Syntax section — instead use the expanded multiple-line format <a href="#multiple_lines">described above</a>.</p>
+
+<p>While the formal notation provides a concise mechanism for describing complex syntax, it is not familiar to many developers, and can <em>conflict</em> with valid syntax for particular programming languages. For example, <code>[ ]</code> indictes both an "optional parameter" and a JavaScript {{jsxref("Array")}}. You can see this in the formal syntax for {{jsxref("Array.prototype.slice()")}} below:</p>
+
+<pre class="brush: js">arr.slice([begin[, end]])</pre>
+
+<p>For specific cases where it is seen as beneficial, a separate <strong>Formal syntax</strong> section may be declared using the formal notification.</p>
+
 
 <h5 id="Concise_syntax_blocks">Concise syntax blocks</h5>
 
@@ -95,8 +114,9 @@ new Date(<var>year</var>, <var>monthIndex</var> [, <var>day</var> [, <var>hours<
 
 <p>The name of each parameter in the list should be contained in a {{HTMLElement("code")}} block.</p>
 
-<div class="note">
-<p><strong>Note</strong>: If the feature does not take any parameters, you don't need to include a "Parameters" section, but you can if you wish include it with content of "None".</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>If the feature does not take any parameters, you don't need to include a "Parameters" section, but you can if you wish include it with content of "None".</p>
 </div>
 
 <h4 id="Return_value_section">Return value section</h4>
@@ -111,8 +131,9 @@ new Date(<var>year</var>, <var>monthIndex</var> [, <var>day</var> [, <var>hours<
 
 <p>The exception names and explanations should be included in a description list.</p>
 
-<div class="note">
-<p><strong>Note</strong>: If no exceptions can be raised on the feature, you don't need to include an "Exceptions" section, but you can if you wish include it with content of "None".</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>If no exceptions can be raised on the feature, you don't need to include an "Exceptions" section, but you can if you wish include it with content of "None".</p>
 </div>
 
 <h3 id="Properties">Properties</h3>
@@ -163,8 +184,9 @@ new Date(<var>year</var>, <var>monthIndex</var> [, <var>day</var> [, <var>hours<
 
 <p>CSS property reference pages include a "Syntax" section, which used to be found at the top of the page but is increasingly commonly found below a section containing a block of code showing typical usage of the feature, plus a live example to illustrate what the feature does (see {{CSSxRef("animation")}} for example).</p>
 
-<div class="note">
-<p><strong>Note</strong>: We do this because CSS formal syntax is complex, not used by many of the MDN readership, and offputting for beginners. Real syntax and examples are more useful to the majority of people.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>We do this because CSS formal syntax is complex, not used by many of the MDN readership, and offputting for beginners. Real syntax and examples are more useful to the majority of people.</p>
 </div>
 
 <p>Inside the syntax section you'll find the following contents.</p>

--- a/files/en-us/mdn/structures/syntax_sections/index.html
+++ b/files/en-us/mdn/structures/syntax_sections/index.html
@@ -25,9 +25,9 @@ tags:
 <pre class="brush: html">
   &lt;h2 id="Syntax"&gt;Syntax&lt;/h2&gt;
 
-  &lt;pre class="brush: js"&gt;slice()
-  slice(start)
-  slice(start, end)
+  &lt;pre class="brush: js"&gt;slice();
+  slice(start);
+  slice(start, end);
   &lt;/pre&gt;
 </pre>
 
@@ -36,21 +36,14 @@ tags:
 <p>A few rules to follow in terms of markup within the syntax block:</p>
 
 <ul>
- <li>Do <var>not</var> use {{HTMLElement("code")}} within the syntax block (or within any code sample block on MDN, either). Not only is it generally useless, but our markup does not want it, and will not render the way you want it to look if you include it.</li>
+ <li>Do <strong>not</strong> use &lt;code&gt; within the syntax block (or within any code sample block on MDN, either). Not only is it generally useless, but our markup does not want it, and will not render the way you want it to look if you include it.</li>
  <li>Only specify the function and arguments. Example showing "corrected" examples below
-  <pre class="brush: js">querySelector(<var>selector</var>)
-//<var>responseStr</var> = <var>element</var>.querySelector(<var>selector</var>);
+  <pre class="brush: js">querySelector(selector);
+//responseStr = element.querySelector(selector);
 
-new IntersectionObserver(<var>callback</var>, <var>options</var>)
-// var observer = new IntersectionObserver(<var>callback</var>, <var>options</var>);
+new IntersectionObserver(callback, options);
+// var observer = new IntersectionObserver(callback, options);
 </pre> 
- </li>
- <li>  
-  <p>All programmer-specified content in a syntax block should be italicized using the {{HTMLElement("var")}} element:</p>
-
-  <pre class="brush: js">querySelector(<var>selector</var>)</pre> 
-
-  <p>Here, <code>selector</code> is the placeholder for an input parameter to the method.</p>
  </li>
 </ul>
 
@@ -60,37 +53,37 @@ new IntersectionObserver(<var>callback</var>, <var>options</var>)
 
 <p>Start with a syntax block, like this (from the {{DOMxRef("IntersectionObserver.IntersectionObserver", "IntersectionObserver constructor")}} page):</p>
 
-<pre class="brush: js">new IntersectionObserver(<var>callback</var>, <var>options</var>)</pre>
+<pre class="brush: js">new IntersectionObserver(callback, options);</pre>
 
 <p>or this (from {{DOMxRef("Document.hasStorageAccess")}}):</p>
 
-<pre class="brush: js">hasStorageAccess()</pre>
+<pre class="brush: js">hasStorageAccess();</pre>
 
 <h5 id="Multiple_lines">Multiple lines/Optional parameters</h5>
 
 <p>Methods that can be used in many different different ways should be expanded out into multiple lines, showing all possible variations.</p>
 
 <p>Each option should be on its own line, omitting both per-option comments and assignment. For example, {{jsxref("Array.prototype.slice()")}} has two optional parameters, and would be documented as shown below:</p>
-<pre class="brush: js">Array slice()
-Array slice(<var>begin</var>)
-Array slice(<var>begin</var>, <var>end</var>)</pre>
+<pre class="brush: js">Array slice();
+Array slice(begin);
+Array slice(begin, end);</pre>
 
 <p>Similarly, for {{DOMxRef("CanvasRenderingContext2D.drawImage")}}:</p>
 
-<pre class="brush: js">drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>)
-drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>)
-drawImage(<var>image</var>, <var>sx</var>, <var>sy</var>, <var>sWidth</var>, <var>sHeight</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>)</pre>
+<pre class="brush: js">drawImage(image, dx, dy);
+drawImage(image, dx, dy, dWidth, dHeight);
+drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);</pre>
 
 <p>Similarly for the {{jsxref("Date")}} constructor:</p>
 
 <pre class="brush: js">new Date();
-new Date(<var>value</var>)
-new Date(<var>dateString</var>)
-new Date(<var>year</var>, <var>monthIndex</var>)
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>)
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>)
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>)
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>, <var>seconds</var>, <var>milliseconds</var>)
+new Date(value);
+new Date(dateString);
+new Date(year, monthIndex);
+new Date(year, monthIndex, day);
+new Date(year, monthIndex, day, hours);
+new Date(year, monthIndex, day, hours, minutes);
+new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds);
 </pre>
 
 <h5 id="Formal_syntax">Formal syntax</h5>
@@ -108,13 +101,13 @@ new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var
 
 <p>The aim is to make the syntax block as pure and unambiguous as definition of the feature's syntax as possible — don't include any irrelevant syntax. For example, you may see this syntax form used to describe promises in many places on the site:</p>
 
-<pre class="brush: js"><var>caches</var>.match(<var>request</var>, <var>options</var>).then(function(<var>response</var>) {
+<pre class="brush: js">caches.match(request, options).then(function(response) {
   // Do something with the response
 });</pre>
 
 <p>But this version is much more concise, and doesn't include the superfluous {{JSxRef("Promise.prototype.then()")}} method call:</p>
 
-<pre class="brush: js">match(<var>request</var>, <var>options</var>)</pre>
+<pre class="brush: js">match(request, options);</pre>
 
 <h4 id="Parameters_section">Parameters section</h4>
 
@@ -150,12 +143,12 @@ new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var
 
 <p>Start with a syntax block, like this (see {{DOMxRef("IntersectionObserver.root")}}):</p>
 
-<pre class="brush: js"><var>var <var>root</var> = IntersectionObserver</var>.root;</pre>
+<pre class="brush: js">var root = IntersectionObserver.root;</pre>
 
 <p>For a non-read-only property, it is a good idea to include two lines, which show getting and setting the property (see {{DOMxRef("AudioParam.value")}}):</p>
 
-<pre class="brush: js"><var>gain</var> = <var>gainNode</var>.gain.value;
-<var>gainNode</var>.gain.value = 0;</pre>
+<pre class="brush: js">gain = gainNode.gain.value;
+gainNode.gain.value = 0;</pre>
 
 <h4 id="Value_section">Value section</h4>
 
@@ -173,7 +166,7 @@ new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var
 
 <p>Start with a syntax block, like this (see {{DOMxRef("Window.onvrdisplaypresentchange")}}):</p>
 
-<pre class="brush: js"><var>window</var>.onvrdisplaypresentchange = <var>functionRef</var>;</pre>
+<pre class="brush: js">window.onvrdisplaypresentchange = functionRef;</pre>
 
 <p>And that's it — event handler properties are always settable, and always contain a function, therefore no more information is needed.</p>
 

--- a/files/en-us/mdn/structures/syntax_sections/index.html
+++ b/files/en-us/mdn/structures/syntax_sections/index.html
@@ -37,12 +37,20 @@ tags:
 
 <ul>
  <li>Do <var>not</var> use {{HTMLElement("code")}} within the syntax block (or within any code sample block on MDN, either). Not only is it generally useless, but our markup does not want it, and will not render the way you want it to look if you include it.</li>
- <li>
+ <li>Only specify the function and arguments. Example showing "corrected" examples below
+  <pre class="brush: js">querySelector(<var>selector</var>)
+//<var>responseStr</var> = <var>element</var>.querySelector(<var>selector</var>);
+
+new IntersectionObserver(<var>callback</var>, <var>options</var>)
+// var observer = new IntersectionObserver(<var>callback</var>, <var>options</var>);
+</pre> 
+ </li>
+ <li>  
   <p>All programmer-specified content in a syntax block should be italicized using the {{HTMLElement("var")}} element:</p>
 
-  <pre class="brush: js"><var>responseStr</var> = <var>element</var>.querySelector(<var>selector</var>);</pre> 
+  <pre class="brush: js">querySelector(<var>selector</var>)</pre> 
 
-  <p>Here, <code>responseStr</code> is the return value (a variable named by the developer), <code>element</code> is a placeholder for the variable referencing an {{DOMxRef("Element")}} object, and <code>selector</code> is the placeholder for an input parameter to the method.</p>
+  <p>Here, <code>selector</code> is the placeholder for an input parameter to the method.</p>
  </li>
 </ul>
 
@@ -52,11 +60,11 @@ tags:
 
 <p>Start with a syntax block, like this (from the {{DOMxRef("IntersectionObserver.IntersectionObserver", "IntersectionObserver constructor")}} page):</p>
 
-<pre class="brush: js">new IntersectionObserver(<var>callback</var>, <var>options</var>);</pre>
+<pre class="brush: js">new IntersectionObserver(<var>callback</var>, <var>options</var>)</pre>
 
-<p>or this (from {{DOMxRef("WindowOrWorkerGlobalScope.fetch")}}):</p>
+<p>or this (from {{DOMxRef("Document.hasStorageAccess")}}):</p>
 
-<pre class="brush: js"><var>promiseResponse</var> = fetch(<var>input</var>, <var>init</var>);</pre>
+<pre class="brush: js">hasStorageAccess()</pre>
 
 <h5 id="Multiple_lines">Multiple lines/Optional parameters</h5>
 
@@ -69,20 +77,20 @@ Array slice(<var>begin</var>, <var>end</var>)</pre>
 
 <p>Similarly, for {{DOMxRef("CanvasRenderingContext2D.drawImage")}}:</p>
 
-<pre class="brush: js">drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>);
-drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>);
-drawImage(<var>image</var>, <var>sx</var>, <var>sy</var>, <var>sWidth</var>, <var>sHeight</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>);</pre>
+<pre class="brush: js">drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>)
+drawImage(<var>image</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>)
+drawImage(<var>image</var>, <var>sx</var>, <var>sy</var>, <var>sWidth</var>, <var>sHeight</var>, <var>dx</var>, <var>dy</var>, <var>dWidth</var>, <var>dHeight</var>)</pre>
 
 <p>Similarly for the {{jsxref("Date")}} constructor:</p>
 
 <pre class="brush: js">new Date();
-new Date(<var>value</var>);
-new Date(<var>dateString</var>);
-new Date(<var>year</var>, <var>monthIndex</var>);
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>);
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>);
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>);
-new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>, <var>seconds</var>, <var>milliseconds</var>);
+new Date(<var>value</var>)
+new Date(<var>dateString</var>)
+new Date(<var>year</var>, <var>monthIndex</var>)
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>)
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>)
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>)
+new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var>, <var>minutes</var>, <var>seconds</var>, <var>milliseconds</var>)
 </pre>
 
 <h5 id="Formal_syntax">Formal syntax</h5>
@@ -106,7 +114,7 @@ new Date(<var>year</var>, <var>monthIndex</var>, <var>day</var>, <var>hours</var
 
 <p>But this version is much more concise, and doesn't include the superfluous {{JSxRef("Promise.prototype.then()")}} method call:</p>
 
-<pre class="brush: js"><var>promiseResponse</var> = <var>caches</var>.match(<var>request</var>, <var>options</var>);</pre>
+<pre class="brush: js">match(<var>request</var>, <var>options</var>)</pre>
 
 <h4 id="Parameters_section">Parameters section</h4>
 


### PR DESCRIPTION
This attempts to reflect discussion in https://github.com/mdn/content/issues/2202

Specifically syntax sections are now split out multi-line rather than using formal BNF-style notation. I've also made this a little more proscriptive - i.e. "do it this way by preference" rather than "this is a way you can do it"

Note, I have no idea how you're supposed to find the doc https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections 



