### PR TITLE
CSS Cookbook: Making examples easier to read and fixing raised issue

### DIFF
--- a/files/en-us/web/css/layout_cookbook/media_objects/index.html
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h2 id="The_recipe">The recipe</h2>
 
-<p class="codepen">{{EmbedGHLiveSample("css-examples/css-cookbook/media-objects.html", '100%', 1200)}}</p>
+<p class="codepen">{{EmbedGHLiveSample("css-examples/css-cookbook/media-objects.html", '100%', 2700)}}</p>
 
 <div class="note">
 <p class="codepen"><a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/media-objects--download.html">Download this example</a></p>
@@ -53,7 +53,7 @@ tags:
 
 <p>There are a number of possible fallbacks for this pattern, depending on the browsers you wish to support. A good catch-all would be to float the image left, and to add a clearfix to the box to ensure that it contained the floats.</p>
 
-<p class="codepen">{{EmbedGHLiveSample("css-examples/css-cookbook/media-objects-fallback.html", '100%', 1200)}}</p>
+<p class="codepen">{{EmbedGHLiveSample("css-examples/css-cookbook/media-objects-fallback.html", '100%', 3000)}}</p>
 
 <div class="note">
 <p class="codepen"><a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/media-objects-fallback--download.html">Download this example</a></p>


### PR DESCRIPTION
Fixes #2844 

The raised issue was actually fixed in the css-examples repo, this PR changes the height of the examples so we don't have a multiple scrollbar situation happening.