### PR TITLE
Mark <rb> and <rtc> as deprecated

### DIFF
--- a/files/en-us/web/html/element/rb/index.html
+++ b/files/en-us/web/html/element/rb/index.html
@@ -2,6 +2,7 @@
 title: '<rb>: The Ruby Base element'
 slug: Web/HTML/Element/rb
 tags:
+  - Deprecated
   - Element
   - HTML
   - HTML text-level semantics
@@ -10,7 +11,7 @@ tags:
   - Text
   - Web
 ---
-<div>{{HTMLRef}}{{Non-standard_Header}}</div>
+<div>{{HTMLRef}}{{deprecated_header}}</div>
 
 <p><span class="seoSummary">The <strong>HTML Ruby Base (<code>&lt;rb&gt;</code>) element</strong> is used to delimit the base text component of a  {{HTMLElement("ruby") }} annotation, i.e. the text that is being annotated.</span> One <code>&lt;rb&gt;</code> element should wrap each separate atomic segment of the base text.</p>
 

--- a/files/en-us/web/html/element/rtc/index.html
+++ b/files/en-us/web/html/element/rtc/index.html
@@ -2,6 +2,7 @@
 title: '<rtc>: The Ruby Text Container element'
 slug: Web/HTML/Element/rtc
 tags:
+  - Deprecated
   - Element
   - HTML
   - HTML text-level semantics
@@ -12,7 +13,7 @@ tags:
   - Web
   - rtc
 ---
-<div>{{HTMLRef}}</div>
+<div>{{HTMLRef}}{{deprecated_header}}</div>
 
 <p>The <strong>HTML Ruby Text Container (<code>&lt;rtc&gt;</code>) element</strong> embraces semantic annotations of characters presented in a ruby of {{HTMLElement("rb")}} elements used inside of {{ HTMLElement("ruby") }} element. {{HTMLElement("rb")}} elements can have both pronunciation ({{HTMLElement("rt")}}) and semantic ({{HTMLElement("rtc")}}) annotations.</p>
 


### PR DESCRIPTION
They are both not in Living Standard, and are already deprecated at BCD.