### PR TITLE
Split fullscreenElement to avoid having mixin page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1944,7 +1944,7 @@
 /en-US/docs/DOM/document.location	/en-US/docs/Web/API/Document/location
 /en-US/docs/DOM/document.mozCancelFullScreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/DOM/document.mozFullScreen	/en-US/docs/Web/API/Document/fullscreen
-/en-US/docs/DOM/document.mozFullScreenElement	/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement
+/en-US/docs/DOM/document.mozFullScreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/DOM/document.mozFullScreenEnabled	/en-US/docs/Web/API/Document/fullscreenEnabled
 /en-US/docs/DOM/document.mozSetImageElement	/en-US/docs/Web/API/Document/mozSetImageElement
 /en-US/docs/DOM/document.mozSyntheticDocument	/en-US/docs/Web/API/Document/mozSyntheticDocument
@@ -3312,7 +3312,7 @@
 /en-US/docs/Document_Object_Model_(DOM)/document.location	/en-US/docs/Web/API/Document/location
 /en-US/docs/Document_Object_Model_(DOM)/document.mozCancelFullScreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Document_Object_Model_(DOM)/document.mozFullScreen	/en-US/docs/Web/API/Document/fullscreen
-/en-US/docs/Document_Object_Model_(DOM)/document.mozFullScreenElement	/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement
+/en-US/docs/Document_Object_Model_(DOM)/document.mozFullScreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/Document_Object_Model_(DOM)/document.mozFullScreenEnabled	/en-US/docs/Web/API/Document/fullscreenEnabled
 /en-US/docs/Document_Object_Model_(DOM)/document.mozSetImageElement	/en-US/docs/Web/API/Document/mozSetImageElement
 /en-US/docs/Document_Object_Model_(DOM)/document.mozSyntheticDocument	/en-US/docs/Web/API/Document/mozSyntheticDocument
@@ -7522,13 +7522,12 @@
 /en-US/docs/Web/API/Document/elementFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot/elementFromPoint
 /en-US/docs/Web/API/Document/elementsFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot/elementsFromPoint
 /en-US/docs/Web/API/Document/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
-/en-US/docs/Web/API/Document/fullscreenElement	/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement
 /en-US/docs/Web/API/Document/getAnimations	/en-US/docs/Web/API/DocumentOrShadowRoot/getAnimations
 /en-US/docs/Web/API/Document/getSelection	/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection
 /en-US/docs/Web/API/Document/inputEncoding	/en-US/docs/Web/API/document/characterSet
 /en-US/docs/Web/API/Document/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/Document/mozCancelFullScreen	/en-US/docs/Web/API/Document/exitFullscreen
-/en-US/docs/Web/API/Document/mozFullScreenElement	/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement
+/en-US/docs/Web/API/Document/mozFullScreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/Web/API/Document/mozFullScreenEnabled	/en-US/docs/Web/API/Document/fullscreenEnabled
 /en-US/docs/Web/API/Document/msElementsFromRect	/en-US/docs/Web/API/DocumentOrShadowRoot/msElementsFromRect
 /en-US/docs/Web/API/Document/namespaceURI	/en-US/docs/Web/API/Node/namespaceURI
@@ -7567,6 +7566,7 @@
 /en-US/docs/Web/API/DocumentFragment/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/DocumentFragment/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/DocumentOrShadowRoot/activeElement	/en-US/docs/Web/API/Document/activeElement
+/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/Web/API/DocumentOrShadowRoot/nodeFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot
 /en-US/docs/Web/API/DocumentOrShadowRoot/nodesFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot
 /en-US/docs/Web/API/DocumentOrShadowRoot/pictureInPictureEnabled	/en-US/docs/Web/API/DocumentOrShadowRoot/pictureInPictureElement
@@ -9318,7 +9318,7 @@
 /en-US/docs/Web/API/document.location	/en-US/docs/Web/API/Document/location
 /en-US/docs/Web/API/document.mozCancelFullScreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Web/API/document.mozFullScreen	/en-US/docs/Web/API/Document/fullscreen
-/en-US/docs/Web/API/document.mozFullScreenElement	/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement
+/en-US/docs/Web/API/document.mozFullScreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/Web/API/document.mozFullScreenEnabled	/en-US/docs/Web/API/Document/fullscreenEnabled
 /en-US/docs/Web/API/document.mozSetImageElement	/en-US/docs/Web/API/Document/mozSetImageElement
 /en-US/docs/Web/API/document.mozSyntheticDocument	/en-US/docs/Web/API/Document/mozSyntheticDocument

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -44371,29 +44371,6 @@
       "jpmedley"
     ]
   },
