### PR TITLE
Deprecate NavigatorPlugins, its subfeatures, and related objects

### DIFF
--- a/files/en-us/web/api/mimetype/index.html
+++ b/files/en-us/web/api/mimetype/index.html
@@ -7,7 +7,7 @@ tags:
   - Plugins
   - Reference
 ---
-<p>{{SeeCompatTable}}{{APIRef("HTML DOM")}}</p>
+<p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
 <p>The <strong><code>MimeType</code></strong> interface provides contains information about a MIME type associated with a particular plugin. {{domxref("NavigatorPlugins.mimeTypes")}} returns an array of this object.</p>
 

--- a/files/en-us/web/api/mimetypearray/index.html
+++ b/files/en-us/web/api/mimetypearray/index.html
@@ -7,7 +7,7 @@ tags:
   - Reference
   - mimeType
 ---
-<p>{{SeeCompatTable}}{{APIRef("HTML DOM")}}</p>
+<p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
 <p>The <strong><code>MimeTypeArray</code></strong> interface returns an array of {{domxref('MimeType')}} instances, each of which contains information about a supported browser plugins. This object is returned by {{domxref("NavigatorPlugins.mimeTypes")}}.</p>
 

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -37,7 +37,7 @@ tags:
  <dd>Returns a {{domxref("Geolocation")}} object allowing accessing the location of the device.</dd>
  <dt>{{domxref("NavigatorConcurrentHardware.hardwareConcurrency")}} {{readonlyInline}}</dt>
  <dd>Returns the number of logical processor cores available.</dd>
- <dt>{{domxref("NavigatorPlugins.javaEnabled")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("NavigatorPlugins.javaEnabled")}} {{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("Boolean")}} flag indicating whether the host browser is Java-enabled or not.</dd>
  <dt>{{domxref('Navigator.keyboard')}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref('Keyboard')}} object which provides access to functions that retrieve keyboard layout maps and toggle capturing of key presses from the physical keyboard.</dd>
