### PR TITLE
Rename "middle" to "center" for consistency with CSS

### DIFF
--- a/files/en-us/web/api/webvtt_api/index.html
+++ b/files/en-us/web/api/webvtt_api/index.html
@@ -546,7 +546,7 @@ Third
      <td>top</td>
     </tr>
     <tr>
-     <th><code>align:middle</code></th>
+     <th><code>align:center</code></th>
      <td>centred horizontally</td>
      <td>centred vertically</td>
      <td>centred vertically</td>


### PR DESCRIPTION
The WebVTT API should list `align: center` instead of `align: middle` to be consistent with the CSS property value.

References:
* w3c/webvtt#244
* https://www.w3.org/TR/webvtt1/#webvtt-cue-center-alignment