### PR TITLE
CamelCased Option value to match Option String

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.html
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.html
@@ -618,11 +618,11 @@ textarea.onkeyup = function(){
 &lt;div class="output" style="height: 300px;"&gt;
   &lt;label for="theme"&gt;Select theme: &lt;/label&gt;
   &lt;select id="theme"&gt;
-    &lt;option value="white"&gt;White&lt;/option&gt;
-    &lt;option value="black"&gt;Black&lt;/option&gt;
-    &lt;option value="purple"&gt;Purple&lt;/option&gt;
-    &lt;option value="yellow"&gt;Yellow&lt;/option&gt;
-    &lt;option value="psychedelic"&gt;Psychedelic&lt;/option&gt;
+    &lt;option value="White"&gt;White&lt;/option&gt;
+    &lt;option value="Black"&gt;Black&lt;/option&gt;
+    &lt;option value="Purple"&gt;Purple&lt;/option&gt;
+    &lt;option value="Yellow"&gt;Yellow&lt;/option&gt;
+    &lt;option value="Psychedelic"&gt;Psychedelic&lt;/option&gt;
   &lt;/select&gt;
 
   &lt;h1&gt;This is my website&lt;/h1&gt;


### PR DESCRIPTION
CamelCased the `option value` to be same as option string, otherwise a learner might end up figuring out why options are not matching, until they inspect the `select` tag.