### PR TITLE
Fixes to String.p.replaceAll() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.html
@@ -113,7 +113,8 @@ tags:
   replacement patterns do <em>not</em> apply in this case.)</p>
 
 <p>Note that the function will be invoked multiple times for each full match to be
-  replaced if the regular expression in the first parameter is global.</p>
+  replaced if the first provided the first argument of <code>replaceAll()</code> 
+  was a {{jsxref("RegExp")}} object.</p>
 
 <p>The arguments to the function are as follows:</p>
 
@@ -132,7 +133,7 @@ tags:
     <tr>
       <td><code>p1, p2, ...</code></td>
       <td>The <var>n</var>th string found by a parenthesized capture group, provided the
-        first argument to <code>replace()</code> was a {{jsxref("RegExp")}} object.
+        first argument to <code>replaceAll()</code> was a {{jsxref("RegExp")}} object.
         (Corresponds to <code>$1</code>, <code>$2</code>, etc. above.) For example,
         if <code>/(\a+)(\b+)/</code>, was given, <code>p1</code> is the match for
         <code>\a+</code>, and <code>p2</code> for <code>\b+</code>.</td>

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.html
@@ -112,9 +112,7 @@ tags:
   used as the replacement string. (<strong>Note:</strong> The above-mentioned special
   replacement patterns do <em>not</em> apply in this case.)</p>
 
-<p>Note that the function will be invoked multiple times for each full match to be
-  replaced if the first provided the first argument of <code>replaceAll()</code> 
-  was a {{jsxref("RegExp")}} object.</p>
+<p>Note that if the first argument of an <code>replaceAll()</code> invocation is a {{jsxref("RegExp")}} object or regular expression literal, the function will be invoked multiple times.</p>
 
 <p>The arguments to the function are as follows:</p>
 


### PR DESCRIPTION
1. Suggesting to remove " if the regular expression in the first parameter is global" from the note, since documentation explicitly states that `RegExp` must be global (otherwise an error is thrown). 
2. Typo with a function name, should be `replaceAll()` instead of `replace()`