### PR TITLE
Add deprecated header to WebVR docs

### DIFF
--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - displayId
 ---
-<p>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</p>
+<p>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>displayId</code></strong> read-only property of the {{domxref("Gamepad")}} interface <dfn>returns the {{domxref("VRDisplay.displayId")}} of the associated {{domxref("VRDisplay")}} — the <code>VRDisplay</code> that the gamepad is controlling the displayed scene of.</dfn></p>
 

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - cancelAnimationFrame()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>cancelAnimationFrame()</strong></code> method of the {{domxref("VRDisplay")}} interface is a special implementation of {{domxref("Window.cancelAnimationFrame")}} that unregisters callbacks registered with {{domxref("VRDisplay.requestAnimationFrame()")}}.</p>
 

--- a/files/en-us/web/api/vrdisplay/capabilities/index.html
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - capabilities
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>capabilities</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRDisplayCapabilities")}} object that indicates the various capabilities of the <code>VRDisplay</code>.</p>
 

--- a/files/en-us/web/api/vrdisplay/depthfar/index.html
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - depthFar
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>depthFar</strong></code> property of the {{domxref("VRDisplay")}} interface gets and sets the z-depth defining the far plane of the <a href="https://en.wikipedia.org/wiki/Viewing_frustum">eye view frustum</a>, i.e. the furthest viewable boundary of the scene.</p>
 

--- a/files/en-us/web/api/vrdisplay/depthnear/index.html
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - depthNear
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>depthNear</strong></code> property of the {{domxref("VRDisplay")}} interface gets and sets the z-depth defining the near plane of the <a href="https://en.wikipedia.org/wiki/Viewing_frustum">eye view frustum</a>, i.e. the nearest viewable boundary of the scene.</p>
 

--- a/files/en-us/web/api/vrdisplay/displayid/index.html
+++ b/files/en-us/web/api/vrdisplay/displayid/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - displayId
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>displayId</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns an identifier for this particular <code>VRDisplay</code>, which is also used as an association point in the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a> (see {{domxref("Gamepad.displayId")}}).</p>
 

--- a/files/en-us/web/api/vrdisplay/displayname/index.html
+++ b/files/en-us/web/api/vrdisplay/displayname/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - displayName
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>displayName</code></strong> read-only property of the {{domxref("VRDisplay")}} interface returns a human-readable name to identify the <code>VRDisplay</code>.</p>
 

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - exitPresent()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>exitPresent()</strong></code> method of the {{domxref("VRDisplay")}} interface stops the <code>VRDisplay</code> presenting a scene.</p>
 

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - getEyeParameters()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>getEyeParameters()</strong></code> method of the {{domxref("VRDisplay")}} interface returns the {{domxref("VREyeParameters")}} object containing the eye parameters for the specified eye.</p>
 

--- a/files/en-us/web/api/vrdisplay/getframedata/index.html
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - getFrameData
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>getFrameData()</strong></code> method of the {{domxref("VRDisplay")}} interface accepts a {{domxref("VRFrameData")}} object and populates it with the information required to render the current frame.</p>
 

--- a/files/en-us/web/api/vrdisplay/getlayers/index.html
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - getLayers()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>getLayers()</strong></code> method of the {{domxref("VRDisplay")}} interface returns the layers currently being presented by the <code>VRDisplay</code>.</p>
 

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -13,7 +13,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRDisplay</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents any VR device supported by this API. It includes generic information such as device IDs and descriptions, as well as methods for starting to present a VR scene, retrieving eye parameters and display capabilities, and other important functionality.</p>
 

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -13,7 +13,7 @@ tags:
   - WebVR
   - isConnected
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>isConnected</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is connected to the computer.</p>
 

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - isPresenting
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>isPresenting</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("Boolean")}} indicating whether the <code>VRDisplay</code> is currently having content presented through it.</p>
 

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - requestAnimationFrame()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>requestAnimationFrame()</strong></code> method of the {{domxref("VRDisplay")}} interface is a special implementation of {{domxref("Window.requestAnimationFrame")}} containing a callback function that will be called every time a new frame of the <code>VRDisplay</code> presentation is rendered:</p>
 

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - requestPresent()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>requestPresent()</strong></code> method of the {{domxref("VRDisplay")}} interface starts the <code>VRDisplay</code> presenting a scene.</p>
 

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - stageParameters
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>stageParameters</strong></code> read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRStageParameters")}} object containing room-scale parameters, if the <code>VRDisplay</code> is capable of supporting room-scale experiences.</p>
 

