### PR TITLE
Fix typo in “Test your skills: Form structure”

### DIFF
--- a/files/en-us/learn/forms/test_your_skills_colon__form_validation/index.html
+++ b/files/en-us/learn/forms/test_your_skills_colon__form_validation/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{learnsidebar}}</div>
 
-<p>The aim <!--'This' on line 14 is change to 'The'--> of this skill test is to assess whether you've understood our <a href="/en-US/docs/Learn/Forms/Form_validation">Client-side form validation</a> article.</p>
+<p>The aim of this skill test is to assess whether you've understood our <a href="/en-US/docs/Learn/Forms/Form_validation">Client-side form validation</a> article.</p>
 
 <div class="notecard note">
 <p><strong>Note</strong>: You can try out solutions locally, however it may be helpful to put your code in an online tool such as <a href="https://codepen.io/">CodePen</a>, <a href="https://jsfiddle.net/">jsFiddle</a>, or <a href="https://glitch.com/">Glitch</a> to work on the tasks.<br>


### PR DESCRIPTION
Found a typo error on Test-your-skills-Form-structure, 'This' on line 14 is changed to 'The'.