### PR TITLE
Drop ariaRelevant spec table (ariaRelevant is not actually in ARIA 1.2)

### DIFF
--- a/files/en-us/web/api/element/ariarelevant/index.html
+++ b/files/en-us/web/api/element/ariarelevant/index.html
@@ -10,7 +10,7 @@ tags:
   - AriaMixin
   - Element
 ---
-<div>{{DefaultAPISidebar("DOM")}}</div>
+<div>{{DefaultAPISidebar("DOM")}}{{SeeCompatTable}}</div>
 
 <p class="summary">The <strong><code>ariaRelevant</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-relevant_attribute"><code>aria-relevant</code></a> attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an <code>aria-live</code> region are relevant and should be announced.</p>
 

--- a/files/en-us/web/api/element/ariarelevant/index.html
+++ b/files/en-us/web/api/element/ariarelevant/index.html
@@ -44,23 +44,6 @@ console.log(el.ariaRelevant); // all
 el.ariaRelevant = "text"
 console.log(el.ariaRelevant); // text</pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ARIA 1.2','#dom-ariamixin-ariarelevant','ariaRelevant')}}</td>
-   <td>{{Spec2('ARIA 1.2')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>


### PR DESCRIPTION
Reflection of the `aria-relevant` content attribute to the `ariaRelevant` IDL attribute has been dropped from ARIA 1.2:

https://github.com/w3c/aria/issues/1267

> The prose of `aria-relevant` includes some special rules that cannot be expressed in standard WebIDL, so I'm removing its DOMString-based reflection in ARIA 1.2. … I think we should be able to bring this back in 1.3.

https://www.w3.org/TR/wai-aria-1.2/ (last published 18 December 2019) is not up to date with that change, but https://w3c.github.io/aria/ (last published 22 February 2021) is — and it doesn’t have `ariaRelevant`.

So, we should drop the Specifications table from the `ariaRelevant` MDN article for now.