-  "Web/API/DocumentOrShadowRoot/fullscreenElement": {
-    "modified": "2020-10-15T21:03:34.946Z",
-    "contributors": [
-      "mfuji09",
-      "Sheppy",
-      "sideshowbarker",
-      "jpmedley",
-      "fscholz",
-      "chrisdavidmills",
-      "jabcreations",
-      "atpc",
-      "shivarajnaidu",
-      "Sebastianz",
-      "teoli",
-      "khanalom",
-      "MHasan",
-      "cvrebert",
-      "kscarfone",
-      "Reachmeatshivam",
-      "ziyunfei",
-      "ernestd"
-    ]
-  },
   "Web/API/DocumentOrShadowRoot/getAnimations": {
     "modified": "2020-12-13T19:52:52.030Z",
     "contributors": [
@@ -165875,6 +165852,29 @@
       "fscholz",
       "bede",
       "david_ross"
+    ]
+  },
+  "Web/API/Document/fullscreenElement": {
+    "modified": "2020-10-15T21:03:34.946Z",
+    "contributors": [
+      "mfuji09",
+      "Sheppy",
+      "sideshowbarker",
+      "jpmedley",
+      "fscholz",
+      "chrisdavidmills",
+      "jabcreations",
+      "atpc",
+      "shivarajnaidu",
+      "Sebastianz",
+      "teoli",
+      "khanalom",
+      "MHasan",
+      "cvrebert",
+      "kscarfone",
+      "Reachmeatshivam",
+      "ziyunfei",
+      "ernestd"
     ]
   }
 }

--- a/files/en-us/web/api/document/fullscreenchange_event/index.html
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.html
@@ -36,7 +36,7 @@ tags:
 
 <p>The event is sent to the <code>Element</code> that is transitioning into or out of full-screen mode, and this event then bubbles up to the <code>Document</code>.</p>
 
-<p>To find out whether the <code>Element</code> is entering or exiting full-screen mode, check the value of {{domxref("DocumentOrShadowRoot/fullscreenElement", "DocumentOrShadowRoot.fullscreenElement")}}: if this value is <code>null</code> then the element is exiting full-screen mode, otherwise it is entering full-screen mode.</p>
+<p>To find out whether the <code>Element</code> is entering or exiting full-screen mode, check the value of {{domxref("Document.fullscreenElement")}}: if this value is <code>null</code> then the element is exiting full-screen mode, otherwise it is entering full-screen mode.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/document/fullscreenelement/index.html
+++ b/files/en-us/web/api/document/fullscreenelement/index.html
@@ -1,10 +1,9 @@
 ---
-title: DocumentOrShadowRoot.fullscreenElement
+title: Document.fullscreenElement
 slug: Web/API/Document/fullscreenElement
 tags:
   - API
   - Document
-  - DocumentOrShadowRoot
   - Full-screen
   - Fullscreen API
   - Graphics
@@ -17,7 +16,7 @@ tags:
 <div>{{ApiRef("Fullscreen API")}}</div>
 
 <p><span class="seoSummary">The
-    <code><strong>DocumentOrShadowRoot.fullscreenElement</strong></code> read-only
+    <code><strong>Document.fullscreenElement</strong></code> read-only
     property returns the {{ domxref("Element") }} that is currently being presented in
     full-screen mode in this document, or <code>null</code> if full-screen mode is not
     currently in use.</span></p>
@@ -28,7 +27,7 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><var>var element</var> = <var>document</var>.fullscreenElement;</pre>
+  class="brush: js"><var>document</var>.fullscreenElement</pre>
 
 <h3 id="Return_value">Return value</h3>
 
@@ -58,23 +57,18 @@ tags:
   <thead>
     <tr>
       <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName("Fullscreen", "#dom-document-fullscreenelement",
-        "Document.fullscreenElement")}}</td>
-      <td>{{Spec2("Fullscreen")}}</td>
-      <td>Initial definition</td>
+      <td>{{SpecName("Fullscreen", "#dom-document-fullscreenelement", "Document.fullscreenElement")}}</td>
     </tr>
   </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentOrShadowRoot.fullscreenElement")}}</p>
