### PR TITLE
Safari supports non-standard “autocorrect” for textarea

### DIFF
--- a/files/en-us/web/html/element/textarea/index.html
+++ b/files/en-us/web/html/element/textarea/index.html
@@ -54,6 +54,14 @@ tags:
 
  <p>If the <code>autocomplete</code> attribute is not specified on a <code>&lt;textarea&gt;</code> element, then the browser uses the <code>autocomplete</code> attribute value of the <code>&lt;textarea&gt;</code> element's form owner. The form owner is either the {{HTMLElement("form")}} element that this <code>&lt;textarea&gt;</code> element is a descendant of or the form element whose <code>id</code> is specified by the <code>form</code> attribute of the input element. For more information, see the {{htmlattrxref("autocomplete", "form")}} attribute in {{HTMLElement("form")}}.</p>
  </dd>
+ <dt>{{ htmlattrdef("autocorrect") }} {{non-standard_inline}}</dt>
+ <dd>A Safari extension, the <code>autocorrect</code> attribute is a string which indicates whether or not to activate automatic correction while the user is editing this field. Permitted values are:</p></dd>
+ <dl>
+  <dt><code>on</code></dt>
+  <dd>Enable automatic correction of typos, as well as processing of text substitutions if any are configured.</dd>
+  <dt><code>off</code></dt>
+  <dd>Disable automatic correction and text substitutions.</dd>
+ </dl>
  <dt>{{ htmlattrdef("autofocus") }}</dt>
  <dd>This Boolean attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified.</dd>
  <dt>{{ htmlattrdef("cols") }}</dt>

--- a/files/en-us/web/html/element/textarea/index.html
+++ b/files/en-us/web/html/element/textarea/index.html
@@ -55,12 +55,12 @@ tags:
  <p>If the <code>autocomplete</code> attribute is not specified on a <code>&lt;textarea&gt;</code> element, then the browser uses the <code>autocomplete</code> attribute value of the <code>&lt;textarea&gt;</code> element's form owner. The form owner is either the {{HTMLElement("form")}} element that this <code>&lt;textarea&gt;</code> element is a descendant of or the form element whose <code>id</code> is specified by the <code>form</code> attribute of the input element. For more information, see the {{htmlattrxref("autocomplete", "form")}} attribute in {{HTMLElement("form")}}.</p>
  </dd>
  <dt>{{ htmlattrdef("autocorrect") }} {{non-standard_inline}}</dt>
- <dd>A Safari extension, the <code>autocorrect</code> attribute is a string which indicates whether or not to activate automatic correction while the user is editing this field. Permitted values are:</p></dd>
+ <dd>A string which indicates whether or not to activate automatic spelling correction and processing of text substitutions (if any are configured) while the user is editing this <code>textarea</code>. Permitted values are:</p></dd>
  <dl>
   <dt><code>on</code></dt>
-  <dd>Enable automatic correction of typos, as well as processing of text substitutions if any are configured.</dd>
+  <dd>Enable automatic spelling correction and text substitutions.</dd>
   <dt><code>off</code></dt>
-  <dd>Disable automatic correction and text substitutions.</dd>
+  <dd>Disable automatic spelling correction and text substitutions.</dd>
  </dl>
  <dt>{{ htmlattrdef("autofocus") }}</dt>
  <dd>This Boolean attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified.</dd>


### PR DESCRIPTION
You can test this affirmation on https://codepen.io/oliviertassinari/pen/wvoqYoY, here the outcome after you type `<im`.

<img width="318" alt="Screenshot 2021-02-20 at 20 10 58" src="https://user-images.githubusercontent.com/3165635/108606021-d6823900-73b7-11eb-8546-213c4ee6f30b.png">

```html
<textarea></textarea>
<textarea autocorrect="off"></textarea>
```

On Safari 12, iOS 14.4.

I have used the description used in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocorrect.