### PR TITLE
Drop "Properties included from Slotable" section of Element doc

### DIFF
--- a/files/en-us/web/api/element/index.html
+++ b/files/en-us/web/api/element/index.html
@@ -99,15 +99,6 @@ tags:
 <p>This change is implemented in Chrome since version 46.0 and Firefox since version 48.0.</p>
 </div>
 
-<h3 id="Properties_included_from_Slotable">Properties included from Slotable</h3>
-
-<p><em>The <code>Element</code> interface includes the following property, defined on the {{DOMxRef("Slotable")}} mixin.</em></p>
-
-<dl>
- <dt>{{DOMxRef("Slotable.assignedSlot")}}{{readonlyInline}}</dt>
- <dd>Returns a {{DOMxRef("HTMLSlotElement")}} representing the {{htmlelement("slot")}} the node is inserted in.</dd>
-</dl>
-
 <h3 id="Properties_included_from_Aria">Properties included from ARIA</h3>
 
 <p><em>The <code>Element</code> interface includes the following properties, defined on the <code>ARIAMixin</code> mixin.</em></p>


### PR DESCRIPTION
This removes the section "Properties included from Slotable" from the page . Follow up issue #1136 . 