### PR TITLE
List accept headers: remove broken source links

### DIFF
--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -30,14 +30,14 @@ tags:
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8</code> (since Firefox 65)</p>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</code> (before)</p>
    </td>
-   <td>In Firefox 65 and earlier, this value can be modified using the <a href="http://kb.mozillazine.org/Network.http.accept.default"><code>network.http.accept.default</code></a> parameter. (<a href="https://hg.mozilla.org/mozilla-central/file/tip/modules/libpref/init/all.js#l1750">source)</a></td>
+   <td>In Firefox 65 and earlier, this value can be modified using the <a href="http://kb.mozillazine.org/Network.http.accept.default"><code>network.http.accept.default</code></a> parameter.</td>
   </tr>
   <tr>
    <td>Safari, Chrome</td>
    <td>
     <p><code>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8</code></p>
    </td>
-   <td><a href="https://chromium.googlesource.com/chromium/src.git/+/master/services/network/loader_util.cc#24">(source)</a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Safari 5</td>
@@ -82,7 +82,7 @@ tags:
      <p><code>*/*</code> (since Firefox 47)</p>
      <p><code>image/png,image/*;q=0.8,*/*;q=0.5</code> (before)</p>
    </td>
-   <td>This value can be modified using the <code>image.http.accept</code> parameter. <a href="https://hg.mozilla.org/mozilla-central/file/tip/modules/libpref/init/all.js#l3779"><span style="font-size: x-small;">source</span></a></td>
+   <td>This value can be modified using the <code>image.http.accept</code> parameter. <a href="https://searchfox.org/mozilla-central/search?q=image.http.accept"><span style="font-size: x-small;">source</span></a></td>
   </tr>
   <tr>
    <td>Safari</td>
@@ -92,7 +92,7 @@ tags:
   <tr>
    <td>Chrome</td>
    <td><code>image/avif,image/webp,image/apng,image/*,*/*;q=0.8</code></td>
-   <td><a href="https://chromium.googlesource.com/chromium/src.git/+/master/content/renderer/loader/web_url_loader_impl.cc#99"><span style="font-size: x-small;">source</span></a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Internet Explorer 8 or earlier</td>
@@ -102,7 +102,7 @@ tags:
   <tr>
    <td>Internet Explorer 9</td>
    <td><code>image/png,image/svg+xml,image/*;q=0.8, */*;q=0.5</code></td>
-   <td>See <a href="https://docs.microsoft.com/en-us/archive/blogs/fiddler/fiddler-and-the-ie9-release-candidate">Fiddler is better with Internet Explorer 9 (IEInternals' MSDN blog)</a></td>
+   <td></td>
   </tr>
  </tbody>
 </table>
@@ -131,7 +131,7 @@ tags:
   <tr>
    <td>Chrome</td>
    <td><code>*/*</code></td>
-   <td><a href="https://chromium.googlesource.com/chromium/src.git/+/master/services/network/loader_util.cc#27"><span style="font-size: x-small;">source</span></a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Internet Explorer 8 or earlier</td>
@@ -155,12 +155,12 @@ tags:
   <tr>
    <td>Firefox 3.6 and later</td>
    <td><code>audio/webm,audio/ogg,audio/wav,audio/*;q=0.9,application/ogg;q=0.7,video/*;q=0.6,*/*;q=0.5</code></td>
-   <td>See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=489071">bug 489071</a> <a href="https://hg.mozilla.org/mozilla-central/file/tip/dom/html/HTMLAudioElement.cpp#l81"><span style="font-size: x-small;">source</span></a></td>
+   <td>See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=489071">bug 489071</a> <a href="https://searchfox.org/mozilla-central/source/dom/html/HTMLAudioElement.cpp#92"><span style="font-size: x-small;">source</span></a></td>
   </tr>
   <tr>
    <td>Safari, Chrome</td>
    <td><code>*/*</code></td>
-   <td><a href="https://chromium.googlesource.com/chromium/src.git/+/master/services/network/loader_util.cc#27"><span style="font-size: x-small;">source</span></a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Internet Explorer 8 or earlier</td>
@@ -194,7 +194,7 @@ tags:
   <tr>
    <td>Safari, Chrome</td>
    <td><code>*/*</code></td>
-   <td><a href="https://chromium.googlesource.com/chromium/src.git/+/master/services/network/loader_util.cc#27"><span style="font-size: x-small;">source</span></a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Internet Explorer 8 or earlier</td>
@@ -204,7 +204,7 @@ tags:
   <tr>
    <td>Internet Explorer 9</td>
    <td><code>application/javascript, */*;q=0.8</code></td>
-   <td>See <a href="https://docs.microsoft.com/en-us/archive/blogs/fiddler/fiddler-and-the-ie9-release-candidate">Fiddler is better with Internet Explorer 9 (IEInternals' MSDN blog)</a></td>
+   <td></td>
   </tr>
  </tbody>
 </table>
@@ -223,7 +223,7 @@ tags:
   <tr>
    <td>Firefox 4</td>
    <td><code>text/css,*/*;q=0.1</code></td>
-   <td>See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=170789">bug 170789</a> <a href="https://hg.mozilla.org/mozilla-central/file/tip/layout/style/Loader.cpp#l1548"><span style="font-size: x-small;">source</span></a></td>
+   <td>See <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=170789">bug 170789</a> <a href="https://hg.mozilla.org/mozilla-central/file/tip/layout/style/Loader.cpp#l769"><span style="font-size: x-small;">source</span></a></td>
   </tr>
   <tr>
    <td>Internet Explorer 8 or earlier</td>
@@ -233,12 +233,12 @@ tags:
   <tr>
    <td>Internet Explorer 9</td>
    <td><code>text/css</code></td>
-   <td>See <a href="https://docs.microsoft.com/en-us/archive/blogs/fiddler/fiddler-and-the-ie9-release-candidate">Fiddler is better with Internet Explorer 9 (IEInternals' MSDN blog)</a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Safari, Chrome</td>
    <td><code>text/css,*/*;q=0.1</code></td>
-   <td><a href="https://chromium.googlesource.com/chromium/src.git/+/master/content/renderer/loader/web_url_loader_impl.cc#98"><span style="font-size: x-small;">source</span></a></td>
+   <td></td>
   </tr>
   <tr>
    <td>Opera 11.10</td>


### PR DESCRIPTION
Fixes #2580

This removes all the broken source links in the [List of default accept headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values), as discussed here: https://github.com/mdn/content/issues/2580#issuecomment-783725200

Mostly this affects Chrome/Safari. Couldn't find any replacements (would have liked to; useful for tracking changes)