### PR TITLE
Fix indent

### DIFF
--- a/files/en-us/web/html/element/summary/index.html
+++ b/files/en-us/web/html/element/summary/index.html
@@ -96,7 +96,7 @@ tags:
 
 <pre class="brush: html">&lt;details open&gt;
   &lt;summary&gt;&lt;h4&gt;Overview&lt;/h4&gt;&lt;/summary&gt;
-    &lt;ol&gt;
+  &lt;ol&gt;
     &lt;li&gt;Cash on hand: $500.00&lt;/li&gt;
     &lt;li&gt;Current invoice: $75.30&lt;/li&gt;
     &lt;li&gt;Due date: 5/6/19&lt;/li&gt;


### PR DESCRIPTION
Fixed this

> ![example of Summaries as headings with wrong indent](https://user-images.githubusercontent.com/355808/109067311-32dca580-76a3-11eb-83b4-e9e660ebf783.png)

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary