### PR TITLE
Fixed broken links related to XPath

### DIFF
--- a/files/en-us/web/xpath/axes/index.html
+++ b/files/en-us/web/xpath/axes/index.html
@@ -8,9 +8,9 @@ tags:
   - XSLT
   - XSLT_Reference
 ---
-<p>{{ XsltRef() }} There are thirteen different axes in the <a href="/en-US/docs/Web/XPath">XPath</a> specification. An axis represents a relationship to the context node, and is used to locate nodes relative to that node on the tree. The following is an extremely brief description of the thirteen available axes and the degree of support available in <a href="/en/Gecko">Gecko</a>.</p>
+<p>{{ XsltRef() }} There are thirteen different axes in the <a href="/en-US/docs/Web/XPath">XPath</a> specification. An axis represents a relationship to the context node, and is used to locate nodes relative to that node on the tree.</p>
 
-<p>For further information on using XPath expressions, please see the <a href="/en/Transforming_XML_with_XSLT/For_Further_Reading">For Further Reading</a> section at the end of <a href="/en/Transforming_XML_with_XSLT">Transforming XML with XSLT</a> document. Also see the <a href="https://www.w3.org/TR/xpath-30/#axes">'axes' section in the xpath spec</a>.</p>
+<p>For further information on using XPath expressions, please see the <a href="/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT">For Further Reading</a> section at the end of <a href="/en-US/Transforming_XML_with_XSLT">Transforming XML with XSLT</a> document. Also see the <a href="https://www.w3.org/TR/xpath-30/#axes">'axes' section in the xpath spec</a>.</p>
 
 
 <dl>

--- a/files/en-us/web/xpath/comparison_with_css_selectors/index.html
+++ b/files/en-us/web/xpath/comparison_with_css_selectors/index.html
@@ -31,15 +31,15 @@ tags:
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/XPath/Axes/child"><code>child</code></a> axis</td>
-   <td><a href="/en-US/docs/Web/CSS/Child_selectors">Child combinator</a></td>
+   <td><a href="/en-US/docs/Web/CSS/Child_combinator">Child combinator</a></td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/XPath/Axes/descendant"><code>descendant</code></a> axis</td>
-   <td><a href="/en-US/docs/Web/CSS/Descendant_selectors">Descendant combinator</a></td>
+   <td><a href="/en-US/docs/Web/CSS/Descendant_combinator">Descendant combinator</a></td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/XPath/Axes/following-sibling"><code>following-sibling</code></a> axis</td>
-   <td><a href="/en-US/docs/Web/CSS/General_sibling_selectors">General sibling combinator</a> or <a href="/en-US/docs/Web/CSS/Adjacent_sibling_selectors">adjacent sibling combinator</a></td>
+   <td><a href="/en-US/docs/Web/CSS/General_sibling_combinator">General sibling combinator</a> or <a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">adjacent sibling combinator</a></td>
   </tr>
   <tr>
    <td><a href="/en-US/docs/Web/XPath/Axes/self"><code>self</code></a> axis</td>

--- a/files/en-us/web/xpath/functions/format-number/index.html
+++ b/files/en-us/web/xpath/functions/format-number/index.html
@@ -23,7 +23,7 @@ tags:
  <dt><code><em>pattern</em></code></dt>
  <dd>A string in the format of the <a href="http://java.sun.com/products/archive/jdk/1.1/">JDK 1.1</a> DecimalFormat class. (The documentation for JDK 1.1 is not available online. Here is the <a href="http://java.sun.com/javase/6/docs/api/java/text/DecimalFormat.html">Java SE 6 DecimalFormat</a>.)</dd>
  <dt><code><em>decimal-format</em></code> (optional)</dt>
- <dd>The name of an <code><a href="/en-US/XSLT/decimal-format"> xsl:decimal-format</a></code> element that defines the number format to be used. If omitted, the default decimal-format will be used.</dd>
+ <dd>The name of an <code><a href="/en-US/docs/Web/XSLT/Element/decimal-format">xsl:decimal-format</a></code> element that defines the number format to be used. If omitted, the default decimal-format will be used.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>

--- a/files/en-us/web/xpath/functions/index.html
+++ b/files/en-us/web/xpath/functions/index.html
@@ -8,7 +8,7 @@ tags:
   - XSLT
   - XSLT_Reference
 ---
