### PR TITLE
Split pointerLockElement to avoid mixin page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7548,7 +7548,6 @@
 /en-US/docs/Web/API/Document/onselect	/en-US/docs/Web/API/GlobalEventHandlers/onselect
 /en-US/docs/Web/API/Document/onselectionchange	/en-US/docs/Web/API/GlobalEventHandlers/onselectionchange
 /en-US/docs/Web/API/Document/onsubmit	/en-US/docs/Web/API/GlobalEventHandlers/onsubmit
-/en-US/docs/Web/API/Document/pointerLockElement	/en-US/docs/Web/API/DocumentOrShadowRoot/pointerLockElement
 /en-US/docs/Web/API/Document/resourcetimingbufferfull_event	/en-US/docs/Web/API/Performance/resourcetimingbufferfull_event
 /en-US/docs/Web/API/Document/styleSheets	/en-US/docs/Web/API/DocumentOrShadowRoot/styleSheets
 /en-US/docs/Web/API/Document/timeline/currentTime	/en-US/docs/Web/API/AnimationTimeline/currentTime
@@ -7565,6 +7564,7 @@
 /en-US/docs/Web/API/DocumentOrShadowRoot/nodesFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot
 /en-US/docs/Web/API/DocumentOrShadowRoot/pictureInPictureElement	/en-US/docs/Web/API/Document/pictureInPictureElement
 /en-US/docs/Web/API/DocumentOrShadowRoot/pictureInPictureEnabled	/en-US/docs/Web/API/Document/pictureInPictureEnabled
+/en-US/docs/Web/API/DocumentOrShadowRoot/pointerLockElement	/en-US/docs/Web/API/Document/pointerLockElement
 /en-US/docs/Web/API/DocumentTouch.createTouch	/en-US/docs/Web/API/Document/createTouch
 /en-US/docs/Web/API/DocumentTouch.createTouchList	/en-US/docs/Web/API/Document/createTouchList
 /en-US/docs/Web/API/DocumentTouch/createTouch	/en-US/docs/Web/API/Document/createTouch
@@ -9332,7 +9332,7 @@
 /en-US/docs/Web/API/document.open	/en-US/docs/Web/API/Document/open
 /en-US/docs/Web/API/document.origin	/en-US/docs/Web/API/Document/origin
 /en-US/docs/Web/API/document.plugins	/en-US/docs/Web/API/Document/plugins
-/en-US/docs/Web/API/document.pointerLockElement	/en-US/docs/Web/API/DocumentOrShadowRoot/pointerLockElement
+/en-US/docs/Web/API/document.pointerLockElement	/en-US/docs/Web/API/Document/pointerLockElement
 /en-US/docs/Web/API/document.popupNode	/en-US/docs/Web/API/Document/popupNode
 /en-US/docs/Web/API/document.preferredStyleSheetSet	/en-US/docs/Web/API/Document/preferredStyleSheetSet
 /en-US/docs/Web/API/document.queryCommandState	/en-US/docs/Web/API/Document/queryCommandState

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -44368,21 +44368,6 @@
       "mattwojo"
     ]
   },
