### PR TITLE
add clarifying words to increase readability

### DIFF
--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>The <strong><code>getFloatFrequencyData()</code></strong> method of the {{domxref("AnalyserNode")}} Interface copies the current frequency data into a {{domxref("Float32Array")}} array passed into it.</p>
 
-<p>Each item in the array represents the decibel value for a specific frequency. The frequencies are spread linearly from 0 to 1/2 of the sample rate. For example, for <code>48000</code> sample rate, the last item of the array will represent the decibel value for <code>24000</code> Hz.</p>
+<p>Each item in the array represents the decibel value for a specific frequency. The frequencies are spread linearly from 0 to 1/2 of the sample rate. For example, for a <code>48000</code> Hz sample rate, the last item of the array will represent the decibel value for <code>24000</code> Hz.</p>
 
 <p>If you need higher performance and don't care about precision, you can use {{domxref("AnalyserNode.getByteFrequencyData()")}} instead, which works on a {{domxref("Uint8Array")}}.</p>
 


### PR DESCRIPTION
This is a very small pull request that just adds "a" and "Hz" to increase the readability of a sentence in the [`AnalyserNode.getFloatFrequencyData()` article](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/getFloatFrequencyData).

Without this pull request, the sentence reads, "For example, for 48000 sample rate, the last item of the array will represent the decibel value for 24000 Hz."

If we merge this pull request, the sentence would say, "For example, for **a** 48000 **Hz** sample rate, the last item of the array will represent the decibel value for 24000 Hz."

Update: I created ticket #2539 to track this issue. This pull request closes #2539.