### PR TITLE
How to CSS index page

### DIFF
--- a/files/en-us/learn/css/howto/create_fancy_boxes/index.html
+++ b/files/en-us/learn/css/howto/create_fancy_boxes/index.html
@@ -7,7 +7,7 @@ tags:
   - CodingScripting
   - Learn
 ---
-<p class="summary">CSS boxes are the building blocks of any web page styled with CSS. Making them nice looking is both fun and challenging. It's fun because it's all about turning a design idea into working code; It's challenging because of annoying constraints and crazy freedom in the use of CSS. Let's do some fancy boxes.</p>
+<p class="summary">CSS boxes are the building blocks of any web page styled with CSS. Making them nice looking is both fun and challenging. It's fun because it's all about turning a design idea into working code; it's challenging because of the constraints of CSS. Let's do some fancy boxes.</p>
 
 <p>Before we start getting into the practical side of it, make sure you are familiar with <a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model">the CSS box model</a>. It's also a good idea, but not a prerequisite, to be familiar with some <a href="/en-US/docs/Learn/CSS/CSS_layout/Introduction">CSS layout basics</a>.</p>
 
@@ -57,7 +57,7 @@ tags:
 
   /* Let's make sure we have a square.
      If it's not a square, we'll get an
-     ellipsis rather than a circle ;) */
+     ellipsis rather than a circle ; */
   width  : 4em;
   height : 4em;
 
@@ -118,7 +118,7 @@ tags:
 <p>{{ EmbedLiveSample('Backgrounds', '100%', '200') }}</p>
 
 <div class="note">
-<p>Gradients can be used in some very creative ways. If you want to see some crazy examples, take a look at <a href="http://lea.verou.me/css3patterns/">Lea Verou's CSS patterns</a>. Just remember that such use of gradient is quite expensive, performance wise. If you want to learn more about gradient, feel free to get into <a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">our dedicated article</a>.</p>
+<p>Gradients can be used in some very creative ways. If you want to see some creative examples, take a look at <a href="http://lea.verou.me/css3patterns/">Lea Verou's CSS patterns</a>. Just remember that such use of gradient is quite expensive, performance wise. If you want to learn more about gradient, feel free to get into <a href="/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients">our dedicated article</a>.</p>
 </div>
 
 <h2 id="Pseudo-elements">Pseudo-elements</h2>