-  "Web/API/DocumentOrShadowRoot/pointerLockElement": {
-    "modified": "2020-10-15T21:25:15.470Z",
-    "contributors": [
-      "mfuji09",
-      "mfluehr",
-      "jpmedley",
-      "fscholz",
-      "chrisdavidmills",
-      "erikadoyle",
-      "wbamberg",
-      "teoli",
-      "kscarfone",
-      "Jeremie"
-    ]
-  },
   "Web/API/DocumentOrShadowRoot/styleSheets": {
     "modified": "2020-10-19T21:57:52.891Z",
     "contributors": [
@@ -165805,6 +165790,21 @@
     "contributors": [
       "chrisdavidmills",
       "germain"
+    ]
+  },
+  "Web/API/Document/pointerLockElement": {
+    "modified": "2020-10-15T21:25:15.470Z",
+    "contributors": [
+      "mfuji09",
+      "mfluehr",
+      "jpmedley",
+      "fscholz",
+      "chrisdavidmills",
+      "erikadoyle",
+      "wbamberg",
+      "teoli",
+      "kscarfone",
+      "Jeremie"
     ]
   }
 }

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -70,6 +70,8 @@ tags:
  <dd>Returns true if the picture-in-picture feature is enabled.</dd>
  <dt>{{DOMxRef("Document.plugins")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a list of the available plugins.</dd>
+ <dt>{{DOMxRef("Document.pointerLockElement")}} {{ReadOnlyInline}}</dt>
+ <dd>Returns the element set as the target for mouse events while the pointer is locked. <code>null</code> if lock is pending, pointer is unlocked, or if the target is in another document.</dd>
  <dt>{{DOMxRef("Document.featurePolicy")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Returns the {{DOMxRef("FeaturePolicy")}} interface which provides a simple API for introspecting the feature policies applied to a specific document.</dd>
  <dt>{{DOMxRef("Document.scripts")}}{{ReadOnlyInline}}</dt>
@@ -122,8 +124,6 @@ tags:
 <p><em>The <code>Document</code> interface includes the following properties defined on the {{DOMxRef("DocumentOrShadowRoot")}} mixin. Note that this is currently only implemented by Chrome; other browsers still implement them directly on the {{DOMxRef("Document")}} interface.</em></p>
 
 <dl>
- <dt>{{DOMxRef("DocumentOrShadowRoot.pointerLockElement")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
- <dd>Returns the element set as the target for mouse events while the pointer is locked. <code>null</code> if lock is pending, pointer is unlocked, or if the target is in another document.</dd>
  <dt>{{DOMxRef("DocumentOrShadowRoot.styleSheets")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef('StyleSheetList')}} of {{DOMxRef('CSSStyleSheet')}} objects for stylesheets explicitly linked into, or embedded in a document.</dd>
 </dl>

--- a/files/en-us/web/api/document/pointerlockelement/index.html
+++ b/files/en-us/web/api/document/pointerlockelement/index.html
@@ -1,14 +1,14 @@
 ---
 title: DocumentOrShadowRoot.pointerLockElement
-slug: Web/API/DocumentOrShadowRoot/pointerLockElement
+slug: Web/API/Document/pointerLockElement
 tags:
-- API
-- DOM
-- Document
-- Property
-- Reference
-- ShadowRoot
-- mouse lock
+  - API
+  - DOM
+  - Document
+  - Property
+  - Reference
+  - ShadowRoot
+  - mouse lock
 ---
 <div>{{APIRef("DOM")}}</div>
 

--- a/files/en-us/web/api/document/pointerlockelement/index.html
+++ b/files/en-us/web/api/document/pointerlockelement/index.html
@@ -1,5 +1,5 @@
 ---
-title: DocumentOrShadowRoot.pointerLockElement
+title: Document.pointerLockElement
 slug: Web/API/Document/pointerLockElement
 tags:
   - API
@@ -7,25 +7,37 @@ tags:
   - Document
   - Property
   - Reference
-  - ShadowRoot
   - mouse lock
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p><span class="seoSummary">The <strong><code>pointerLockElement</code></strong> property
-    of the {{domxref("Document")}} and {{domxref("ShadowRoot")}} interfaces provides the
+<p><span class="seoSummary">The read-only <strong><code>pointerLockElement</code></strong> property
+    of the {{domxref("Document")}} interfaces provides the
     element set as the target for mouse events while the pointer is locked. It is
     <code>null</code> if lock is pending, pointer is unlocked, or the target is in another
     document.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <var>element</var> = <var>document</var>.pointerLockElement;
-</pre>
+<pre class="brush: js"><var>document</var>.pointerLockElement;</pre>
 
-<h3 id="Return_value">Return value</h3>
+<h3 id="Value">Value</h3>
 
 <p>An {{domxref("Element")}} or <code>null</code>.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Determine if a canvas element is currently pointer locked.</p>
+
+<pre class="brush: js">
+if (document.pointerLockElement === canvasElement) {
+  console.log('The pointer lock status is now locked');
+  // Do something useful in response
+} else {
+  console.log('The pointer lock status is now unlocked');
+  // Do something useful in response
+}
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -39,8 +51,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Pointer
-        Lock','#extensions-to-the-documentorshadowroot-mixin','pointerLockElement')}}</td>
+      <td>{{SpecName('Pointer Lock','#extensions-to-the-documentorshadowroot-mixin','pointerLockElement')}}</td>
       <td>{{Spec2('Pointer Lock')}}</td>
       <td>Extend the <code>Document</code> interface</td>
     </tr>
@@ -49,12 +60,12 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentOrShadowRoot.pointerLockElement")}}</p>
+<p>{{Compat("api.Document.pointerLockElement")}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
   <li>{{ domxref("Document.exitPointerLock()") }}</li>
   <li>{{ domxref("Element.requestPointerLock()") }}</li>
-  <li><a href="/en-US/docs/WebAPI/Pointer_Lock">Pointer Lock</a></li>
+  <li><a href="/en-US/docs/Web/API/Pointer_Lock_API">Pointer Lock</a></li>
 </ul>

--- a/files/en-us/web/api/document/pointerlockelement/index.html
+++ b/files/en-us/web/api/document/pointerlockelement/index.html
@@ -12,7 +12,7 @@ tags:
 <div>{{APIRef("DOM")}}</div>
 
 <p><span class="seoSummary">The read-only <strong><code>pointerLockElement</code></strong> property
-    of the {{domxref("Document")}} interfaces provides the
+    of the {{domxref("Document")}} interface provides the
     element set as the target for mouse events while the pointer is locked. It is
     <code>null</code> if lock is pending, pointer is unlocked, or the target is in another
     document.</span></p>

--- a/files/en-us/web/api/shadowroot/index.html
+++ b/files/en-us/web/api/shadowroot/index.html
@@ -32,6 +32,8 @@ tags:
  <dd>The mode of the <code>ShadowRoot</code> — either <code>open</code> or <code>closed</code>. This defines whether or not the shadow root's internal features are accessible from JavaScript.</dd>
  <dt>{{DOMxRef("ShadowRoot.pictureInPictureElement")}} {{ReadOnlyInline}}</dt>
  <dd>Returns the {{DOMxRef('Element')}} within the shadow tree that is currently being presented in picture-in-picture mode.</dd>
+ <dt>{{DOMxRef("ShadowRoot.pointerLockElement")}} {{ReadOnlyInline}}</dt>
+ <dd>Returns the {{DOMxRef('Element')}} set as the target for mouse events while the pointer is locked. <code>null</code> if lock is pending, pointer is unlocked, or if the target is in another tree.</dd>
 </dl>
 
 <h3 id="Properties_included_from_DocumentOrShadowRoot">Properties included from DocumentOrShadowRoot</h3>

--- a/files/en-us/web/api/shadowroot/pointerlockelement/index.html
+++ b/files/en-us/web/api/shadowroot/pointerlockelement/index.html
@@ -1,0 +1,59 @@
+---
+title: ShadowRoot.pointerLockElement
+slug: Web/API/ShadowRoot/pointerLockElement
+tags:
+  - API
+  - DOM
+  - ShadowRoot
+  - Property
+  - Reference
+  - mouse lock
+---
+<div>{{APIRef("DOM")}}</div>
+
+<p><span class="seoSummary">The read-only <strong><code>pointerLockElement</code></strong> property
+    of the {{domxref("ShadowRoot")}} interface provides the
+    element set as the target for mouse events while the pointer is locked. It is
+    <code>null</code> if lock is pending, pointer is unlocked, or the target is in another
+    tree.</span></p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js"><var>shadowRoot</var>.pointerLockElement;</pre>
+
+<h3 id="Value">Value</h3>
+
+<p>An {{domxref("Element")}} or <code>null</code>.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<pre class="brush: js">let customElem = document.querySelector('my-shadow-dom-element');
+let shadow = customElem.shadowRoot;
+let pleElem = shadow.pointerLockElement;</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('Pointer Lock','#extensions-to-the-documentorshadowroot-mixin','pointerLockElement')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.ShadowRoot.pointerLockElement")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{ domxref("Document.exitPointerLock()") }}</li>
+  <li>{{ domxref("Element.requestPointerLock()") }}</li>
+  <li><a href="/en-US/docs/Web/API/Pointer_Lock_API">Pointer Lock</a></li>
+</ul>


### PR DESCRIPTION
Split this up https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/pointerLockElement so there are two pages:

http://localhost:3000/en-US/docs/Web/API/ShadowRoot/pointerLockElement
http://localhost:3000/en-US/docs/Web/API/Document/pointerLockElement

Provide correct compat data and relevant example code for each.