### PR TITLE
Spelling fix

### DIFF
--- a/files/en-us/web/html/attributes/step/index.html
+++ b/files/en-us/web/html/attributes/step/index.html
@@ -83,7 +83,7 @@ tags:
 
 <pre class="brush: html">&lt;input id="myNumber" name="myNumber" type="number" step="2" min="1.2"&gt;</pre>
 
-<p>Valid values include <code>1.2</code>, <code>3.2</code>, <code>5.2</code>, <code>7.2</code>, <code>9.2</code>, <code>11.2</code>, and so on. Integers and even numbers follwed by .2 are not valid. As we included an invalid value, supporting browsers will show the value as invalid. The number spinner, if present, will only show valid float values of <code>1.2</code> and greater</p>
+<p>Valid values include <code>1.2</code>, <code>3.2</code>, <code>5.2</code>, <code>7.2</code>, <code>9.2</code>, <code>11.2</code>, and so on. Integers and even numbers followed by .2 are not valid. As we included an invalid value, supporting browsers will show the value as invalid. The number spinner, if present, will only show valid float values of <code>1.2</code> and greater</p>
 
 <p>{{EmbedLiveSample("min_impact_on_step",200,55)}}</p>
 


### PR DESCRIPTION
Fixed the spelling of "follow" from "follw" in the "HTML attribute: step" documentation page.
URL: [https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step)