### PR TITLE
add warnings about manually editing _redirects.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ are specified within [`files/en-us/_redirects.txt`](files/en-us/_redirects.txt),
 one redirect per line. Each line specifies a `from` and `to` URI
 separated by whitespace. When you move a document, you'll need to add a
 redirect to this file specifying that its old URI now redirects to its new URI.
+Both of these tasks are done using the `yarn content move` tool — see
+[Moving one or more documents](#moving-one-or-more-documents).
+**Don't edit the `_redirects.txt` file manually!**
 If both an `index.html` file and a redirect exist for a document, the
 document takes precedence and the redirect is ignored.
 - **A document's `index.html` starts with "front-matter"** -- Each
@@ -323,8 +326,8 @@ underlying issue(s), you can ask for help. Your pull request will not be
 approved and merged if these tests are failing.
 
 1. If your pull request has merge conflicts with the `main` branch (GitHub
-checks for this automatically and notifies you), you are responsible to
-resolve them. You can do this by merging the `main` branch into your
+checks for this automatically and notifies you), you are responsible for
+resolving them. You can do this by merging the `main` branch into your
 branch (`git pull mdn main`), and then pushing the updated branch to
 your fork (`git push`).
 
@@ -449,6 +452,12 @@ push your branch to your fork:
     ```
 
 1. Now you're ready to create your [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+
+**Important: `yarn content move` automatically adds the necessary redirect
+information to the `_redirects.txt` file so that the old location will redirect
+to the new one. Don't edit the `_redirects.txt` file manually!
+mistakes can easily creep in if you do. If you need to add a redirect without
+moving a file, talk to us about it.**
 
 ### Deleting a document
 


### PR DESCRIPTION
As per a conversation we had yesterday , I'm updating the README file to add in specific warnings about not manually editing `_redirects.txt`, along a bit more context and direction.