### PR TITLE
Fix deep link in “web and XML development using the DOM”

### DIFF
--- a/files/en-us/web/api/event/stoppropagation/index.html
+++ b/files/en-us/web/api/event/stoppropagation/index.html
@@ -35,7 +35,7 @@ tags:
 <h2 id="Examples">Examples</h2>
 
 <p>See Example 5: <a
-    href="/en-US/docs/DOM/DOM_Reference/Examples#Example_5:_Event_Propagation">Event
+    href="/en-US/docs/DOM/DOM_Reference/Examples#example_5_event_propagation">Event
     Propagation</a> in the Examples chapter for a more detailed example of this method and
   event propagation in the DOM.</p>
 


### PR DESCRIPTION
Fix the deep link to the fifth example.
