### PR TITLE
FF74 did not enable Feature-Policy HTTP header

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1565,6 +1565,53 @@ tags:
  </tbody>
 </table>
 
+
+<h4 id="Feature_policy">Feature policy</h4>
+
+<p><a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> allows web developers to selectively enable, disable, and modify the behavior of certain features and APIs in the browser. It is similar to CSP but controls features instead of security behavior.</p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The <code>Feature-Policy</code> header has now been renamed to <code>Permissions-Policy</code> in the spec, and this article will eventually be updated to reflect that change.</p>
+</div>
+
+<table class="standard-table" style="max-width: 42rem;">
+  <thead>
+   <tr>
+    <th scope="col" style="vertical-align: bottom;">Release channel</th>
+    <th scope="col" style="vertical-align: bottom;">Version added</th>
+    <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <th scope="row">Nightly</th>
+    <td>65</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Developer Edition</th>
+    <td>65</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Beta</th>
+    <td>65</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Release</th>
+    <td>65</td>
+    <td>No</td>
+   </tr>
+   <tr>
+    <th scope="row">Preference name</th>
+    <th colspan="2"><code>dom.security.featurePolicy.header.enabled</code></th>
+   </tr>
+  </tbody>
+ </table>
+
+
 <h4 id="FTP_support_disabled">FTP support disabled</h4>
 
 <p>For security reasons, Mozilla intends to remove support for {{Glossary("FTP")}} from Firefox in 2020, effective in Firefox 82. See {{bug(1622409)}} for implementation progress. The <code>network.ftp.enabled</code> preference must be enabled (set to <code>true</code>) to allow FTP to be used.</p>

