### PR TITLE
Fix up link to http session

### DIFF
--- a/files/en-us/web/http/basics_of_http/index.html
+++ b/files/en-us/web/http/basics_of_http/index.html
@@ -31,8 +31,8 @@ tags:
  <dd>Since HTTP/1.0, different types of content can be transmitted. This article explains how this is accomplished using the {{HTTPHeader("Content-Type")}} header and the MIME standard.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs">Choosing between www and non-www URLs</a></dt>
  <dd>This article provides guidance on how to choose whether to use a www-prefixed domain or not, along with the consequences of that choice.</dd>
- <dt><a href="/en-US/docs/Web/HTTP/Flow_of_an_HTTP_session">Flow of an HTTP session</a></dt>
- <dd>This fundamental article describes a typical HTTP session: What happens under the hood when you click on a link in your browser.</dd>
+ <dt><a href="/en-US/docs/Web/HTTP/Session">Flow of an HTTP session</a></dt>
+ <dd>This article describes a typical HTTP session; i.e. what happens when you follow a link or load an image into a web page.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Messages">HTTP Messages</a></dt>
  <dd>HTTP Messages transmitted during requests or responses have a very clear structure. This introductory article describes this structure, its purpose, and its possibilities.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Frame_and_message_structure_in_HTTP_2">Frame and message structure in HTTP/2</a></dt>

--- a/files/en-us/web/http/session/index.html
+++ b/files/en-us/web/http/session/index.html
@@ -22,7 +22,10 @@ tags:
 
 <p>With TCP the default port, for an HTTP server on a computer, is port 80. Other ports can also be used, like 8000 or 8080. The URL of a page to fetch contains both the domain name, and the port number, though the latter can be omitted if it is 80. See <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web">Identifying resources on the Web</a> for more details.</p>
 
-<div class="note"><strong>Note:</strong> The client-server model does not allow the server to send data to the client without an explicit request for it. To work around this problem, web developers use several techniques: ping the server periodically via the {{domxref("XMLHTTPRequest")}}, {{domxref("Fetch")}} APIs, using the <a href="/en-US/docs/WebSockets">WebSockets API</a>, or similar protocols.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The client-server model does not allow the server to send data to the client without an explicit request for it. To work around this problem, web developers use several techniques: ping the server periodically via the {{domxref("XMLHTTPRequest")}}, {{domxref("WindowOrWorkerGlobalScope.fetch")}} APIs, using the <a href="/en-US/docs/Web/API/WebSockets_API">WebSockets API</a>, or similar protocols.</p>
+</div>
 
 <h2 id="Sending_a_client_request">Sending a client request</h2>
 
@@ -66,7 +69,7 @@ name=Joe%20User&amp;request=Send%20me%20one%20of%20your%20catalogue
 
 <ul>
  <li>The {{HTTPMethod("GET")}} method requests a data representation of the specified resource. Requests using <code>GET</code> should only retrieve data.</li>
- <li>The {{HTTPMethod("POST")}} method sends data to a server so it may change its state. This is the method often used for <a href="/en-US/docs/Web/Guide/HTML/Forms">HTML Forms</a>.</li>
+ <li>The {{HTTPMethod("POST")}} method sends data to a server so it may change its state. This is the method often used for <a href="/en-US/docs/Learn/Forms">HTML Forms</a>.</li>
 </ul>
 
 <h2 id="Structure_of_a_server_response">Structure of a server response</h2>


### PR DESCRIPTION
Fixes #2910

As suggested by the author of that issue, the broken link can reasonably be fixed by a link to /en-US/docs/Web/HTTP/Session (this also fixes fixable flaws in that issue).

Note, that /en-us/web/http/basics_of_http/index.html still has two flaws related to broken links to HTTP/2 docs that do not exist.


