### PR TITLE
Mark WEBGL_compressed_texture_atc deprecated

### DIFF
--- a/files/en-us/web/api/webgl_api/compressed_texture_formats/index.html
+++ b/files/en-us/web/api/webgl_api/compressed_texture_formats/index.html
@@ -36,7 +36,7 @@ slug: Web/API/WebGL_API/Compressed_texture_formats
    <td>Yes</td>
   </tr>
   <tr>
-   <td>WEBGL_compressed_texture_atc {{Obsolete_Inline}}</td>
+   <td>WEBGL_compressed_texture_atc {{Deprecated_Inline}}</td>
    <td>Not usable with compressedTexSubImage2D/copyTexSubImage2D.</td>
    <td>No</td>
    <td>No</td>

--- a/files/en-us/web/api/webgl_api/constants/index.html
+++ b/files/en-us/web/api/webgl_api/constants/index.html
@@ -3473,7 +3473,7 @@ var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);</pre>
  </tbody>
 </table>
 
-<h3 id="domxref(WEBGL_compressed_texture_atc)">{{domxref("WEBGL_compressed_texture_atc")}}{{Obsolete_Inline}}</h3>
+<h3 id="domxref(WEBGL_compressed_texture_atc)">{{domxref("WEBGL_compressed_texture_atc")}}{{Deprecated_Inline}}</h3>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -81,7 +81,7 @@ tags:
  <li>{{domxref("OVR_multiview2")}}</li>
  <li>{{domxref("WEBGL_color_buffer_float")}}</li>
  <li>{{domxref("WEBGL_compressed_texture_astc")}}</li>
- <li>{{domxref("WEBGL_compressed_texture_atc")}}{{Obsolete_Inline}}</li>
+ <li>{{domxref("WEBGL_compressed_texture_atc")}}{{Deprecated_Inline}}</li>
  <li>{{domxref("WEBGL_compressed_texture_etc")}}</li>
  <li>{{domxref("WEBGL_compressed_texture_etc1")}}</li>
  <li>{{domxref("WEBGL_compressed_texture_pvrtc")}}</li>

--- a/files/en-us/web/api/webgl_compressed_texture_atc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_atc/index.html
@@ -7,7 +7,7 @@ tags:
   - WebGL
   - WebGL extensions
 ---
-<div>{{APIRef("WebGL")}}{{Obsolete_Header}}</div>
+<div>{{APIRef("WebGL")}}{{Deprecated_Header}}</div>
 
 <p>The <code><strong>WEBGL_compressed_texture_atc</strong></code> extension is part of the <a href="/en-US/docs/Web/API/WebGL_API">WebGL API</a> and exposes 3 ATC compressed texture formats. ATC is a proprietary compression algorithm for compressing textures on handheld devices.</p>
 


### PR DESCRIPTION
We use *deprecated* now (rather than *obsolete*).

(*Obsolete* is now obsolete. :p)