-<p>{{ XsltRef() }} The following is an annotated list of core <a href="/en-US/docs/Web/XPath">XPath</a> functions and <a href="/en/XSLT">XSLT</a>-specific additions to XPath, including a description, syntax, a list of arguments, result-type, source in the appropriate W3C Recommendation, and degree of present <a href="/en/Gecko">Gecko</a> support. For further information on using XPath/XSLT functions, please see the <a href="/en/Transforming_XML_with_XSLT/For_Further_Reading">For Further Reading</a> page.</p>
+<p>{{ XsltRef() }} The following is an annotated list of core <a href="/en-US/docs/Web/XPath">XPath</a> functions and <a href="/en-US/XSLT">XSLT</a>-specific additions to XPath, including a description, syntax, a list of arguments, result-type, source in the appropriate W3C Recommendation. For further information on using XPath/XSLT functions, please see the <a href="/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT">For Further Reading</a> page.</p>
 
 <ul>
  <li><a href="/en-US/docs/Web/XPath/Functions/boolean">boolean()</a></li>
@@ -25,7 +25,7 @@ tags:
  <li><a href="/en-US/docs/Web/XPath/Functions/format-number">format-number()</a> <em>XSLT-specific</em></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/function-available">function-available()</a></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/generate-id">generate-id()</a> <em>XSLT-specific</em></li>
- <li><a href="/en-US/docs/Web/XPath/Functions/id">id()</a> <em>(partially supported)</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/id">id()</a></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/key">key()</a> <em>XSLT-specific</em></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/lang">lang()</a></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/last">last()</a></li>
@@ -47,7 +47,7 @@ tags:
  <li><a href="/en-US/docs/Web/XPath/Functions/system-property">system-property()</a> <em>XSLT-specific</em></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/translate">translate()</a></li>
  <li><a href="/en-US/docs/Web/XPath/Functions/true">true()</a></li>
- <li><a href="/en-US/docs/Web/XPath/Functions/unparsed-entity-url">unparsed-entity-url()</a> <em>XSLT-specific</em> <em>(not supported)</em></li>
+ <li><a href="/en-US/docs/Web/XPath/Functions/unparsed-entity-url">unparsed-entity-url()</a> <em>XSLT-specific</em></li>
 </ul>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/XPath")}}</p>

--- a/files/en-us/web/xpath/functions/key/index.html
+++ b/files/en-us/web/xpath/functions/key/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt><code><em>keyname</em></code></dt>
- <dd>A string containing the name of the <code><a href="/en-US/XSLT/key"> xsl:key</a></code> element to be used.</dd>
+ <dd>A string containing the name of the <code><a href="/en-US/docs/Web/XSLT/Element/key">xsl:key</a></code> element to be used.</dd>
  <dt><code><em>value</em></code></dt>
  <dd>The returned node-set will contain every node that has this value for the given key.</dd>
 </dl>
@@ -31,7 +31,7 @@ tags:
 <h3 id="Notes">Notes</h3>
 
 <ul>
- <li>The <code><a href="/en-US/XSLT/key"> xsl:key</a></code> element defines what attribute on what given elements will be used to match the key.</li>
+ <li>The <code><a href="/en-US/docs/Web/XSLT/Element/key">xsl:key</a></code> element defines what attribute on what given elements will be used to match the key.</li>
 </ul>
 
 <p>This function is an XSLT-specific addition to XPath. It is not a part of the core XPath function library.</p>

--- a/files/en-us/web/xpath/functions/last/index.html
+++ b/files/en-us/web/xpath/functions/last/index.html
@@ -22,7 +22,7 @@ tags:
 <h3 id="Notes">Notes</h3>
 
 <ul>
- <li>This is often used with the <a href="/en-US/XPath/Functions/position"> position()</a> function to determine if a particular node is the last in a node-set.</li>
+ <li>This is often used with the <a href="/en-US/docs/Web/XPath/Functions/position"> position()</a> function to determine if a particular node is the last in a node-set.</li>
 </ul>
 
 <h3 id="Defined">Defined</h3>

--- a/files/en-us/web/xpath/functions/number/index.html
+++ b/files/en-us/web/xpath/functions/number/index.html
@@ -31,7 +31,7 @@ tags:
 <ul>
  <li>Strings are converted to a number by stripping the leading whitespace in the string before the number and ignoring whitespace after the number. If the string does not match this pattern, then the string is converted to NaN.</li>
  <li>Boolean true is converted to 1. False is converted to 0.</li>
