### PR TITLE
Navigator.serial and WorkerNavigator.serial

### DIFF
--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -57,7 +57,7 @@ tags:
  <dd>Returns {{domxref("MediaSession")}} object which can be used to provide metadata that can be used by the browser to present information about the currently-playing media to the user, such as in a global media controls UI.</dd>
  <dt>{{domxref("NavigatorPlugins.mimeTypes")}} {{readonlyInline}}</dt>
  <dd>Returns an {{domxref("MimeTypeArray")}} listing the MIME types supported by the browser.</dd>
- <dt>{{domxref("Navigator.onLine")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("NavigatorOnLine.onLine")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("Boolean")}} indicating whether the browser is working online.</dd>
  <dt>{{domxref("Navigator.permissions")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref("Permissions")}} object that can be used to query and update permission status of APIs covered by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.</dd>
@@ -65,6 +65,8 @@ tags:
  <dd>Returns a {{domxref("PluginArray")}} listing the plugins installed in the browser.</dd>
  <dt>{{domxref("Navigator.presentation")}} {{readonlyInline}} {{experimental_inline}}</dt>
  <dd>Returns a reference to the {{domxref("Presentation")}} API.</dd>
+ <dt>{{domxref("Navigator.serial")}} {{readonlyInline}}</dt>
+ <dd>Returns a {{domxref("Serial")}} object,  which represents the entry point into the {{domxref("Web Serial API")}} to enable the control of serial ports.</dd>
  <dt>{{domxref("Navigator.serviceWorker")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("ServiceWorkerContainer")}} object, which provides access to registration, removal, upgrade, and communication with the {{domxref("ServiceWorker")}} objects for the <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">associated document</a>.</dd>
  <dt>{{domxref("NavigatorStorage.storage")}} {{readonlyinline}}</dt>
@@ -76,7 +78,7 @@ tags:
  <dt>{{domxref("Navigator.webdriver")}} {{readonlyInline}} {{experimental_inline}}</dt>
  <dd>Indicates whether the user agent is controlled by automation.</dd>
  <dt>{{domxref("Navigator.xr")}} {{readonlyInline}} {{experimental_inline}}</dt>
- <dd>Returns {{domxref("XR")}} object, which represents the entry point into the <a href="/en-US/docs/Web/API/WebXR_API">WebXR API</a>.</dd>
+ <dd>Returns {{domxref("XRSystem")}} object, which represents the entry point into the <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR API</a>.</dd>
 </dl>
 
 <h3 id="Non-standard_properties">Non-standard properties</h3>

--- a/files/en-us/web/api/navigator/serial/index.html
+++ b/files/en-us/web/api/navigator/serial/index.html
@@ -25,7 +25,8 @@ tags:
 
 <p>The following example uses the <code>getPorts()</code> method to initialize a list of available ports.</p>
 
