### PR TITLE
use const instead of let declaration for some vars

### DIFF
--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.html
@@ -87,7 +87,7 @@ const audioCtx = new AudioContext();</pre>
 
 <p>First of all, we'll create our periodic wave. To do so, We need to pass real and imaginary values into the {{domxref("BaseAudioContext.createPeriodicWave()")}} method.:</p>
 
-<pre class="brush: js">let wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
+<pre class="brush: js">const wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
 </pre>
 
 <div class="note">
@@ -99,7 +99,7 @@ const audioCtx = new AudioContext();</pre>
 <p>Now we can create an {{domxref("OscillatorNode")}} and set its wave to the one we've created:</p>
 
 <pre class="brush: js">function playSweep(time) {
-     let osc = audioCtx.createOscillator();
+     const osc = audioCtx.createOscillator();
      osc.setPeriodicWave(wave);
      osc.frequency.value = 440;
      osc.connect(audioCtx.destination);
@@ -170,20 +170,20 @@ function playSweep(time) {
 
 <p>We'll set up our first {{domxref("OscillatorNode")}} the same way as our sweep sound, except we won't use a wavetable to set a bespoke wave — we'll just use the default <code>sine</code> wave:</p>
 
-<pre class="brush: js">let osc = audioCtx.createOscillator();
+<pre class="brush: js">const osc = audioCtx.createOscillator();
 osc.type = 'sine';
 osc.frequency.value = 880;</pre>
 
 <p>Now we're going to create a {{domxref("GainNode")}}, as it's the <code>gain</code> value that we will oscillate with our second, low frequency oscillator:</p>
 
-<pre class="brush: js">let amp = audioCtx.createGain();
+<pre class="brush: js">const amp = audioCtx.createGain();
 amp.gain.setValueAtTime(1, audioCtx.currentTime);</pre>
 
 <h3 id="Creating_the_second_low_frequency_oscillator">Creating the second, low frequency, oscillator</h3>
 
 <p>We'll now create a second — <code>square</code> — wave (or pulse) oscillator, to alter the amplification of our first sine wave:</p>
 
-<pre class="brush: js">let lfo = audioCtx.createOscillator();
+<pre class="brush: js">const lfo = audioCtx.createOscillator();
 lfo.type = 'square';
 lfo.frequency.value = 30;</pre>
 
@@ -460,8 +460,8 @@ bpmControl.addEventListener('input', function() {
 
 <p>Then we'll create variables to define how far ahead we want to look, and how far ahead we want to schedule:</p>
 
-<pre class="brush: js">let lookahead = 25.0; // How frequently to call scheduling function (in milliseconds)
-let scheduleAheadTime = 0.1; // How far ahead to schedule audio (sec)</pre>
+<pre class="brush: js">const lookahead = 25.0; // How frequently to call scheduling function (in milliseconds)
+const scheduleAheadTime = 0.1; // How far ahead to schedule audio (sec)</pre>
 
 <p>Let's create a function that moves the note forwards by one beat, and loops back to the first when it reaches the 4th (last) one:</p>
 


### PR DESCRIPTION
In the live version of the sequencer this page describes how to create, there exists a commit that does the same thing as this commit does for this page, except it does it for all applicable variable declarations, instead of the subset I verified on this page. There are probably more variable declarations that can use `const` instead of `let` on this page.

See https://github.com/mdn/webaudio-examples/commit/1217eb894d4a1865058939df211e4209bcb9205d.