### PR TITLE
Document "url" support in tabs.onUpdated's properties filter

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
@@ -79,7 +79,12 @@ browser.tabs.onUpdated.hasListener(listener)
    <li>"sharingState"</li>
    <li>"status"</li>
    <li>"title"</li>
+   <li>"url"</li>
   </ul>
+
+  <div class="notecard note">
+    <p><strong>Note:</strong> The "url" value is supported since Firefox 88. In Firefox 87 and earlier, "url" changes can be observed by filtering by "status".</p>
+  </div>
   </dd>
   <dt><code>tabId</code></dt>
   <dd><code>Integer</code>. Fire this event only for the tab identified by this ID.</dd>

--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -55,6 +55,10 @@ tags:
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
+<ul>
+  <li><code>url</code> can now be used to limit the properties for which the {{WebExtAPIRef("tabs.onUpdated")}} event is triggered ({{bug(1680279)}}).</li>
+</ul>
+
 <h4 id="removals_webext">Removals</h4>
 
 <h2 id="Older_versions">Older versions</h2>


### PR DESCRIPTION
Documentation for change from https://bugzilla.mozilla.org/show_bug.cgi?id=1680279