### PR TITLE
Fix typo in AudioContext doc

### DIFF
--- a/files/en-us/web/api/audiocontext/index.html
+++ b/files/en-us/web/api/audiocontext/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p><span class="seoSummary">The <code>AudioContext</code> interface represents an audio-processing graph built from audio modules linked together, each represented by an {{domxref("AudioNode")}}.</span> An audio context controls both the creation of the nodes it contains and the execution of the audio processing, or decoding. You need to create an <code>AudioContext</code> before you do anything else, as everything happens inside a context. It's recommended to create one AudioContext and reuse it instead of initializing a new one each time, and it's OK to use a single <code>AudioContext</code> for several different audio source and pipeline concurrently.</p>
+<p><span class="seoSummary">The <code>AudioContext</code> interface represents an audio-processing graph built from audio modules linked together, each represented by an {{domxref("AudioNode")}}.</span> An audio context controls both the creation of the nodes it contains and the execution of the audio processing, or decoding. You need to create an <code>AudioContext</code> before you do anything else, as everything happens inside a context. It's recommended to create one AudioContext and reuse it instead of initializing a new one each time, and it's OK to use a single <code>AudioContext</code> for several different audio sources and pipeline concurrently.</p>
 
 <p>{{InheritanceDiagram}}</p>
 


### PR DESCRIPTION
The last sentence of the first paragraph of the [AudioContext page of the Web API documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) says, "It's recommended to create one AudioContext and reuse it instead of initializing a new one each time, and it's OK to use a single AudioContext for several different audio source and pipeline concurrently."

I believe there's a typo in the sentence I just quoted and it should say "several different audio sources" instead of "several different audio source": this pull request fixes that.