### PR TITLE
Add <code></code> tags to header in JS Boolean doc (consistency)

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.html
@@ -72,7 +72,7 @@ var s = Boolean(myString);      // initial value of true
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Creating_Boolean_objects_with_an_initial_value_of_false">Creating Boolean objects with an initial value of false</h3>
+<h3 id="Creating_Boolean_objects_with_an_initial_value_of_false">Creating <code>Boolean</code> objects with an initial value of <code>false</code></h3>
 
 <pre class="brush: js">var bNoParam = new Boolean();
 var bZero = new Boolean(0);


### PR DESCRIPTION
Adds code tags to style one of the headers.
This achieves consistency with a similar header below the target one.

[Link to the broken header](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#creating_boolean_objects_with_an_initial_value_of_false)
