### PR TITLE
Fix missing image guide for web designers link

### DIFF
--- a/files/en-us/web/media/formats/index.html
+++ b/files/en-us/web/media/formats/index.html
@@ -22,17 +22,14 @@ tags:
 
 <p><span class="seoSummary">This guide provides an overview of the media file types, {{Glossary("codec", "codecs")}}, and algorithms that may comprise media used on the web.</span> It also provides browser support information for various combinations of these, and suggestions for prioritization of formats, as well as which formats excel at specific types of content.</p>
 
-<div class="row topicpage-table">
-<div class="section">
-<h2 class="Documentation" id="References">References</h2>
+
+<h2 id="References">References</h2>
 
 <h3 id="Images">Images</h3>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Media/Formats/Image_types">Image file type and format guide</a></dt>
- <dd>Covers support of image file types and content formats across the major web browsers, as well as providing basic information about each type: benefits, limitations, and use cases of interest to web designers and developers.</dd>
- <dt><a href="/en-US/docs/Web/Media/Formats/Images_for_web_designers">Image file types for web designers</a></dt>
- <dd>Fundamental information about the various image file types that may be useful for web designers, including best practices and use cases for each type, and guidelines for choosing the right image file format for specific types of content.</dd>
+ <dd>A guide to the main image file types and content formats used on the Internet. This includes a high level overview of: browser support, benefits, and limitations, along with best-practice guidelines to help web designers choose the right image file format for specific types of content.</dd>
 </dl>
 
 <h3 id="Media_file_types_and_codecs">Media file types and codecs</h3>
@@ -49,9 +46,8 @@ tags:
  <dt><a href="/en-US/docs/Web/Media/Formats/WebRTC_codecs">Codecs used by WebRTC</a></dt>
  <dd><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a> doesn't use a container, but instead streams the encoded media itself from peer to peer using {{domxref("MediaStreamTrack")}} objects to represent each audio or video track. This guide discusses the codecs commonly used with WebRTC.</dd>
 </dl>
-</div>
 
-<div class="section">
+
 <h2 class="Documentation" id="Guides">Guides</h2>
 
 <h3 id="Concepts">Concepts</h3>
@@ -78,5 +74,3 @@ tags:
  <dt><a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a></dt>
  <dd>The Media Capabilities API lets you discover the encoding and decoding capabilities of the device your app or site is running on. This lets you make real-time decisions about what formats to use and when.</dd>
 </dl>
-</div>
-</div>


### PR DESCRIPTION
Fixes #2480 

- Cleans up some of the (unnecessary?) sectioning.
- Removes the link to "Image file types for web designers". This section does not exist, but more important, is covered by [Image file type and format guide](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#choosing_an_image_format). So I also updated the preceding point to make that clear. 