### PR TITLE
Typo: add Svelte tutorial to the list

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/main_features/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/main_features/index.html
@@ -298,11 +298,11 @@ it("Increments the count when clicked", () =&gt; {
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started">React</a></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_getting_started">Ember</a></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started">Vue</a></li>
- <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started">Vue</a></li>
+ <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started">Svelte</a></li>
 </ul>
 
 <div class="notecard note">
-<p><strong>Note</strong>: We only have four framework tutorial series available now, but we hope to have more available in the future.</p>
+<p><strong>Note</strong>: We have four framework tutorial series available now, and we hope to have more available in the future.</p>
 </div>
 
 <p>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</p>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/main_features/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/main_features/index.html
@@ -298,10 +298,11 @@ it("Increments the count when clicked", () =&gt; {
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started">React</a></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_getting_started">Ember</a></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started">Vue</a></li>
+ <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started">Vue</a></li>
 </ul>
 
 <div class="notecard note">
-<p><strong>Note</strong>: We only have three framework tutorial series available now, but we hope to have more available in the future.</p>
+<p><strong>Note</strong>: We only have four framework tutorial series available now, but we hope to have more available in the future.</p>
 </div>
 
 <p>{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}</p>


### PR DESCRIPTION
Simple typo: the list of existing framework tutorials wasn't updated to have the Svelte tutorial.