### PR TITLE
Adds updated default HTTP accept value for FF86

### DIFF
--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -25,8 +25,8 @@ tags:
   <tr>
    <td>Firefox</td>
    <td>
-    <p><code>*/*</code> (since Firefox 66)<br></p>
-    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (in Firefox 65)</p>
+    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8</code> (since Firefox 86)<br></p>
+    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (since Firefox 65)</p>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (before)</p>
    </td>
    <td>In Firefox 65 and earlier, this value can be modified using the <a class="external" href="http://kb.mozillazine.org/Network.http.accept.default"><code>network.http.accept.default</code></a> parameter. (<a class="external" href="https://hg.mozilla.org/mozilla-central/file/tip/modules/libpref/init/all.js#l1750">source)</a></td>


### PR DESCRIPTION
This adds new accept value for the **default** HTTP accept value in FF86 (note, I updated the one for images, but missed this).

This also fixes #2430. Versions to at least FF79 match the value we had for FF65. I have therefore assumed that the `*/*` is a typo (which I almost certainly injected).