### PR TITLE
Update spelling to en-US: "organise"->"organize"

### DIFF
--- a/files/en-us/learn/server-side/django/admin_site/index.html
+++ b/files/en-us/learn/server-side/django/admin_site/index.html
@@ -241,7 +241,7 @@ class BookInstanceAdmin(admin.ModelAdmin):
 
 <p><img alt="Admin Site - BookInstance List Filters" src="admin_improved_bookinstance_list_filters.png"></p>
 
-<h3 id="Organise_detail_view_layout">Organize detail view layout</h3>
+<h3 id="organize_detail_view_layout">Organize detail view layout</h3>
 
 <p>By default, the detail views lay out all fields vertically, in their order of declaration in the model. You can change the order of declaration, which fields are displayed (or excluded), whether sections are used to organize the information, whether fields are displayed horizontally or vertically, and even what edit widgets are used in the admin forms.</p>
 

--- a/files/en-us/learn/server-side/django/admin_site/index.html
+++ b/files/en-us/learn/server-side/django/admin_site/index.html
@@ -241,9 +241,9 @@ class BookInstanceAdmin(admin.ModelAdmin):
 
 <p><img alt="Admin Site - BookInstance List Filters" src="admin_improved_bookinstance_list_filters.png"></p>
 
-<h3 id="Organise_detail_view_layout">Organise detail view layout</h3>
+<h3 id="Organise_detail_view_layout">Organize detail view layout</h3>
 
-<p>By default, the detail views lay out all fields vertically, in their order of declaration in the model. You can change the order of declaration, which fields are displayed (or excluded), whether sections are used to organise the information, whether fields are displayed horizontally or vertically, and even what edit widgets are used in the admin forms.</p>
+<p>By default, the detail views lay out all fields vertically, in their order of declaration in the model. You can change the order of declaration, which fields are displayed (or excluded), whether sections are used to organize the information, whether fields are displayed horizontally or vertically, and even what edit widgets are used in the admin forms.</p>
 
 <div class="note">
 <p><strong>Note</strong>: The <em>LocalLibrary</em> models are relatively simple so there isn't a huge need for us to change the layout; we'll make some changes anyway however, just to show you how.</p>


### PR DESCRIPTION
organise -> organize 
except for the CSS ID _Organise_detail_view_layout_

https://developer.mozilla.org/en-us/docs/MDN/Guidelines/Writing_style_guide#spelling