### PR TITLE
Unmention getFloatFrequency in AnalyserNode.p.maxDecibels doc

### DIFF
--- a/files/en-us/web/api/analysernode/maxdecibels/index.html
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary">The <strong><code>maxDecibels</code></strong> property of the {{domxref("AnalyserNode")}} interface is a double value representing the maximum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte/float values — basically, this specifies the maximum value for the range of results when using <code>getFloatFrequencyData()</code> or <code>getByteFrequencyData()</code>.</p>
+<p class="summary">The <strong><code>maxDecibels</code></strong> property of the {{domxref("AnalyserNode")}} interface is a double value representing the maximum power value in the scaling range for the FFT analysis data, for conversion to unsigned byte values — basically, this specifies the maximum value for the range of results when using <code>getByteFrequencyData()</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -23,7 +23,7 @@ tags:
 
 <p>A double, representing the maximum <a href="https://en.wikipedia.org/wiki/Decibel" title="Decibel on Wikipedia">decibel</a> value for scaling the FFT analysis data, where <code>0</code> dB is the loudest possible sound, <code>-10</code> dB is a 10th of that, etc. The default value is <code>-30</code> dB.</p>
 
-<p>When getting data from <code>getFloatFrequencyData()</code> or <code>getByteFrequencyData()</code>, any frequencies with an amplitude of <code>maxDecibels</code> or higher will be returned as <code>+1.0</code> or <code>255</code>, respectively.</p>
+<p>When getting data from <code>getByteFrequencyData()</code>, any frequencies with an amplitude of <code>maxDecibels</code> or higher will be returned as <code>255</code>.</p>
 
 <p class="note"><strong>Note</strong>: If a value less than or equal to <code>AnalyserNode.minDecibels</code> is set, an <code>IndexSizeError</code> exception is thrown.</p>
 


### PR DESCRIPTION
Removing info about getFloatFrequency as it's not relevant - see #1651