### PR TITLE
Use camelCase variable names in doc for scroll event

### DIFF
--- a/files/en-us/web/api/document/scroll_event/index.html
+++ b/files/en-us/web/api/document/scroll_event/index.html
@@ -49,19 +49,19 @@ tags:
 
 <pre class="brush: js notranslate">// Reference: http://www.html5rocks.com/en/tutorials/speed/animations/
 
-let last_known_scroll_position = 0;
+let lastKnownScrollPosition = 0;
 let ticking = false;
 
-function doSomething(scroll_pos) {
+function doSomething(scrollPos) {
   // Do something with the scroll position
 }
 
 document.addEventListener('scroll', function(e) {
-  last_known_scroll_position = window.scrollY;
+  lastKnownScrollPosition = window.scrollY;
 
   if (!ticking) {
     window.requestAnimationFrame(function() {
-      doSomething(last_known_scroll_position);
+      doSomething(lastKnownScrollPosition);
       ticking = false;
     });
 


### PR DESCRIPTION
In JavaScript, the convention is to name variables using camelCase. It's good style to follow this convention in code examples when possible.