### PR TITLE
HTTP Referrer-Policy - new default value in spec

### DIFF
--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -58,8 +58,9 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
+  <li>The default <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy">Referrer-Policy</a></code> has been changed to <code><a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#strict-origin-when-cross-origin">strict-origin-when-cross-origin</a></code> (from <code>no-referrer-when-downgrade</code>), reducing the risk of leaking referrer information in cross-origin requests ({{bug(1589074)}}).</li>
   <li><code><a href="/en-US/docs/Web/HTTP/Headers/Content-Length">Content-Length</a></code> has been added to the list of <a href="/en-US/docs/Glossary/CORS-safelisted_response_header">CORS-safelisted response headers</a> ({{bug(1460299)}}).</li>
- </ul>
+</ul>
 
 <h4 id="Removals_5">Removals</h4>
 

--- a/files/en-us/web/http/headers/referer/index.html
+++ b/files/en-us/web/http/headers/referer/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>The <code><strong>Referer</strong></code> HTTP request header contains an absolute or partial address of the page making the request. When following a link, this would be the address of the page containing the link. When making resource requests to another domain, this would be the address of the page using the resource. The <code>Referer</code> header allows servers to identify where people are visiting them from, which can then be used for analytics, logging, optimized caching, and more.</p>
 
-<p>The <code>Referer</code> header may not contain URL fragments (i.e. "#section") or "username:password" information. It can potentially contain an <em>origin</em>, <em>path</em>, and <em>querystring</em>. What is sent depends on the <em>referrer policy</em> for the request. See {{HTTPHeader("Referrer-Policy")}} for <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives">information</a> and <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples">examples</a>.
+<p>The <code>Referer</code> header may not contain URL fragments (i.e. "#section") or "username:password" information. It can potentially contain an <em>origin</em>, <em>path</em>, and <em>querystring</em>. What is sent, if anything, depends on the <em>referrer policy</em> for the request. See {{HTTPHeader("Referrer-Policy")}} for <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives">information</a> and <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples">examples</a>.
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/http/headers/referer/index.html
+++ b/files/en-us/web/http/headers/referer/index.html
@@ -10,20 +10,19 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <code><strong>Referer</strong></code> request header contains the address of the page making the request. When following a link, this would be the url of the page containing the link. When making AJAX requests to another domain, this would be your page's url. The <code>Referer</code> header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.</p>
+<p>The <code><strong>Referer</strong></code> HTTP request header contains an absolute or partial address of the page making the request. When following a link, this would be the address of the page containing the link. When making resource requests to another domain, this would be the address of the page using the resource. The <code>Referer</code> header allows servers to identify where people are visiting them from, which can then be used for analytics, logging, optimized caching, and more.</p>
 
-<div class="warning">
-<p><strong>Important</strong>: Although this header has many innocent uses it can have undesirable consequences for user security and privacy. See <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns">Referer header: privacy and security concerns</a> for more information and mitigations.</p>
+<p>The <code>Referer</code> header may not contain URL fragments (i.e. "#section") or "username:password" information. It can potentially contain an <em>origin</em>, <em>path</em>, and <em>querystring</em>. What is sent depends on the <em>referrer policy</em> for the request. See {{HTTPHeader("Referrer-Policy")}} for <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives">information</a> and <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples">examples</a>.
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The header name "referer" is actually a misspelling of the word "referrer". See {{interwiki("wikipedia", "HTTP_referer", "HTTP referer on Wikipedia")}} for more details.</p>
 </div>
 
-<p>Note that referer is actually a misspelling of the word "referrer". See {{interwiki("wikipedia", "HTTP_referer", "HTTP referer on Wikipedia")}} for more details.</p>
-
-<p>A <code>Referer</code> header is not sent by browsers if:</p>
-
-<ul>
- <li>The referring resource is a local "file" or "data" URI.</li>
- <li>An unsecured HTTP request is used and the referring page was received with a secure protocol (HTTPS).</li>
-</ul>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>Although this header has many innocent uses it can have undesirable consequences for user security and privacy. See <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns">Referer header: privacy and security concerns</a> for more information and mitigations.</p>
+</div>
 
 <table class="properties">
  <tbody>
