### PR TITLE
Fix code typo

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.html
@@ -244,7 +244,7 @@ Reflect.defineProperty(ev.wrappedJSObject,        // privileged reflection can o
   'propC', {
      get: exportFunction(function() {             // getters must be exported like regular functions
        return 'propC';
-     }
+     })
   }
 );
 


### PR DESCRIPTION
This adds a missing parentheses to the code examples . This fixes #2670 