- <li>A node-set is first converted to a string as if by a call to the <a href="/en-US/XPath/Functions/string">string()</a> function and then converted in the same way as a string argument.</li>
+ <li>A node-set is first converted to a string as if by a call to the <a href="/en-US/docs/Web/XPath/Functions/string">string()</a> function and then converted in the same way as a string argument.</li>
  <li>An object of a type other than the four basic types is converted to a number in a way that is dependent on that type.</li>
 </ul>
 

--- a/files/en-us/web/xpath/functions/sum/index.html
+++ b/files/en-us/web/xpath/functions/sum/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt><em><code>node-set</code></em></dt>
- <dd>The node-set to be evaluated. Each node in this node-set is evaluated as if it were passed to the <a href="/en-US/XPath/Functions/number">number()</a> function, and a sum of the resulting numbers is returned.</dd>
+ <dd>The node-set to be evaluated. Each node in this node-set is evaluated as if it were passed to the <a href="/en-US/docs/Web/XPath/Functions/number">number()</a> function, and a sum of the resulting numbers is returned.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>

--- a/files/en-us/web/xpath/index.html
+++ b/files/en-us/web/xpath/index.html
@@ -38,10 +38,8 @@ tags:
  <dd>XSLT uses XPath to address code segments in an XML document that it wishes to transform.</dd>
  <dt><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></dt>
  <dd>These are JavaScript utility functions, that can be used in your own code, based on  <a class="external external-icon" href="https://www.w3.org/TR/DOM-Level-3-XPath/">DOM Level 3 XPath </a>APIs.</dd>
- <dt><a href="http://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></dt>
+ <dt><a href="https://www.xml.com/pub/a/2000/08/holman/">What is XSLT?</a></dt>
  <dd>This extensive introduction to XSLT and XPath assumes no prior knowledge of the technologies, and guides the reader through background, context, structure, concepts, and introductory terminology.</dd>
- <dt><a href="/en-US/docs/JXON">JXON</a></dt>
- <dd><strong>JXON</strong> (lossless <strong>J</strong>avaScript <strong>X</strong>ML <strong>O</strong>bject <strong>N</strong>otation) is a generic name by which is defined the representation of JavaScript Objects using <a href="/en-US/XML">XML</a>. There are some cases in which the whole content of an XML document must be read from the JavaScript interpreter (like for web-apps languages or settings XML documents, for example). In these cases JXON could represent the most practical way and valid alternative to XPath.</dd>
 </dl>
 
 </div>
@@ -61,7 +59,7 @@ tags:
 <h2 id="Related_Topics">Related Topics</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/XSLT">XSLT</a>, <a href="/en-US/docs/XQuery">XQuery</a>, <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/en-US/docs/JXON">JXON</a>, <a href="/en-US/docs/JSON/JSONPath">JSONPath</a></li>
+ <li><a href="/en-US/docs/Web/XSLT">XSLT</a>, <a href="/en-US/docs/Web/XML">XML</a>, <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a></li>
  <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li>
 </ul>
 </div>

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.html
@@ -12,27 +12,27 @@ tags:
   - XPath
   - XSLT
 ---
-<p>This document describes the interface for using <a href="/en-US/docs/XPath">XPath</a> in JavaScript internally, in extensions, and from websites. Mozilla implements a fair amount of the <a href="https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/">DOM 3 XPath</a>, which means that XPath expressions can be run against both HTML and XML documents.</p>
+<p>This document describes the interface for using <a href="/en-US/docs/Web/XPath">XPath</a> in JavaScript internally, in extensions, and from websites. Mozilla implements a fair amount of the <a href="https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/">DOM 3 XPath</a>, which means that XPath expressions can be run against both HTML and XML documents.</p>
 
-<p>The main interface to using XPath is the <a href="/en-US/docs/Web/API/document.evaluate">evaluate</a> function of the <a href="/en-US/docs/Web/API/document">document</a> object.</p>
+<p>The main interface to using XPath is the <a href="/en-US/docs/Web/API/Document/evaluate">evaluate</a> function of the <a href="/en-US/docs/Web/API/Document">document</a> object.</p>
 
 <h2 id="document.evaluate">document.evaluate</h2>
 
