### PR TITLE
FF87 RelNote: CSS inactive rules

### DIFF
--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -19,10 +19,17 @@ tags:
 
 <h3 id="Developer_Tools">Developer Tools</h3>
 
+
+
 <ul>
-  <li>The {{cssxref("table-layout")}} property is now marked as inactive for non-table elements. ({{bug(1551571)}}).</li>
-  <li>The {{cssxref("scroll-padding")}} shorthand and longhand properties are now marked as inactive for non-scrollable elements. ({{bug(1551577)}}).</li>
-  <li>The {{cssxref("text-overflow")}} property was previously incorrectly marked as inactive for some {{cssxref("overflow")}} values. This got fixed in {{bug(1671457)}}.</li>
+
+  <li>Firefox <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#rule_display">Page Inspector</a> improvements and bug fixes related to inactive CSS rules:
+    <ul>
+      <li>The {{cssxref("table-layout")}} property is now marked as inactive for non-table elements ({{bug(1551571)}}).</li>
+      <li>The {{cssxref("scroll-padding")}} properties (shorthand and longhand) are now marked as inactive for non-scrollable elements ({{bug(1551577)}}).</li>
+      <li>The {{cssxref("text-overflow")}} property was previously incorrectly marked as inactive for some {{cssxref("overflow")}} values ({{bug(1671457)}}).</li>
+    </ul>
+  </li>
 </ul>
 
 <h4 id="Removals">Removals</h4>


### PR DESCRIPTION
Improves the release note for #2505. Essentially this groups the set of fixes to the Page inspector that are related to display/warnings on inactive CSS rules, and provides a link to the inspector so that it is obvious to readers what part of the story is impacted.

Fixes #2505