### PR TITLE
Adds initial-value descriptor

### DIFF
--- a/files/en-us/web/css/@property/initial-value/index.html
+++ b/files/en-us/web/css/@property/initial-value/index.html
@@ -1,6 +1,6 @@
 ---
-title: 'inherits'
-slug: Web/CSS/@property/inherits
+title: 'initial-value'
+slug: Web/CSS/@property/initial-value
 tags:
   - CSS
   - Reference
@@ -10,7 +10,9 @@ tags:
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>The <strong><code>inherits</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> descriptor is required when using the {{cssxref("@property")}} {{cssxref("at-rule")}} and controls whether the custom property registration specified by <code>@property</code> inherits by default.</p>
+<p>The <strong><code>initial-value</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> descriptor is required when using the {{cssxref("@property")}} {{cssxref("at-rule")}} unless the syntax accepts any valid token stream. It sets the initial-value for the property.</p>
+
+<p>The value chosen as the <code>initial-value</code> must parse correctly according to the syntax definition. Therefore, if syntax is <code>&lt;color&gt;</code> then the initial-value must be a valid {{cssxref("color")}} value.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -28,12 +30,7 @@ tags:
 
 <h2 id="Values">Values</h2>
 
-<dl>
-  <dt><code>true</code></dt>
-  <dd>The property inherits by default.</dd>
-  <dt><code>false</code></dt>
-  <dd>The property does not inherit by default.</dd>
-</dl>
+<p>A string with a value which is a correct value for the chosen <code>syntax</code>.</p>
 
 <h2 id="Formal_definition">Formal definition</h2>
 
@@ -45,7 +42,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>Add type checking to <code>--my-color</code> {{cssxref('--*', 'custom property')}}, as a color, a default value, and not allow it to inherit its value:</p>
+<p>Add type checking to <code>--my-color</code> {{cssxref('--*', 'custom property')}}, as a color, the initial-value being a valid color:</p>
 
 <p>Using <a href="/en-US/docs/Web/CSS">CSS</a> {{cssxref('@property')}} <a href="/en-US/docs/Web/CSS/At-rule">at-rule</a>:</p>
 
@@ -76,7 +73,7 @@ tags:
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('CSS Properties and Values API', '#inherits-descriptor', 'inherits')}}</td>
+   <td>{{SpecName('CSS Properties and Values API', '#initial-value-descriptor', 'initial-value')}}</td>
    <td>{{Spec2('CSS Properties and Values API')}}</td>
    <td>Initial definition.</td>
   </tr>
@@ -87,7 +84,7 @@ tags:
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("css.at-rules.property.inherits")}}</p>
+<p>{{Compat("css.at-rules.property.initial-value")}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Adding the descriptor initial-value: https://drafts.css-houdini.org/css-properties-values-api-1/#initial-value-descriptor

Also corrected the BCD line for `inherits` as I just moved those in the BCD PR.