### PR TITLE
Unmention getFloatFrequency in AnalyserNode.p.minDecibels doc

### DIFF
--- a/files/en-us/web/api/analysernode/mindecibels/index.html
+++ b/files/en-us/web/api/analysernode/mindecibels/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p class="summary">The <strong><code>minDecibels</code></strong> property of the {{ domxref("AnalyserNode") }} interface is a double value representing the minimum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte/float values — basically, this specifies the minimum value for the range of results when using <code>getFloatFrequencyData()</code> or <code>getByteFrequencyData()</code>.</p>
+<p class="summary">The <strong><code>minDecibels</code></strong> property of the {{ domxref("AnalyserNode") }} interface is a double value representing the minimum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the minimum value for the range of results when using <code>getByteFrequencyData()</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -24,7 +24,7 @@ tags:
 
 <p>A double, representing the minimum <a href="https://en.wikipedia.org/wiki/Decibel" title="Decibel on Wikipedia">decibel</a> value for scaling the FFT analysis data, where <code>0</code> dB is the loudest possible sound, <code>-10</code> dB is a 10th of that, etc. The default value is <code>-100</code> dB.</p>
 
-<p>When getting data from <code>getFloatFrequencyData()</code> or <code>getByteFrequencyData()</code>, any frequencies with an amplitude of <code>minDecibels</code> or lower will be returned as <code>0.0</code> or <code>0</code>, respectively.</p>
+<p>When getting data from <code>getByteFrequencyData()</code>, any frequencies with an amplitude of <code>minDecibels</code> or lower will be returned as <code>0</code>.</p>
 
 <div class="note">
 <p><strong>Note</strong>: If a value greater than <code>AnalyserNode.maxDecibels</code> is set, an <code>INDEX_SIZE_ERR</code> exception is thrown.</p>


### PR DESCRIPTION
Removing info about getFloatFrequency as it's not relevant - see https://github.com/mdn/content/issues/1651