### PR TITLE
user-select - clarify intro

### DIFF
--- a/files/en-us/web/css/user-select/index.html
+++ b/files/en-us/web/css/user-select/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <code><strong>user-select</strong></code> <a href="/en-US/docs/Web/CSS">CSS</a> property controls whether the user can select text. This doesn't have any effect on content loaded as {{Glossary("Chrome", "chrome")}}, except in textboxes.</p>
+<p>The <code><strong>user-select</strong></code> <a href="/en-US/docs/Web/CSS">CSS</a> property controls whether the user can select text. This doesn't have any effect on content loaded as part of a browser's user interface (its {{Glossary("Chrome", "chrome")}}), except in textboxes.</p>
 
 <pre class="brush:css">/* Keyword values */
 user-select: none;


### PR DESCRIPTION
Reword the intro for `user-select` to make it not use browser developer-internal wording as the primary phrasing.