### PR TITLE
adding cookiechangeevent

### DIFF
--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -32,7 +32,7 @@ tags:
   <dt><code>expires</code></dt>
   <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
   <dt><code>secure</code></dt>
-  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie is from a site with a secure context (HTTPS rather than HTTP).</dd>
   <dt><code>sameSite</code></dt>
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been changed by the given `CookieChangeEvent` instance.</p>
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been changed by the given <code>CookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns any cookies that have been changed by the given <code>CookieChangeEvent</code> instance.</p>
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been changed.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -32,7 +32,7 @@ tags:
   <dt><code>expires</code></dt>
   <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
   <dt><code>secure</code></dt>
-  <dd>A {{jsxref("boolean")}} indicating whether the cookie is to be used in secure contexts only.</dd>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
   <dt><code>sameSite</code></dt>
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -10,15 +10,15 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been changed by the given <code>CookieChangeEvent</code> instance.</p>
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns any cookies that have been changed by the given <code>CookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>obj</var> = <var>CookieChangeEvent</var>.changed;</pre>
+<pre class="syntaxbox notranslate">var <var>array</var> = <var>CookieChangeEvent</var>.changed;</pre>
 
 <h3>Value</h3>
 
-<p>An object containing the changed cookie. This object contains the following properties:</p>
+<p>An array of objects containing the changed cookie(s). Each object contains the following properties:</p>
 
 <dl>
   <dt><code>name</code></dt>
@@ -53,10 +53,10 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. It contains an object representing the cookie that has just been set.</p>
+<p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. The first item in that array contains an object representing the cookie that has just been set.</p>
 
 <pre class="brush:js">cookieStore.addEventListener('change', (event) => {
-  console.log(event.changed);
+  console.log(event.changed[0]);
 });
 
 const one_day = 24 * 60 * 60 * 1000;

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -39,7 +39,7 @@ tags:
       <dt><code>"strict"</code></dt>
       <dd>Cookies will only be sent in a first-party context and not be sent with requests initiated by third party websites.</dd>
       <dt><code>"lax"</code></dt>
-      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
+      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating within the origin site (i.e. when following a link).</dd>
       <dt><code>"none"</code></dt>
       <dd>Cookies will be sent in all contexts.</dd>
     </dl>

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -14,7 +14,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>array</var> = <var>CookieChangeEvent</var>.changed;</pre>
+<pre class="syntaxbox notranslate">var array = CookieChangeEvent.changed;</pre>
 
 <h3>Value</h3>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -37,7 +37,7 @@ tags:
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>
       <dt><code>"strict"</code></dt>
