### PR TITLE
Fixed wording on the CSS :visited page

### DIFF
--- a/files/en-us/web/css/_colon_visited/index.html
+++ b/files/en-us/web/css/_colon_visited/index.html
@@ -28,7 +28,7 @@ a:visited {
  <li>Allowable CSS properties are {{ cssxref("color") }}, {{ cssxref("background-color") }}, {{ cssxref("border-color") }}, {{ cssxref("border-bottom-color") }}, {{ cssxref("border-left-color") }}, {{ cssxref("border-right-color") }}, {{ cssxref("border-top-color") }}, {{ cssxref("column-rule-color") }}, {{ cssxref("outline-color") }}, {{ cssxref("text-decoration-color") }}, and {{ cssxref("text-emphasis-color") }}.</li>
  <li>Allowable SVG attributes are {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}.</li>
  <li>The alpha component of the allowed styles will be ignored. The alpha component of the element's non-<code>:visited</code> state will be used instead, except when that component is <code>0</code>, in which case the style set in <code>:visited</code> will be ignored entirely.</li>
- <li>Although these styles can be change the appearance of colors to the end user, the {{domxref("window.getComputedStyle")}} method will lie and always return the value of the non-<code>:visited</code> color.</li>
+ <li>Although these styles can change the appearance of colors to the end user, the {{domxref("window.getComputedStyle")}} method will lie and always return the value of the non-<code>:visited</code> color.</li>
  <li>The <code><a href="/en-US/docs/Web/HTML/Element/link">&lt;link&gt;</a></code> element is never matched by <code>:visited</code>.</li>
 </ul>
 


### PR DESCRIPTION
Removed "be" in 

> Although these styles can be change the appearance of colors to the end user, the window.getComputedStyle method will lie and always return the value of the non-:visited color.