### PR TITLE
Removed doubled entry, Fixes #2935

### DIFF
--- a/files/en-us/web/api/text/index.html
+++ b/files/en-us/web/api/text/index.html
@@ -37,8 +37,6 @@ tags:
  </dd>
  <dt>{{domxref("Text.wholeText")}} {{readonlyInline}}</dt>
  <dd>Returns a {{domxref("DOMString")}} containing the text of all <code>Text</code> nodes logically adjacent to this {{domxref("Node")}}, concatenated in document order.</dd>
- <dt>{{domxref("Text.assignedSlot")}} {{readonlyinline}}</dt>
- <dd>Returns the {{domxref("HTMLSlotElement")}} object associated with the element.</dd>
 </dl>
 
 <h2 id="Methods_2">Methods</h2>


### PR DESCRIPTION
Fixes #2935 

I decided for the first entry because I think its more accurate.

The spec says

> The assignedSlot attribute’s getter must return the result of find a slot given this and with the open flag set.


> 4.2.2.3. Finding slots and slottables
> To find a slot for a given slottable slottable and an optional open flag (unset unless stated otherwise), run these steps:
> 
> If slottable’s parent is null, then return null.
> 
> Let shadow be slottable’s parent’s shadow root.
> 
> If shadow is null, then return null.
> 
> If the open flag is set and shadow’s mode is not "open", then return null.
> 
> Return the first slot in tree order in shadow’s descendants whose name is slottable’s name, if any, and null otherwise.


https://dom.spec.whatwg.org/#find-a-slot