### PR TITLE
Remove extra space inside <code> element

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.html
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.html
@@ -224,7 +224,7 @@ function change(event) {
   }
 };</pre>
 
-<p>Without <code>aria-atomic="true" </code>the screenreader announces only the changed value of year. With <code>aria-atomic="true"</code>, the screenreader announces "The set year is: <em>changed value</em>"</p>
+<p>Without <code>aria-atomic="true"</code> the screenreader announces only the changed value of year. With <code>aria-atomic="true"</code>, the screenreader announces "The set year is: <em>changed value</em>"</p>
 
 <h3 id="basic-example-aria-relevant">Basic example: <code>aria-relevant</code></h3>
 


### PR DESCRIPTION
## Main changes

- Remove extra space inside `<code>` element.