### PR TITLE
Update links to Mozilla Hacks

### DIFF
--- a/files/en-us/mdn/contribute/localize/index.html
+++ b/files/en-us/mdn/contribute/localize/index.html
@@ -50,6 +50,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="https://hacks.mozilla.org/an-update-on-mdn-web-docs-localization-strategy/">An update on MDN Web Docs’ localization strategy</a> — the latest state of localization on MDN</li>
+ <li><a href="https://hacks.mozilla.org/mdn-localization-update-february-2021/">MDN localization update, February 2021</a> — the latest state of localization on MDN</li>
+ <li><a href="https://hacks.mozilla.org/an-update-on-mdn-web-docs-localization-strategy/">An update on MDN Web Docs’ localization strategy</a> — updated strategy based on community feedback </li>
  <li><a href="https://hacks.mozilla.org/mdn-web-docs-evolves-lowdown-on-the-upcoming-new-platform/">MDN Web Docs evolves! Lowdown on the upcoming new platform</a> — more on the advantages of the new platform, and the rationale behind the localization changes.</li>
 </ul>

--- a/files/en-us/mdn/contribute/localize/index.html
+++ b/files/en-us/mdn/contribute/localize/index.html
@@ -50,6 +50,6 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="https://hacks.mozilla.org/2020/12/an-update-on-mdn-web-docs-localization-strategy/">An update on MDN Web Docs’ localization strategy</a> — the latest state of localization on MDN</li>
- <li><a href="https://hacks.mozilla.org/2020/10/mdn-web-docs-evolves-lowdown-on-the-upcoming-new-platform/">MDN Web Docs evolves! Lowdown on the upcoming new platform</a> — more on the advantages of the new platform, and the rationale behind the localization changes.</li>
+ <li><a href="https://hacks.mozilla.org/an-update-on-mdn-web-docs-localization-strategy/">An update on MDN Web Docs’ localization strategy</a> — the latest state of localization on MDN</li>
+ <li><a href="https://hacks.mozilla.org/mdn-web-docs-evolves-lowdown-on-the-upcoming-new-platform/">MDN Web Docs evolves! Lowdown on the upcoming new platform</a> — more on the advantages of the new platform, and the rationale behind the localization changes.</li>
 </ul>


### PR DESCRIPTION
Apparently the URL scheme changed, the old links were broken. While tracking them down I noticed there is another blogpost in the series, so I added that and updated the descriptions as well - I tried to come up with a decent brief summary of the December post, now that it's not the latest any more, but any improvements on the description there are welcome!