### PR TITLE
Update isolation

### DIFF
--- a/files/en-us/web/css/isolation/index.html
+++ b/files/en-us/web/css/isolation/index.html
@@ -15,7 +15,7 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/css/isolation.html")}}</div>
 
-<p>This property is especially helpful when used in conjunction with {{cssxref("mix-blend-mode")}}.</p>
+<p>This property is especially helpful when used in conjunction with {{cssxref("mix-blend-mode")}} and {{cssxref("z-index")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
I added that it is often used in conjunction with z-index too, since it creates a new stacking context which does not interact with the content surrounding it.

This is especially true for the body, which has a default z-index of auto and prevents the user from interacting with elements with a negative z-index if isolation is set to none.

See https://coder-coder.com/z-index-isnt-working/ for more information.