### PR TITLE
fix jsexample-bad syntax

### DIFF
--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.html
@@ -48,7 +48,7 @@ tags:
 
 <p>And not equivalent to the following which would always perform an assignment:</p>
 
-<pre class="brush: jsexample-bad">x = x &amp;&amp; y;
+<pre class="brush: js example-bad">x = x &amp;&amp; y;
 </pre>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.html
@@ -53,7 +53,7 @@ tags:
 
 <p>And not equivalent to the following which would always perform an assignment:</p>
 
-<pre class="brush: jsexample-bad">x = x ?? y;
+<pre class="brush: js example-bad">x = x ?? y;
 </pre>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.html
@@ -49,7 +49,7 @@ tags:
 
 <p>And not equivalent to the following which would always perform an assignment:</p>
 
-<pre class="brush: jsexample-bad">x = x || y;
+<pre class="brush: js example-bad">x = x || y;
 </pre>
 
 <p>Note that this behavior is different to mathematical and bitwise assignment operators.


### PR DESCRIPTION
E.g. on http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment

Before:
<img width="778" alt="Screen Shot 2021-03-01 at 9 49 07 AM" src="https://user-images.githubusercontent.com/26739/109514021-a56ace00-7a73-11eb-887c-508242a40c1a.png">

After:
<img width="877" alt="Screen Shot 2021-03-01 at 9 49 24 AM" src="https://user-images.githubusercontent.com/26739/109514094-aa2f8200-7a73-11eb-9ea1-4c170e2a2f8a.png">
