### PR TITLE
Clarify that fetch "credentials" value affects response credentials too

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -53,11 +53,8 @@ tags:
   <dt><code><var>resource</var></code></dt>
   <dd>This defines the resource that you wish to fetch. This can either be:
     <ul>
-      <li>A {{domxref("USVString")}} containing the direct URL of the resource you want to
-        fetch. Some browsers accept the <code>blob:</code> and <code>data:</code> schemes.
-      </li>
+      <li>A string or any other object with a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers">stringifier</a> — including a {{domxref("URL")}} object — that provides the URL of the resource you want to fetch.</li>
       <li>A {{domxref("Request")}} object.</li>
-      <li>A {{domxref("URL")}} object, or any other object with a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers">stringifier</a> that provides the URL for the resource you want to fetch.</li>
     </ul>
   </dd>
   <dt><code><var>init</var></code> {{optional_inline}}</dt>

--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -2,15 +2,15 @@
 title: WindowOrWorkerGlobalScope.fetch()
 slug: Web/API/WindowOrWorkerGlobalScope/fetch
 tags:
-- API
-- Experimental
-- Fetch
-- Fetch API
-- GlobalFetch
-- Method
-- Reference
-- WindowOrWorkerGlobalScope
-- request
+  - API
+  - Experimental
+  - Fetch
+  - Fetch API
+  - GlobalFetch
+  - Method
+  - Reference
+  - WindowOrWorkerGlobalScope
+  - request
 ---
 <p>{{APIRef("Fetch API")}}</p>
 
@@ -34,7 +34,7 @@ tags:
   {{domxref("Response.status")}} properties.</p>
 
 <p>The <code>fetch()</code> method is controlled by the <code>connect-src</code> directive
-  of <a href="/en-US/docs/Security/CSP/CSP_policy_directives">Content Security Policy</a>
+  of <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy">Content Security Policy</a>
   rather than the directive of the resources it's retrieving.</p>
 
 <div class="note">
@@ -57,7 +57,7 @@ tags:
         fetch. Some browsers accept the <code>blob:</code> and <code>data:</code> schemes.
       </li>
       <li>A {{domxref("Request")}} object.</li>
-      <li>A {{domxref("URL")}} object, or any other object with a <a href="https://developer.mozilla.org/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers">stringifier</a> that provides the URL for the resource you want to fetch.</li>
+      <li>A {{domxref("URL")}} object, or any other object with a <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file#stringifiers">stringifier</a> that provides the URL for the resource you want to fetch.</li>
     </ul>
   </dd>
   <dt><code><var>init</var></code> {{optional_inline}}</dt>
@@ -130,7 +130,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A {{domxref("Promise")}} that resolves to a {{domxref("Response")}} object.</p>
+<p>A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.</p>
 
 <h3 id="Exceptions">Exceptions</h3>
 
@@ -255,7 +255,7 @@ let myRequest = new Request('flowers.jpg', myInit);
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a></li>
-  <li><a href="/en-US/docs/Web/API/ServiceWorker_API">ServiceWorker API</a></li>
+  <li><a href="/en-US/docs/Web/API/Service_Worker_API">ServiceWorker API</a></li>
   <li><a href="/en-US/docs/Web/HTTP/CORS">HTTP access control (CORS)</a></li>
   <li><a href="/en-US/docs/Web/HTTP">HTTP</a></li>
 </ul>

--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -86,14 +86,17 @@ tags:
       <dd>The mode you want to use for the request, e.g., <code>cors</code>,
         <code>no-cors</code>, or <code>same-origin</code>.</dd>
       <dt><code>credentials</code></dt>
-      <dd>The request credentials you want to use for the request: <code>omit</code>,
-        <code>same-origin</code>, or <code>include</code>. To automatically send cookies
-        for the current domain, this option must be provided. Starting with Chrome 50,
-        this property also takes a {{domxref("FederatedCredential")}} instance or a
-        {{domxref("PasswordCredential")}} instance.</dd>
-      <dt><code>cache</code></dt>
-      <dd>The <a href="/en-US/docs/Web/API/Request/cache">cache mode</a> you want to use
-        for the request.</dd>
+      <dd>
+        <p>Controls what browsers do with credentials (<a href="/en-US/docs/Web/HTTP/Cookies">cookies</a>, <a href="/en-US/docs/Web/HTTP/Authentication">HTTP authentication</a> entries, and TLS client certificates). Must be one of the following strings:</p>
+        <dl>
+          <dt><code>omit</code></dt>
+          <dd>Tells browsers to exclude credentials from the request, and ignore any credentials sent back in the response (e.g., any {{HTTPHeader("Set-Cookie")}} header).</dd>
+          <dt><code>same-origin</code></dt>
+          <dd>Tells browsers to include credentials with requests to same-origin URLs, and use any credentials sent back in responses from same-origin URLs.</dd>
+          <dt><code>include</code></dt>
+          <dd>Tells browsers to always include credentials in requests, and always use any credentials sent back in responses.</dd>
+        </dl>
+      </dd>
 <dt><code>redirect</code></dt>
 <dd>How to handle a <code>redirect</code> response:
     <ul>


### PR DESCRIPTION
This change updates the documentation on the `fetch()` method, to clarify that the `credentials` value affects whether browsers use credentials sent back in responses (e.g., any `Set-Cookie` response headers) — not just whether credentials are sent with the request. Fixes https://github.com/mdn/content/issues/2409. Related: https://github.com/whatwg/fetch/pull/1174.

@annevk, would be great if you could also review the 4843f89 part of this (the other commit is some automated lint fixing).