### PR TITLE
Correct part of the accesskey attribute doc

### DIFF
--- a/files/en-us/web/html/global_attributes/accesskey/index.html
+++ b/files/en-us/web/html/global_attributes/accesskey/index.html
@@ -52,7 +52,7 @@ tags:
   </tr>
   <tr>
    <th>Google Chrome</th>
-   <td style="text-align: center;"><kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd><em>key</em></kbd></td>
+   <td style="text-align: center;"><kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
   </tr>
   <tr>
    <th>Safari</th>


### PR DESCRIPTION
This fixes typo in the page . This commit is to address issue fix #2565 . 