### PR TITLE
List hgroup only as a deprecated element

### DIFF
--- a/files/en-us/web/html/element/hgroup/index.html
+++ b/files/en-us/web/html/element/hgroup/index.html
@@ -6,7 +6,6 @@ tags:
   - Element
   - Experimental
   - HTML
-  - HTML sections
   - HTML5
   - Reference
   - Web


### PR DESCRIPTION
The `hgroup` element is deprecated. It is currently listed at the bottom of the [HTML elements reference page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) under the [Obsolete and deprecated elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#obsolete_and_deprecated_elements) section, but also appears alongside non-deprecated elements in the [Content sectioning](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#content_sectioning) section.

Removing this tag will remove it from the section of non-deprecated elements, created from the reference on [line 38 of elements/index.html](https://github.com/mdn/content/blob/f37c24de21200c64921064e536ea591d71df6cb3/files/en-us/web/html/element/index.html#L38).