-<p>This method evaluates <a href="/en-US/docs/XPath">XPath</a> expressions against an <a href="/en-US/docs/Glossary/XML">XML</a> based document (including HTML documents), and returns a <code><a href="/en-US/docs/XPathResult">XPathResult</a></code> object, which can be a single node or a set of nodes. The existing documentation for this method is located at <a href="/en-US/docs/Web/API/Document.evaluate">document.evaluate</a>, but it is rather sparse for our needs at the moment; a more comprehensive examination will be given below.</p>
+<p>This method evaluates <a href="/en-US/docs/Web/XPath">XPath</a> expressions against an <a href="/en-US/docs/Glossary/XML">XML</a> based document (including HTML documents), and returns a <code><a href="/en-US/docs/Web/API/XPathResult">XPathResult</a></code> object, which can be a single node or a set of nodes. The existing documentation for this method is located at <a href="/en-US/docs/Web/API/Document/evaluate">document.evaluate</a>, but it is rather sparse for our needs at the moment; a more comprehensive examination will be given below.</p>
 
 <pre class="brush: js">var xpathResult = document.evaluate( xpathExpression, contextNode, namespaceResolver, resultType, result );
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
-<p>The <a href="/en-US/docs/Web/API/Document.evaluate">evaluate</a> function takes a total of five parameters:</p>
+<p>The <a href="/en-US/docs/Web/API/Document/evaluate">evaluate</a> function takes a total of five parameters:</p>
 
 <ul>
  <li><code>xpathExpression</code>: A string containing the XPath expression to be evaluated.</li>
- <li><code>contextNode</code>: A node in the document against which the <code>xpathExpression</code> should be evaluated, including any and all of its child nodes. The <a href="/en-US/docs/Web/API/document">document</a> node is the most commonly used.</li>
+ <li><code>contextNode</code>: A node in the document against which the <code>xpathExpression</code> should be evaluated, including any and all of its child nodes. The <a href="/en-US/docs/Web/API/Document">document</a> node is the most commonly used.</li>
  <li><code>namespaceResolver</code>: A function that will be passed any namespace prefixes contained within <code>xpathExpression</code> which returns a string representing the namespace URI associated with that prefix. This enables conversion between the prefixes used in the XPath expressions and the possibly different prefixes used in the document. The function can be either:
   <ul>
-   <li><a href="#implementing_a_default_namespace_resolver">Created</a> by using the <code><a href="/en-US/docs/Web/API/Document.createNSResolver">createNSResolver</a></code> method of a <code><a href="/en-US/docs/Using_XPath#Node-specific_evaluator_function">XPathEvaluator</a></code> object. You should use this virtually all of the time.</li>
+   <li><a href="#implementing_a_default_namespace_resolver">Created</a> by using the <code><a href="/en-US/docs/Web/API/Document/createNSResolver">createNSResolver</a></code> method of a <code><a href="/en-US/docs/Web/API/XPathEvaluator">XPathEvaluator</a></code> object. You should use this virtually all of the time.</li>
    <li><code>null</code>, which can be used for HTML documents or when no namespace prefixes are used. Note that, if the <code>xpathExpression</code> contains a namespace prefix, this will result in a <code>DOMException</code> being thrown with the code <code>NAMESPACE_ERR</code>.</li>
    <li>A custom user-defined function. See the <a href="#implementing_a_user_defined_namespace_resolver">Using a User Defined Namespace Resolver</a> section in the appendix for details.</li>
   </ul>
@@ -47,7 +47,7 @@ tags:
 
 <h3 id="Implementing_a_Default_Namespace_Resolver">Implementing a Default Namespace Resolver</h3>
 
