### PR TITLE
Mention case sensitivity in lead of String.p.includes doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/includes/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>includes()</code></strong> method determines whether one string may
+<p>The <strong><code>includes()</code></strong> method performs a case-sensitive search to determine whether one string may
   be found within another string, returning <code>true</code> or <code>false</code> as
   appropriate.</p>
 


### PR DESCRIPTION
It is rather key that `includes` performs a _case-sensitive_ search for the `searchString` provided. As such, I thought it would be good to include this in the opening paragraph.