### PR TITLE
rel note cleanup around the 86 release

### DIFF
--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -9,7 +9,12 @@ tags:
 ---
 <p>{{FirefoxSidebar}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 86 that will affect developers. Firefox 86 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">February 23, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 86 that will affect developers. Firefox 86 was released on February 23, 2021.</p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p class="summary">See also <a href="https://hacks.mozilla.org/2021/02/a-fabulous-february-firefox-86/">A Fabulous February Firefox — 86!</a> on Mozilla Hacks.</p>
+</div>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -9,20 +9,16 @@ tags:
 ---
 <p>{{FirefoxSidebar}}{{draft}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 87 that will affect developers. Firefox 87 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">March 23, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 87 that will affect developers. Firefox 87 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">March 23, 2021</a>.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
-
-<ul>
-  <li>Developers can now use the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#viewing_common_pseudo-classes">Page Inspector</a> to toggle the {{cssxref(":target")}} pseudo-class for the currently selected element (in addition to the pseudo-classes that were previously supported: {{cssxref(":hover")}}, {{cssxref(":active")}} and {{cssxref(":focus")}}, {{cssxref(":focus-within")}}, {{cssxref(":focus-visible")}}, and {{cssxref(":visited")}}). ({{bug(1689899)}}).</li>
-</ul>
 
 <h3 id="Developer_Tools">Developer Tools</h3>
 
 
 
 <ul>
-
+  <li>Developers can now use the <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#viewing_common_pseudo-classes">Page Inspector</a> to toggle the {{cssxref(":target")}} pseudo-class for the currently selected element (in addition to the pseudo-classes that were previously supported: {{cssxref(":hover")}}, {{cssxref(":active")}} and {{cssxref(":focus")}}, {{cssxref(":focus-within")}}, {{cssxref(":focus-visible")}}, and {{cssxref(":visited")}}). ({{bug(1689899)}}).</li>
   <li>Firefox <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#rule_display">Page Inspector</a> improvements and bug fixes related to inactive CSS rules:
     <ul>
       <li>The {{cssxref("table-layout")}} property is now marked as inactive for non-table elements ({{bug(1551571)}}).</li>
@@ -58,7 +54,7 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
-  <li>Some enterprise authentication services require that TLS client certificates be <a href="/en-US/docs/Web/HTTP/CORS#Preflight_requests_and_credentials">sent in CORS preflight requests</a>. Users of these services can enable this (non-specification compliant) behavior using the <code>network.cors_preflight.allow_client_cert</code> preference ({{bug(1511151)}}).</li>
+  <li>Some enterprise authentication services require that TLS client certificates be <a href="/en-US/docs/Web/HTTP/CORS#preflight_requests_and_credentials">sent in CORS preflight requests</a>. Users of these services can enable this (non-specification compliant) behavior using the <code>network.cors_preflight.allow_client_cert</code> preference ({{bug(1511151)}}).</li>
   <li>The default <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy">Referrer-Policy</a></code> has been changed to <code><a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy#strict-origin-when-cross-origin">strict-origin-when-cross-origin</a></code> (from <code>no-referrer-when-downgrade</code>), reducing the risk of leaking referrer information in cross-origin requests ({{bug(1589074)}}).</li>
   <li><code><a href="/en-US/docs/Web/HTTP/Headers/Content-Length">Content-Length</a></code> has been added to the list of <a href="/en-US/docs/Glossary/CORS-safelisted_response_header">CORS-safelisted response headers</a> ({{bug(1460299)}}).</li>
 </ul>

--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -1,0 +1,62 @@
+---
+title: Firefox 88 for developers
+slug: Mozilla/Firefox/Releases/88
+tags:
+  - '88'
+  - Firefox
+  - Mozilla
+  - Release
+---
+<p>{{FirefoxSidebar}}{{draft}}</p>
+
+<p class="summary">This article provides information about the changes in Firefox 88 that will affect developers. Firefox 88 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">April 20, 2021</a>.</p>
+
+<h2 id="Changes_for_web_developers">Changes for web developers</h2>
+
+<h3 id="Developer_Tools">Developer Tools</h3>
+
+<h4 id="removals_devtools">Removals</h4>
+
+<h3 id="HTML">HTML</h3>
+
+<h4 id="removals_html">Removals</h4>
+
+<h3 id="CSS">CSS</h3>
+
+<h4 id="removals_css">Removals</h4>
+
+<h3 id="JavaScript">JavaScript</h3>
+
+<h4 id="removals_js">Removals</h4>
+
+<h3 id="HTTP">HTTP</h3>
+
+<h4 id="removals_http">Removals</h4>
+
+<h3 id="Security">Security</h3>
+
+<h4 id="removals_sec">Removals</h4>
+
+<h3 id="APIs">APIs</h3>
+
+<h4 id="DOM">DOM</h4>
+
+<h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
+
+<h4 id="removals_media">Removals</h4>
+
+<h3 id="WebAssembly">WebAssembly</h3>
+
+<h4 id="removals_wasm">Removals</h4>
+
+<h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
+
+<h4 id="removals_webdriver">Removals</h4>
+
+<h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
+
+<h4 id="removals_webext">Removals</h4>
+
+<h2 id="Older_versions">Older versions</h2>
+
+<p>{{Firefox_for_developers(87)}}</p>


### PR DESCRIPTION
This provides the last bits of cleanup related to https://github.com/mdn/content/issues/1720, including:

* Creating a new page for the Fx 88 rel notes, and stating that as now being Fx Nightly
* Updating the 86/87 rel notes as release/Beta now 86 is out
* Linking to the hacks release post from the 86 rel notes