### PR TITLE
Fix link to ece2610 chapter about IIR Filters

### DIFF
--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.html
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.html
@@ -37,7 +37,7 @@ tags:
 
 <p>With the IIRFIlter node it's up to you to set what <code>feedforward</code> and <code>feedback</code> values the filter needs — this determines the characteristics of the filter. The downside is that this involves some complex maths.</p>
 
-<p>If you are looking to learn more there's some <a href="http://www.eas.uccs.edu/~mwickert/ece2610/lecture_notes/ece2610_chap8.pdf">information about the maths behind IIR filters here</a>. This enters the realms of signal processing theory — don't worry if you look at it and feel like it's not for you.</p>
+<p>If you are looking to learn more there's some <a href="http://ece.uccs.edu/~mwickert/ece2610/lecture_notes/ece2610_chap8.pdf">information about the maths behind IIR filters here</a>. This enters the realms of signal processing theory — don't worry if you look at it and feel like it's not for you.</p>
 
 <p>If you want to play with the IIR filter node and need some values to help along the way, there's <a href="http://www.dspguide.com/CH20.PDF">a table of already calculated values here</a>; on pages 4 &amp; 5 of the linked PDF the a<em>n</em> values refer to the <code>feedForward</code> values and the b<em>n</em> values refer to the <code>feedback</code>. <a href="http://musicdsp.org/">musicdsp.org</a> is also a great resource if you want to read more about different filters and how they are implemented digitally.</p>
 


### PR DESCRIPTION
I fixed the broken external link. The course website changed but the chapters are still available at http://ece.uccs.edu/~mwickert/ece2610/

Fixes issue #2625 