### PR TITLE
Firefox 87 link changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -41,6 +41,7 @@ tags:
 
 <ul>
   <li>The non-standard values of {{cssxref("caption-side")}} (<code>left</code>, <code>right</code>, <code>top-outside</code>, and <code>bottom-outside</code>) have been removed and placed behind the <code>layout.css.caption-side-non-standard.enabled</code> flag ({{bug(1688695)}}).</li>
+  <li>The {{HTMLElement("link")}} element is no longer matched by {{cssxref(":link")}}, {{cssxref(":visited")}}, or {{cssxref(":any-link")}}. This aligns the behavior in Firefox to existing behavior in Chrome and to a recent spec change ({{bug(1687538)}}).</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>

--- a/files/en-us/web/css/_colon_any-link/index.html
+++ b/files/en-us/web/css/_colon_any-link/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>:any-link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> selector represents an element that acts as the source anchor of a hyperlink, independent of whether it has been visited. In other words, it matches every {{HTMLElement("a")}}, {{HTMLElement("area")}}, or {{HTMLElement("link")}} element that has an <code>href</code> attribute. Thus, it matches all elements that match {{cssxref(":link")}} or {{cssxref(":visited")}}.</p>
+<p>The <strong><code>:any-link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> selector represents an element that acts as the source anchor of a hyperlink, independent of whether it has been visited. In other words, it matches every {{HTMLElement("a")}} or {{HTMLElement("area")}} element that has an <code>href</code> attribute. Thus, it matches all elements that match {{cssxref(":link")}} or {{cssxref(":visited")}}.</p>
 
 <pre class="brush: css no-line-numbers">/* Selects any element that would be matched by :link or :visited */
 :any-link {

--- a/files/en-us/web/css/_colon_link/index.html
+++ b/files/en-us/web/css/_colon_link/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{ CSSRef }}</div>
 
-<p>The <strong><code>:link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents an element that has not yet been visited. It matches every unvisited {{HTMLElement("a")}}, {{HTMLElement("area")}}, or {{HTMLElement("link")}} element that has an <code>href</code> attribute.</p>
+<p>The <strong><code>:link</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents an element that has not yet been visited. It matches every unvisited {{HTMLElement("a")}} or {{HTMLElement("area")}} element that has an <code>href</code> attribute.</p>
 
 <pre class="brush: css no-line-numbers">/* Selects any &lt;a&gt; that has not been visited yet */
 a:link {


### PR DESCRIPTION
Working on: #2506 

Updating `:link` and `:any-link` which mentioned matching `<link>`, adding to release notes.