@@ -47,12 +46,15 @@ tags:
 
 <dl>
  <dt>&lt;url&gt;</dt>
- <dd>An absolute or partial address of the previous web page from which a link to the currently requested page was followed. URL fragments (i.e. "#section") and userinfo (i.e. "username:password" in "https://username:password@example.com/foo/bar/") are not included.</dd>
+ <dd>An absolute or partial address of the web page making the request. URL fragments (i.e. "#section") and userinfo (i.e. "username:password" in "https://username:password@example.com/foo/bar/") are not included. Origin, path, and querystring may be included, depending on the <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives">referrer policy</a>.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
 
-<pre>Referer: https://developer.mozilla.org/en-US/docs/Web/JavaScript</pre>
+<pre>Referer: https://developer.mozilla.org/en-US/docs/Web/JavaScript
+Referer: https://example.com/page?q=123
+Referer: https://example.com/
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -80,6 +82,10 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{interwiki("wikipedia", "HTTP_referer", "HTTP referer on Wikipedia")}}</li>
- <li>{{HTTPHeader("Referrer-Policy")}}</li>
-</ul>
+  <li>{{interwiki("wikipedia", "HTTP_referer", "HTTP referer on Wikipedia")}}</li>
+  <li><a href="/en-US/docs/Web/API/Fetch_API">Fetch</a>: {{domxref("Request.referrerPolicy")}}</li>
+  <li>The obsolete {{HTTPHeader("Content-Security-Policy")}} {{HTTPHeader("Content-Security-Policy/referrer", "referrer")}} {{Obsolete_Inline}} directive.</li>
+  <li><a href="/en-US/docs/Web/Security/Same-origin_policy">Same-origin policy</a></li>
+  <li><a href="https://blog.mozilla.org/security/2015/01/21/meta-referrer/">Tighter Control Over Your Referrers – Mozilla Security Blog</a></li>
+ </ul>
+ 

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -51,19 +51,19 @@ Referrer-Policy: unsafe-url
  <dt><code>no-referrer</code></dt>
  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer information is sent along with requests.</dd>
  <dt><code>no-referrer-when-downgrade</code></dt>
- <dd>The {{glossary("origin")}}, path, and querystring of the URL are sent as a referrer when the protocol security level stays the same (HTTP→HTTP, HTTPS→HTTPS) or improves (HTTP→HTTPS), but isn't sent to less secure destinations (HTTPS→HTTP, HTTPS→file).
+ <dd>Send the {{glossary("origin")}}, path, and querystring in {{HTTPHeader("Referer")}} when the protocol security level stays the same or improves (HTTP→HTTP, HTTP→HTTPS, HTTPS→HTTPS. Don't send the {{HTTPHeader("Referer")}} header for requests to less secure destinations (HTTPS→HTTP, HTTPS→file).
  </dd>
  <dt><code>origin</code></dt>
- <dd>Only send the {{glossary("origin")}} of the document as the referrer.<br>
+ <dd>Send the {{glossary("origin")}} (only) in the {{HTTPHeader("Referer")}} header.<br>
  For example, a document at <code>https://example.com/page.html</code> will send the referrer <code>https://example.com/</code>.</dd>
  <dt><code>origin-when-cross-origin</code></dt>
- <dd>Send the {{glossary("origin")}}, path, and query string when performing a {{glossary("Same-origin_policy", "same-origin")}} request, but only send the origin of the document for other cases.</dd>
+ <dd>Send the {{glossary("origin")}}, path, and query string when performing a {{glossary("Same-origin_policy", "same-origin")}} request to the same protocol level. Send origin (only) for cross origin requests and requests to less secure destinations.</dd>
  <dt><code>same-origin</code></dt>
- <dd>A referrer will be sent for <a href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but cross-origin requests will send no referrer information.</dd>
+ <dd>Send the {{glossary("origin")}}, path, and query string for {{glossary("Same-origin_policy", "same-origin")}} requests. Don't send the {{HTTPHeader("Referer")}} header for cross-origin requests.</dd>
  <dt><code>strict-origin</code></dt>
- <dd>Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</dd>
- <dt><code>strict-origin-when-cross-origin</code> (default)</dt>
- <dd>Send the origin, path, and querystring when performing a same-origin request, only send the origin when the protocol security level stays the same while performing a cross-origin request (HTTPS→HTTPS), and send no header to any less-secure destinations (HTTPS→HTTP).
+ <dd>Send the origin (only) when the protocol security level stays the same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).</dd>
+ <dt><a id="strict-origin-when-cross-origin"></a><code>strict-origin-when-cross-origin</code> (default)</dt>
+ <dd>Send the origin, path, and querystring when performing a same-origin request. For cross-origin requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).
 
   <div class="notecard note">
     <h4>Note</h4>

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -51,7 +51,7 @@ Referrer-Policy: unsafe-url
  <dt><code>no-referrer</code></dt>
  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer information is sent along with requests.</dd>
  <dt><code>no-referrer-when-downgrade</code></dt>