--- a/files/en-us/mozilla/firefox/releases/74/index.html
+++ b/files/en-us/mozilla/firefox/releases/74/index.html
@@ -90,7 +90,6 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
- <li>Feature Policy is now enabled by default! Use the {{HTMLElement("iframe")}} element's {{htmlattrxref("allow", "iframe")}} attribute (and the {{domxref("HTMLIFrameElement")}} property {{domxref("HTMLIFrameElement.allow", "allow")}}) to set permissions for your frames ({{bug(1617219)}}).</li>
  <li>The <code><a href="/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy">Cross-Origin-Resource-Policy</a></code> header is now enabled by default (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1602363">bug 1602363</a>).</li>
 </ul>
 

--- a/files/en-us/web/http/feature_policy/index.html
+++ b/files/en-us/web/http/feature_policy/index.html
@@ -18,8 +18,9 @@ tags:
 
 <p class="summary"><span class="seoSummary">Feature Policy allows web developers to selectively enable, disable, and modify the behavior of certain features and APIs in the browser. It is similar to {{Glossary("CSP", "Content Security Policy")}} but controls features instead of security behavior.</span></p>
 
-<div class="note">
-<p>The <code>Feature-Policy</code> header has now been renamed to <code>Permissions-Policy</code> in the spec, and this article will eventually be updated to reflect that change.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>The {{httpheader("Feature-Policy")}} header has now been renamed to <code>Permissions-Policy</code> in the spec, and this article will eventually be updated to reflect that change.</p>
 </div>
 
 <h2 id="In_a_nutshell">In a nutshell</h2>
@@ -106,7 +107,7 @@ tags:
 
 <p>The web provides functionality and APIs that may have privacy or security risks if abused. In some cases, you may wish to strictly limit how such functionality is used on a website. There are policy-controlled features to allow functionality to be enabled/disabled for specific origins or frames within a website. Where available, the feature integrates with the Permissions API, or feature-specific mechanisms to check if the feature is available.</p>
 
-<p>The features include (see <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#Directives">Features list</a>):</p>
+<p>The features include (see <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives">Features list</a>):</p>
 
 <ul>
  <li>Accelerometer</li>

--- a/files/en-us/web/http/headers/feature-policy/index.html
+++ b/files/en-us/web/http/headers/feature-policy/index.html
@@ -13,15 +13,18 @@ tags:
   - Web
   - header
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>The header has now been renamed to <code>Permissions-Policy</code> in the spec, and this article will eventually be updated to reflect that change.</p>
+  </div>
 
 <p><span class="seoSummary">The HTTP <strong><code>Feature-Policy</code></strong> header provides a mechanism to allow and deny the use of browser features in its own frame, and in content within any {{HTMLElement("iframe")}} elements in the document.</span></p>
 
-<div class="note">
-<p>This header is still in an experimental state, and is subject to change at any time. Be wary of this when implementing it on your website. The header has now been renamed to <code>Permissions-Policy</code> in the spec, and this article will eventually be updated to reflect that change.</p>
-</div>
 
-<p>For more information, see the main <a href="/docs/Web/HTTP/Feature_Policy">Feature Policy</a> article.</p>
+
+<p>For more information, see the main <a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a> article.</p>
 
 <table class="properties">
  <tbody>
@@ -57,7 +60,7 @@ tags:
  <dt>{{httpheader('Feature-Policy/autoplay','autoplay')}}</dt>
  <dd>Controls whether the current document is allowed to autoplay media requested through the {{domxref("HTMLMediaElement")}} interface. When this policy is disabled and there were no user gestures, the {{jsxref("Promise")}} returned by {{domxref("HTMLMediaElement.play()")}} will reject with a {{domxref("DOMException")}}. The autoplay attribute on {{HTMLELement("audio")}} and {{HTMLElement("video")}} elements will be ignored.</dd>
  <dt>{{httpheader('Feature-Policy/battery','battery')}}</dt>
- <dd>Controls whether the use of the <a href="/docs/Web/API/Battery_Status_API">Battery Status API</a> is allowed. When this policy is disabled, the {{JSxRef("Promise")}} returned by {{DOMxRef("Navigator.getBattery","Navigator.getBattery()")}} will reject with a {{Exception("NotAllowedError")}} {{DOMxRef("DOMException")}}.</dd>
+ <dd>Controls whether the use of the <a href="/en-US/docs/Web/API/Battery_Status_API">Battery Status API</a> is allowed. When this policy is disabled, the {{JSxRef("Promise")}} returned by {{DOMxRef("Navigator.getBattery","Navigator.getBattery()")}} will reject with a {{Exception("NotAllowedError")}} {{DOMxRef("DOMException")}}.</dd>
  <dt>{{httpheader('Feature-Policy/camera', 'camera')}}</dt>
  <dd>Controls whether the current document is allowed to use video input devices. When this policy is disabled, the {{jsxref("Promise")}} returned by {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} will reject with a {{Exception("NotAllowedError")}} {{DOMxRef("DOMException")}}.</dd>
  <dt>{{HTTPHeader('Feature-Policy/display-capture', 'display-capture')}}</dt>
@@ -73,7 +76,7 @@ tags:
  <dt>{{httpheader('Feature-Policy/fullscreen','fullscreen')}}</dt>
  <dd>Controls whether the current document is allowed to use {{DOMxRef("Element.requestFullScreen()")}}. When this policy is disabled, the returned {{JSxRef("Promise")}} rejects with a {{JSxRef("TypeError")}}.</dd>
  <dt>{{httpheader('Feature-Policy/geolocation','geolocation')}}</dt>
- <dd>Controls whether the current document is allowed to use the {{domxref('Geolocation')}} Interface. When this policy is disabled, calls to {{domxref('Geolocation.getCurrentPosition','getCurrentPosition()')}} and {{domxref('Geolocation.watchPosition','watchPosition()')}} will cause those functions' callbacks to be invoked with a {{domxref('PositionError')}} code of <code>PERMISSION_DENIED</code>.</dd>
+ <dd>Controls whether the current document is allowed to use the {{domxref('Geolocation')}} Interface. When this policy is disabled, calls to {{domxref('Geolocation.getCurrentPosition','getCurrentPosition()')}} and {{domxref('Geolocation.watchPosition','watchPosition()')}} will cause those functions' callbacks to be invoked with a {{domxref('GeolocationPositionError')}} code of <code>PERMISSION_DENIED</code>.</dd>
  <dt>{{httpheader('Feature-Policy/gyroscope','gyroscope')}}</dt>
  <dd>Controls whether the current document is allowed to gather information about the orientation of the device through the {{DOMxRef("Gyroscope")}} interface.</dd>
  <dt>{{httpheader('Feature-Policy/layout-animations','layout-animations')}}</dt>


### PR DESCRIPTION
Fixes non-BCD parts of #2685 - Release notes tidy, experimental features addition, minor mods to Feature Policy pages.