### PR TITLE
Update Firefox User-Agent string reference for Mac OS X

### DIFF
--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -93,6 +93,8 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <p>Here, <em>x.y</em> is the version of Mac OS X (for instance, Mac OS X 10.15). Starting in Firefox 87, Firefox caps the reported Mac OS X version number to 10.15, so macOS 11.0 Big Sur and later will be reported as "10.15" in the User-Agent string.</p>
 
+<p>Note that <a href="https://support.mozilla.org/kb/firefox-no-longer-works-mac-os-10-4-or-powerpc">Firefox no longer officially supports Mac OS X on PowerPC</a>.</p>
+
 <table class="standard-table">
  <thead>
   <tr>
@@ -104,6 +106,10 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
   <tr>
    <td>Mac OS X on x86, x86_64, or aarch64</td>
    <td>Mozilla/5.0 (Macintosh; Intel Mac OS X <em>x.y</em>; rv:10.0) Gecko/20100101 Firefox/10.0</td>
+  </tr>
+  <tr>
+   <td>Mac OS X on PowerPC</td>
+   <td>Mozilla/5.0 (Macintosh; PPC Mac OS X <em>x.y</em>; rv:10.0) Gecko/20100101 Firefox/10.0</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -105,10 +105,6 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
    <td>Mac OS X on x86, x86_64, or aarch64</td>
    <td>Mozilla/5.0 (Macintosh; Intel Mac OS X <em>x.y</em>; rv:10.0) Gecko/20100101 Firefox/10.0</td>
   </tr>
-  <tr>
-   <td>Mac OS X on PowerPC</td>
-   <td>Mozilla/5.0 (Macintosh; PPC Mac OS X <em>x.y</em>; rv:10.0) Gecko/20100101 Firefox/10.0</td>
-  </tr>
  </tbody>
 </table>
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -91,7 +91,7 @@ Mozilla/5.0 (Android 4.4; <strong>Tablet</strong>; rv:41.0) Gecko/41.0 Firefox/4
 
 <h2 id="Macintosh">Macintosh</h2>
 
-<p>Here, <em>x.y</em> is the version of Mac OS X (for instance, Mac OS X 10.6).</p>
+<p>Here, <em>x.y</em> is the version of Mac OS X (for instance, Mac OS X 10.15). Starting in Firefox 87, Firefox caps the reported Mac OS X version number to 10.15, so macOS 11.0 Big Sur and later will be reported as "10.15" in the User-Agent string.</p>
 
 <table class="standard-table">
  <thead>


### PR DESCRIPTION
1. Firefox 87 caps Mac OS X version at 10.15. This change was made in https://bugzilla.mozilla.org/show_bug.cgi?id=1679929 to work around webcompat problems from websites that broke when the User-Agent string reported "Mac OS X 11.0". Safari also caps the reported Mac OS X version at 10.15 and Chrome plans to cap soon, too.
1. Firefox no longer supports PPC Mac OS X, so remove mention of PPC Mac OS X.