### PR TITLE
csp: script-src: examples: avoid id collision

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.html
@@ -118,7 +118,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
  <li>{{domxref("window.execScript")}} {{non-standard_inline}} (IE &lt; 11 only)</li>
 </ul>
 
-<h3 id="strict-dynamic">strict-dynamic</h3>
+<h3 id="examples-strict-dynamic">strict-dynamic</h3>
 
 <p>The <code>'strict-dynamic'</code> source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any whitelist or source expressions such as <code>'self'</code> or <code>'unsafe-inline'</code> will be ignored. For example, a policy such as <code>script-src 'strict-dynamic' 'nonce-R4nd0m' https://whitelisted.com/</code> would allow loading of a root script with <code>&lt;script nonce="R4nd0m" src="https://example.com/loader.js"&gt;</code> and propagate that trust to any script loaded by <code>loader.js</code>, but disallow loading scripts from <code>https://whitelisted.com/</code> unless accompanied by a nonce or loaded from a trusted script.</p>
 


### PR DESCRIPTION
Avoids an id/anchor collision between Example's and Sources's strict-dynamic sections.

This document embeds the Sources section from `Web/HTTP/Headers/Content-Security-Policy/default-src` which already sets a `strict-dynamic` id, and both end up in the resulting page[1]. Consequently, the `strict-dynamic` anchor in this document here - the second one in the DOM - was not linkable as desired.

This change is a bit desperate as it is only a manual solution for the one problem I spotted. A systemic solution would be preferred. I can envision e.g. consistently tagging the sources - so all of them become linkable - and doing so with a "sources" prefix to limit the likelihood of collisions but that would break existing links/bookmarks. I assume this is not the first time a problem like this popped up in a large project like this and maybe someone has a goto solution which can be applied as a follow-up.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
