### PR TITLE
Content-Length added to CORs safelisted headers

### DIFF
--- a/files/en-us/glossary/cors-safelisted_response_header/index.html
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.html
@@ -7,8 +7,9 @@ tags:
   - Glossary
   - HTTP
 ---
-<p><span class="seoSummary">A <em>CORS-safelisted response header</em> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> which has been safelisted so that it will not be filtered when responses are processed by CORS, since they're considered <em>safe</em> (as the headers listed in {{HTTPHeader("Access-Control-Expose-Headers")}}).</span> By default, the safelist includes the following response headers:</p>
+<p><span class="seoSummary">A <em>CORS-safelisted response header</em> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> in a <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> response that it is considered <em>safe</em> to expose to client scripts (only safelisted headers are made available to web pages).</span></p>
 
+<p>By default, the safelist includes the following response headers:</p> 
 <ul>
  <li>{{HTTPHeader("Cache-Control")}}</li>
  <li>{{HTTPHeader("Content-Language")}}</li>
@@ -19,7 +20,13 @@ tags:
  <li>{{HTTPHeader("Pragma")}}</li>
 </ul>
 
-<p>{{HTTPHeader("Content-Length")}} was not part of the original set safelisted response headers [<a href="https://github.com/whatwg/fetch/pull/626">ref</a>]</p>
+<p>Additional headers can be added to the safelist using {{HTTPHeader("Access-Control-Expose-Headers")}}.</p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>{{HTTPHeader("Content-Length")}} was not part of the original set safelisted response headers [<a href="https://github.com/whatwg/fetch/pull/626">ref</a>]</p>
+</div>
+
 
 <h2 id="Examples">Examples</h2>
 
@@ -27,7 +34,7 @@ tags:
 
 <p>You can extend the list of CORS-safelisted response headers by using the {{HTTPHeader("Access-Control-Expose-Headers")}} header:</p>
 
-<pre class="brush: plain">Access-Control-Expose-Headers: X-Custom-Header, Content-Length</pre>
+<pre class="brush: plain">Access-Control-Expose-Headers: X-Custom-Header, Content-Encoding</pre>
 
 <section id="Quick_links">
 <ol>

--- a/files/en-us/glossary/cors-safelisted_response_header/index.html
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.html
@@ -7,7 +7,7 @@ tags:
   - Glossary
   - HTTP
 ---
-<p><span class="seoSummary">A <em>CORS-safelisted response header</em> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> in a <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> response that it is considered <em>safe</em> to expose to client scripts (only safelisted headers are made available to web pages).</span></p>
+<p><span class="seoSummary">A <em>CORS-safelisted response header</em> is an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a> in a <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> response that it is considered <em>safe</em> to expose to client scripts. Only safelisted response headers are made available to web pages.</span></p>
 
 <p>By default, the safelist includes the following response headers:</p> 
 <ul>

--- a/files/en-us/glossary/cors-safelisted_response_header/index.html
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.html
@@ -24,7 +24,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>{{HTTPHeader("Content-Length")}} was not part of the original set safelisted response headers [<a href="https://github.com/whatwg/fetch/pull/626">ref</a>]</p>
+  <p>{{HTTPHeader("Content-Length")}} was not part of the original set of safelisted response headers [<a href="https://github.com/whatwg/fetch/pull/626">ref</a>]</p>
 </div>
 
 

--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -49,6 +49,10 @@ tags:
 
 <h3 id="HTTP">HTTP</h3>
 
+<ul>
+  <li><code><a href="/en-US/docs/Web/HTTP/Headers/Content-Length">Content-Length</a></code> has been added to the list of <a href="/en-US/docs/Glossary/CORS-safelisted_response_header">CORS-safelisted response headers</a> ({{bug(1460299)}}).</li>
+ </ul>
+
 <h4 id="Removals_5">Removals</h4>
 
 <h3 id="Security">Security</h3>

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.html
@@ -9,21 +9,9 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <strong><code>Access-Control-Expose-Headers</code></strong> response header indicates which headers can be exposed as part of the response by listing their names.</p>
+<p>The <strong><code>Access-Control-Expose-Headers</code></strong> allows a server to indicate which response headers should be made available to  scripts running in the browser, in response to a cross-origin request.</p>
 
