### PR TITLE
Remove mask-type from CSS code

### DIFF
--- a/files/en-us/web/css/mask-type/index.html
+++ b/files/en-us/web/css/mask-type/index.html
@@ -101,8 +101,7 @@ mask-type: unset;
   width: 100px;
   background-color: rgb(128, 128, 128);
   border: solid 1px black;
-  mask: url("#m");
-  mask-type:luminance;
+  mask: url("#m");  
 }</pre>
 
 <h4 id="Result_2">Result</h4>


### PR DESCRIPTION
`mask-type` property doesn't apply to html elements.