### PR TITLE
Fix formatting in fetch Response doc

### DIFF
--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -111,13 +111,13 @@ fetch('flowers.jpg')
 
 <pre class="brush: js">// Function to do an Ajax call
 const doAjax = async () =&gt; {
-    const response = await fetch('Ajax.php'); // Generate the Response object
-    if (response.ok) {
-        const jsonValue = await response.json(); // Get JSON value from the response body
-        return Promise.resolve(jsonValue);
-    } else {
-        return Promise.reject('*** PHP file not found');
-    }
+  const response = await fetch('Ajax.php'); // Generate the Response object
+  if (response.ok) {
+    const jsonValue = await response.json(); // Get JSON value from the response body
+    return Promise.resolve(jsonValue);
+  } else {
+    return Promise.reject('*** PHP file not found');
+  }
 }
 
 // Call the function and output value or error message to console

--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -94,9 +94,9 @@ tags:
 <p>You'll notice that since we are requesting an image, we need to run {{domxref("Body.blob")}} ({{domxref("Response")}} implements Body) to give the response its correct MIME type.</p>
 
 <pre class="brush: js">const image = document.querySelector('.my-image');
-fetch('flowers.jpg').then((response) =&gt; {
-  return response.blob();
-}).then((blob) =&gt; {
+fetch('flowers.jpg')
+.then(response =&gt; response.blob())
+.then(blob =&gt; {
   const objectURL = URL.createObjectURL(blob);
   image.src = objectURL;
 });</pre>

--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -94,9 +94,9 @@ tags:
 <p>You'll notice that since we are requesting an image, we need to run {{domxref("Body.blob")}} ({{domxref("Response")}} implements Body) to give the response its correct MIME type.</p>
 
 <pre class="brush: js">const image = document.querySelector('.my-image');
-fetch('flowers.jpg').then(function(response) {
+fetch('flowers.jpg').then((response) =&gt; {
   return response.blob();
-}).then(function(blob) {
+}).then((blob) =&gt; {
   const objectURL = URL.createObjectURL(blob);
   image.src = objectURL;
 });</pre>
@@ -113,10 +113,9 @@ fetch('flowers.jpg').then(function(response) {
 const doAjax = async () =&gt; {
     const response = await fetch('Ajax.php'); // Generate the Response object
     if (response.ok) {
-        const jVal = await response.json(); // Get JSON value from the response body
-        return Promise.resolve(jVal);
-        }
-    else {
+        const jsonValue = await response.json(); // Get JSON value from the response body
+        return Promise.resolve(jsonValue);
+    } else {
         return Promise.reject('*** PHP file not found');
     }
 }


### PR DESCRIPTION
Formatting fixes and cleanup
- changed a semi-brackets location
- renamed `jVal` to `jsonValue` for clarity
- changed anonymous functions to be arrow functions for consistent syntax