### PR TITLE
Restore headlines by removing escaped HTML entites.

### DIFF
--- a/files/en-us/web/html/attributes/crossorigin/index.html
+++ b/files/en-us/web/html/attributes/crossorigin/index.html
@@ -85,19 +85,19 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="&lt;script_crossorigin&gt;">&lt;script crossorigin&gt;</h3>
+<h3 id="script_crossorigin">script crossorigin</h3>
 
 <p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.script.crossorigin")}}</p>
 
-<h3 id="&lt;video_crossorigin&gt;">&lt;video crossorigin&gt;</h3>
+<h3 id="video_crossorigin">video crossorigin</h3>
 
 <p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.video.crossorigin")}}</p>
 
-<h3 id="&lt;link_crossorigin&gt;">&lt;link crossorigin&gt;</h3>
+<h3 id="link_crossorigin">link crossorigin</h3>
 
 <p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 


### PR DESCRIPTION
I noticed this while looking into #1916.

As far as I could determine, it's the only occurence with this bug.
Previously, the `video crossorigin` rendered a `<video>` tag inside the headline.
(The other headlines had interpreted elements, too).

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>