--- a/files/en-us/web/api/vrdisplay/submitframe/index.html
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - submitFrame()
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>submitFrame()</strong></code> method of the {{domxref("VRDisplay")}} interface captures the current state of the {{domxref("VRLayerInit")}} currently being presented and displays it on the <code>VRDisplay</code>.</p>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - canPresent
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>canPresent</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display is capable of presenting content (e.g. through an HMD).</p>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - hasExternalDisplay
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>hasExternalDisplay</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display is separate from the device's primary display.</p>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
@@ -13,7 +13,7 @@ tags:
   - WebVR
   - hasOrientation
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_header}}</div>
 
 <p>The <strong><code>hasOrientation</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display can track and return orientation information.</p>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - hasPosition
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>hasPosition</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a {{domxref("Boolean")}} stating whether the VR display can track and return position information.</p>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRDisplayCapabilities</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> describes the capabilities of a {{domxref("VRDisplay")}} — its features can be used to perform VR device capability tests, for example can it return position information.</p>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - maxLayers
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>maxLayers</code></strong> read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a number indicating the maximum number of {{domxref("VRLayer")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("Display.requestPresent()")}} can accept.)</p>
 

--- a/files/en-us/web/api/vrdisplayevent/display/index.html
+++ b/files/en-us/web/api/vrdisplayevent/display/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - display
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>display</code></strong> read-only property of the {{domxref("VRDisplayEvent")}} interface returns the {{domxref("VRDisplay")}} associated with this event.</p>
 

--- a/files/en-us/web/api/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRDisplayEvent</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents the event object of WebVR-related events (see the<a href="/en-US/docs/Web/API/WebVR_API#Window"> list of WebVR window extensions</a>).</p>
 

--- a/files/en-us/web/api/vrdisplayevent/reason/index.html
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - reason
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>reason</code></strong> read-only property of the {{domxref("VRDisplayEvent")}} interface returns a human-readable reason why the event was fired.</p>
 

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The {{domxref("VRDisplayEvent")}} constructor creates a <code>VRDisplayEvent</code> object instance.</p>
 

--- a/files/en-us/web/api/vreyeparameters/index.html
+++ b/files/en-us/web/api/vreyeparameters/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VREyeParameters</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents all the information required to correctly render a scene for a given eye, including field of view information.</p>
 

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - renderHeight
 ---