@@ -55,13 +55,13 @@ tags:
  <dd>Returns a reference to a {{domxref("MediaDevices")}} object which can then be used to get information about available media devices ({{domxref("MediaDevices.enumerateDevices()")}}), find out what constrainable properties are supported for media on the user's computer and user agent ({{domxref("MediaDevices.getSupportedConstraints()")}}), and to request access to media using {{domxref("MediaDevices.getUserMedia()")}}.</dd>
  <dt>{{domxref("Navigator.mediaSession")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns {{domxref("MediaSession")}} object which can be used to provide metadata that can be used by the browser to present information about the currently-playing media to the user, such as in a global media controls UI.</dd>
- <dt>{{domxref("NavigatorPlugins.mimeTypes")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("NavigatorPlugins.mimeTypes")}} {{readonlyInline}}{{deprecated_inline}}</dt>
  <dd>Returns an {{domxref("MimeTypeArray")}} listing the MIME types supported by the browser.</dd>
  <dt>{{domxref("NavigatorOnLine.onLine")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("Boolean")}} indicating whether the browser is working online.</dd>
  <dt>{{domxref("Navigator.permissions")}} {{readonlyinline}} {{experimental_inline}}</dt>
  <dd>Returns a {{domxref("Permissions")}} object that can be used to query and update permission status of APIs covered by the <a href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>.</dd>
- <dt>{{domxref("NavigatorPlugins.plugins")}} {{readonlyInline}}</dt>
+ <dt>{{domxref("NavigatorPlugins.plugins")}} {{readonlyInline}}{{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("PluginArray")}} listing the plugins installed in the browser.</dd>
  <dt>{{domxref("Navigator.presentation")}} {{readonlyInline}} {{experimental_inline}}</dt>
  <dd>Returns a reference to the {{domxref("Presentation")}} API.</dd>

--- a/files/en-us/web/api/navigatorplugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/index.html
@@ -12,16 +12,16 @@ tags:
   - Plugins
   - Reference
 ---
-<p>{{APIRef("HTML DOM")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
 <p>The <code><strong>NavigatorPlugins</strong></code> {{Glossary("mixin")}} adds to the {{domxref("Navigator")}} interface methods and properties for discovering and interacting with plugins installed into the browser.</p>
 
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref("NavigatorPlugins.mimeTypes")}} {{readonlyInline}}{{experimental_inline}}</dt>
+ <dt>{{domxref("NavigatorPlugins.mimeTypes")}} {{readonlyInline}}{{deprecated_inline}}</dt>
  <dd>Returns an {{domxref("MimeTypeArray")}} listing the MIME types supported by the browser.</dd>
- <dt>{{domxref("NavigatorPlugins.plugins")}} {{readonlyInline}}{{experimental_inline}}</dt>
+ <dt>{{domxref("NavigatorPlugins.plugins")}} {{readonlyInline}}{{deprecated_inline}}</dt>
  <dd>Returns a {{domxref("PluginArray")}} listing the plugins installed in the browser.</dd>
 </dl>
 
@@ -30,7 +30,7 @@ tags:
 <p><em>The <code>NavigatorPlugins</code> interface doesn't inherit any methods.</em></p>
 
 <dl>
- <dt>{{domxref("NavigatorPlugins.javaEnabled", "NavigatorPlugins.javaEnabled()")}}</dt>
+ <dt>{{domxref("NavigatorPlugins.javaEnabled", "NavigatorPlugins.javaEnabled()")}}{{deprecated_inline}}</dt>
  <dd>Returns false.</dd>
 </dl>
 

--- a/files/en-us/web/api/navigatorplugins/mimetypes/index.html
+++ b/files/en-us/web/api/navigatorplugins/mimetypes/index.html
@@ -6,7 +6,7 @@ tags:
 - Property
 - Reference
 ---
-<div>{{ ApiRef("HTML DOM") }}</div>
+<div>{{ ApiRef("HTML DOM") }}{{deprecated_header}}</div>
 
 <p>Returns a {{domxref("MimeTypeArray")}} object, which contains a list of
 	{{domxref("MimeType")}} objects representing the MIME types recognized by the browser.

--- a/files/en-us/web/api/navigatorplugins/plugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/plugins/index.html
@@ -10,17 +10,17 @@ tags:
 - Property
 - Reference
 ---
-<p>{{APIRef("HTML DOM")}}</p>
+<p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
 <p>Returns a {{DOMxRef("PluginArray")}} object, listing the {{DOMxRef("Plugin")}} objects
-  describing the <a href="/en-US/docs/Mozilla/Add-ons/Plugins">plugins</a> installed in
+  describing the plugins installed in
   the application.</p>
 
 <div class="note">
   <p>In Firefox 29 and later, enumeration of the <code>navigator.plugins</code> array may
     be restricted as a privacy measure. Applications that must check for the presence of a
     browser plugin should query <code>navigator.plugins</code> or
-    {{DOMxRef("navigator.mimeTypes")}} by exact name instead of enumerating the
+    {{DOMxRef("NavigatorPlugins.mimeTypes", "navigator.mimeTypes")}} by exact name instead of enumerating the
     <code>navigator.plugins</code> array and comparing every plugin's name. This privacy
     change does not disable any plugins; it just hides some plugin names from enumeration.
   </p>

--- a/files/en-us/web/api/plugin/index.html
+++ b/files/en-us/web/api/plugin/index.html
@@ -9,9 +9,9 @@ tags:
   - Plug-in
   - Plugins
 ---
-<div>{{ApiRef("HTML DOM")}}</div>
+<div>{{ApiRef("HTML DOM")}}{{deprecated_header}}</div>
 
-<p>The <code>Plugin</code> interface provides information about a browser <a href="/en-US/docs/Mozilla/Add-ons/Plugins">plugin</a>.</p>
+<p>The <code>Plugin</code> interface provides information about a browser plugin.</p>
 
 <div class="note">
 <p><strong>Note</strong>: Own properties of <code>Plugin</code> objects are no longer enumerable in the latest browser versions.</p>

--- a/files/en-us/web/api/pluginarray/index.html
+++ b/files/en-us/web/api/pluginarray/index.html
@@ -9,9 +9,9 @@ tags:
   - NeedsContent
   - Plugins
 ---
-<p>{{APIRef("HTML DOM")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
-<p>The <code>PluginArray</code> interface is used to store a list of {{DOMxRef("Plugin")}} objects describing the available <a href="/en-US/docs/Mozilla/Add-ons/Plugins">plugins</a>; it's returned by the {{DOMxRef("window.navigator.plugins")}} property. The <code>PluginArray</code> is not a JavaScript array, but has the <code>length</code> property and supports accessing individual items using bracket notation (<code>plugins[2]</code>), as well as via <code>item(<var>index</var>)</code> and <code>namedItem(<em>"name"</em>)</code> methods.</p>
+<p>The <code>PluginArray</code> interface is used to store a list of {{DOMxRef("Plugin")}} objects describing the available <a href="/en-US/docs/Mozilla/Add-ons/Plugins">plugins</a>; it's returned by the {{DOMxRef("NavigatorPlugins.plugins", "navigator.plugins")}} property. The <code>PluginArray</code> is not a JavaScript array, but has the <code>length</code> property and supports accessing individual items using bracket notation (<code>plugins[2]</code>), as well as via <code>item(<var>index</var>)</code> and <code>namedItem(<em>"name"</em>)</code> methods.</p>
 
 <div class="note">
 <p><strong>Note</strong>: Own properties of <code>PluginArray</code> objects are no longer enumerable in the latest browser versions.</p>


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/obsolete.html#navigatorplugins

Related BCD change: https://github.com/mdn/browser-compat-data/pull/9338