### PR TITLE
Update Save-Data sd token value type

### DIFF
--- a/files/en-us/web/http/headers/save-data/index.html
+++ b/files/en-us/web/http/headers/save-data/index.html
@@ -33,7 +33,7 @@ tags:
 
 <dl>
   <dt><code>&lt;sd-token&gt;</code></dt>
-  <dd>A numerical value indicating whether the client wants to opt in to reduced data
+  <dd>A value indicating whether the client wants to opt in to reduced data
     usage mode. <code>on</code> indicates yes, while <code>off</code> (the default)
     indicates no.</dd>
 </dl>


### PR DESCRIPTION
Submitted for https://github.com/mdn/content/issues/2308
According to https://tools.ietf.org/html/draft-grigorik-http-client-hints-03#section-7 
7.  The Save-Data Hint

   **The "Save-Data" header field is a boolean** that, in requests,
   indicates client's preference for reduced data usage, due to high
   transfer costs, slow connection speeds, or other reasons.

     Save-Data = 1

   The boolean is a signal indicating explicit user opt-in into a
   reduced data usage mode on the client, and when communicated to
   origins allows them to deliver alternate content honoring such
   preference - e.g. smaller image and video resources, alternate
   markup, and so on.