### PR TITLE
link AggregateError to the latest spec

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/index.html
@@ -65,7 +65,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('Promise.any', '#sec-aggregate-error-objects', 'AggregateError')}}</td>
+   <td>{{SpecName('ESDraft', '#sec-aggregate-error-objects', 'AggregateError')}}</td>
   </tr>
  </tbody>
 </table>
@@ -78,4 +78,5 @@ tags:
 
 <ul>
  <li>{{JSxRef("Error")}}</li>
+ <li>{{JSxRef("Promise.any")}}</li>
 </ul>


### PR DESCRIPTION
This feature is now part of the ECMAScript spec: https://github.com/tc39/notes/blob/master/meetings/2020-07/july-21.md#promiseany--aggregateerror-for-stage-4
