### PR TITLE
Document that the only valid octal escape sequence is \0

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -153,11 +153,8 @@ console.log(eval(s2))         // returns the string "2 + 2"
   </thead>
   <tbody>
     <tr>
-      <td><code>\<var>XXX</var></code><br>
-        (where <code><var>XXX</var></code> is 1–3 octal digits; range of
-        <code>0</code>–<code>377</code>)</td>
-      <td>ISO-8859-1 character / Unicode code point between <code>U+0000</code> and
-        <code>U+00FF</code></td>
+      <td><code>\0</code><br></td>
+      <td>Null char</td>
     </tr>
     <tr>
       <td><code>\'</code></td>

--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -153,7 +153,7 @@ console.log(eval(s2))         // returns the string "2 + 2"
   </thead>
   <tbody>
     <tr>
-      <td><code>\0</code><br></td>
+      <td><code>\0</code></td>
       <td>Null char</td>
     </tr>
     <tr>

--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -154,7 +154,7 @@ console.log(eval(s2))         // returns the string "2 + 2"
   <tbody>
     <tr>
       <td><code>\0</code></td>
-      <td>Null char</td>
+      <td>U+0000 NULL character</td>
     </tr>
     <tr>
       <td><code>\'</code></td>


### PR DESCRIPTION
The only valid numeric escape in strict mode is '\0'