### PR TITLE
No longer mark childNode.remove() as experimental

### DIFF
--- a/files/en-us/web/api/childnode/remove/index.html
+++ b/files/en-us/web/api/childnode/remove/index.html
@@ -5,7 +5,6 @@ tags:
 - API
 - ChildNode
 - DOM
-- Experimental
 - Method
 ---
 <div>{{APIRef("DOM")}}</div>


### PR DESCRIPTION
IMO childNode.remove() is no longer experimental as it has been supported in all maintained browsers for years now. Also the BCD table indicates it is no longer experimental.

Closes #2385