-<p>We create a namespace resolver using the <code>createNSResolver</code> method of the <a href="/en-US/docs/Web/API/document">document</a> object.</p>
+<p>We create a namespace resolver using the <code>createNSResolver</code> method of the <a href="/en-US/docs/Web/API/Document">document</a> object.</p>
 
 <pre class="brush: js">var nsResolver = document.createNSResolver( contextNode.ownerDocument == null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
 </pre>
@@ -63,7 +63,7 @@ var nsResolver = xpEvaluator.createNSResolver( contextNode.ownerDocument == null
 
 <h3 id="Notes">Notes</h3>
 
-<p>Adapts any DOM node to resolve namespaces so that an <a href="/en-US/docs/XPath">XPath</a> expression can be easily evaluated relative to the context of the node where it appeared within the document. This adapter works like the DOM Level 3 method <code>lookupNamespaceURI</code> on nodes in resolving the <code>namespaceURI</code> from a given prefix using the current information available in the node's hierarchy at the time <code>lookupNamespaceURI</code> is called. Also correctly resolves the implicit <code>xml</code> prefix.</p>
+<p>Adapts any DOM node to resolve namespaces so that an <a href="/en-US/docs/Web/XPath">XPath</a> expression can be easily evaluated relative to the context of the node where it appeared within the document. This adapter works like the DOM Level 3 method <code>lookupNamespaceURI</code> on nodes in resolving the <code>namespaceURI</code> from a given prefix using the current information available in the node's hierarchy at the time <code>lookupNamespaceURI</code> is called. Also correctly resolves the implicit <code>xml</code> prefix.</p>
 
 <h3 id="Specifying_the_Return_Type">Specifying the Return Type</h3>
 
@@ -89,7 +89,7 @@ var nsResolver = xpEvaluator.createNSResolver( contextNode.ownerDocument == null
 
 <h5 id="Example">Example</h5>
 
-<p>The following uses the XPath expression <code><a href="/en-US/docs/XPath/Functions/count">count(//p)</a></code> to obtain the number of <code>&lt;p&gt;</code> elements in an HTML document:</p>
+<p>The following uses the XPath expression <code><a href="/en-US/docs/Web/XPath/Functions/count">count(//p)</a></code> to obtain the number of <code>&lt;p&gt;</code> elements in an HTML document:</p>
 
 <pre class="brush: js">var paragraphCount = document.evaluate( 'count(//p)', document, null, XPathResult.ANY_TYPE, null );
 
@@ -211,7 +211,7 @@ alert( 'The first phone number found is ' + firstPhoneNumber.singleNodeValue.tex
 
 <p>Notice that, since HTML does not have namespaces, we have passed <code>null</code> for the <code>namespaceResolver</code> parameter.</p>
 
-<p>Since we wish to search over the entire document for the headings, we have used the <a href="/en-US/docs/Web/API/document">document</a> object itself as the <code>contextNode</code>.</p>
+<p>Since we wish to search over the entire document for the headings, we have used the <a href="/en-US/docs/Web/API/Document">document</a> object itself as the <code>contextNode</code>.</p>
 
 <p>The result of this expression is an <code>XPathResult</code> object. If we wish to know the type of result returned, we may evaluate the <code>resultType</code> property of the returned object. In this case, that will evaluate to <code>4</code>, an <code>UNORDERED_NODE_ITERATOR_TYPE</code>. This is the default return type when the result of the XPath expression is a node set. It provides access to a single node at a time and may not return nodes in a particular order. To access the returned nodes, we use the <code>iterateNext()</code> method of the returned object:</p>
 
@@ -277,7 +277,7 @@ var personIterator = xmlDoc.evaluate('//person', xmlDoc, nsResolver, XPathResult
 <pre>'//xhtml:td/mathml:math'
 </pre>
 
-<p>will select all <a href="/en-US/docs/Web/API/MathML">MathML</a> expressions that are the children of (X)HTML table data cell elements.</p>
+<p>will select all <a href="/en-US/docs/Web/MathML">MathML</a> expressions that are the children of (X)HTML table data cell elements.</p>
 
 <p>In order to associate the '<code>mathml:</code>' prefix with the namespace URI '<code>http://www.w3.org/1998/Math/MathML</code>' and '<code>xhtml:</code>' with the URI '<code>http://www.w3.org/1999/xhtml</code>' we provide a function:</p>
 
@@ -329,7 +329,7 @@ doc.evaluate('//myns:entry', doc, resolver, XPathResult.ANY_TYPE, null)
 
 <p>If one wishes to provide flexibility in namespaces (as they are intended) by not necessarily requiring a particular prefix to be used when finding a namespaced element or attribute, one must use special techniques.</p>
 
-<p>While one can adapt the approach in the above section to test for namespaced elements regardless of the prefix chosen (using <code><a href="/en-US/docs/XPath/Functions/local-name">local-name()</a></code> in combination with <code><a href="/en-US/docs/XPath/Functions/namespace-uri">namespace-uri()</a></code> instead of <code><a href="/en-US/docs/XPath/Functions/name">name()</a></code>), a more challenging situation occurs, however, if one wishes to grab an element with a particular namespaced attribute in a predicate (given the absence of implementation-independent variables in XPath 1.0).</p>
+<p>While one can adapt the approach in the above section to test for namespaced elements regardless of the prefix chosen (using <code><a href="/en-US/docs/Web/XPath/Functions/local-name">local-name()</a></code> in combination with <code><a href="/en-US/docs/Web/XPath/Functions/namespace-uri">namespace-uri()</a></code> instead of <code><a href="/en-US/docs/Web/XPath/Functions/name">name()</a></code>), a more challenging situation occurs, however, if one wishes to grab an element with a particular namespaced attribute in a predicate (given the absence of implementation-independent variables in XPath 1.0).</p>
 
 <p>For example, one might try (incorrectly) to grab an element with a namespaced attribute as follows: <code>var xpathlink = someElements[local-name(@*)="href" and namespace-uri(@*)='http://www.w3.org/1999/xlink'];</code></p>
 

--- a/files/en-us/web/xpath/snippets/index.html
+++ b/files/en-us/web/xpath/snippets/index.html
@@ -39,18 +39,18 @@ function evaluateXPath(aNode, aExpr) {
   var xpe = aNode.ownerDocument || aNode;
 </pre>
 
-<p>In that case the creation of the <a href="/en-US/docs/DOM/document.createNSResolver">XPathNSResolver</a> can be simplified as:</p>
+<p>In that case the creation of the <a href="/en-US/docs/Web/API/Document/createNSResolver">XPathNSResolver</a> can be simplified as:</p>
 
 <pre class="brush: js">  var nsResolver = xpe.createNSResolver(xpe.documentElement);
 </pre>
 
-<p>Note however that <code>createNSResolver</code> should only be used if you are sure the namespace prefixes in the XPath expression match those in the document you want to query (and that no default namespace is being used (though see <a href="/en-US/docs/DOM/document.createNSResolver">document.createNSResolver</a> for a workaround)). Otherwise, you have to provide your own implementation of XPathNSResolver.</p>
+<p>Note however that <code>createNSResolver</code> should only be used if you are sure the namespace prefixes in the XPath expression match those in the document you want to query (and that no default namespace is being used (though see <a href="/en-US/docs/Web/API/Document/createNSResolver">document.createNSResolver</a> for a workaround)). Otherwise, you have to provide your own implementation of XPathNSResolver.</p>
 
-<p>If you are using <a href="/en/XMLHttpRequest">XMLHttpRequest</a> to read a local or remote XML file into a DOM tree (as described in <a href="/en/Parsing_and_serializing_XML">Parsing and serializing XML</a>), the first argument to <code>evaluateXPath()</code> should be <code>req.responseXML</code>.</p>
+<p>If you are using <a href="/en-US/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a> to read a local or remote XML file into a DOM tree (as described in <a href="/en-US/docs/Web/Guide/Parsing_and_serializing_XML">Parsing and serializing XML</a>), the first argument to <code>evaluateXPath()</code> should be <code>req.responseXML</code>.</p>
 
 <h4 id="Sample_usage">Sample usage</h4>
 
-<p>Assume we have the following XML document (see also <a href="/en/How_to_create_a_DOM_tree">How to Create a DOM tree</a> and <a href="/en/Parsing_and_serializing_XML">Parsing and serializing XML</a>):</p>
+<p>Assume we have the following XML document (see also <a href="/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree">How to Create a DOM tree</a> and <a href="/en-US/docs/Web/Guide/Parsing_and_serializing_XML">Parsing and serializing XML</a>):</p>
 
 <h5 id="Example_An_XML_document_to_use_with_the_custom_evaluateXPath()_utility_function">Example: An XML document to use with the custom <code>evaluateXPath()</code> utility function </h5>
 
@@ -91,7 +91,7 @@ alert(results.length);
 
 <h3 id="docEvaluateArray">docEvaluateArray</h3>
 
-<p>The following is a simple utility function to get (ordered) XPath results into an array, regardless of whether there is a special need for namespace resolvers, etc. It avoids the more complex syntax of <code><a href="/en-US/docs/DOM/document.evaluate">document.evaluate()</a></code> for cases when it is not required as well as the need to use the special iterators on <code><a href="/en-US/docs/Web/XPathResult">XPathResult</a></code> (by returning an array instead).</p>
+<p>The following is a simple utility function to get (ordered) XPath results into an array, regardless of whether there is a special need for namespace resolvers, etc. It avoids the more complex syntax of <code><a href="/en-US/docs/Web/API/Document/evaluate">document.evaluate()</a></code> for cases when it is not required as well as the need to use the special iterators on <code><a href="/en-US/docs/Web/API/XPathResult">XPathResult</a></code> (by returning an array instead).</p>
 
 <h5 id="Example_Defining_a_simple_docEvaluateArray()_utility_function">Example: Defining a simple <code>docEvaluateArray()</code> utility function</h5>
 


### PR DESCRIPTION
This fixes the broken links I found on all the XPath pages.

Note that while XPath is strongly related to XSLT and links to it in many different places, this patch _only_ covers the pages directly related to XPath to keep the patch small. Broken links on XSLT pages will be handled in their own patch.

Also, the patch doesn't touch the other contents related to XPath, though they should get updated and get some BCD info at some point.