### PR TITLE
Fix broken "Using the User Timing API" link

### DIFF
--- a/files/en-us/web/api/user_timing_api/index.html
+++ b/files/en-us/web/api/user_timing_api/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p><code><strong>mark</strong></code> events are <em>named</em> by the application and can be set at any location in an application. <code><strong>measure</strong></code> events are also <em>named</em> by the application but they are placed between two marks thus they are effectively a <em>midpoint</em> between two marks.</p>
 
-<p>This document provides an overview of the <code>mark</code> and <code>measure</code> {{domxref("PerformanceEntry.entryType","performance event types")}} including the four <code>User Timing</code> methods that extend the {{domxref("Performance")}} interface. For more details and example code regarding these two performance event types and the methods, see <a href="/docs/Web/API/User_Timing_API/Using_the_User_Timing_API">Using the User Timing API</a>.</p>
+<p>This document provides an overview of the <code>mark</code> and <code>measure</code> {{domxref("PerformanceEntry.entryType","performance event types")}} including the four <code>User Timing</code> methods that extend the {{domxref("Performance")}} interface. For more details and example code regarding these two performance event types and the methods, see <a href="/en-US/docs/Web/API/User_Timing_API/Using_the_User_Timing_API">Using the User Timing API</a>.</p>
 
 <h2 id="Performance_marks">Performance <code>marks</code></h2>
 

--- a/files/en-us/web/api/user_timing_api/index.html
+++ b/files/en-us/web/api/user_timing_api/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p><code><strong>mark</strong></code> events are <em>named</em> by the application and can be set at any location in an application. <code><strong>measure</strong></code> events are also <em>named</em> by the application but they are placed between two marks thus they are effectively a <em>midpoint</em> between two marks.</p>
 
-<p>This document provides an overview of the <code>mark</code> and <code>measure</code> {{domxref("PerformanceEntry.entryType","performance event types")}} including the four <code>User Timing</code> methods that extend the {{domxref("Performance")}} interface. For more details and example code regarding these two performance event types and the methods, see <a href="/Web/API/User_Timing_API/Using_the_User_Timing_API">Using the User Timing API</a>.</p>
+<p>This document provides an overview of the <code>mark</code> and <code>measure</code> {{domxref("PerformanceEntry.entryType","performance event types")}} including the four <code>User Timing</code> methods that extend the {{domxref("Performance")}} interface. For more details and example code regarding these two performance event types and the methods, see <a href="/docs/Web/API/User_Timing_API/Using_the_User_Timing_API">Using the User Timing API</a>.</p>
 
 <h2 id="Performance_marks">Performance <code>marks</code></h2>
 


### PR DESCRIPTION
On https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API, the "Using the User Timing API" link is broken