### PR TITLE
Reword note regarding postMessage() timing

### DIFF
--- a/files/en-us/web/api/window/postmessage/index.html
+++ b/files/en-us/web/api/window/postmessage/index.html
@@ -228,11 +228,11 @@ window.addEventListener("message", (event) =&gt; {
   not possible for the caller of <code>postMessage</code> to detect when an event handler
   listening for events sent by <code>postMessage</code> throws an exception.</p>
 
-<p><code>postMessage()</code> schedules the {{domxref("MessageEvent")}} to be dispatched
-  <em>only after all pending execution contexts have finished</em>. For example, if
-  <code>postMessage()</code> is invoked in an event handler, that event handler will run
-  to completion, as will any remaining handlers for that same event, before the
-  {{domxref("MessageEvent")}} is dispatched.</p>
+<p>After <code>postMessage()</code> is called, the {{domxref("MessageEvent")}} will be
+  dispatched <em>only after all pending execution contexts have finished</em>. 
+  For example, if <code>postMessage()</code> is invoked in an event handler, that event
+  handler will run to completion, as will any remaining handlers for that same event,
+  before the {{domxref("MessageEvent")}} is dispatched.</p>
 
 <p>The value of the <code>origin</code> property of the dispatched event is not affected
   by the current value of <code>document.domain</code> in the calling window.</p>


### PR DESCRIPTION
It came up in conversation that this wording is gramatically ambiguous, because
it is not clear whether the emphasized part referred to “schedules” or
“dispatched” as its verb.

This has practical implications in cases like `postMessage(42); while(true);`,
where it matters that the scheduling takes place immediately.

I’ve reworded this to avoid future misunderstandings. :)