### PR TITLE
Add inline experimental icon to the `loading` attribute

### DIFF
--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -133,7 +133,7 @@ tags:
 		<p><strong>Note:</strong> This attribute is allowed only if the <code>&lt;img&gt;</code> element is a descendant of an {{htmlelement("a")}} element with a valid {{htmlattrxref("href","a")}} attribute. This gives users without pointing devices a fallback destination.</p>
 	</div>
 	</dd>
-	<dt>{{htmlattrdef("loading")}}</dt>
+	<dt>{{htmlattrdef("loading")}} {{experimental_inline}}</dt>
 	<dd>Indicates how the browser should load the image:
 	<ul>
 		<li><code>eager</code>: Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value).</li>


### PR DESCRIPTION
The [MDN page for `HTMLImageElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading#browser_compatibility) marks the `loading` attribute as experimental.