### PR TITLE
Fix example typo in HTMLScriptElement/referrerPolicy

### DIFF
--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
@@ -73,7 +73,7 @@ tags:
 <pre class="brush: js;highlight:[3]">var scriptElem = document.createElement("script");
 scriptElem.src = "/";
 scriptElem.referrerPolicy = "unsafe-url";
-document.body.appendChild(script);
+document.body.appendChild(scriptElem);
 </pre>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Issue: https://github.com/mdn/content/issues/2436
Fix the code in example.