### PR TITLE
Remove an extraneous parenthesis

### DIFF
--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -35,7 +35,7 @@ tags:
    <ul>
     <li>The {{HTTPHeader("Content-Disposition")}} HTTP header</li>
     <li>The final segment in the URL <a href="/en-US/docs/Web/API/URL/pathname">path</a></li>
-    <li>The {{Glossary("MIME_type", "media type")}} (from the ({{HTTPHeader("Content-Type")}} header, the start of a <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URL</a>, or {{domxref("Blob.type")}} for a <a href="/en-US/docs/Web/API/URL/createObjectURL"><code>blob:</code> URL</a>)</li>
+    <li>The {{Glossary("MIME_type", "media type")}} (from the {{HTTPHeader("Content-Type")}} header, the start of a <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URL</a>, or {{domxref("Blob.type")}} for a <a href="/en-US/docs/Web/API/URL/createObjectURL"><code>blob:</code> URL</a>)</li>
    </ul>
   </li>
   <li>Defining a value suggests it as the filename. <code>/</code> and <code>\</code> characters are converted to underscores (<code>_</code>). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary.</li>


### PR DESCRIPTION
```
The media type (from the (Content-Type header, the start of a data: URL, or Blob.type for a blob: URL)
-------------------------^ this
```