### PR TITLE
Add missing aria-atomic attribute to example

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.html
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.html
@@ -206,7 +206,7 @@ setInterval(updateClock, 60000);
 &lt;/label&gt;
 &lt;/div&gt;
 
-&lt;div id="date-output" aria-live="polite"&gt;
+&lt;div id="date-output" aria-atomic="true" aria-live="polite"&gt;
 The set year is:
 &lt;span id="year-output"&gt;1990&lt;/span&gt;
 &lt;/div&gt;</pre>


### PR DESCRIPTION
The date input example of the [`aria-atomic` section](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#basic-examples-aria-atomic) is missing the `aria-atomic` attribute, and the user might not know where to place it just by reading the following paragraph.
