### PR TITLE
Wording fixes to “CSS and JavaScript animation performance” doc

### DIFF
--- a/files/en-us/web/performance/css_javascript_animation_performance/index.html
+++ b/files/en-us/web/performance/css_javascript_animation_performance/index.html
@@ -10,7 +10,7 @@ tags:
   - Performance
   - Transitions
 ---
-<p class="summary">Animations are critical for a pleasurable user experience on many applications. There are many ways to implement web animations, such as CSS {{cssxref("transition","transitions")}}/{{cssxref("animation","animations")}} or JavaScript-based animations (using {{domxref("Window.requestAnimationFrame","requestAnimationFrame()")}}). In this article, we analyse the performance differences between CSS- and JavaScript-based animation.</p>
+<p class="summary">Animations are critical for a pleasurable user experience on many applications. There are many ways to implement web animations, such as CSS {{cssxref("transition","transitions")}}/{{cssxref("animation","animations")}} or JavaScript-based animations (using {{domxref("Window.requestAnimationFrame","requestAnimationFrame()")}}). In this article, we analyze the performance differences between CSS-based and JavaScript-based animation.</p>
 
 <h2 id="CSS_transitions_and_animations">CSS transitions and animations</h2>
 


### PR DESCRIPTION
opening paragraph fixes: analyse -> analyze and adding a missing word