-      <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
+      <dd>Cookies will only be sent in a first-party context and not be sent with requests initiated by third party websites.</dd>
       <dt><code>"lax"</code></dt>
       <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
       <dt><code>"none"</code></dt>

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been changed by a <code>changed</code> change event.</p>
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been changed by the given `CookieChangeEvent` instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -1,0 +1,91 @@
+---
+title: CookieChangeEvent.changed
+slug: Web/API/CookieChangeEvent/changed
+tags:
+  - API
+  - Property
+  - Reference
+  - changed
+  - CookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been changed by a <code>changed</code> change event.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>obj</var> = <var>CookieChangeEvent</var>.changed;</pre>
+
+<h3>Value</h3>
+
+<p>An object containing the changed cookie. This object contains the following properties:</p>
+
+<dl>
+  <dt><code>name</code></dt>
+  <dd>A {{domxref("USVString")}} containing the name of the cookie.</dd>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("USVString")}} containing the value of the cookie.</dd>
+  <dt><code>domain</code></dt>
+  <dd>A {{domxref("USVString")}} containing the domain of the cookie.</dd>
+  <dt><code>path</code></dt>
+  <dd>A {{domxref("USVString")}} containing the path of the cookie.</dd>
+  <dt><code>expires</code></dt>
+  <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
+  <dt><code>secure</code></dt>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie is to be used in secure contexts only.</dd>
+  <dt><code>sameSite</code></dt>
+  <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
+    <dl>
+      <dt><code>"strict"</code></dt>
+      <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
+      <dt><code>"lax"</code></dt>
+      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
+      <dt><code>"none"</code></dt>
+      <dd>Cookies will be sent in all contexts.</dd>
+    </dl>
+
+    <div class="notecard note">
+      <h4>Note</h4>
+      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+    </div>
+  </dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example when the cookie is set the event listener logs the {{domxref("CookieChangeEvent.changed","changed")}} property to the console. It contains an object representing the cookie that has just been set.</p>
+
+<pre class="brush:js">cookieStore.addEventListener('change', (event) => {
+  console.log(event.changed);
+});
+
+const one_day = 24 * 60 * 60 * 1000;
+cookieStore.set({
+  name: "cookie1",
+  value: "cookie1-value",
+  expires: Date.now() + one_day,
+  domain: "example.com"
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#dom-cookiechangeevent-changed','CookieChangeEvent.changed')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CookieChangeEvent.changed")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -53,7 +53,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is set the event listener logs the {{domxref("CookieChangeEvent.changed","changed")}} property to the console. It contains an object representing the cookie that has just been set.</p>
+<p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. It contains an object representing the cookie that has just been set.</p>
 
 <pre class="brush:js">cookieStore.addEventListener('change', (event) => {
   console.log(event.changed);

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">var <var>CookieChangeEvent</var> = new CookieChangeEvent(<var>type</var>,<var>eventInitDict</var>);</pre>
+<pre class="syntaxbox">var CookieChangeEvent = new CookieChangeEvent(type,eventInitDict);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -11,6 +11,11 @@ tags:
 
 <p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
+<div class="notecard note">
+  <h4>Note</h4>
+    <p>This event constructor is generally not needed for production web sites. It's primary use is for tests that require an instance of this event.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>CookieChangeEvent</var> = new CookieChangeEvent(<var>type</var>,<var>eventInitDict</var>);</pre>
@@ -24,9 +29,9 @@ tags:
   <dd>An object containing:
     <dl>
       <dt><code>changed</code></dt>
-      <dd>An object containing a changed cookie.</dd>
+      <dd>An array containing a changed cookie.</dd>
       <dt><code>deleted</code></dt>
-      <dd>An object containing a deleted cookie.</dd>
+      <dd>An array containing a deleted cookie.</dd>
     </dl>
   </dd>
 </dl>

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
+<p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -1,0 +1,55 @@
+---
+title: CookieChangeEvent.CookieChangeEvent()
+slug: Web/API/CookieChangeEvent/CookieChangeEvent
+tags:
+  - API
+  - Constructor
+  - Reference
+  - CookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type for <code>CookieChange</code> events. This constructor is called by the browser when a change event occurs.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>CookieChangeEvent</var> = new CookieChangeEvent(<var>type</var>,<var>eventInitDict</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>type</code></dt>
+  <dd>A {{domxref("DOMString")}} with the value <code>"changed"</code> or <code>"deleted"</code>.</dd>
+  <dt><code>eventInitDict</code>{{Optional_Inline}}</dt>
+  <dd>An object containing:
+    <dl>
+      <dt><code>changed</code></dt>
+      <dd>An object containing a changed cookie.</dd>
+      <dt><code>deleted</code></dt>
+      <dd>An object containing a deleted cookie.</dd>
+    </dl>
+  </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#dom-cookiechangeevent-cookiechangeevent','CookieChangeEvent()')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CookieChangeEvent.CookieChangeEvent")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type for <code>CookieChange</code> events. This constructor is called by the browser when a change event occurs.</p>
+<p class="summary">The <strong><code>CookieChangeEvent()</code></strong> constructor creates a new {{domxref("CookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -10,15 +10,15 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been deleted by the given <code>CookieChangeEvent</code> instance.</p>
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns any cookies that have been deleted by the given <code>CookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>obj</var> = <var>CookieChangeEvent</var>.deleted;</pre>
+<pre class="syntaxbox notranslate">var <var>array</var> = <var>CookieChangeEvent</var>.deleted;</pre>
 
 <h3>Value</h3>
 
-<p>An object containing the deleted cookie. This object contains the following properties:</p>
+<p>An array of objects containing the deleted cookie(s). Each object contains the following properties:</p>
 
 <dl>
   <dt><code>name</code></dt>
@@ -53,10 +53,10 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is deleted the event listener logs the <code>CookieChangeEvent.deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
+<p>In this example when the cookie is deleted the event listener logs the first item in the <code>CookieChangeEvent.deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
 
 <pre class="brush:js">cookieStore.addEventListener('change', (event) => {
-  console.log(event.deleted);
+  console.log(event.deleted[0]);
 });</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -32,7 +32,7 @@ tags:
   <dt><code>expires</code></dt>
   <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
   <dt><code>secure</code></dt>
-  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie is from a site with a secure context (HTTPS rather than HTTP).</dd>
   <dt><code>sameSite</code></dt>
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns any cookies that have been deleted by the given <code>CookieChangeEvent</code> instance.</p>
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been deleted by the given <code>CookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -37,7 +37,7 @@ tags:
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>
       <dt><code>"strict"</code></dt>
-      <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
+      <dd>Cookies will only be sent in a first-party context and not be sent with requests initiated by third party websites.</dd>
       <dt><code>"lax"</code></dt>
       <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating within the origin site (i.e. when following a link).</dd>
       <dt><code>"none"</code></dt>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been deleted by the given `CookieChangeEvent` instance.</p>
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been deleted by the given <code>CookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -14,7 +14,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>array</var> = <var>CookieChangeEvent</var>.deleted;</pre>
+<pre class="syntaxbox notranslate">var array = CookieChangeEvent.deleted;</pre>
 
 <h3>Value</h3>
 

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -32,7 +32,7 @@ tags:
   <dt><code>expires</code></dt>
   <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
   <dt><code>secure</code></dt>
-  <dd>A {{jsxref("boolean")}} indicating whether the cookie is to be used in secure contexts only.</dd>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
   <dt><code>sameSite</code></dt>
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -39,7 +39,7 @@ tags:
       <dt><code>"strict"</code></dt>
       <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
       <dt><code>"lax"</code></dt>
-      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
+      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating within the origin site (i.e. when following a link).</dd>
       <dt><code>"none"</code></dt>
       <dd>Cookies will be sent in all contexts.</dd>
     </dl>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -1,0 +1,83 @@
+---
+title: CookieChangeEvent.deleted
+slug: Web/API/CookieChangeEvent/deleted
+tags:
+  - API
+  - Property
+  - Reference
+  - deleted
+  - CookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been deleted by a <code>deleted</code> change event.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>obj</var> = <var>CookieChangeEvent</var>.deleted;</pre>
+
+<h3>Value</h3>
+
+<p>An object containing the deleted cookie. This object contains the following properties:</p>
+
+<dl>
+  <dt><code>name</code></dt>
+  <dd>A {{domxref("USVString")}} containing the name of the cookie.</dd>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("USVString")}} containing the value of the cookie.</dd>
+  <dt><code>domain</code></dt>
+  <dd>A {{domxref("USVString")}} containing the domain of the cookie.</dd>
+  <dt><code>path</code></dt>
+  <dd>A {{domxref("USVString")}} containing the path of the cookie.</dd>
+  <dt><code>expires</code></dt>
+  <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
+  <dt><code>secure</code></dt>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie is to be used in secure contexts only.</dd>
+  <dt><code>sameSite</code></dt>
+  <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
+    <dl>
+      <dt><code>"strict"</code></dt>
+      <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
+      <dt><code>"lax"</code></dt>
+      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
+      <dt><code>"none"</code></dt>
+      <dd>Cookies will be sent in all contexts.</dd>
+    </dl>
+
+    <div class="notecard note">
+      <h4>Note</h4>
+      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+    </div>
+  </dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example when the cookie is deleted the event listener logs the <code>CookieChangeEvent.deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
+
+<pre class="brush:js">cookieStore.addEventListener('change', (event) => {
+  console.log(event.deleted);
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#dom-cookiechangeevent-deleted','CookieStoreManager.deleted')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CookieChangeEvent.deleted")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been deleted by a <code>deleted</code> change event.</p>
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("CookieChangeEvent")}} interface returns the cookie that has been deleted by the given `CookieChangeEvent` instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -39,7 +39,7 @@ tags:
   <dt>{{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an array containing the changed cookie.</dd>
   <dt>{{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an object containing the deleted cookie.</dd>
+  <dd>Returns an array containing the deleted cookie.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -37,7 +37,7 @@ tags:
 
 <dl>
   <dt>{{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an object containing the changed cookie.</dd>
+  <dd>Returns an array containing the changed cookie.</dd>
   <dt>{{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an object containing the deleted cookie.</dd>
 </dl>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -37,9 +37,9 @@ tags:
 
 <dl>
   <dt>{{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an array containing the changed cookie.</dd>
+  <dd>Returns an array containing one or more changed cookies.</dd>
   <dt>{{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an array containing the deleted cookie.</dd>
+  <dd>Returns an array containing one or more deleted cookies.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted").</p>
 
 <p>Cookie changes that will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
 

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store')}} API is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
 
 <p>Cookie changes that will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
 

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
 
 <p>Cookie changes that will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
 

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -1,0 +1,83 @@
+---
+title: CookieChangeEvent
+slug: Web/API/CookieChangeEvent
+tags:
+  - API
+  - Interface
+  - Reference
+  - CookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store')}} API dispatches events against {{domxref("CookieStore")}} objects when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+
+<p>Cookies changes which will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
+
+<ul>
+  <li>A cookie is newly created and not immediately removed. In this case <code>type</code> is "changed".</li>
+  <li>A cookie is newly created and immediately removed. In this case <code>type</code> is "deleted"</li>
+  <li>A cookie is removed. In this case <code>type</code> is "deleted".</li>
+</ul>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>A cookie which is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
+</div>
+
+<h2 id="Constructor">Constructor</h2>
+
+<dl>
+  <dt>{{domxref("CookieChangeEvent.CookieChangeEvent()")}}</dt>
+  <dd>Creates a new <code>CookieChangeEvent</code> which is the event type for <code>CookieChange</code> events.</dd>
+</dl>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>This interface also inherits properties from {{domxref("Event")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
+  <dd>The <code>changed</code> property returns an object containing the changed cookie.</dd>
+  <dt>{{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
+  <dd>The <code>deleted</code> property returns an object containing the deleted cookie.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example when the cookie is set the event listener logs the event to the console. This is a <code>CookieChangeEvent</code> object with the {{domxref("CookieChangeEvent.changed","changed")}} property containing an object representing the cookie that has just been set.</p>
+
+<pre class="brush:js">cookieStore.addEventListener('change', (event) => {
+  console.log(event);
+});
+
+const one_day = 24 * 60 * 60 * 1000;
+cookieStore.set({
+  name: "cookie1",
+  value: "cookie1-value",
+  expires: Date.now() + one_day,
+  domain: "example.com"
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#CookieChangeEvent','CookieChangeEvent')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.CookieChangeEvent")}}</p>
+

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -44,7 +44,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is set the event listener logs the event to the console. This is a <code>CookieChangeEvent</code> object with the {{domxref("CookieChangeEvent.changed","changed")}} property containing an object representing the cookie that has just been set.</p>
+<p>In this example when the cookie is set, the event listener logs the event to the console. This is a <code>CookieChangeEvent</code> object with the {{domxref("CookieChangeEvent.changed","changed")}} property containing an object representing the cookie that has just been set.</p>
 
 <pre class="brush:js">cookieStore.addEventListener('change', (event) => {
   console.log(event);

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -39,7 +39,7 @@ tags:
   <dt>{{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an object containing the changed cookie.</dd>
   <dt>{{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
-  <dd>The <code>deleted</code> property returns an object containing the deleted cookie.</dd>
+  <dd>Returns an object containing the deleted cookie.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -21,7 +21,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>A cookie which is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
+  <p>A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
 </div>
 
 <h2 id="Constructor">Constructor</h2>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store')}} API dispatches events against {{domxref("CookieStore")}} objects when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+<p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store')}} API is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
 
 <p>Cookies changes which will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
 
@@ -80,4 +80,3 @@ cookieStore.set({
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.CookieChangeEvent")}}</p>
-

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -37,7 +37,7 @@ tags:
 
 <dl>
   <dt>{{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
-  <dd>The <code>changed</code> property returns an object containing the changed cookie.</dd>
+  <dd>Returns an object containing the changed cookie.</dd>
   <dt>{{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
   <dd>The <code>deleted</code> property returns an object containing the deleted cookie.</dd>
 </dl>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p class="summary">The <strong><code>CookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store')}} API is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} and {{domxref("CookieStore.onchange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
 
-<p>Cookies changes which will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
+<p>Cookie changes that will cause the <code>CookieChangeEvent</code> to be dispatched are:</p>
 
 <ul>
   <li>A cookie is newly created and not immediately removed. In this case <code>type</code> is "changed".</li>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -28,7 +28,7 @@ tags:
 
 <dl>
   <dt>{{domxref("CookieChangeEvent.CookieChangeEvent()")}}</dt>
-  <dd>Creates a new <code>CookieChangeEvent</code> which is the event type for <code>CookieChange</code> events.</dd>
+  <dd>Creates a new <code>CookieChangeEvent</code>.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>


### PR DESCRIPTION
Adds CookieChangeEvent, part of the Cookie Store API

Spec: https://wicg.github.io/cookie-store/#CookieChangeEvent

Reviewer: @jpmedley 

Joe, this is the one I mentioned on our call which extends event. It also needs BCD (I think the service worker version also needs BCD). Should I go ahead and add that?