- <dd>The {{glossary("origin")}}, path, and querystring of the URL are sent as a referrer when the protocol security level stays the same (HTTP→HTTP, HTTPS→HTTPS) or improves (HTTP→HTTPS), but isn't sent to less secure destinations (HTTPS→HTTP).
+ <dd>The {{glossary("origin")}}, path, and querystring of the URL are sent as a referrer when the protocol security level stays the same (HTTP→HTTP, HTTPS→HTTPS) or improves (HTTP→HTTPS), but isn't sent to less secure destinations (HTTPS→HTTP, HTTPS→file).
  </dd>
  <dt><code>origin</code></dt>
  <dd>Only send the {{glossary("origin")}} of the document as the referrer.<br>

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p><span class="seoSummary">The <strong><code>Referrer-Policy</code></strong> {{glossary("HTTP header")}} controls how much <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns">referrer information</a> (sent via the {{HTTPHeader("Referer")}} header) should be included with requests. Aside from the HTTP header, you can <a href="#Integration_with_HTML">set this policy in HTML</a>.</span></p>
+<p><span class="seoSummary">The <strong><code>Referrer-Policy</code></strong> {{glossary("HTTP header")}} controls how much <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns">referrer information</a> (sent via the {{HTTPHeader("Referer")}} header) should be included with requests. Aside from the HTTP header, you can <a href="#integration_with_html">set this policy in HTML</a>.</span></p>
 
 <table class="properties">
  <tbody>
@@ -30,10 +30,6 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<div class="notecard note">
-<p>The original header name {{HTTPHeader("Referer")}} is a misspelling of the word "referrer". The <code>Referrer-Policy</code> header does not share this misspelling.</p>
-</div>
-
 <pre class="brush: html">Referrer-Policy: no-referrer
 Referrer-Policy: no-referrer-when-downgrade
 Referrer-Policy: origin
@@ -44,14 +40,18 @@ Referrer-Policy: strict-origin-when-cross-origin
 Referrer-Policy: unsafe-url
 </pre>
 
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The original header name {{HTTPHeader("Referer")}} is a misspelling of the word "referrer". The <code>Referrer-Policy</code> header does not share this misspelling.</p>
+</div>
+
 <h2 id="Directives">Directives</h2>
 
 <dl>
  <dt><code>no-referrer</code></dt>
  <dd>The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer information is sent along with requests.</dd>
