### PR TITLE
Mark navigator.javaEnabled() as not-readonly

### DIFF
--- a/files/en-us/web/api/navigatorplugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/index.html
@@ -30,8 +30,8 @@ tags:
 <p><em>The <code>NavigatorPlugins</code> interface doesn't inherit any methods.</em></p>
 
 <dl>
- <dt>{{domxref("NavigatorPlugins.javaEnabled", "NavigatorPlugins.javaEnabled()")}} {{experimental_inline}}</dt>
- <dd>Returns a {{domxref("Boolean")}} flag indicating whether the host browser is Java-enabled or not.</dd>
+ <dt>{{domxref("NavigatorPlugins.javaEnabled", "NavigatorPlugins.javaEnabled()")}}</dt>
+ <dd>Returns false.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/navigatorplugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/index.html
@@ -30,7 +30,7 @@ tags:
 <p><em>The <code>NavigatorPlugins</code> interface doesn't inherit any methods.</em></p>
 
 <dl>
- <dt>{{domxref("NavigatorPlugins.javaEnabled", "NavigatorPlugins.javaEnabled()")}} {{readonlyInline}}{{experimental_inline}}</dt>
+ <dt>{{domxref("NavigatorPlugins.javaEnabled", "NavigatorPlugins.javaEnabled()")}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref("Boolean")}} flag indicating whether the host browser is Java-enabled or not.</dd>
 </dl>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66655515/110045606-cb0c0780-7cff-11eb-96da-a4e39c013faf.png)
![image](https://user-images.githubusercontent.com/66655515/110045632-d19a7f00-7cff-11eb-8d88-18a81d508311.png)

`javaEnabled()` isn't read only be spec while it is marked as read only here.