### PR TITLE
Fix typo / adjust phrasing in Map documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.html
@@ -85,8 +85,7 @@ tags:
           insertion.</p>
       </td>
       <td>
-        <p>Although the keys of an ordinary <code>Object</code> are ordered now, they
-          didn't use to be, and the order is complex. As a result, it's best not to rely
+        <p>Although the keys of an ordinary <code>Object</code> are ordered now, this was not always the case, and the order is complex. As a result, it's best not to rely
           on property order.</p>
 
         <p>The order was first defined for own properties only in ECMAScript 2015;


### PR DESCRIPTION
Originally just wanted to correct a minor typo:
"they didn't **use** to be"  ➡️ "they didn't **used** to be"

Instead rephrased it as "this was not always the case"