### PR TITLE
Remove members from ClipboardItem doc

### DIFF
--- a/files/en-us/web/api/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/index.html
@@ -46,16 +46,7 @@ tags:
  <dt>{{domxref("ClipboardItem.presentationStyle", "presentationStyle")}} {{ReadOnlyInline}}</dt>
  <dd>Returns one of the following: <code>"unspecified"</code>, <code>"inline"</code> or <code>"attachment"</code>.</dd>
 
- <dt>{{domxref("ClipboardItem.delayed", "delayed")}} {{ReadOnlyInline}}</dt>
- <dd>Returns a boolean which if true indicates the <strong><code>ClipboardItem</code></strong> was created using the static <code>createDelayed()</code> method.</dd>
-
- <dt>{{domxref("ClipboardItem.lastModified", "lastModified")}} {{ReadOnlyInline}}</dt>
- <dd>Returns an {{domxref("DOMTimeStamp")}} representing the time at which the <strong><code>ClipboardItem</code></strong> was last modified.</dd>
 </dl>
-
-<div class="note">
-  <p><strong>Note:</strong> Neither <code>ClipboardItem.delayed</code> nor <code>ClipboardItem.lastModified</code> have been implemented by any browsers at this time. Check the <a href="#browser_compatibility">compatibility table</a> for details.</p>
-</div>
 
 <h2 id="Methods">Methods</h2>
 
@@ -65,17 +56,6 @@ tags:
  <dt>{{domxref("ClipboardItem.getType", "getType()")}}</dt>
  <dd>Returns a {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}} of the requested {{Glossary("MIME type")}}, or an error if the MIME type is not found.</dd>
 </dl>
-
-<h2 id="Static_Methods">Static Methods</h2>
-
-<dl>
- <dt>{{domxref("ClipboardItem.createDelayed()")}}</dt>
- <dd>Creates a new <strong><code>ClipboardItem</code></strong> object, with the {{Glossary("MIME type")}} as the key and {{domxref("Blob")}} as the value.</dd>
-</dl>
-
-<div class="note">
-  <p><strong>Note:</strong> <code>ClipboardItem.createDelayed()</code> has not been implemented by any browsers at this time. Check the <a href="#browser_compatibility">compatibility table</a> for details.</p>
-</div>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Removing lastModified, delayed and createDelayed(). As we are not adding them to BCD it's also confusing to have them on the landing page

https://github.com/mdn/content/issues/2514