### PR TITLE
Removed redutant part and fixed headings logic.

### DIFF
--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.html
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.html
@@ -21,17 +21,13 @@ tags:
 
 <p>The {{cssxref("align-content")}} property applies to the block axis in order to align the contents of the box within its container. If a content distribution method such as <code>space-between</code>, <code>space-around</code> or <code>space-evenly</code> is requested then the fallback alignment will be used, as the content is treated as a single <a href="/en-US/docs/Glossary/Alignment_Subject">alignment subject</a>.</p>
 
-<h2 id="justify-self">justify-self</h2>
+<h3 id="justify-self">justify-self</h2>
 
 <p>The {{cssxref("justify-self")}} property is used to align an item inside its containing block on the inline axis.</p>
 
 <p>This property does not apply to floated elements or table cells.</p>
 
-<h3 id="Absolutely_positioned_elements">Absolutely positioned elements</h3>
-
-<p>The alignment container is the positioned block, accounting for the offset values of top, left, bottom, and right. The normal keyword resolves to <code>stretch</code>, unless the positioned item is a replaced element, in which case it resolves to <code>start</code>.</p>
-
-<h2 id="align-self">align-self</h2>
+<h3 id="align-self">align-self</h2>
 
 <p>The {{cssxref("align-self")}} property does not apply to block-level boxes (including floats), because there is more than one item in the block axis. It also does not apply to table cells.</p>
 


### PR DESCRIPTION
Although styling between `<h3>` and `<h2>`  doesn't make sense, as `<h3>` stands out more.