-<pre class="brush: js notranslate">navigator.serial.getPorts().then((ports) => {
+<pre class="brush: js notranslate">navigator.serial.getPorts()
+.then((ports) => {
   // Initialize the list of available ports with `ports` on page load.
 });</pre>
 

--- a/files/en-us/web/api/navigator/serial/index.html
+++ b/files/en-us/web/api/navigator/serial/index.html
@@ -1,0 +1,60 @@
+---
+title: Navigator.serial
+slug: Web/API/Navigator/serial
+tags:
+  - API
+  - Property
+  - Reference
+  - serial
+  - Navigator
+---
+<div>{{APIRef("HTML DOM")}}</div>
+
+<p class="summary">The <strong><code>serial</code></strong> read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.</p>
+
+<p>When getting, the same instance of the {{domxref("Serial")}} object will always be returned.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>serialObj</var> = Navigator.serial;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("Serial")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example uses the <code>getPorts()</code> method to initialize a list of available ports.</p>
+
+<pre class="brush: js notranslate">navigator.serial.getPorts().then((ports) => {
+  // Initialize the list of available ports with `ports` on page load.
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Web Serial API','#extensions-to-the-navigator-interface','Extensions to the Navigator Interface')}}</td>
+    <td>{{Spec2('Web Serial API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.Navigator.serial")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/serial/">Read from and write to a serial port</a></li>
+  <li><a href="https://codelabs.developers.google.com/codelabs/web-serial#0">Getting started with the web serial API</a></li>
+</ul>

--- a/files/en-us/web/api/workernavigator/index.html
+++ b/files/en-us/web/api/workernavigator/index.html
@@ -25,7 +25,9 @@ tags:
  <dd>Returns a {{DOMxRef("LockManager")}} object which provides methods for requesting a new {{DOMxRef('Lock')}} object and querying for an existing <code>Lock</code> object.</dd>
  <dt>{{DOMxRef("WorkerNavigator.permissions")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef("Permissions")}} object that can be used to query and update permission status of APIs covered by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.</dd>
- <dt>{{DOMxRef("Navigator.storage")}}{{ReadOnlyInline}} {{experimental_inline}}</dt>
+ <dt>{{domxref("WorkerNavigator.serial")}} {{readonlyInline}}</dt>
+ <dd>Returns a {{domxref("Serial")}} object,  which represents the entry point into the {{domxref("Web Serial API")}} to enable the control of serial ports.</dd>
+ <dt>{{DOMxRef("NavigatorStorage.storage")}}{{ReadOnlyInline}} {{experimental_inline}}</dt>
  <dd>Returns a {{DOMxRef('StorageManager')}} interface for managing persistance permissions and estimating available storage.</dd>
 </dl>
 
@@ -85,6 +87,5 @@ tags:
 
 <ul>
  <li>Other Worker-related interfaces: {{DOMxRef("Worker")}}, {{DOMxRef("WorkerLocation")}}, and {{DOMxRef("WorkerGlobalScope")}}.</li>
- <li><a href="/en-US/docs/Web/Guide/Performance/Using_web_workers">Using web workers.</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Using web workers.</a></li>
 </ul>
-

--- a/files/en-us/web/api/workernavigator/serial/index.html
+++ b/files/en-us/web/api/workernavigator/serial/index.html
@@ -25,7 +25,8 @@ tags:
 
 <p>The following example uses the <code>getPorts()</code> method to initialize a list of available ports.</p>
 
-<pre class="brush: js notranslate">self.navigator.serial.getPorts().then((ports) => {
+<pre class="brush: js notranslate">self.navigator.serial.getPorts()
+.then((ports) => {
   // Initialize the list of available ports.
 });</pre>
 

--- a/files/en-us/web/api/workernavigator/serial/index.html
+++ b/files/en-us/web/api/workernavigator/serial/index.html
@@ -1,0 +1,60 @@
+---
+title: WorkerNavigator.serial
+slug: Web/API/WorkerNavigator/serial
+tags:
+  - API
+  - Property
+  - Reference
+  - serial
+  - WorkerNavigator
+---
+<p>{{APIRef("Web Workers API")}}</p>
+
+<p class="summary">The <strong><code>serial</code></strong> read-only property of the {{domxref("WorkerNavigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.</p>
+
+<p>When getting, the same instance of the {{domxref("Serial")}} object will always be returned.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>serialObj</var> = self.navigator.serial;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("Serial")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example uses the <code>getPorts()</code> method to initialize a list of available ports.</p>
+
+<pre class="brush: js notranslate">self.navigator.serial.getPorts().then((ports) => {
+  // Initialize the list of available ports.
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Web Serial API','#extensions-to-the-workernavigator-interface','Extensions to the Worker Navigator Interface')}}</td>
+    <td>{{Spec2('Web Serial API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.WorkerNavigator.serial")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/serial/">Read from and write to a serial port</a></li>
+  <li><a href="https://codelabs.developers.google.com/codelabs/web-serial#0">Getting started with the web serial API</a></li>
+</ul>


### PR DESCRIPTION
Adding the pages for the extensions to `Navigator` and `WorkerNavigator` for the Serial API. Relates to (and probably should be merged after) https://github.com/mdn/content/pull/2700

Reviewer: @jpmedley 