### PR TITLE
Drop link to outdated “New in JavaScript” doc

### DIFF
--- a/files/en-us/web/javascript/index.html
+++ b/files/en-us/web/javascript/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{JsSidebar}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>JavaScript</strong> (<strong>JS</strong>) is a lightweight, interpreted, or <a href="https://en.wikipedia.org/wiki/Just-in-time_compilation">just-in-time</a> compiled programming language with {{Glossary("First-class Function", "first-class functions")}}. While it is most well-known as the scripting language for Web pages, <a class="external" href="https://en.wikipedia.org/wiki/JavaScript#Uses_outside_Web_pages">many non-browser environments</a> also use it, such as {{Glossary("Node.js")}}, <a class="external" href="https://couchdb.apache.org/">Apache CouchDB</a> and <a class="external" href="http://www.adobe.com/devnet/acrobat/javascript.html">Adobe Acrobat</a>.</span> JavaScript is a {{Glossary("Prototype-based programming", "prototype-based")}}, multi-paradigm, single-threaded, dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles. Read more <a href="/en-US/docs/Web/JavaScript/About_JavaScript">about JavaScript</a>.</p>
+<p class="summary"><span class="seoSummary"><strong>JavaScript</strong> (<strong>JS</strong>) is a lightweight, interpreted, or <a href="https://en.wikipedia.org/wiki/Just-in-time_compilation">just-in-time</a> compiled programming language with {{Glossary("First-class Function", "first-class functions")}}. While it is most well-known as the scripting language for Web pages, <a href="https://en.wikipedia.org/wiki/JavaScript#Uses_outside_Web_pages">many non-browser environments</a> also use it, such as {{Glossary("Node.js")}}, <a href="https://couchdb.apache.org/">Apache CouchDB</a> and <a href="http://www.adobe.com/devnet/acrobat/javascript.html">Adobe Acrobat</a>.</span> JavaScript is a {{Glossary("Prototype-based programming", "prototype-based")}}, multi-paradigm, single-threaded, dynamic language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles. Read more <a href="/en-US/docs/Web/JavaScript/About_JavaScript">about JavaScript</a>.</p>
 
 <p>This section is dedicated to the JavaScript language itself, and not the parts that are specific to Web pages or other host environments. For information about {{Glossary("API","API")}} specifics to Web pages, please see <a href="/en-US/docs/Web/API">Web APIs</a> and {{Glossary("DOM")}}.</p>
 
@@ -113,30 +113,29 @@ tags:
  <dd><a href="/en-US/docs/Tools/Web_Console">Web Console</a>, <a href="/en-US/docs/Tools/Performance">JavaScript Profiler</a>, <a href="/en-US/docs/Tools/Debugger">Debugger</a>, and more.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Shells">JavaScript Shells</a></dt>
  <dd>A JavaScript shell allows you to quickly test snippets of JavaScript code.</dd>
- <dt><a href="https://learnjavascript.online/" class="external">Learn JavaScript</a></dt>
+ <dt><a href="https://learnjavascript.online/">Learn JavaScript</a></dt>
  <dd>An excellent resource for aspiring web developers — Learn JavaScript in an interactive environment, with short lessons and interactive tests, guided by automated assessment. The first 40 lessons are free, and the complete course is available for a small one-time payment.</dd>
- <dt><a href="https://togetherjs.com/" class="external">TogetherJS</a></dt>
+ <dt><a href="https://togetherjs.com/">TogetherJS</a></dt>
  <dd>Collaboration made easy. By adding TogetherJS to your site, your users can help each other out on a website in real-time!</dd>
- <dt><a href="https://stackoverflow.com/questions/tagged/javascript" class="external">Stack Overflow</a></dt>
+ <dt><a href="https://stackoverflow.com/questions/tagged/javascript">Stack Overflow</a></dt>
  <dd>Stack Overflow questions tagged with "JavaScript".</dd>
- <dd>Browse JavaScript's feature history and implementation status.</dd>
- <dt><a href="https://jsfiddle.net/" class="external">JSFiddle</a></dt>
+ <dt><a href="https://jsfiddle.net/">JSFiddle</a></dt>
  <dd>Edit JavaScript, CSS, HTML and get live results. Use external resources and collaborate with your team online.</dd>
- <dt><a href="https://plnkr.co/" class="external">Plunker</a></dt>
+ <dt><a href="https://plnkr.co/">Plunker</a></dt>
  <dd>Plunker is an online community for creating, collaborating on and sharing your web development ideas. Edit your JavaScript, CSS, HTML files and get live results and file structure.</dd>
- <dt><a href="https://jsbin.com/" class="external">JSBin</a></dt>
+ <dt><a href="https://jsbin.com/">JSBin</a></dt>
  <dd>
  <p>JS Bin is an open-source collaborative web development debugging tool.</p>
  </dd>