- <dt><code>no-referrer-when-downgrade</code> (default)</dt>
- <dd>This is the default behavior if no policy is specified, or if the provided value is invalid. The {{glossary("origin")}}, path, and querystring of the URL are sent as a referrer when the protocol security level stays the same (HTTP→HTTP, HTTPS→HTTPS) or improves (HTTP→HTTPS), but isn't sent to less secure destinations (HTTPS→HTTP).
- <div class="note">There is effort from browsers in moving to a stricter default value, namely <code>strict-origin-when-cross-origin</code> (see <a href="https://github.com/whatwg/fetch/pull/952">https://github.com/whatwg/fetch/pull/952</a>), consider using this value (or a stricter one), if possible, when changing the Referrer-Policy.</div>
+ <dt><code>no-referrer-when-downgrade</code></dt>
+ <dd>The {{glossary("origin")}}, path, and querystring of the URL are sent as a referrer when the protocol security level stays the same (HTTP→HTTP, HTTPS→HTTPS) or improves (HTTP→HTTPS), but isn't sent to less secure destinations (HTTPS→HTTP).
  </dd>
  <dt><code>origin</code></dt>
  <dd>Only send the {{glossary("origin")}} of the document as the referrer.<br>
@@ -62,12 +62,19 @@ Referrer-Policy: unsafe-url
  <dd>A referrer will be sent for <a href="/en-US/docs/Web/Security/Same-origin_policy">same-site origins</a>, but cross-origin requests will send no referrer information.</dd>
  <dt><code>strict-origin</code></dt>
  <dd>Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).</dd>
- <dt><code>strict-origin-when-cross-origin</code></dt>
- <dd>Send the origin, path, and querystring when performing a same-origin request, only send the origin when the protocol security level stays the same while performing a cross-origin request (HTTPS→HTTPS), and send no header to any less-secure destinations (HTTPS→HTTP).</dd>
+ <dt><code>strict-origin-when-cross-origin</code> (default)</dt>
+ <dd>Send the origin, path, and querystring when performing a same-origin request, only send the origin when the protocol security level stays the same while performing a cross-origin request (HTTPS→HTTPS), and send no header to any less-secure destinations (HTTPS→HTTP).
+
+  <div class="notecard note">
+    <h4>Note</h4>
+    <p>This is the default policy if no policy is specified, or if the provided value is invalid (see spec revision <a href="https://github.com/whatwg/fetch/pull/1066">November 2020</a>). Previously the default was <code>no-referrer-when-downgrade</code>.    </p>
+  </div>
+ </dd>
  <dt><code>unsafe-url</code></dt>
  <dd>Send the origin, path, and query string when performing any request, regardless of security.
  <div class="notecard warning">
- <p>This policy will leak potentially-private information from HTTPS resource URLs to insecure origins. Carefully consider the impact of this setting.</p>
+   <h4>Warning</h4>
+   <p>This policy will leak potentially-private information from HTTPS resource URLs to insecure origins. Carefully consider the impact of this setting.</p>
  </div>
  </dd>
 </dl>
@@ -78,7 +85,7 @@ Referrer-Policy: unsafe-url
 
 <pre class="brush: html">&lt;meta name="referrer" content="origin"&gt;</pre>
 
-<p>Or set it for individual requests with <a href="https://developer.mozilla.org/en-US/search?q=referrerPolicy">the <code>referrerpolicy</code> attribute</a> on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("img")}}, {{HTMLElement("iframe")}}, {{HTMLElement("script")}}, or {{HTMLElement("link")}} elements:</p>
+<p>Or set it for individual requests with <a href="/en-US/search?q=referrerPolicy">the <code>referrerpolicy</code> attribute</a> on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("img")}}, {{HTMLElement("iframe")}}, {{HTMLElement("script")}}, or {{HTMLElement("link")}} elements:</p>
 
 <pre class="brush: html">&lt;a href="http://example.com" referrerpolicy="origin"&gt;</pre>
 
@@ -87,7 +94,8 @@ Referrer-Policy: unsafe-url
 <pre class="brush: html">&lt;a href="http://example.com" rel="noreferrer"&gt;</pre>
 
 <div class="notecard warning">
-<p>As seen above, the <code>noreferrer</code> link relation is written without a dash — <code>noreferrer</code>. When the referrer policy is specified for the entire document with a {{HTMLElement("meta")}} element, it's written <em>with</em> a dash: <code>&lt;meta name="referrer" content="no-referrer"&gt;</code>.</p>
+  <h4>Warning</h4>
+  <p>As seen above, the <code>noreferrer</code> link relation is written without a dash — <code>noreferrer</code>. When the referrer policy is specified for the entire document with a {{HTMLElement("meta")}} element, it's written <em>with</em> a dash: <code>&lt;meta name="referrer" content="no-referrer"&gt;</code>.</p>
 </div>
 
 <h2 id="Integration_with_CSS">Integration with CSS</h2>
