### PR TITLE
Drop CSP plugin-types spec reference & deprecate

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
@@ -12,7 +12,7 @@ tags:
   - Plugins
   - Security
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}}{{deprecated_header}}</div>
 
 <p>The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
   <code><strong>plugin-types</strong></code> directive restricts the set of plugins that
@@ -104,11 +104,6 @@ Content-Security-Policy: plugin-types &lt;type&gt;/&lt;subtype&gt; &lt;type&gt;/
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>{{specName("CSP 3.0", "#directive-plugin-types", "plugin-types")}}</td>
-      <td>{{Spec2('CSP 3.0')}}</td>
-      <td>No changes.</td>
-    </tr>
     <tr>
       <td>{{specName("CSP 1.1", "#directive-plugin-types", "plugin-types")}}</td>
       <td>{{Spec2('CSP 1.1')}}</td>

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
@@ -2,15 +2,15 @@
 title: 'CSP: plugin-types'
 slug: Web/HTTP/Headers/Content-Security-Policy/plugin-types
 tags:
-- CSP
-- Content-Security-Policy
-- Directive
-- Flash
-- HTTP
-- Java
-- Plugin
-- Plugins
-- Security
+  - CSP
+  - Content-Security-Policy
+  - Directive
+  - Flash
+  - HTTP
+  - Java
+  - Plugin
+  - Plugins
+  - Security
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -58,7 +58,7 @@ Content-Security-Policy: plugin-types &lt;type&gt;/&lt;subtype&gt; &lt;type&gt;/
 <dl>
   <dt>&lt;type&gt;/&lt;subtype&gt;</dt>
   <dd>A valid <a
-      href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types">MIME
+      href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types">MIME
       type</a>.</dd>
 </dl>
 


### PR DESCRIPTION
https://github.com/w3c/webappsec-csp/issues/394 completely removed the `plugin-types` directive from the CSP spec. So it’s now deprecated and no longer part of any current spec.