### PR TITLE
Fix self-link to page as per issue 2911

### DIFF
--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -58,8 +58,6 @@ tags:
 
 <p>We present three scenarios that demonstrate how Cross-Origin Resource Sharing works. All these examples use {{domxref("XMLHttpRequest")}}, which can make cross-site requests in any supporting browser.</p>
 
-<p>A discussion of Cross-Origin Resource Sharing from a server perspective (including PHP code snippets) can be found in the <a class="internal" href="/en-US/docs/Web/HTTP/CORS">Server-Side Access Control (CORS)</a> article.</p>
-
 <h3 id="Simple_requests">Simple requests</h3>
 
 <p>Some requests don’t trigger a <a href="#preflighted_requests">CORS preflight</a>. Those are called <em>“simple requests”</em> in this article, though the {{SpecName('Fetch')}} spec (which defines CORS) doesn’t use that term. A “simple request” is one that <strong>meets all the following conditions</strong>:</p>


### PR DESCRIPTION
Fixes #2911

Removes self-link to cors doc for "server side access control". The old link used to be a redirect, which then got fixed in a flaw fix https://github.com/mdn/content/commit/f2dd8868559781d31f3b484e0cd00a89bc6100af to be a concrete link.
Anyway, the doc does not exist so best fix here is to remove the link.