@@ -95,8 +103,8 @@ Referrer-Policy: unsafe-url
 <p>CSS can fetch resources referenced from stylesheets. These resources follow a referrer policy as well:</p>
 
 <ul>
- <li>External CSS stylesheets use the default policy (<code>no-referrer-when-downgrade</code>), unless it's overwritten via a <code>Referrer-Policy</code> HTTP header on the CSS stylesheet’s response.</li>
- <li>For {{HTMLElement("style")}} elements or <a href="/en-US/docs/Web/API/HTMLElement/style"><code>style</code> attributes</a>, the owner document's referrer policy is used.</li>
+ <li>External CSS stylesheets use the default policy (<code>strict-origin-when-cross-origin</code>), unless it's overwritten via a <code>Referrer-Policy</code> HTTP header on the CSS stylesheet’s response.</li>
+ <li>For {{HTMLElement("style")}} elements or <a href="/en-US/docs/Web/API/ElementCSSInlineStyle/style"><code>style</code> attributes</a>, the owner document's referrer policy is used.</li>
 </ul>
 
 <h2 id="Examples">Examples</h2>
@@ -232,25 +240,12 @@ Referrer-Policy: unsafe-url
 
 <p>{{Compat("http.headers.Referrer-Policy")}}</p>
 
-<div class="note">
-<ul>
- <li>From version 53 onwards, Gecko has a pref available in <code>about:config</code> to allow users to set their default <code>Referrer-Policy</code> — <span class="quote"> <code>network.http.referer.userControlPolicy</code>.</span></li>
- <li>From version 59 onwards (See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=587523">#587523</a>), this has been replaced by <code>network.http.referer.defaultPolicy</code> and <code>network.http.referer.defaultPolicy.pbmode</code>.</li>
-</ul>
-
-<p>Possible values are:</p>
-
-<ul>
- <li>0 — <code>no-referrer</code></li>
- <li>1 — <code>same-origin</code></li>
- <li>2 — <code>strict-origin-when-cross-origin</code></li>
- <li>3 — <code>no-referrer-when-downgrade</code> (the default)</li>
-</ul>
-</div>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
+
+  
+ <li><a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns">Web security > Referer header: privacy and security concerns</a></li> 
  <li>{{interwiki("wikipedia", "HTTP_referer", "HTTP referer on Wikipedia")}}</li>
  <li>When using <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a>: {{domxref("Request.referrerPolicy")}}</li>
  <li>The obsolete <span style="white-space: nowrap;">{{HTTPHeader("Content-Security-Policy")}}</span> {{HTTPHeader("Content-Security-Policy/referrer", "referrer")}} {{Obsolete_Inline}} directive.</li>

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -243,8 +243,6 @@ Referrer-Policy: unsafe-url
 <h2 id="See_also">See also</h2>
 
 <ul>
-
-  
  <li><a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns">Web security > Referer header: privacy and security concerns</a></li> 
  <li>{{interwiki("wikipedia", "HTTP_referer", "HTTP referer on Wikipedia")}}</li>
  <li>When using <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a>: {{domxref("Request.referrerPolicy")}}</li>

--- a/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.html
+++ b/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.html
@@ -12,26 +12,26 @@ tags:
 
 <h2 id="The_referrer_problem">The referrer problem</h2>
 
-<p>The {{httpheader("Referer")}} (sic) header contains the address of the previous web page from which a link to the currently requested page was followed, which has lots of fairly innocent uses including analytics, logging, or optimized caching. However, there are more problematic uses such as tracking or stealing information, or even just side effects such as inadvertently leaking sensitive information.</p>
+<p>The {{httpheader("Referer")}} (sic) header contains the address of a request (for example, the address of the previous web page from which a link to the currently requested page was followed, or the address of a page loading an image or other resource). This has many fairly innocent uses, including analytics, logging, or optimized caching. However, there are more problematic uses such as tracking or stealing information, or even just side effects such as inadvertently leaking sensitive information.</p>
 
 <p>For example, consider a "reset password" page with a social media link in a footer. If the link was followed, depending on how information was shared the social media site may receive the reset password URL and may still be able to use the shared information, potentially compromising a user's security.</p>
 
-<p>By the same logic, an image hosted on a third party side but embedded in your page could result in sensitive information being leaked to the third party. Even if security is not compromised, the information may not be something the user wants shared.</p>
+<p>By the same logic, an image from a third party site embedded in your page could result in sensitive information being leaked to the third party. Even if security is not compromised, the information may not be something the user wants shared.</p>
 
 <h2 id="How_can_we_fix_this">How can we fix this?</h2>
 
-<p>Much of this risk can be mitigated by sensible design of applications. A sensible application would remove such risks by making password reset URLs only usable for a single use, or when combined with a unique user token, and transmitting sensitive data in different ways.</p>
+<p>Much of this risk can be mitigated by sensible design of applications. A sensible application would remove such risks by making single-use password reset URLs, or combining them with a unique user token. The risk can also be reduced by transmitting sensitive data in more secure ways.</p>
 
 <p>You should use {{HTTPMethod("POST")}} rather than {{HTTPMethod("GET")}} wherever possible, to avoid passing sensitive data to other locations via URLs.</p>
 
-<p>You should always use {{glossary("HTTPS")}} for your sites. This has many security advantages, including the fact that HTTPS sites will never transmit referer information to non-HTTPS sites. This is becoming less useful in this context now that most of the web is using HTTPS, but it is still a worthy consideration.</p>
+<p>You should always use {{glossary("HTTPS")}} for your sites. This has many security advantages, including the fact that HTTPS sites will never transmit referrer information to non-HTTPS sites. This advice is less relevant now that most of the web is using HTTPS, but it is still a worthy consideration.</p>
 
 <p>In addition, you should consider removing any third party content (e.g. social networking widgets embedded in {{htmlelement("iframe")}}) from secure areas of your website, like password reset pages, payment forms, login areas, etc.</p>
 
 <p>You can also mitigate such risks using:</p>
 
 <ul>
- <li>The {{httpheader("Referrer-Policy")}} header on your server to control what information is sent through the <code>Referer</code> header. Again, a directive of <code>no-referrer</code> would omit the Referer header entirely.</li>
+ <li>The {{httpheader("Referrer-Policy")}} header on your server to control what information is sent through the {{httpheader("Referer")}} header. For example, a directive of <code>no-referrer</code> would omit the Referer header entirely.</li>
  <li>The <code>referrerpolicy</code> attribute on HTML elements that are in danger of leaking such information (such as {{HTMLElement("img")}} and {{HTMLElement("a")}}). This can for example be set to <code>no-referrer</code> to stop the <code>Referer</code> header being sent altogether.</li>
  <li>The <code>rel</code> attribute set to <code>noreferrer</code> on HTML elements that are in danger of leaking such information (such as {{HTMLElement("img")}} and {{HTMLElement("a")}}). See <a href="/en-US/docs/Web/HTML/Link_types">Link types</a> and search for <code>noreferrer</code> for more information.</li>
  <li>The <a href="https://geekthis.net/post/hide-http-referer-headers/#exit-page-redirect">Exit page</a> technique.</li>


### PR DESCRIPTION
Content fixes for #2516

- HTTP `Referrer-Policy` 
  - fix flaws and update the default from `no-referrer-when-downgrade` to `strict-origin-when-cross-origin`
  - NOTE, I have not specified any info on the versions that the default changed other than the PR. I hope the BCD update will be what captures this: https://github.com/mdn/browser-compat-data/pull/9303
- HTTP `Referer` - mostly make it clear that address sent may be partial, or nothing at all, and that what is sent depends on the referer policy. I haven't attempted to explain that policy, just link to it more clearly.
- Referer header: privacy and security concerns - minor subedit/ better cross linking.
- FF87 Release note