### PR TITLE
Fix problems with SVG textLength doc

### DIFF
--- a/files/en-us/web/svg/attribute/textlength/index.html
+++ b/files/en-us/web/svg/attribute/textlength/index.html
@@ -32,6 +32,7 @@ tags:
   &lt;text y="20" textLength="6em"&gt;Small text length&lt;/text&gt;
   &lt;text y="40" textLength="120%"&gt;Big text length&lt;/text&gt;
 &lt;/svg&gt;</pre>
+</div>
 
 <p>{{EmbedLiveSample("topExample", "200", "100")}}</p>
 
@@ -125,7 +126,7 @@ widthSlider.dispatchEvent(new Event("input"));
 
 <p>After fetching the element references, an {{domxref("EventListener")}} is established by calling {{domxref("EventTarget.addEventListener", "addEventListener()")}} on the slider control, to receive any {{event("input")}} events which occur. These events will be sent any time the slider's value changes, even if the user hasn't stopped moving it, so we can responsively adjust the text width.</p>
 
-<p>When an <code>"input"</code> event occurs, we call {{domxref("SVGLength.newValueSpecifiedUnits()")}} to set the value of <code>textLength</code> to the slider's new value, using the <code>SVGLength</code> interface's <code>SVG_LENGTHTYPE_PX</code> unit type to indicate that the value represents pixels. Note that we have to dive into <code>textLength</code> to get its <code>baseVal</code> property; <code>textLength</code> is stored as an {{domxref("SVGLength")}} object, so we can't treat it like a plain number.</p>
+<p>When an <code>"input"</code> event occurs, we call <code>newValueSpecifiedUnits()</code> to set the value of <code>textLength</code> to the slider's new value, using the <code>SVGLength</code> interface's <code>SVG_LENGTHTYPE_PX</code> unit type to indicate that the value represents pixels. Note that we have to dive into <code>textLength</code> to get its <code>baseVal</code> property; <code>textLength</code> is stored as an {{domxref("SVGLength")}} object, so we can't treat it like a plain number.</p>
 
 <p>After updating the text width, the contents of the <code>widthDisplay</code> box are updated with the new value as well, and we're finished.</p>
 
@@ -162,7 +163,6 @@ widthSlider.dispatchEvent(new Event("input"));
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("svg.attributes.textLength")}}</p>
-</div>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
- Move misplaced `</div>` end tag that breaks rendering; see
  https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/textLength
- Fix broken macro ref for undocumented `newValueSpecifiedUnits()` method