### PR TITLE
-moz-outline-radius removal note

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -223,7 +223,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Property_outline">Property: outline property to follow border-radius shape</h3>
+<h3 id="outline_property">outline property to follow border-radius shape</h3>
 
 <p>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property will be removed. (See {{bug(315209)}} and {{bug(1694146)}} for more details.)</p>
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -23,7 +23,7 @@ tags:
 
 <h3 id="Element_&lt;dialog&gt;">Element: &lt;dialog&gt;</h3>
 
-<p>The HTML {{HTMLElement("dialog")}} element and its associated DOM APIs provide support for HTML-based modal dialog boxes. The current implementation is a little inelegant but is basically functional. See {{bug(840640)}} for more details.</p>
+<p>The HTML {{HTMLElement("dialog")}} element and its associated DOM APIs provide support for HTML-based modal dialog boxes. The current implementation is a little inelegant but is basically functional. (See {{bug(840640)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -63,7 +63,7 @@ tags:
 
 <h3 id="Global_attribute_inputmode">Global attribute: inputmode</h3>
 
-<p>Our implementation of the <code><a href="/en-US/docs/Web/HTML/Global_attributes/inputmode">inputmode</a></code> global attribute has been updated as per the WHATWG spec ({{bug(1509527)}}), but we still need to make other changes too, like making it available on contenteditable content. See also {{bug(1205133)}} for details.</p>
+<p>Our implementation of the <code><a href="/en-US/docs/Web/HTML/Global_attributes/inputmode">inputmode</a></code> global attribute has been updated as per the WHATWG spec ({{bug(1509527)}}), but we still need to make other changes too, like making it available on contenteditable content. (See {{bug(1205133)}} for details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -103,7 +103,7 @@ tags:
 
 <h3 id="inert_attribute">inert attribute</h3>
 
-<p>The {{domxref("HTMLElement")}} property {{DOMxRef("HTMLElement.inert")}} is a {{jsxref("Boolean")}}, when present, may make the browser "ignore" the element from assistive technologies, page search and text selection. For more details on the status of this feature see {{bug(1655722)}}. </p>
+<p>The {{domxref("HTMLElement")}} property {{DOMxRef("HTMLElement.inert")}} is a {{jsxref("Boolean")}}, when present, may make the browser "ignore" the element from assistive technologies, page search and text selection. For more details on the status of this feature see {{bug(1655722)}}.</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -143,7 +143,7 @@ tags:
 
 <h3 id="Layout_for_input_typesearch">Layout for input type="search"</h3>
 
-<p>Layout for <code>input type="search"</code> has been updated. This causes a search field to have a clear icon once someone starts typing in it, to match other browser implementations. ({{bug(558594)}})</p>
+<p>Layout for <code>input type="search"</code> has been updated. This causes a search field to have a clear icon once someone starts typing in it, to match other browser implementations. (See {{bug(558594)}} for more details)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -185,9 +185,7 @@ tags:
 
 <h3 id="Display_stray_control_characters_in_CSS_as_hex_boxes">Display stray control characters in CSS as hex boxes</h3>
 
-<p>This feature renders control characters (Unicode category Cc) other than <em>tab</em> (<code>U+0009</code>), <em>line feed</em> (<code>U+000A</code>), <em>form feed</em> (<code>U+000C</code>), and <em>carriage return</em> (<code>U+000D</code>) as a hexbox when they are not expected.<br>
- <br>
- See {{bug(1099557)}} for more details.</p>
+<p>This feature renders control characters (Unicode category Cc) other than <em>tab</em> (<code>U+0009</code>), <em>line feed</em> (<code>U+000A</code>), <em>form feed</em> (<code>U+000C</code>), and <em>carriage return</em> (<code>U+000D</code>) as a hexbox when they are not expected. (See {{bug(1099557)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -225,11 +223,9 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Property_outline">Property: outline should follow border-radius</h3>
+<h3 id="Property_outline">Property: outline property to follow border-radius shape</h3>
 
-<p>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property will be removed.<br>
- <br>
- See {{bug(315209)}} and {{bug(1694146)}} for more details.</p>
+<p>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property will be removed. (See {{bug(315209)}} and {{bug(1694146)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -269,9 +265,7 @@ tags:
 
 <h3 id="Property_initial-letter">Property: initial-letter</h3>
 
-<p>The {{cssxref("initial-letter")}} CSS property is part of the {{SpecName("CSS3 Inline")}} specification and allows you to specify how dropped, raised, and sunken initial letters are displayed.<br>
- <br>
- See {{bug(1223880)}} for more details.</p>
+<p>The {{cssxref("initial-letter")}} CSS property is part of the {{SpecName("CSS3 Inline")}} specification and allows you to specify how dropped, raised, and sunken initial letters are displayed. (See {{bug(1223880)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -311,9 +305,7 @@ tags:
 
 <h3 id="Property_aspect-ratio">Property: aspect-ratio</h3>
 
-<p>The {{cssxref("aspect-ratio")}} CSS property is part of the {{SpecName("CSS4 Sizing")}} specification and allows you to create boxes which conform to an aspect ratio.<br>
- <br>
- See {{bug(1639963)}} and {{bug(1646096)}} for more details.</p>
+<p>The {{cssxref("aspect-ratio")}} CSS property is part of the {{SpecName("CSS4 Sizing")}} specification and allows you to create boxes which conform to an aspect ratio. (See {{bug(1639963)}} and {{bug(1646096)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -353,7 +345,7 @@ tags:
 
 <h3 id="Single_numbers_as_aspect_ratio_in_media_queries">Single numbers as aspect ratio in media queries</h3>
 
-<p>Support for using a single {{cssxref("number")}} as a {{cssxref("ratio")}} when specifying the aspect ratio for a <a href="/en-US/docs/Web/CSS/Media_Queries">media query</a>. See {{bug(1565562)}} for more details.</p>
+<p>Support for using a single {{cssxref("number")}} as a {{cssxref("ratio")}} when specifying the aspect ratio for a <a href="/en-US/docs/Web/CSS/Media_Queries">media query</a>. (See {{bug(1565562)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -393,7 +385,7 @@ tags:
 
 <h3 id="Property_backdrop-filter">Property: backdrop-filter</h3>
 
-<p>The {{cssxref("backdrop-filter")}} property applies filter effects to the area behind an element. See {{bug(1178765)}} for more details.</p>
+<p>The {{cssxref("backdrop-filter")}} property applies filter effects to the area behind an element. (See {{bug(1178765)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -515,7 +507,7 @@ tags:
 
 <h3 id="Property_math-style">Property: math-style </h3>
 
-<p>The {{cssxref("math-style")}} property  indicates whether MathML equations should render with normal or compact height. See {{bug(1665975)}} for more details.</p>
+<p>The {{cssxref("math-style")}} property  indicates whether MathML equations should render with normal or compact height. (See {{bug(1665975)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -714,7 +706,7 @@ tags:
 
 <h4 id="Interface_OffscreenCanvas">Interface: OffscreenCanvas</h4>
 
-<p>The {{domxref("OffscreenCanvas")}} interface provides a canvas that can be rendered offscreen. It is available in both the window and <a href="/en-US/docs/Web/API/Web_Workers_API">worker</a> contexts. See {{bug(1390089)}} for more details.</p>
+<p>The {{domxref("OffscreenCanvas")}} interface provides a canvas that can be rendered offscreen. It is available in both the window and <a href="/en-US/docs/Web/API/Web_Workers_API">worker</a> contexts. (See {{bug(1390089)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1082,7 +1074,7 @@ tags:
 
 <h4 id="GeometryUtils_methods_convertPointFromNode_convertRectFromNode_and_convertQuadFromNode">GeometryUtils methods: convertPointFromNode(), convertRectFromNode(), and convertQuadFromNode()</h4>
 
-<p>The {{domxref("GeometryUtils")}} methods {{domxref("GeometryUtils.convertPointFromNode", "convertPointFromNode()")}}, {{domxref("GeometryUtils.convertRectFromNode", "convertRectFromNode()")}}, and {{domxref("GeometryUtils.convertQuadFromNode", "convertQuadFromNode()")}} map the given point, rectangle, or quadruple from the {{domxref("Node")}} on which they're called to another node. See {{bug(918189)}} for more details.</p>
+<p>The {{domxref("GeometryUtils")}} methods {{domxref("GeometryUtils.convertPointFromNode", "convertPointFromNode()")}}, {{domxref("GeometryUtils.convertRectFromNode", "convertRectFromNode()")}}, and {{domxref("GeometryUtils.convertQuadFromNode", "convertQuadFromNode()")}} map the given point, rectangle, or quadruple from the {{domxref("Node")}} on which they're called to another node. (See {{bug(918189)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1122,7 +1114,7 @@ tags:
 
 <h4 id="GeometryUtils_method_getBoxQuads">GeometryUtils method: getBoxQuads()</h4>
 
-<p>The {{domxref("GeometryUtils")}} method {{domxref("GeometryUtils.getBoxQuads", "getBoxQuads()")}} returns the CSS boxes for a {{domxref("Node")}} relative to any other node or viewport. See {{bug(917755)}} for more details.</p>
+<p>The {{domxref("GeometryUtils")}} method {{domxref("GeometryUtils.getBoxQuads", "getBoxQuads()")}} returns the CSS boxes for a {{domxref("Node")}} relative to any other node or viewport. (See {{bug(917755)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1164,7 +1156,7 @@ tags:
 
 <h4 id="Primary_payment_handling">Primary payment handling</h4>
 
-<p>The <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> provides support for handling web-based payments within web content or apps. Due to a bug that came up during testing of the user interface, we have decided to postpone shipping this API while discussions over potential changes to the API are held. Work is ongoing. See {{bug(1318984)}} for more details on the state of this API.</p>
+<p>The <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> provides support for handling web-based payments within web content or apps. Due to a bug that came up during testing of the user interface, we have decided to postpone shipping this API while discussions over potential changes to the API are held. Work is ongoing. (See {{bug(1318984)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1371,7 +1363,7 @@ tags:
 
 <h4 id="AVIF_AV1_Image_File_format_support">AVIF (AV1 Image File format) support</h4>
 
-<p>With this feature enabled, Firefox supports the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AV1 Image File (AVIF)</a> format. This is a still image file format that leverages the capabilities of the AV1 video compression algorithms to reduce image size. See {{bug(1443863)}} for more details.</p>
+<p>With this feature enabled, Firefox supports the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AV1 Image File (AVIF)</a> format. This is a still image file format that leverages the capabilities of the AV1 video compression algorithms to reduce image size. (See {{bug(1443863)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1533,7 +1525,7 @@ tags:
 
 <h4 id="Upgrading_mixed_display_content">Upgrading mixed display content</h4>
 
-<p>When enabled, this preference causes Firefox to automatically upgrade requests for media content from HTTP to HTTPS on secure pages. The intent is to prevent mixed-content conditions in which some content is loaded securely while other content is insecure. If the upgrade fails (because the media's host doesn't support HTTPS), the media is not loaded. See {{bug(1435733)}} for more details.</p>
+<p>When enabled, this preference causes Firefox to automatically upgrade requests for media content from HTTP to HTTPS on secure pages. The intent is to prevent mixed-content conditions in which some content is loaded securely while other content is insecure. If the upgrade fails (because the media's host doesn't support HTTPS), the media is not loaded. (See {{bug(1435733)}} for more details.)</p>
 
 <p>This also changes the console warning; if the upgrade succeeds, the message indicates that the request was upgraded, instead of showing a warning.</p>
 
@@ -1619,9 +1611,7 @@ tags:
 
 <h4 id="Color_scheme_simulation">Color scheme simulation</h4>
 
-<p>Adds an option to simulate different color schemes allowing to test {{cssxref("@media/prefers-color-scheme", "@prefers-color-scheme")}} media queries. Using this media query lets your style sheet specify whether it prefers a light or dark user interface. This feature lets you test your code without having to change settings in your browser (or operating system, if the browser follows a system-wide color scheme setting).</p>
-
-<p>See {{bug(1550804)}} and {{bug(1137699)}} for more details.</p>
+<p>Adds an option to simulate different color schemes allowing to test {{cssxref("@media/prefers-color-scheme", "@prefers-color-scheme")}} media queries. Using this media query lets your style sheet specify whether it prefers a light or dark user interface. This feature lets you test your code without having to change settings in your browser (or operating system, if the browser follows a system-wide color scheme setting). (See {{bug(1550804)}} and {{bug(1137699)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1661,7 +1651,7 @@ tags:
 
 <h4 id="Execution_context_selector">Execution context selector</h4>
 
-<p>This feature displays a button on the console's command line that lets you change the context in which the expression you enter will be executed. See {{bug(1605154)}} and {{bug(1605153)}} for more details.</p>
+<p>This feature displays a button on the console's command line that lets you change the context in which the expression you enter will be executed. (See {{bug(1605154)}} and {{bug(1605153)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1701,7 +1691,7 @@ tags:
 
 <h4 id="Mobile_gesture_support_in_Responsive_Design_Mode">Mobile gesture support in Responsive Design Mode</h4>
 
-<p>Mouse gestures are used to simulate mobile gestures like swiping/scrolling, double-tap and pinch-zooming and long-press to select/open the context menu. See {{bug(1621781)}}, {{bug(1245183)}}, and {{bug(1401304)}} for more details.</p>
+<p>Mouse gestures are used to simulate mobile gestures like swiping/scrolling, double-tap and pinch-zooming and long-press to select/open the context menu. (See {{bug(1621781)}}, {{bug(1245183)}}, and {{bug(1401304)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1743,7 +1733,7 @@ tags:
 
 <h4 id="Server-sent_events_in_Network_Monitor">Server-sent events in Network Monitor</h4>
 
-<p>The Network Monitor displays information for <a href="/en-US/docs/Web/API/Server-sent_events">server-sent</a> events. See {{bug(1405706)}}.</p>
+<p>The Network Monitor displays information for <a href="/en-US/docs/Web/API/Server-sent_events">server-sent</a> events. (See {{bug(1405706)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>
@@ -1825,7 +1815,7 @@ tags:
 
 <h4 id="Desktop_zooming">Desktop zooming</h4>
 
-<p>This feature lets you enable smooth pinch zooming on desktop computers without requiring layout reflows, just like mobile devices do. See {{bug(1245183)}} and {{bug(1620055)}} for further details.</p>
+<p>This feature lets you enable smooth pinch zooming on desktop computers without requiring layout reflows, just like mobile devices do. (See {{bug(1245183)}} and {{bug(1620055)}} for more details.)</p>
 
 <table class="standard-table" style="max-width: 42rem;">
  <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -225,6 +225,48 @@ tags:
  </tbody>
 </table>
 
+<h3 id="Property_outline">Property: outline should follow border-radius</h3>
+
+<p>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property will be removed.<br>
+ <br>
+ See {{bug(315209)}} and {{bug(1694146)}} for more details.</p>
+
+<table class="standard-table" style="max-width: 42rem;">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>87</td>
+   <td>Yes</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>87</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>87</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>87</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>layout.css.outline-follows-border-radius.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
 <h3 id="Property_initial-letter">Property: initial-letter</h3>
 
 <p>The {{cssxref("initial-letter")}} CSS property is part of the {{SpecName("CSS3 Inline")}} specification and allows you to specify how dropped, raised, and sunken initial letters are displayed.<br>
@@ -1327,44 +1369,44 @@ tags:
 </table>
 
 
-<h4 id="AVIF_AV1_Image_File_format_support">AVIF (AV1 Image File format) support</h4>	
+<h4 id="AVIF_AV1_Image_File_format_support">AVIF (AV1 Image File format) support</h4>
 
-<p>With this feature enabled, Firefox supports the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AV1 Image File (AVIF)</a> format. This is a still image file format that leverages the capabilities of the AV1 video compression algorithms to reduce image size. See {{bug(1443863)}} for more details.</p>	
+<p>With this feature enabled, Firefox supports the <a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AV1 Image File (AVIF)</a> format. This is a still image file format that leverages the capabilities of the AV1 video compression algorithms to reduce image size. See {{bug(1443863)}} for more details.</p>
 
-<table class="standard-table" style="max-width: 42rem;">	
- <thead>	
-  <tr>	
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>	
-   <th scope="col" style="vertical-align: bottom;">Version added</th>	
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>	
-  </tr>	
- </thead>	
- <tbody>	
-  <tr>	
-   <th scope="row">Nightly</th>	
-   <td>77</td>	
-   <td>No</td>	
-  </tr>	
-  <tr>	
-   <th scope="row">Developer Edition</th>	
-   <td>77</td>	
-   <td>No</td>	
-  </tr>	
-  <tr>	
-   <th scope="row">Beta</th>	
-   <td>77</td>	
-   <td>No</td>	
-  </tr>	
-  <tr>	
-   <th scope="row">Release</th>	
-   <td>77</td>	
-   <td>No</td>	
-  </tr>	
-  <tr>	
-   <th scope="row">Preference name</th>	
-   <th colspan="2"><code>image.avif.enabled</code></th>	
-  </tr>	
- </tbody>	
+<table class="standard-table" style="max-width: 42rem;">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>77</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>77</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>77</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>77</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>image.avif.enabled</code></th>
+  </tr>
+ </tbody>
 </table>
 
 <h4 id="AV1_support_for_Firefox_on_Android">AV1 support for Firefox on Android</h4>

--- a/files/en-us/web/css/-moz-outline-radius-bottomleft/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-bottomleft/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard warning">
   <h4>Scheduled for removal</h4>
-  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
 </div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-bottomleft</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the bottom-left corner of an element's {{cssxref("outline")}}.</p>

--- a/files/en-us/web/css/-moz-outline-radius-bottomleft/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-bottomleft/index.html
@@ -10,7 +10,12 @@ tags:
   - Reference
   - 'recipe:css-property'
 ---
-<div>{{Non-standard_header}}{{CSSRef}}</div>
+<div>{{CSSRef}}</div>
+
+<div class="notecard warning">
+  <h4>Scheduled for removal</h4>
+  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-bottomleft</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the bottom-left corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-bottomright/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-bottomright/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard warning">
   <h4>Scheduled for removal</h4>
-  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
 </div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-bottomright</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the bottom-right corner of an element's {{cssxref("outline")}}.</p>

--- a/files/en-us/web/css/-moz-outline-radius-bottomright/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-bottomright/index.html
@@ -10,7 +10,12 @@ tags:
   - Reference
   - 'recipe:css-property'
 ---
-<div>{{Non-standard_header}}{{CSSRef}}</div>
+<div>{{CSSRef}}</div>
+
+<div class="notecard warning">
+  <h4>Scheduled for removal</h4>
+  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-bottomright</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the bottom-right corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-topleft/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-topleft/index.html
@@ -10,7 +10,12 @@ tags:
   - Reference
   - 'recipe:css-property'
 ---
-<div>{{Non-standard_header}}{{CSSRef}}</div>
+<div>{{CSSRef}}</div>
+
+<div class="notecard warning">
+  <h4>Scheduled for removal</h4>
+  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-topleft</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the top-left corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-topleft/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-topleft/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard warning">
   <h4>Scheduled for removal</h4>
-  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
 </div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-topleft</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the top-left corner of an element's {{cssxref("outline")}}.</p>

--- a/files/en-us/web/css/-moz-outline-radius-topright/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-topright/index.html
@@ -10,7 +10,12 @@ tags:
   - Reference
   - 'recipe:css-property'
 ---
-<div>{{Non-standard_header}}{{CSSRef}}</div>
+<div>{{CSSRef}}</div>
+
+<div class="notecard warning">
+  <h4>Scheduled for removal</h4>
+  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-topright</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the top-right corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-topright/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-topright/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard warning">
   <h4>Scheduled for removal</h4>
-  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
 </div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-topright</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the top-right corner of an element's {{cssxref("outline")}}.</p>

--- a/files/en-us/web/css/-moz-outline-radius/index.html
+++ b/files/en-us/web/css/-moz-outline-radius/index.html
@@ -9,7 +9,12 @@ tags:
   - Reference
   - 'recipe:css-shorthand-property'
 ---
-<div>{{CSSRef}}{{Non-standard_header}}</div>
+<div>{{CSSRef}}</div>
+
+<div class="notecard warning">
+  <h4>Scheduled for removal</h4>
+  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+</div>
 
 <p>In Mozilla applications like Firefox, the <strong><code>-moz-outline-radius</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> can be used to give an element's {{cssxref("outline")}} rounded corners.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius/index.html
+++ b/files/en-us/web/css/-moz-outline-radius/index.html
@@ -13,7 +13,7 @@ tags:
 
 <div class="notecard warning">
   <h4>Scheduled for removal</h4>
-  <p>This property will be removed in Firefox 88, however the standard {{cssxref("outline")}} property will follow the {{cssxref("border-radius")}} from this release making <code>-moz-outline-radius</code> redundant.</p>
+  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
 </div>
 
 <p>In Mozilla applications like Firefox, the <strong><code>-moz-outline-radius</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> can be used to give an element's {{cssxref("outline")}} rounded corners.</p>


### PR DESCRIPTION
Working on #2507 

This is only enabled by default in Nightly for this release, so I have added to experimental features and added a note about the pending removal to the relevant property pages.

Looks like it will ship in 88. 