### PR TITLE
Console styled output: using %c multiple times

### DIFF
--- a/files/en-us/web/api/console/index.html
+++ b/files/en-us/web/api/console/index.html
@@ -154,6 +154,10 @@ console.info("My first car was a", car, ". The object is:", someObject);</pre>
 
 <p><img alt="" src="css-styling.png" style="display: block; margin: 0 auto;"></p>
 
+<p>You may use <code>%c</code> multiple times:</p>
+
+<pre class="brush: js notranslate">console.log("Multiple styles: %cred %corange", "color: red", "color: orange", "Additional unformatted message");</pre>
+
 <p>The properties usable along with the <code>%c</code> syntax are as follows (at least, in Firefox — they may differ in other browsers):</p>
 
 <ul>


### PR DESCRIPTION
Hello, just a small update to the article.

Rendering in Firefox and Chrome:
![image](https://user-images.githubusercontent.com/1437027/108353183-20b4c000-71e8-11eb-985d-5407c2f79c78.png)
