### PR TITLE
Removed errant < within H3 heading

### DIFF
--- a/files/en-us/web/javascript/guide/numbers_and_dates/index.html
+++ b/files/en-us/web/javascript/guide/numbers_and_dates/index.html
@@ -315,7 +315,7 @@ var notANum = Number.NaN;
  <li>A set of integer values for year, month, day, hour, minute, and seconds. For example, <code>var Xmas95 = new Date(1995, 11, 25, 9, 30, 0);</code>.</li>
 </ul>
 
-<h3 id="Methods_of_the_Date&lt;_object">Methods of the Date&lt; object</h3>
+<h3 id="Methods_of_the_Date_object">Methods of the Date object</h3>
 
 <p>The <code>Date</code> object methods for handling dates and times fall into these broad categories:</p>
 


### PR DESCRIPTION
"Methods of the Date object" has an errant '<' visible within text. Originally "Methods of the Date< object"

Fixes the following (images of original page):
![image](https://user-images.githubusercontent.com/159109/109910400-0235d680-7c76-11eb-920a-ad82e738a8c6.png)
![image](https://user-images.githubusercontent.com/159109/109910397-006c1300-7c76-11eb-8f6d-dcc8832890c2.png)