@@ -301,8 +301,3 @@ blockquote i {
 
 <p>{{ EmbedLiveSample('All_together_and_more', '100%', '100') }}</p>
 
-<h2 id="What's_next">What's next</h2>
-
-<p>In many ways, making a  fancy box is mostly about adding color and images within the background, so it could worth digging into <a href="/en-US/docs/Learn/CSS/Howto/manage_colors_and_images">managing colors and images</a>. Also, fancy boxes themselves are quite useless if they are not part of a larger layout. If you haven't checked this out yet, you should look at <a href="/en-US/docs/Learn/CSS/CSS_layout/Introduction">the basics of layout</a>.</p>
-
-<div class="grammarly-disable-indicator"> </div>

--- a/files/en-us/learn/css/howto/create_fancy_boxes/index.html
+++ b/files/en-us/learn/css/howto/create_fancy_boxes/index.html
@@ -57,7 +57,7 @@ tags:
 
   /* Let's make sure we have a square.
      If it's not a square, we'll get an
-     ellipsis rather than a circle ; */
+     ellipsis rather than a circle */
   width  : 4em;
   height : 4em;
 

--- a/files/en-us/learn/css/howto/index.html
+++ b/files/en-us/learn/css/howto/index.html
@@ -8,82 +8,69 @@ tags:
 ---
 <div>{{LearnSidebar}}</div>
 
-<p class="summary">The following links provide solutions to common problems you may face when working with CSS.</p>
+<p class="summary">This page rounds up questions and answers, and other material on the MDN site that can help you to solve common CSS problems.</p>
 
-<h2 id="Common_use_cases">Common use cases</h2>
+<h2 id="Styling_boxes">Styling boxes</h2>
 
-<div class="column-container">
-<div class="column-half">
-<h3 id="Basics">Basics</h3>
+<dl>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Add_a_shadow">How do I add a drop-shadow to an element?</a></dt>
+  <dd>Shadows can be added to boxes with the {{cssxref("box-shadow")}} property. This tutorial explains how it works and shows an example.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Fill_a_box_with_an_image">How do I fill a box with an image without distorting the image?</a></dt>
+  <dd>The {{cssxref("object-fit")}} property provides different ways to fit an image into a box which has a different aspect ratio, and you can find out how to use them in this tutorial.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/create_fancy_boxes">Which methods can be used to style boxes?</a></dt>
+  <dd>A rundown of the different properties that might be useful when styling boxes using CSS.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Make_box_transparent">How can I make elements semi-transparent?</a></dt>
+  <dd>The {{cssxref("opacity")}} property and color values with an alpha channel can be used for this; find out which to use when.</dd>
+</dl>
 
-<ul>
- <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works#applying_css_to_the_dom">How to apply CSS to the DOM</a></li>
- <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured#white_space">How to use whitespace in CSS</a></li>
- <li><a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured#comments">How to write comments in CSS</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors#type_class_and_id_selectors">How to select elements via element name, class or ID</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors#attribute_selectors">How to select elements via attribute name and content</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors#pseudo-classes_and_pseudo-elements">How to use pseudo-classes</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors#pseudo-classes_and_pseudo-elements">How to use pseudo-elements</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors#selector_lists">How to apply multiple selectors to the same rule</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#color">How to specify colors in CSS</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Debugging_CSS#inspecting_the_applied_css">How to debug CSS in the browser</a></li>
-</ul>
-
-<h3 id="CSS_and_text">CSS and text</h3>
+<h3 id="Box_guides">Box styling lessons and guides</h3>
 
 <ul>
- <li><a href="/en-US/docs/Learn/CSS/Styling_text/Fundamentals">How to style text</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Styling_text/Styling_lists">How to customize a list of elements</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Styling_text/Styling_links">How to style links</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Styling_text/Fundamentals#text_drop_shadows">How to add shadows to text</a></li>
+  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model">The Box Model</a></li>
+  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders">Styling backgrounds and borders</a></li>
 </ul>
+
+
+<h2 id="CSS_and_text">CSS and text</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Add_a_text_shadow">How do I add a shadow to text?</a></dt>
+  <dd>Shadows can be added to boxes with the {{cssxref("text-shadow")}} property. This tutorial explains how it works and shows an example.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Highlight_first_line">How do I highlight the first line of a paragraph?</a></dt>
+  <dd>Find out how to target the first formatted line of text with the {{cssxref("::first-line")}} pseudo-element.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Highlight_first_para">How do I highlight the first paragraph in an article?</a></dt>
+  <dd>Find out how to target the first paragraph with the {{cssxref(":first-child")}} pseudo-class.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Highlight_para_after_h1">How do I highlight a paragraph only if it comes right after a heading?</a></dt>
+  <dd>Combinators can help you to precisely target elements based on where they are in the document, this tutorial explains how to use them to apply CSS to a paragraph only if it immediately follows a heading.</dd>
+</dl>
+
+<h3 id="Text_guides">Text styling lessons and guides</h3>
+
+<ul>
+  <li><a href="/en-US/docs/Learn/CSS/Styling_text/Fundamentals">How to style text</a></li>
+  <li><a href="/en-US/docs/Learn/CSS/Styling_text/Styling_lists">How to customize a list of elements</a></li>
+  <li><a href="/en-US/docs/Learn/CSS/Styling_text/Styling_links">How to style links</a></li>
+  <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors">CSS Selectors</a></li>
+</ul>
+
+<h2 id="CSS_layout">CSS Layout</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Center_an_item">How do I center an item?</a></dt>
+  <dd>Centering an item inside another box horizontally and vertically used to be tricky, however Flexbox now makes it simple.</dd>
+</dl>
+
+<h3 id="Layout_guides">Layout guides</h3>
+
+<ul>
+  <li><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Using CSS Flexbox</a></li>
+  <li><a href="/en-US/docs/Web/CSS/CSS_Columns/Using_multi-column_layouts">Using CSS multi-column layouts</a></li>
+  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Using CSS Grid Layout</a></li>
+  <li><a href="/en-US/docs/Learn/CSS/Howto/Generated_content">Using CSS generated content</a></li>
+ </ul>
+
+<div class="notecard note">
+  <h3>The CSS Layout Cookbook</h3>
+  <p>We have a cookbook dedicated to <a href="/en-US/docs/Web/CSS/Layout_cookbook">CSS Layout solutions</a>, with fully worked examples and explanations of common layout tasks.</p>
 </div>
 
-<div class="column-half">
-<h3 id="Boxes_and_layouts">Boxes and layouts</h3>
-
-<ul>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model#box_properties">How to size CSS boxes</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Overflowing_content">How to control overflowing content</a></li>
- <li><a href="/en-US/docs/Web/CSS/background-clip">How to control the part of a CSS box that the background is drawn under</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model#types_of_css_boxes">How do I define inline, block, and inline-block?</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Howto/create_fancy_boxes">How to create fancy boxes</a> (also see the <a href="/en-US/docs/Learn/CSS/Building_blocks">Styling boxes</a> module, generally).</li>
- <li><a href="/en-US/docs/Web/CSS/background-clip">How to use <code>background-clip</code> to control how much of the box your background image covers</a>.</li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/The_box_model#changing_the_box_model_completely">How to change the box model completely using <code>box-sizing</code></a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders">How to control backgrounds</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders">How to control borders</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Styling_tables">How to style an HTML table</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects#box_shadows">How to add shadows to boxes</a></li>
-</ul>
-</div>
-</div>
-
-<h2 id="Uncommon_and_advanced_techniques">Uncommon and advanced techniques</h2>
-
-<p>CSS allows some advanced design techniques. These articles help demystify some of the more complicated use cases.</p>
-
-<h3 id="General">General</h3>
-
-<ul>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance#specificity">How to calculate specificity of a CSS selector</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance#controlling_inheritance">How to control inheritance in CSS</a></li>
-</ul>
-
-<h3 id="Advanced_effects">Advanced effects</h3>
-
-<ul>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects#filters">How to use filters in CSS</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects#blend_modes">How to use blend modes in CSS</a></li>
-</ul>
-
-<h3 id="Layout">Layout</h3>
-
-<ul>
- <li><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Using CSS flexible boxes</a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Columns/Using_multi-column_layouts">Using CSS multi-column layouts</a></li>
- <li><a href="/en-US/docs/Learn/CSS/Howto/Generated_content">Using CSS generated content</a></li>
-</ul>
-
-<h2 id="See_also">See also</h2>
-
-<p><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">CSS FAQ</a> — A variety of topics: from debugging to selector usage.</p>

--- a/files/en-us/learn/css/howto/index.html
+++ b/files/en-us/learn/css/howto/index.html
@@ -20,7 +20,7 @@ tags:
   <dt><a href="/en-US/docs/Learn/CSS/Howto/create_fancy_boxes">Which methods can be used to style boxes?</a></dt>
   <dd>A rundown of the different properties that might be useful when styling boxes using CSS.</dd>
   <dt><a href="/en-US/docs/Learn/CSS/Howto/Make_box_transparent">How can I make elements semi-transparent?</a></dt>
-  <dd>The {{cssxref("opacity")}} property and color values with an alpha channel can be used for this; find out which to use when.</dd>
+  <dd>The {{cssxref("opacity")}} property and color values with an alpha channel can be used for this; find out which one to use when.</dd>
 </dl>
 
 <h3 id="Box_guides">Box styling lessons and guides</h3>
@@ -34,14 +34,14 @@ tags:
 <h2 id="CSS_and_text">CSS and text</h2>
 
 <dl>
-  <dt><a href="/en-US/docs/Learn/CSS/Howto/Add_a_text_shadow">How do I add a shadow to text?</a></dt>
-  <dd>Shadows can be added to boxes with the {{cssxref("text-shadow")}} property. This tutorial explains how it works and shows an example.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS/Howto/Add_a_text_shadow">How do I add a drop-shadow to text?</a></dt>
+  <dd>Shadows can be added to text with the {{cssxref("text-shadow")}} property. This tutorial explains how it works and shows an example.</dd>
   <dt><a href="/en-US/docs/Learn/CSS/Howto/Highlight_first_line">How do I highlight the first line of a paragraph?</a></dt>
-  <dd>Find out how to target the first formatted line of text with the {{cssxref("::first-line")}} pseudo-element.</dd>
+  <dd>Find out how to target the first line of text in a paragraph with the {{cssxref("::first-line")}} pseudo-element.</dd>
   <dt><a href="/en-US/docs/Learn/CSS/Howto/Highlight_first_para">How do I highlight the first paragraph in an article?</a></dt>
   <dd>Find out how to target the first paragraph with the {{cssxref(":first-child")}} pseudo-class.</dd>
   <dt><a href="/en-US/docs/Learn/CSS/Howto/Highlight_para_after_h1">How do I highlight a paragraph only if it comes right after a heading?</a></dt>
-  <dd>Combinators can help you to precisely target elements based on where they are in the document, this tutorial explains how to use them to apply CSS to a paragraph only if it immediately follows a heading.</dd>
+  <dd>Combinators can help you to precisely target elements based on where they are in the document; this tutorial explains how to use them to apply CSS to a paragraph only if it immediately follows a heading.</dd>
 </dl>
 
 <h3 id="Text_guides">Text styling lessons and guides</h3>


### PR DESCRIPTION
I have written quite a few of these small examples now so I figured it time to revamp the listing page.

I've removed links to things that essentially dumped people into a page of content with no context, moved links to relevant guides and tutorials up under the sections, then linked in my new content with some description. I've kept them grouped as "text styling", "layout" and so on, as it makes it easier to list useful things.

I have a few more to write but I can add them as I go.