### PR TITLE
Clarify that lastIndex is RegExp instance property, not a static property

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.html
@@ -85,7 +85,7 @@ let re = new RegExp('\\w+')
  <dd>Whether or not the search is sticky.</dd>
  <dt>{{JSxRef("RegExp.prototype.unicode")}}</dt>
  <dd>Whether or not Unicode features are enabled.</dd>
- <dt>{{jsxref("RegExp.lastIndex", "<var>regExp</var>.lastIndex")}}</dt>
+ <dt>{{jsxref("RegExp.lastIndex", "RegExp: lastIndex")}}</dt>
  <dd>The index at which to start the next match.</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.html
@@ -50,7 +50,7 @@ let re = new RegExp('\\w+')
 
 <h3 id="Perl-like_RegExp_properties">Perl-like RegExp properties</h3>
 
-<p>Note that several of the {{JSxRef("RegExp")}} properties have both long and short (Perl-like) names. Both names always refer to the same value. (Perl is the programming language from which JavaScript modeled its regular expressions.). See also <a href="/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#RegExp_Properties">deprecated <code>RegExp</code> properties.</a></p>
+<p>Note that several of the {{JSxRef("RegExp")}} properties have both long and short (Perl-like) names. Both names always refer to the same value. (Perl is the programming language from which JavaScript modeled its regular expressions.). See also <a href="/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#regexp_properties">deprecated <code>RegExp</code> properties.</a></p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.html
@@ -64,8 +64,6 @@ let re = new RegExp('\\w+')
 <dl>
  <dt>{{jsxref("RegExp.@@species", "get RegExp[@@species]")}}</dt>
  <dd>The constructor function that is used to create derived objects.</dd>
- <dt>{{jsxref("RegExp.lastIndex")}}</dt>
- <dd>The index at which to start the next match.</dd>
 </dl>
 
 <h2 id="Instance_properties">Instance properties</h2>
@@ -87,6 +85,8 @@ let re = new RegExp('\\w+')
  <dd>Whether or not the search is sticky.</dd>
  <dt>{{JSxRef("RegExp.prototype.unicode")}}</dt>
  <dd>Whether or not Unicode features are enabled.</dd>
+ <dt>{{jsxref("RegExp.lastIndex", "<var>regExp</var>.lastIndex")}}</dt>
+ <dd>The index at which to start the next match.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.html
@@ -1,5 +1,5 @@
 ---
-title: RegExpInstance.lastIndex
+title: 'RegExp: lastIndex'
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
 tags:
   - JavaScript
@@ -10,7 +10,9 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>lastIndex</code></strong> is a read/write integer property of regular expression instances that specifies the index at which to start the next match.</p>
+<p><strong><code>lastIndex</code></strong> is a read/write integer property of {{jsXref("RegExp")}} instances that specifies the index at which to start the next match.</p>
+
+<p>Note that <code>lastIndex</code> is not a property of the  {{jsXref("RegExp")}} prototype but is instead only exposed from  {{jsXref("RegExp")}} instances.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-lastindex.html")}}</div>
 
@@ -60,7 +62,7 @@ console.log(re.lastIndex);
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('ESDraft', '#sec-properties-of-regexp-instances', 'RegExp.lastIndex')}}</td>
+   <td>{{SpecName('ESDraft', '#sec-properties-of-regexp-instances', 'lastIndex')}}</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
This change updates the `RegExp` article to correct a misclassification of `lastIndex` as a static property; it’s not a static property, but instead an instance property.

However, it’s not a property of `RegExp.prototype` but instead is only exposed from `RegExp` instances — so this change adds some special-casing for that in the article for `lastIndex` itself, as well as in the `RegExp` article.

Fixes https://github.com/mdn/content/issues/2708