### PR TITLE
Fix Django BookInstance.book model to have null default value

### DIFF
--- a/files/en-us/learn/server-side/django/models/index.html
+++ b/files/en-us/learn/server-side/django/models/index.html
@@ -338,7 +338,7 @@ class Book(models.Model):
 class BookInstance(models.Model):
     """Model representing a specific copy of a book (i.e. that can be borrowed from the library)."""
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, help_text='Unique ID for this particular book across whole library')
-    book = models.ForeignKey('Book', on_delete=models.RESTRICT)
+    book = models.ForeignKey('Book', on_delete=models.RESTRICT, null=True)
     imprint = models.CharField(max_length=200)
     due_back = models.DateField(null=True, blank=True)
 


### PR DESCRIPTION
This corresponds to fix https://github.com/mdn/django-locallibrary-tutorial/pull/89

Basically this should not be needed because it should not be possible to get to a state where a bookinstance has no book. Django don't believe that though, so makemigrations fails. This fix just captures what you need to do to get this to work. 