- <dt><a href="https://codepen.io/" class="external">Codepen</a></dt>
+ <dt><a href="https://codepen.io/">Codepen</a></dt>
  <dd>
  <p>Codepen is another collaborative web development tool used as a live result playground.</p>
  </dd>
- <dt><a href="https://stackblitz.com/" class="external">StackBlitz</a></dt>
+ <dt><a href="https://stackblitz.com/">StackBlitz</a></dt>
  <dd>
  <p>StackBlitz is another online playground/debugging tool, which can host and deploy full-stack applications using React, Angular, etc.</p>
  </dd>
- <dt><a href="https://runjs.app/" class="external">RunJS</a></dt>
+ <dt><a href="https://runjs.app/">RunJS</a></dt>
  <dd>
  <p>RunJS is a desktop playground/scratchpad tool, which provides live results and access to both Node and Browser APIs.</p>
  </dd>

--- a/files/en-us/web/javascript/index.html
+++ b/files/en-us/web/javascript/index.html
@@ -113,31 +113,30 @@ tags:
  <dd><a href="/en-US/docs/Tools/Web_Console">Web Console</a>, <a href="/en-US/docs/Tools/Performance">JavaScript Profiler</a>, <a href="/en-US/docs/Tools/Debugger">Debugger</a>, and more.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Shells">JavaScript Shells</a></dt>
  <dd>A JavaScript shell allows you to quickly test snippets of JavaScript code.</dd>
- <dt><a href="https://learnjavascript.online/">Learn JavaScript</a></dt>
+ <dt><a href="https://learnjavascript.online/" class="external">Learn JavaScript</a></dt>
  <dd>An excellent resource for aspiring web developers — Learn JavaScript in an interactive environment, with short lessons and interactive tests, guided by automated assessment. The first 40 lessons are free, and the complete course is available for a small one-time payment.</dd>
- <dt><a href="https://togetherjs.com/">TogetherJS</a></dt>
+ <dt><a href="https://togetherjs.com/" class="external">TogetherJS</a></dt>
  <dd>Collaboration made easy. By adding TogetherJS to your site, your users can help each other out on a website in real-time!</dd>
- <dt><a href="https://stackoverflow.com/questions/tagged/javascript">Stack Overflow</a></dt>
+ <dt><a href="https://stackoverflow.com/questions/tagged/javascript" class="external">Stack Overflow</a></dt>
  <dd>Stack Overflow questions tagged with "JavaScript".</dd>
- <dt><a href="/en-US/docs/Web/JavaScript/New_in_JavaScript">JavaScript versions and release notes</a></dt>
  <dd>Browse JavaScript's feature history and implementation status.</dd>
- <dt><a href="https://jsfiddle.net/">JSFiddle</a></dt>
+ <dt><a href="https://jsfiddle.net/" class="external">JSFiddle</a></dt>
  <dd>Edit JavaScript, CSS, HTML and get live results. Use external resources and collaborate with your team online.</dd>
- <dt><a href="https://plnkr.co/">Plunker</a></dt>
+ <dt><a href="https://plnkr.co/" class="external">Plunker</a></dt>
  <dd>Plunker is an online community for creating, collaborating on and sharing your web development ideas. Edit your JavaScript, CSS, HTML files and get live results and file structure.</dd>
- <dt><a href="https://jsbin.com/">JSBin</a></dt>
+ <dt><a href="https://jsbin.com/" class="external">JSBin</a></dt>
  <dd>
  <p>JS Bin is an open-source collaborative web development debugging tool.</p>
  </dd>
- <dt><a href="https://codepen.io/">Codepen</a></dt>
+ <dt><a href="https://codepen.io/" class="external">Codepen</a></dt>
  <dd>
  <p>Codepen is another collaborative web development tool used as a live result playground.</p>
  </dd>
- <dt><a href="https://stackblitz.com/">StackBlitz</a></dt>
+ <dt><a href="https://stackblitz.com/" class="external">StackBlitz</a></dt>
  <dd>
  <p>StackBlitz is another online playground/debugging tool, which can host and deploy full-stack applications using React, Angular, etc.</p>
  </dd>
- <dt><a href="https://runjs.app/">RunJS</a></dt>
+ <dt><a href="https://runjs.app/" class="external">RunJS</a></dt>
  <dd>
  <p>RunJS is a desktop playground/scratchpad tool, which provides live results and access to both Node and Browser APIs.</p>
  </dd>


### PR DESCRIPTION
Lots of external links on this page, so just running through and adding `class="external"` to them.

Also removed one 'New in JS' link as those articles appear to be archived