### PR TITLE
Document which UA strings Firefox uses on aarch64 macOS/Windows

### DIFF
--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -79,7 +79,7 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
  </thead>
  <tbody>
   <tr>
-   <td>Windows NT on x86 CPU</td>
+   <td>Windows NT on x86 or aarch64 CPU</td>
    <td>Mozilla/5.0 (Windows NT <em>x</em>.<em>y</em>; rv:10.0) Gecko/20100101 Firefox/10.0</td>
   </tr>
   <tr>
@@ -102,7 +102,7 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
  </thead>
  <tbody>
   <tr>
-   <td>Mac OS X on Intel x86 or x86_64</td>
+   <td>Mac OS X on x86, x86_64, or aarch64</td>
    <td>Mozilla/5.0 (Macintosh; Intel Mac OS X <em>x.y</em>; rv:10.0) Gecko/20100101 Firefox/10.0</td>
   </tr>
   <tr>


### PR DESCRIPTION
Firefox intentionally does not expose the aarch64 CPU architecture on Mac and Windows.