### PR TITLE
Remove see also section

### DIFF
--- a/files/en-us/web/api/web_authentication_api/index.html
+++ b/files/en-us/web/api/web_authentication_api/index.html
@@ -249,8 +249,3 @@ navigator.credentials.create(createCredentialDefaultArgs)
 
 <p>{{Compat("api.PublicKeyCredentialRequestOptions")}}</p>
 
-<h2 id="See_also">See also</h2>
-
-<ul>
- <li><a href="https://secure.wphackedhelp.com/blog/wordpress-two-factor-authentication/">WordPress Two-Factor Authentication</a>, (2FA) is an additional layer of security you can add to your <em>WordPress</em> login page.</li>
-</ul>


### PR DESCRIPTION
This link doesn't seem related enough to warrant placement. 
The 2FA wordpress plugin in the link does not use the tech that this article is about, it is a completely different kind of 2FA.