### PR TITLE
Fix comment typo in logical OR precedence example

### DIFF
--- a/files/en-us/web/javascript/reference/operators/logical_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.html
@@ -90,7 +90,7 @@ console.log( B() || A() );
     precedence</a>).</p>
 
 <pre
-  class="brush: js">true || false &amp;&amp; false      // returns true, because || is executed first
+  class="brush: js">true || false &amp;&amp; false      // returns true, because &amp;&amp; is executed first
 (true || false) &amp;&amp; false    // returns false, because operator precedence cannot apply</pre>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
I believe the author meant to say && instead of ||.