### PR TITLE
Removed incorrect "Property attributes of Symbol.unscopables" section

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.html
@@ -21,8 +21,6 @@ tags:
 
 <p>Setting a property to <code>true</code> in an <code>unscopables</code> object will make it <em>unscopable</em> and therefore it won't appear in lexical scope variables. Setting a property to <code>false</code> will make it <code>scopable</code> and thus it will appear in lexical scope variables.</p>
 
-<p>{{js_property_attributes(0,0,0)}}</p>
-
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Scoping_in_with_statements">Scoping in with statements</h3>


### PR DESCRIPTION
No ES standard specifies restrictions on the property attributes of `Symbol.unscopables` objects. Additionally, the built-in `Symbol.unscopables` on `Array.prototype` is both writable and configurable, contrary to these MDN docs.