### PR TITLE
Adding formal definition reference

### DIFF
--- a/files/en-us/web/css/content-visibility/index.html
+++ b/files/en-us/web/css/content-visibility/index.html
@@ -39,6 +39,10 @@ content-visibility: unset;
  <dd>The element turns on layout containment, style containment, and paint containment. If the element is not relevant to the user, it also skips its contents. Unlike hidden, the skipped contents must still be available as normal to user-agent features such as find-in-page, tab order navigation, etc., and must be focusable and selectable as normal.</dd>
 </dl>
 
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
 <h2 id="Accessibility_concerns">Accessibility concerns</h2>
 
 <p>Headings and other content will be suppressed by <code>content-visibility</code> if they are considered off-screen. This means that screen reader users may lose the benefit of having a complete page outline read out loud.</p>


### PR DESCRIPTION
I've checked in [data/css/properties.json](https://github.com/mdn/data/blob/5cf9428d12cb7e21f44ea06e36175acad3923caa/css/properties.json) and there is a definition for the `content-visibility` with the values, so I guessed I just need to set `{{cssinfo}}` on the page.