### PR TITLE
Add information about firefox default preferences

### DIFF
--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -217,6 +217,17 @@ Referrer-Policy: unsafe-url
 
 <p class="note">Specifying multiple values is only supported in the <code>Referrer-Policy</code> HTTP header, and not in the <code>referrerpolicy</code> attribute.</p>
 
+<h2 id="Firefox_preferences">Firefox preferences</h2>
+
+Firefox preferences can be used to configure the <em>default</em> referrer policy. The preference names are version specific:
+<ul>
+  <li>Firefox version 87: <code>network.http.referer.userControlPolicy</code></li>
+  <li>Firefox versions 59 to 86: <code>network.http.referer.defaultPolicy</code> (and <code>network.http.referer.defaultPolicy.pbmode</code> for private networks)</li>
+  <li>Firefox versions 53 to 58: <code>network.http.referer.userControlPolicy</code></li>
+</ul>
+All of these settings take the same set of values: <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade</code>:
+
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -85,7 +85,7 @@ Referrer-Policy: unsafe-url
 
 <pre class="brush: html">&lt;meta name="referrer" content="origin"&gt;</pre>
 
-<p>Or set it for individual requests with <a href="/en-US/search?q=referrerPolicy">the <code>referrerpolicy</code> attribute</a> on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("img")}}, {{HTMLElement("iframe")}}, {{HTMLElement("script")}}, or {{HTMLElement("link")}} elements:</p>
+<p>Or set it for individual requests with the <code>referrerpolicy</code> attribute on {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("img")}}, {{HTMLElement("iframe")}}, {{HTMLElement("script")}}, or {{HTMLElement("link")}} elements:</p>
 
 <pre class="brush: html">&lt;a href="http://example.com" referrerpolicy="origin"&gt;</pre>
 
@@ -217,15 +217,16 @@ Referrer-Policy: unsafe-url
 
 <p class="note">Specifying multiple values is only supported in the <code>Referrer-Policy</code> HTTP header, and not in the <code>referrerpolicy</code> attribute.</p>
 
-<h2 id="Firefox_preferences">Firefox preferences</h2>
+<h2 id="Browser-specific_preferencessettings">Browser-specific preferences/settings</h2>
+<h3 id="Firefox_preferences">Firefox preferences</h3>
 
-Firefox preferences can be used to configure the <em>default</em> referrer policy. The preference names are version specific:
+<p>Firefox preferences can be used to configure the <em>default</em> referrer policy. The preference names are version specific:</p>
 <ul>
   <li>Firefox version 87: <code>network.http.referer.userControlPolicy</code></li>
   <li>Firefox versions 59 to 86: <code>network.http.referer.defaultPolicy</code> (and <code>network.http.referer.defaultPolicy.pbmode</code> for private networks)</li>
   <li>Firefox versions 53 to 58: <code>network.http.referer.userControlPolicy</code></li>
 </ul>
-All of these settings take the same set of values: <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade</code>:
+<p>All of these settings take the same set of values: <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade</code>.</p>
 
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
This adds back information about firefox preferences that can be used to set the default referrer-policy, which were removed in #2792. It contributes to #2516

My intent was to include this information in the BCD (https://github.com/mdn/browser-compat-data/pull/9303). However the position taken is that these preferences are not "compatibility information" and shouldn't be in BCD. If you agree with that position it isn't clear where the information should go.

@chrisdavidmills What I have done is put this in its own section Firefox preferences. That removes it from the BCD and makes it very clear that this is Firefox only. I am not particularly happy with this, but I don't want to throw away the information about there is no better place for it (?). Perhaps we could make this section "Browser preferences" and then anyone who wants to add info about other browsers could do so?

Anyway, I consider this "open for discussion"