### PR TITLE
Fix TC39 homepage link in Public Class Fields page

### DIFF
--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
@@ -13,7 +13,7 @@ tags:
 
   <p>Both Public and private field declarations are an <a
       href="https://github.com/tc39/proposal-class-fields">experimental feature (stage
-      3)</a> proposed at <a href="https://tc39.github.io/beta/">TC39</a>, the JavaScript
+      3)</a> proposed at <a href="https://tc39.es/">TC39</a>, the JavaScript
     standards committee.</p>
 
   <p>Support in browsers is limited, but the feature can be used through a build step with


### PR DESCRIPTION
I did a grep locally and this is the only beta TC39 link we should fix

```
→ rg "tc39.github.io/beta"
files/en-us/web/javascript/reference/classes/public_class_fields/index.html
16:      3)</a> proposed at <a href="https://tc39.github.io/beta/">TC39</a>, the JavaScript
```