-<p>By default, only the 7 {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}} are exposed:</p>
-
-<ul>
- <li>{{HTTPHeader("Cache-Control")}}</li>
- <li>{{HTTPHeader("Content-Language")}}</li>
- <li>{{HTTPHeader("Content-Length")}}</li>
- <li>{{HTTPHeader("Content-Type")}}</li>
- <li>{{HTTPHeader("Expires")}}</li>
- <li>{{HTTPHeader("Last-Modified")}}</li>
- <li>{{HTTPHeader("Pragma")}}</li>
-</ul>
-
-<p>If you want clients to be able to access other headers, you have to list them using the <code>Access-Control-Expose-Headers</code> header. {{HTTPHeader("Content-Length")}} was not part of the original set safelisted response headers [<a href="https://github.com/whatwg/fetch/pull/626">ref</a>].</p>
+<p>Only the {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}} are exposed by default. For clients to be able to access other headers, the server must list them using the <code>Access-Control-Expose-Headers</code> header.</p>
 
 <table class="properties">
  <tbody>
@@ -48,7 +36,7 @@ Access-Control-Expose-Headers: *
 
 <dl>
  <dt>&lt;header-name&gt;</dt>
- <dd>A list of exposed headers consisting of zero or more <a href="/en-US/docs/Web/HTTP/Headers">header names</a> other than the {{Glossary("CORS-safelisted_request_header", "CORS-safelisted request headers")}} that the resource might use and can be exposed.</dd>
+ <dd>A list of zero or more comma-separated <a href="/en-US/docs/Web/HTTP/Headers">header names</a> that clients are allowed to access from a response. These are <em>in addition</em> to the {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}}.</dd>
  <dt><code>*</code> (wildcard)</dt>
  <dd>The value "<code>*</code>" only counts as a special wildcard value for requests without credentials (requests without <a href="/en-US/docs/Web/HTTP/Cookies">HTTP cookies</a> or HTTP authentication information). In requests with credentials, it is treated as the literal header name "<code>*</code>" without special semantics.<br>
  Note that the {{HTTPHeader("Authorization")}} header can't be wildcarded and always needs to be listed explicitly.</dd>
@@ -56,15 +44,15 @@ Access-Control-Expose-Headers: *
 
 <h2 id="Examples">Examples</h2>
 
-<p>To expose a non-CORS-safelisted request header, you can specify:</p>
+<p>The {{Glossary("CORS-safelisted response header", "CORS-safelisted response headers")}} are: {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Language")}}, {{HTTPHeader("Content-Length")}}, {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Expires")}}, {{HTTPHeader("Last-Modified")}}, {{HTTPHeader("Pragma")}}. To expose a non-CORS-safelisted response header, you can specify:</p>
 
-<pre>Access-Control-Expose-Headers: Content-Length</pre>
+<pre>Access-Control-Expose-Headers: Content-Encoding</pre>
 
 <p>To additionally expose a custom header, like <code>X-Kuma-Revision</code>, you can specify multiple headers separated by a comma:</p>
 
-<pre>Access-Control-Expose-Headers: Content-Length, X-Kuma-Revision</pre>
+<pre>Access-Control-Expose-Headers: Content-Encoding, X-Kuma-Revision</pre>
 
-<p>In requests without credentials, you can also use a wildcard value:</p>
+<p>For requests without credentials, a server can also respond with a wildcard value:</p>
 
 <pre>Access-Control-Expose-Headers: *</pre>
 

--- a/files/en-us/web/http/headers/content-length/index.html
+++ b/files/en-us/web/http/headers/content-length/index.html
@@ -21,6 +21,10 @@ tags:
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
       <td>yes</td>
     </tr>
+    <tr>
+      <th scope="row">{{Glossary("CORS-safelisted response header")}}</th>
+      <td>yes</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This fixes #2503

This also updates the explanation of the "CORS-safelisted response headers" and `Access-Control-Expose-Headers` docs which I found confusing. Those need some careful review because I interpreted some docs that felt a little unclear to me.