### PR TITLE
Revise Auditing tools example

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.html
@@ -310,8 +310,8 @@ a:focus, input:focus, button:focus, select:focus {
 
 <ol>
  <li>Go to the <a href="http://wave.webaim.org/">Wave homepage</a>.</li>
- <li>Enter the URL of our <a href="https://mdn.github.io/learning-area/accessibility/html/bad-semantics.html">bad-semantics.html</a> example into the text input at the top of the page (or the URL of another webpage you'd like to analyze) and press <em>Analyse Your Webpage</em>.</li>
- <li>Check out the description of the accessibility problems on the results page (the icons you can click to see what problems are occurring where are rather useful).</li>
+ <li>Enter the URL of our <a href="https://mdn.github.io/learning-area/accessibility/html/bad-semantics.html">bad-semantics.html</a> example into the text input box near the top of the page. Then press enter or click/tap the arrow at the far right edge of the input box.</li>
+ <li>The site should respond with a description of the accessibility problems. Click the icons displayed to see more information about each of the issues identified by Wave's evaluation.</li>
 </ol>
 
 <div class="note">


### PR DESCRIPTION
revise copy for **Auditing tools** example using Wave

In the **Auditing tools** section, I noticed the [Wave website](https://wave.webaim.org/) changed in a way that required an update to the instructions for the example. I removed references to an _Analyse Your Website_ button that no longer exists and revised other related wording.