### PR TITLE
Adds ExtendableCookieChangeEvent

### DIFF
--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -32,7 +32,7 @@ tags:
   <dt><code>expires</code></dt>
   <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
   <dt><code>secure</code></dt>
-  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie is from a site with a secure context (HTTPS rather than HTTP).</dd>
   <dt><code>sameSite</code></dt>
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -10,15 +10,15 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns the cookie that has been changed by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been changed by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>obj</var> = <var>ExtendableCookieChangeEvent</var>.changed;</pre>
+<pre class="syntaxbox notranslate">var <var>array</var> = <var>ExtendableCookieChangeEvent</var>.changed;</pre>
 
 <h3>Value</h3>
 
-<p>An object containing the changed cookie. This object contains the following properties:</p>
+<p>An array of objects containing the changed cookie(s). Each object contains the following properties:</p>
 
 <dl>
   <dt><code>name</code></dt>
@@ -53,7 +53,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. It contains an object representing the cookie that has just been set.</p>
+<p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. The first item in that array contains an object representing the cookie that has just been set.</p>
 
 <pre class="brush:js">self.addEventListener('cookiechange', (event) => {
   console.log(event.changed[0]);

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -1,0 +1,91 @@
+---
+title: ExtendableCookieChangeEvent.changed
+slug: Web/API/ExtendableCookieChangeEvent/changed
+tags:
+  - API
+  - Property
+  - Reference
+  - changed
+  - ExtendableCookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>changed</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns the cookie that has been changed by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>obj</var> = <var>ExtendableCookieChangeEvent</var>.changed;</pre>
+
+<h3>Value</h3>
+
+<p>An object containing the changed cookie. This object contains the following properties:</p>
+
+<dl>
+  <dt><code>name</code></dt>
+  <dd>A {{domxref("USVString")}} containing the name of the cookie.</dd>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("USVString")}} containing the value of the cookie.</dd>
+  <dt><code>domain</code></dt>
+  <dd>A {{domxref("USVString")}} containing the domain of the cookie.</dd>
+  <dt><code>path</code></dt>
+  <dd>A {{domxref("USVString")}} containing the path of the cookie.</dd>
+  <dt><code>expires</code></dt>
+  <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
+  <dt><code>secure</code></dt>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
+  <dt><code>sameSite</code></dt>
+  <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
+    <dl>
+      <dt><code>"strict"</code></dt>
+      <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
+      <dt><code>"lax"</code></dt>
+      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
+      <dt><code>"none"</code></dt>
+      <dd>Cookies will be sent in all contexts.</dd>
+    </dl>
+
+    <div class="notecard note">
+      <h4>Note</h4>
+      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+    </div>
+  </dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. It contains an object representing the cookie that has just been set.</p>
+
+<pre class="brush:js">self.addEventListener('cookiechange', (event) => {
+  console.log(event.changed);
+});
+
+const one_day = 24 * 60 * 60 * 1000;
+cookieStore.set({
+  name: "cookie1",
+  value: "cookie1-value",
+  expires: Date.now() + one_day,
+  domain: "example.com"
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#dom-extendablecookiechangeevent-changed','ExtendableCookieChangeEvent.changed')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.ExtendableCookieChangeEvent.changed")}}</p>

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -56,7 +56,7 @@ tags:
 <p>In this example when the cookie is set, the event listener logs the <code>changed</code> property to the console. It contains an object representing the cookie that has just been set.</p>
 
 <pre class="brush:js">self.addEventListener('cookiechange', (event) => {
-  console.log(event.changed);
+  console.log(event.changed[0]);
 });
 
 const one_day = 24 * 60 * 60 * 1000;

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -32,7 +32,7 @@ tags:
   <dt><code>expires</code></dt>
   <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
   <dt><code>secure</code></dt>
-  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie is from a site with a secure context (HTTPS rather than HTTP).</dd>
   <dt><code>sameSite</code></dt>
   <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
     <dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -56,7 +56,7 @@ tags:
 <p>In this example when the cookie is deleted the event listener logs the <code>deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
 
 <pre class="brush:js">self.addEventListener('cookiechange', (event) => {
-  console.log(event.deleted);
+  console.log(event.deleted[0]);
 });</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -1,0 +1,83 @@
+---
+title: ExtendableCookieChangeEvent.deleted
+slug: Web/API/ExtendableCookieChangeEvent/deleted
+tags:
+  - API
+  - Property
+  - Reference
+  - deleted
+  - ExtendableCookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns the cookie that has been deleted by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox notranslate">var <var>obj</var> = <var>ExtendableCookieChangeEvent</var>.deleted;</pre>
+
+<h3>Value</h3>
+
+<p>An object containing the deleted cookie. This object contains the following properties:</p>
+
+<dl>
+  <dt><code>name</code></dt>
+  <dd>A {{domxref("USVString")}} containing the name of the cookie.</dd>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("USVString")}} containing the value of the cookie.</dd>
+  <dt><code>domain</code></dt>
+  <dd>A {{domxref("USVString")}} containing the domain of the cookie.</dd>
+  <dt><code>path</code></dt>
+  <dd>A {{domxref("USVString")}} containing the path of the cookie.</dd>
+  <dt><code>expires</code></dt>
+  <dd>A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.</dd>
+  <dt><code>secure</code></dt>
+  <dd>A {{jsxref("boolean")}} indicating whether the cookie from a site with a secure context (HTTPS rather than HTTP).</dd>
+  <dt><code>sameSite</code></dt>
+  <dd>One of the following <a href="/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite</a> values:
+    <dl>
+      <dt><code>"strict"</code></dt>
+      <dd>Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.</dd>
+      <dt><code>"lax"</code></dt>
+      <dd>Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link).</dd>
+      <dt><code>"none"</code></dt>
+      <dd>Cookies will be sent in all contexts.</dd>
+    </dl>
+
+    <div class="notecard note">
+      <h4>Note</h4>
+      <p>For more information on SameSite cookies see <a href="https://web.dev/samesite-cookies-explained/">SameSite cookies explained</a>.</p>
+    </div>
+  </dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example when the cookie is deleted the event listener logs the <code>ExtendableCookieChangeEvent.deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
+
+<pre class="brush:js">self.addEventListener('cookiechange', (event) => {
+  console.log(event.deleted);
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#dom-extendablecookiechangeevent-deleted','ExtendableCookieStoreManager.deleted')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.ExtendableCookieChangeEvent.deleted")}}</p>

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -53,7 +53,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is deleted the event listener logs the <code>ExtendableCookieChangeEvent.deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
+<p>In this example when the cookie is deleted the event listener logs the <code>deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
 
 <pre class="brush:js">self.addEventListener('cookiechange', (event) => {
   console.log(event.deleted);

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -10,15 +10,15 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns the cookie that has been deleted by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
+<p class="summary">The <strong><code>deleted</code></strong> read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been deleted by the given <code>ExtendableCookieChangeEvent</code> instance.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate">var <var>obj</var> = <var>ExtendableCookieChangeEvent</var>.deleted;</pre>
+<pre class="syntaxbox notranslate">var <var>array</var> = <var>ExtendableCookieChangeEvent</var>.deleted;</pre>
 
 <h3>Value</h3>
 
-<p>An object containing the deleted cookie. This object contains the following properties:</p>
+<p>An array of objects containing the deleted cookie(s). Each object contains the following properties:</p>
 
 <dl>
   <dt><code>name</code></dt>
@@ -53,7 +53,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example when the cookie is deleted the event listener logs the <code>deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
+<p>In this example when the cookie is deleted the event listener logs the first item in the <code>deleted</code> property to the console. It contains an object representing the cookie that has just been deleted.</p>
 
 <pre class="brush:js">self.addEventListener('cookiechange', (event) => {
   console.log(event.deleted[0]);

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -1,0 +1,55 @@
+---
+title: ExtendableCookieChangeEvent.ExtendableCookieChangeEvent()
+slug: Web/API/ExtendableCookieChangeEvent/ExtendableCookieChangeEvent
+tags:
+  - API
+  - Constructor
+  - Reference
+  - ExtendableCookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>ExtendableCookieChangeEvent()</code></strong> constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}}. This constructor is called by the browser when a change event occurs.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>ExtendableCookieChangeEvent</var> = new ExtendableCookieChangeEvent(<var>type</var>,<var>eventInitDict</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>type</code></dt>
+  <dd>A {{domxref("DOMString")}} with the value <code>"changed"</code> or <code>"deleted"</code>.</dd>
+  <dt><code>eventInitDict</code>{{Optional_Inline}}</dt>
+  <dd>An object containing:
+    <dl>
+      <dt><code>changed</code></dt>
+      <dd>An object containing a changed cookie.</dd>
+      <dt><code>deleted</code></dt>
+      <dd>An object containing a deleted cookie.</dd>
+    </dl>
+  </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#dom-extendablecookiechangeevent-extendablecookiechangeevent','ExtendableCookieChangeEvent()')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent")}}</p>

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -11,9 +11,9 @@ tags:
 
 <p class="summary">The <strong><code>ExtendableCookieChangeEvent()</code></strong> constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
-<div class=“notecard note”>
+<div class="notecard note">
   <h4>Note</h4>
-    <p>This event constructor is generally not needed for production web sites. It’s primary use is for tests that require an instance of this event.</p>
+    <p>This event constructor is generally not needed for production web sites. It's primary use is for tests that require an instance of this event.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -29,7 +29,7 @@ tags:
   <dd>An object containing:
     <dl>
       <dt><code>changed</code></dt>
-      <dd>An object containing a changed cookie.</dd>
+      <dd>An array containing a changed cookie.</dd>
       <dt><code>deleted</code></dt>
       <dd>An object containing a deleted cookie.</dd>
     </dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -31,7 +31,7 @@ tags:
       <dt><code>changed</code></dt>
       <dd>An array containing a changed cookie.</dd>
       <dt><code>deleted</code></dt>
-      <dd>An object containing a deleted cookie.</dd>
+      <dd>An array containing a deleted cookie.</dd>
     </dl>
   </dd>
 </dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">var <var>ExtendableCookieChangeEvent</var> = new ExtendableCookieChangeEvent(<var>type</var>,<var>eventInitDict</var>);</pre>
+<pre class="syntaxbox">var <var>extendableCookieChangeEvent</var> = new ExtendableCookieChangeEvent(<var>type</var>, [<var>eventInitDict</var>]);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -11,6 +11,11 @@ tags:
 
 <p class="summary">The <strong><code>ExtendableCookieChangeEvent()</code></strong> constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object which is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}}. This constructor is called by the browser when a change event occurs.</p>
 
+<div class=“notecard note”>
+  <h4>Note</h4>
+    <p>This event constructor is generally not needed for production web sites. It’s primary use is for tests that require an instance of this event.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>ExtendableCookieChangeEvent</var> = new ExtendableCookieChangeEvent(<var>type</var>,<var>eventInitDict</var>);</pre>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -37,7 +37,7 @@ tags:
 
 <dl>
   <dt>{{domxref("ExtendableCookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an object containing the changed cookie.</dd>
+  <dd>Returns an array containing the changed cookies.</dd>
   <dt>{{domxref("ExtendableCookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an array containing the deleted cookies.</dd>
 </dl>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p class="summary">The <strong><code>ExtendableCookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes have occured. A cookie change event consists of a cookie and a type (either "changed" or "deleted".)</p>
 
-<p>Cookie changes that will cause the <code>ExtendableCookieChangeEvent</code> to be dispatched are:</p>
+<p>Cookie changes that cause the <code>ExtendableCookieChangeEvent</code> to be dispatched are:</p>
 
 <ul>
   <li>A cookie is newly created and not immediately removed. In this case <code>type</code> is "changed".</li>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -44,7 +44,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the below example we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an <code>ExtendableCookieChangeEvent</code> object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.</p>
+<p>In the below example we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. (In service workers, a subscription is required in order to listen for events.) We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an <code>ExtendableCookieChangeEvent</code> object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.</p>
 
 <pre class="brush:js">self.addEventListener('activate', (event) => {
   event.waitUntil(async () => {

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -44,7 +44,6 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In service workers a subscription, associated with the service worker's registration, is required in order to listen for changes.</p>
 <p>In the below example we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an <code>ExtendableCookieChangeEvent</code> object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.</p>
 
 <pre class="brush:js">self.addEventListener('activate', (event) => {

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
-<p class="summary">The <strong><code>ExtendableCookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+<p class="summary">The <strong><code>ExtendableCookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes have occured. A cookie change event consists of a cookie and a type (either "changed" or "deleted".)</p>
 
 <p>Cookie changes that will cause the <code>ExtendableCookieChangeEvent</code> to be dispatched are:</p>
 

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -39,7 +39,7 @@ tags:
   <dt>{{domxref("ExtendableCookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an object containing the changed cookie.</dd>
   <dt>{{domxref("ExtendableCookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an object containing the deleted cookie.</dd>
+  <dd>Returns an array containing the deleted cookies.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -1,0 +1,88 @@
+---
+title: ExtendableCookieChangeEvent
+slug: Web/API/ExtendableCookieChangeEvent
+tags:
+  - API
+  - Interface
+  - Reference
+  - ExtendableCookieChangeEvent
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
+
+<p class="summary">The <strong><code>ExtendableCookieChangeEvent</code></strong> interface of the {{domxref('Cookie Store API')}} is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes have occured. A cookie change consists of a cookie and a type (either "changed" or "deleted".)</p>
+
+<p>Cookie changes that will cause the <code>ExtendableCookieChangeEvent</code> to be dispatched are:</p>
+
+<ul>
+  <li>A cookie is newly created and not immediately removed. In this case <code>type</code> is "changed".</li>
+  <li>A cookie is newly created and immediately removed. In this case <code>type</code> is "deleted"</li>
+  <li>A cookie is removed. In this case <code>type</code> is "deleted".</li>
+</ul>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.</p>
+</div>
+
+<h2 id="Constructor">Constructor</h2>
+
+<dl>
+  <dt>{{domxref("ExtendableCookieChangeEvent.ExtendableCookieChangeEvent()")}}</dt>
+  <dd>Creates a new <code>ExtendableCookieChangeEvent</code>.</dd>
+</dl>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>This interface also inherits properties from {{domxref("ExtendableEvent")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("ExtendableCookieChangeEvent.changed")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an object containing the changed cookie.</dd>
+  <dt>{{domxref("ExtendableCookieChangeEvent.deleted")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an object containing the deleted cookie.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In service workers a subscription, associated with the service worker's registration, is required in order to listen for changes.</p>
+<p>In the below example we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an <code>ExtendableCookieChangeEvent</code> object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.</p>
+
+<pre class="brush:js">self.addEventListener('activate', (event) => {
+  event.waitUntil(async () => {
+    const subscriptions = await self.registration.cookies.getSubscriptions();
+    await self.registration.cookies.unsubscribe(subscriptions);
+
+    await self.registration.cookies.subscribe([
+      {
+        name: 'COOKIE_NAME',
+      }
+    ]);
+  });
+});
+
+self.addEventListener('cookiechange', event => {
+  console.log(event);
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Cookie Store API','#ExtendableCookieChangeEvent','ExtendableCookieChangeEvent')}}</td>
+    <td>{{Spec2('Cookie Store API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.ExtendableCookieChangeEvent")}}</p>


### PR DESCRIPTION
This is the Service Worker version of `CookieChangeEvent` so it may require changed based on what we decide with that one.

https://wicg.github.io/cookie-store/#ExtendableCookieChangeEvent

Reviewer: @jpmedley 