### PR TITLE
Fix list of accept values for FF66/72/88

### DIFF
--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -26,6 +26,8 @@ tags:
    <td>Firefox</td>
    <td>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8</code> (since Firefox 86)<br></p>
+    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (since Firefox 72)</p>
+    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (since Firefox 66)<br>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (since Firefox 65)</p>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (before)</p>
    </td>

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -78,7 +78,6 @@ tags:
   <tr>
    <td>Firefox</td>
    <td>
-     <p><code>image/avif,image/webp,*/*</code> (since Firefox 86)</p>
      <p><code>image/webp,*/*</code> (since Firefox 65)</p>
      <p><code>*/*</code> (since Firefox 47)</p>
      <p><code>image/png,image/*;q=0.8,*/*;q=0.5</code> (before)</p>

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -25,7 +25,6 @@ tags:
   <tr>
    <td>Firefox</td>
    <td>
-    <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8</code> (since Firefox 86)<br></p>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (since Firefox 72)</p>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (since Firefox 66)<br>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (since Firefox 65)</p>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/2581

Tried to fix this the other day but was missing this info. Essentially FF66 to FF72 had a regression where webp was missing from the accept header. This fixes that. 

Also removes the avif changes for FF86 which were removed at the last minute