### PR TITLE
Drop <main role=main> example; refine explanation

### DIFF
--- a/files/en-us/web/html/element/main/index.html
+++ b/files/en-us/web/html/element/main/index.html
@@ -154,12 +154,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The <code>&lt;main&gt;</code> element is widely supported. For Internet Explorer 11 and lower, it's suggested that an {{glossary("ARIA")}} role of <code>"main"</code> be added to the <code>&lt;main&gt;</code> element to ensure it is accessible (screen readers like JAWS, used in combination with older versions of Internet Explorer, understand the semantic meaning of the <code>&lt;main&gt;</code> element when this <code>role</code> attribute is included).</p>
-
-<pre class="brush: html notranslate">&lt;main role="main"&gt;
-  ...
-&lt;/main&gt;
-</pre>
+<p>To support Internet Explorer 11 and lower, you can add an {{glossary("ARIA")}} role of <code>"main"</code> to the <code>&lt;main&gt;</code> element. But understand that the ARIA in HTML specification states that <code>role="main"</code> shouldn't actually be used with the <code>&lt;main&gt;</code> element, and the W3C validator will report a warning for it. However, Internet Explorer 11 and lower will otherwise not correctly expose the <code>&lt;main&gt;</code> element to screen readers such JAWS unless the element also has a <code>role="main"</code> attribute.</p>
 
 <p>{{Compat("html.elements.main")}}</p>
 

--- a/files/en-us/web/html/element/main/index.html
+++ b/files/en-us/web/html/element/main/index.html
@@ -22,11 +22,11 @@ tags:
  <tbody>
   <tr>
    <th scope="row"><a href="/en-US/docs/Web/Guide/HTML/Content_categories">Content categories</a></th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#Flow_content">Flow content</a>, palpable content.</td>
+   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>, palpable content.</td>
   </tr>
   <tr>
    <th scope="row">Permitted content</th>
-   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#Flow_content">Flow content</a>.</td>
+   <td><a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">Flow content</a>.</td>
   </tr>
   <tr>
    <th scope="row">Tag omission</th>
@@ -34,7 +34,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Permitted parents</th>
-   <td>Where <a href="/en-US/docs/Web/Guide/HTML/Content_categories#Flow_content">flow content</a> is expected, but only if it is a <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#hierarchically-correct-main-element" id="the-main-element:hierarchically-correct-main-element">hierarchically correct <code>main</code> element</a>.</td>
+   <td>Where <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content">flow content</a> is expected, but only if it is a <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#hierarchically-correct-main-element" id="the-main-element:hierarchically-correct-main-element">hierarchically correct <code>main</code> element</a>.</td>
   </tr>
   <tr>
    <th scope="row">Implicit ARIA role</th>
@@ -92,7 +92,7 @@ tags:
 
 <h3 id="Landmark">Landmark</h3>
 
-<p>The <code>&lt;main&gt;</code> element behaves like a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Main_role"><code>main</code> landmark</a> role. <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Landmark_roles">Landmarks</a> can be used by assistive technology to quickly identify and navigate to large sections of the document. Prefer using the <code>&lt;main&gt;</code> element over declaring <code>role="main"</code>, unless there are <a href="/en-US/docs/Web/HTML/Element/main#Browser_compatibility">legacy browser support concerns</a>.</p>
+<p>The <code>&lt;main&gt;</code> element behaves like a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Main_role"><code>main</code> landmark</a> role. <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">Landmarks</a> can be used by assistive technology to quickly identify and navigate to large sections of the document. Prefer using the <code>&lt;main&gt;</code> element over declaring <code>role="main"</code>, unless there are <a href="/en-US/docs/Web/HTML/Element/main#browser_compatibility">legacy browser support concerns</a>.</p>
 
 <h3 id="Skip_navigation">Skip navigation</h3>
 
@@ -117,7 +117,7 @@ tags:
 
 <h3 id="Reader_mode">Reader mode</h3>
 
-<p>Browser reader mode functionality looks for the presence of the <code>&lt;main&gt;</code> element, as well as <a href="/en-US/docs/Web/HTML/Element/Heading_Elements">heading</a> and <a href="/en-US/docs/Web/HTML/Element#Content_sectioning">content sectioning elements</a> when converting content into a specialized reader view.</p>
+<p>Browser reader mode functionality looks for the presence of the <code>&lt;main&gt;</code> element, as well as <a href="/en-US/docs/Web/HTML/Element/Heading_Elements">heading</a> and <a href="/en-US/docs/Web/HTML/Element#content_sectioning">content sectioning elements</a> when converting content into a specialized reader view.</p>
 
 <ul>
  <li><a href="https://medium.com/@mandy.michael/building-websites-for-safari-reader-mode-and-other-reading-apps-1562913c86c9">Building websites for Safari Reader Mode and other reading apps.</a></li>


### PR DESCRIPTION
We shouldn’t use the word “recommended” to describe `<main role=main>` — because the ARIA in HTML spec actually normatively recommends against it. So instead, we should just explain that IE 11 and earlier don’t recognize `<main>` but do recognize `role=main`, and leave it to the reader to decide if they want to use it in spite of the spec recommending against it.

Fixes https://github.com/mdn/sprints/issues/3352

Also pushed the “fixable flaws” button to update some links.