-<p>{{APIRef("WebVR API")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("WebVR API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>renderHeight</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the recommended render target height of each eye viewport, in pixels.</p>
 

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - renderWidth
 ---
-<p>{{APIRef("WebVR API")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("WebVR API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>renderWidth</code></strong> read-only property of the {{domxref("VREyeParameters")}} interface describes the recommended render target width of each eye viewport, in pixels.</p>
 

--- a/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <p>{{deprecated_header}}</p>
 
-<p>{{APIRef("WebVR API")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("WebVR API")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>VRFieldOfView()</code></strong> constructor creates a new {{domxref("VRFieldOFView")}} object.</p>
 

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRFrameData</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents all the information needed to render a single frame of a VR scene; constructed by {{domxref("VRDisplay.getFrameData()")}}.</p>
 
@@ -53,7 +53,7 @@ tags:
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('WebVR 1.1', '#interface-vrdisplayevent', 'VRDisplayEvent')}}</td>
+   <td>{{SpecName('WebVR 1.1', '#interface-vrframedata', 'VRFrameData')}}</td>
    <td>{{Spec2('WebVR 1.1')}}</td>
    <td>Initial definition</td>
   </tr>

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - leftProjectionMatrix
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>leftProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the left eye’s rendering.</p>
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - leftViewMatrix
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>leftViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the left eye’s rendering.</p>
 

--- a/files/en-us/web/api/vrframedata/pose/index.html
+++ b/files/en-us/web/api/vrframedata/pose/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - pose
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>pose</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns the {{domxref("VRPose")}} of the {{domxref("VRDisplay")}} at the current {{domxref("VRFrameData.timestamp")}}.</p>
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - rightProjectionMatrix
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>rightProjectionMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the projection to be used for the right eye’s rendering.</p>
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - rightViewMatrix
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>rightViewMatrix</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a {{domxref("Float32Array")}} representing a 4x4 matrix that describes the view transform to be used for the right eye’s rendering.</p>
 

--- a/files/en-us/web/api/vrframedata/timestamp/index.html
+++ b/files/en-us/web/api/vrframedata/timestamp/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - timeStamp
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>timestamp</code></strong> read-only property of the {{domxref("VRFrameData")}} interface returns a constantly increasing timestamp value representing the time a frame update occurred.</p>
 

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The {{domxref("VRFrameData")}} constructor creates a <code>VRFrameData</code> object instance.</p>
 

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -12,7 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRLayerInit</code></strong> interface (dictionary) of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents a content layer (an {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}}) that you want to present in a VR display.</p>
 

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - leftBounds
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>leftBounds</strong></code> property of the {{domxref("VRLayerInit")}} interface (dictionary) defines the left texture bounds of the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.</p>
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - rightBounds
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>rightBounds</strong></code> property of the {{domxref("VRLayerInit")}} interface (dictionary) defines the right texture bounds of the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.</p>
 

--- a/files/en-us/web/api/vrlayerinit/source/index.html
+++ b/files/en-us/web/api/vrlayerinit/source/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - source
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>source</strong></code> property of the {{domxref("VRLayerInit")}} interface (dictionary) defines the canvas whose contents will be presented by the {{domxref("VRDisplay")}}.</p>
 

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -14,7 +14,7 @@ tags:
   - WebVR
   - angularAcceleration
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>angularAcceleration</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the angular acceleration vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second per second.</p>
 

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -14,7 +14,7 @@ tags:
   - WebVR
   - angularVelocity
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>angularVelocity</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the angular velocity vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in radians per second.</p>
 

--- a/files/en-us/web/api/vrpose/index.html
+++ b/files/en-us/web/api/vrpose/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRPose</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents the state of a VR sensor at a given timestamp (which includes orientation, position, velocity, and acceleration information.)</p>
 

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -14,7 +14,7 @@ tags:
   - WebVR
   - linearAcceleration
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>linearAcceleration</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the linear acceleration vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second per second.</p>
 

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -14,7 +14,7 @@ tags:
   - WebVR
   - linearVelocity
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>linearVelocity</code></strong> read-only property of the {{domxref("VRPose")}} interface returns an array representing the linear velocity vector of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}}, in meters per second.</p>
 

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -14,7 +14,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>orientation</code></strong> read-only property of the {{domxref("VRPositionState")}} interface returns the orientation of the sensor at the current {{domxref("VRPose.timestamp")}}, as a quarternion value.</p>
 

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -14,7 +14,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>position</code></strong> read-only property of the {{domxref("VRPose")}} interface returns the position of the {{domxref("VRDisplay")}} at the current {{domxref("VRPose.timestamp")}} as a 3D vector.</p>
 

--- a/files/en-us/web/api/vrstageparameters/index.html
+++ b/files/en-us/web/api/vrstageparameters/index.html
@@ -11,7 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>VRStageParameters</code></strong> interface of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> represents the values describing the stage area for devices that support room-scale experiences.</p>
 

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - sittingToStandingTransform
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>sittingToStandingTransform</code></strong> read-only property of the {{domxref("VRStageParameters")}} interface contains a matrix that transforms the sitting-space view matrices of {{domxref("VRFrameData")}} to standing-space.</p>
 

--- a/files/en-us/web/api/vrstageparameters/sizex/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - sizeX
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>sizeX</code></strong> read-only property of the {{domxref("VRStageParameters")}} interface <dfn>returns the w</dfn>idth of the play-area bounds in meters.</p>
 

--- a/files/en-us/web/api/vrstageparameters/sizey/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.html
@@ -12,7 +12,7 @@ tags:
   - WebVR
   - sizeY
 ---
-<div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>sizeY</code></strong> read-only property of the {{domxref("VRStageParameters")}} interface <dfn>returns the depth</dfn> of the play-area bounds in meters.</p>
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.html
@@ -11,7 +11,7 @@ tags:
   - WebVR
   - controllers
 ---
-<div>{{APIRef("WebVR API")}}</div>
+<div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p class="summary">Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the <a href="/en-US/docs/Web/API/Gamepad_API">Gamepad API</a>, and specifically the <a href="/en-US/docs/Web/API/Gamepad_API#Experimental_Gamepad_extensions">Gamepad Extensions API</a> that adds API features for accessing <a href="/en-US/docs/Web/API/GamepadPose">controller pose</a>, <a href="/en-US/docs/Web/API/GamepadHapticActuator">haptic actuators</a>, and more. This article explains the basics.</p>
 

--- a/files/en-us/web/api/window/onvrdisplayactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplayactivate/index.html
@@ -14,7 +14,7 @@ tags:
 - events
 - onvrdisplayactivate
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplayactivate</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when a display

--- a/files/en-us/web/api/window/onvrdisplayblur/index.html
+++ b/files/en-us/web/api/window/onvrdisplayblur/index.html
@@ -14,7 +14,7 @@ tags:
 - events
 - onvrdisplayblur
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplayblur</code></strong> property of the {{domxref("Window")}}
   interface represents an event handler that will run when presentation to a display has

--- a/files/en-us/web/api/window/onvrdisplayconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplayconnect/index.html
@@ -13,7 +13,7 @@ tags:
 - events
 - onvrdisplayconnect
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>onvrdisplayconnect</strong></code> property of the
   {{domxref("Window")}} interface represents an event handler that will run when a

--- a/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydeactivate/index.html
@@ -14,7 +14,7 @@ tags:
 - events
 - onvrdisplaydeactivate
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplaydeactivate</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when a display

--- a/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
+++ b/files/en-us/web/api/window/onvrdisplaydisconnect/index.html
@@ -13,7 +13,7 @@ tags:
 - events
 - onvrdisplaydisconnect
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>onvrdisplaydisconnect</strong></code> event handler property of the
   {{domxref("Window")}} interface is called when a compatible VR display has been

--- a/files/en-us/web/api/window/onvrdisplayfocus/index.html
+++ b/files/en-us/web/api/window/onvrdisplayfocus/index.html
@@ -14,7 +14,7 @@ tags:
 - events
 - onvrdisplayfocus
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplayfocus</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when

--- a/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerrestricted/index.html
@@ -9,7 +9,7 @@ tags:
 - Window
 - onvrdisplaypointerrestricted
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplaypointerrestricted</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when the VR

--- a/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypointerunrestricted/index.html
@@ -9,7 +9,7 @@ tags:
 - Window
 - onvrdisplaypointerunrestricted
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplaypointerunrestricted</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when the VR

--- a/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
+++ b/files/en-us/web/api/window/onvrdisplaypresentchange/index.html
@@ -13,7 +13,7 @@ tags:
 - events
 - onvrdisplaypresentchange
 ---
-<div>{{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}</div>
+<div>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>onvrdisplaypresentchange</code></strong> property of the
   {{domxref("Window")}} interface represents an event handler that will run when the

--- a/files/en-us/web/api/window/vrdisplayactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayactivate_event/index.html
@@ -8,7 +8,7 @@ tags:
   - onvrdisplayactivate
   - vrdisplayactivate
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplayactivate</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a VR display is able to be presented to, for example if an HMD has been moved to bring it out of standby, or woken up by being put on.</p>
 

--- a/files/en-us/web/api/window/vrdisplayblur_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayblur_event/index.html
@@ -9,7 +9,7 @@ tags:
   - onvrdisplayblur
   - vrdisplayblur
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplayblur</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when presentation to a VR display has been paused for some reason by the browser, OS, or VR hardware — for example, while the user is interacting with a system menu or browser, to prevent tracking or loss of experience.</p>
 

--- a/files/en-us/web/api/window/vrdisplayconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayconnect_event/index.html
@@ -8,7 +8,7 @@ tags:
   - onvrdisplayconnect
   - vrdisplayconnect
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplayconnect</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a compatible VR display is connected to the computer.</p>
 

--- a/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydeactivate_event/index.html
@@ -8,7 +8,7 @@ tags:
   - onvrdisplaydeactivate
   - vrdisplaydeactivate
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplaydeactivate</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a VR display can no longer be presented to, for example if an HMD has gone into standby or sleep mode due to a period of inactivity.</p>
 

--- a/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaydisconnect_event/index.html
@@ -8,7 +8,7 @@ tags:
   - onvrdisplaydisconnect
   - vrdisplaydisconnect
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplaydisconnect</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when a compatible VR display is disconnected from the computer.</p>
 

--- a/files/en-us/web/api/window/vrdisplayfocus_event/index.html
+++ b/files/en-us/web/api/window/vrdisplayfocus_event/index.html
@@ -8,7 +8,7 @@ tags:
   - onvrdisplayfocus
   - vrdisplayfocus
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplayfocus</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when presentation to a VR display has resumed after being blurred.</p>
 

--- a/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.html
@@ -8,7 +8,7 @@ tags:
   - events
   - vrdisplaypointerrestricted
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplaypointerrestricted</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when the VR display's pointer input is restricted to consumption via a <a href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.</p>
 

--- a/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.html
@@ -8,7 +8,7 @@ tags:
   - events
   - vrdisplaypointerunrestricted
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplaypointerunrestricted</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when the VR display's pointer input is no longer restricted to consumption via a <a href="/en-US/docs/Web/API/Pointer_Lock_API">pointerlocked element</a>.</p>
 

--- a/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
+++ b/files/en-us/web/api/window/vrdisplaypresentchange_event/index.html
@@ -8,7 +8,7 @@ tags:
   - onvrdisplaypresentchange
   - vrdisplaypresentchange
 ---
-<div>{{APIRef("Window")}}</div>
+<div>{{APIRef("Window")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>vrdisplaypresentchange</code></strong> event of the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> is fired when the presenting state of a VR display changes — i.e. goes from presenting to not presenting, or vice versa.</p>
 


### PR DESCRIPTION
This change adds a deprecated header to the articles and subarticles for the following features:

- VRDisplayCapabilities
- VRDisplayEvent
- VRDisplay
- VREyeParameters
- VRFrameData
- VRLayerInit
- VRPose
- VRStageParameters

Related: https://github.com/mdn/content/issues/80