+<p>{{Compat("api.Document.fullscreenElement")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fullscreenelement/index.html
+++ b/files/en-us/web/api/document/fullscreenelement/index.html
@@ -1,18 +1,18 @@
 ---
 title: DocumentOrShadowRoot.fullscreenElement
-slug: Web/API/DocumentOrShadowRoot/fullscreenElement
+slug: Web/API/Document/fullscreenElement
 tags:
-- API
-- Document
-- DocumentOrShadowRoot
-- Full-screen
-- Fullscreen API
-- Graphics
-- Property
-- Read-only
-- Reference
-- fullscreenElement
-- screen
+  - API
+  - Document
+  - DocumentOrShadowRoot
+  - Full-screen
+  - Fullscreen API
+  - Graphics
+  - Property
+  - Read-only
+  - Reference
+  - fullscreenElement
+  - screen
 ---
 <div>{{ApiRef("Fullscreen API")}}</div>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -50,6 +50,8 @@ tags:
  <dd>Returns the {{DOMxRef("FontFaceSet")}} interface of the current document.</dd>
  <dt>{{DOMxRef("Document.forms")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a list of the {{HTMLElement("form")}} elements within the current document.</dd>
+ <dt>{{DOMxRef("Document.fullscreenElement")}} {{ReadOnlyInline}}</dt>
+ <dd>The element that's currently in full screen mode for this document.</dd>
  <dt>{{DOMxRef("Document.head")}}{{ReadOnlyInline}}</dt>
  <dd>Returns the {{HTMLElement("head")}} element of the current document.</dd>
  <dt>{{DOMxRef("Document.hidden")}}{{ReadOnlyInline}}</dt>
@@ -118,8 +120,6 @@ tags:
 <p><em>The <code>Document</code> interface includes the following properties defined on the {{DOMxRef("DocumentOrShadowRoot")}} mixin. Note that this is currently only implemented by Chrome; other browsers still implement them directly on the {{DOMxRef("Document")}} interface.</em></p>
 
 <dl>
- <dt>{{DOMxRef("Document.fullscreenElement")}}{{ReadOnlyInline}}</dt>
- <dd>The element that's currently in full screen mode for this document.</dd>
  <dt>{{DOMxRef("DocumentOrShadowRoot.pointerLockElement")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns the element set as the target for mouse events while the pointer is locked. <code>null</code> if lock is pending, pointer is unlocked, or if the target is in another document.</dd>
  <dt>{{DOMxRef("DocumentOrShadowRoot.styleSheets")}}{{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/fullscreen_api/guide/index.html
+++ b/files/en-us/web/api/fullscreen_api/guide/index.html
@@ -72,8 +72,8 @@ if (elem.requestFullscreen) {
 <p>The {{DOMxRef("Document")}} provides some additional information that can be useful when developing fullscreen web applications:</p>
 
 <dl>
- <dt>{{DOMxRef("DocumentOrShadowRoot.fullscreenElement")}}</dt>
- <dd>The <code>fullscreenElement</code> property tells you the {{DOMxRef("Element")}} that's currently being displayed fullscreen. If this is non-null, the document is in fullscreen mode. If this is null, the document is not in fullscreen mode.</dd>
+ <dt>{{DOMxRef("Document.fullscreenElement")}} / {{DOMxRef("ShadowRoot.fullscreenElement")}}</dt>
+ <dd>The <code>fullscreenElement</code> property tells you the {{DOMxRef("Element")}} that's currently being displayed fullscreen. If this is non-null, the document (or shadow DOM) is in fullscreen mode. If this is null, the document (or shadow DOM) is not in fullscreen mode.</dd>
  <dt>{{DOMxRef("Document.fullscreenEnabled")}}</dt>
  <dd>The <code>fullscreenEnabled</code> property tells you whether or not the document is currently in a state that would allow fullscreen mode to be requested.</dd>
 </dl>
@@ -150,7 +150,7 @@ if (elem.requestFullscreen) {
    <td><code>msFullscreenEnabled</code></td>
   </tr>
   <tr>
-   <th scope="row">{{DOMxRef("DocumentOrShadowRoot.fullscreenElement")}}</th>
+   <th scope="row">{{DOMxRef("Document.fullscreenElement")}}</th>
    <td><code>webkitFullscreenElement</code></td>
    <td><code>mozFullScreenElement</code></td>
    <td><code>msFullscreenElement</code></td>

--- a/files/en-us/web/api/fullscreen_api/index.html
+++ b/files/en-us/web/api/fullscreen_api/index.html
@@ -54,8 +54,8 @@ tags:
 <p><em>The {{DOMxRef("Document")}} interface provides properties that can be used to determine if full-screen mode is supported and available, and if full-screen mode is currently active, which element is using the screen.</em></p>
 
 <dl>
- <dt>{{DOMxRef("DocumentOrShadowRoot.fullscreenElement")}}</dt>
- <dd>The <code>fullscreenElement</code> property tells you the {{DOMxRef("Element")}} that's currently being displayed in full-screen mode on the DOM (or shadow DOM). If this is <code>null</code>, the document is not in full-screen mode.</dd>
+ <dt>{{DOMxRef("Document.fullscreenElement")}} / {{DOMxRef("ShadowRoot.fullscreenElement")}}</dt>
+ <dd>The <code>fullscreenElement</code> property tells you the {{DOMxRef("Element")}} that's currently being displayed in full-screen mode on the DOM (or shadow DOM). If this is <code>null</code>, the document (or shadow DOM) is not in full-screen mode.</dd>
  <dt>{{DOMxRef("document.fullscreenEnabled")}}</dt>
  <dd>The <code>fullscreenEnabled</code> property tells you whether or not it is possible to engage full-screen mode. This is <code>false</code> if full-screen mode is not available for any reason (such as the <code>"fullscreen"</code> feature not being allowed, or full-screen mode not being supported).</dd>
 </dl>
@@ -191,7 +191,7 @@ tags:
 
 <div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.DocumentOrShadowRoot.fullscreenElement")}}</p>
+<p>{{Compat("api.Document.fullscreenElement")}}</p>
 
 <h3 id="Document.fullscreenEnabled"><code>Document.fullscreenEnabled</code></h3>
 

--- a/files/en-us/web/api/shadowroot/fullscreenelement/index.html
+++ b/files/en-us/web/api/shadowroot/fullscreenelement/index.html
@@ -1,0 +1,55 @@
+---
+title: ShadowRoot.fullscreenElement
+slug: Web/API/ShadowRoot/fullscreenElement
+tags:
+- API
+- Property
+- Reference
+- ShadowRoot
+- Web Components
+- shadow dom
+---
+<div>{{APIRef("Shadow DOM")}}</div>
+
+<p>The <strong><code>fullscreenElement</code></strong> read-only property of the
+{{domxref("ShadowRoot")}} interface returns the element within the shadow tree that is currently displayed in full screen.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js"><var>shadowRoot</var>.fullscreenElement</pre>
+
+<h3 id="Value">Value</h3>
+
+<p>The {{domxref('Element')}} which is currently is displayed in full screen mode,
+or <code>null</code> if there is no full screen element.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">let customElem = document.querySelector('my-shadow-dom-element');
+let shadow = customElem.shadowRoot;
+let fullscreenElem = shadow.fullscreenElement;</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('HTML WHATWG','#dom-documentorshadowroot-fullscreenelement', 'fullscreenElement')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.ShadowRoot.fullscreenElement")}}</p>
+
+<h2>See also</h2>
+
+<ul>
+  <li>{{domxref("Document.fullscreenElement")}}</li>
+</ul>

--- a/files/en-us/web/api/shadowroot/index.html
+++ b/files/en-us/web/api/shadowroot/index.html
@@ -22,6 +22,8 @@ tags:
  <dd>Returns the {{domxref('Element')}} within the shadow tree that has focus.</dd>
  <dt>{{domxref("ShadowRoot.delegatesFocus")}} {{readonlyinline}} {{non-standard_inline}}</dt>
  <dd>Returns a boolean that indicates whether delegatesFocus was set when the shadow was attached (see {{domxref("Element.attachShadow()")}}).</dd>
+ <dt>{{DOMxRef("ShadowRoot.fullscreenElement")}} {{ReadOnlyInline}}</dt>
+ <dd>The element that's currently in full screen mode for this shadow tree.</dd>
  <dt>{{domxref("ShadowRoot.host")}} {{readonlyinline}}</dt>
  <dd>Returns a reference to the DOM element the <code>ShadowRoot</code> is attached to.</dd>
  <dt>{{domxref("ShadowRoot.innerHTML")}} {{non-standard_inline}}</dt>


### PR DESCRIPTION
Same story as https://github.com/mdn/content/pull/2395

Split things up to avoid the DocumentOrShadowRoot mixin page.