### PR TITLE
Fix 404 in “2D collision detection” doc

### DIFF
--- a/files/en-us/games/techniques/2d_collision_detection/index.html
+++ b/files/en-us/games/techniques/2d_collision_detection/index.html
@@ -174,7 +174,7 @@ if (distance &lt; circle1.radius + circle2.radius) {
  <li><a href="http://www.sevenson.com.au/actionscript/sat/">Separating Axis Theorem (SAT) explanation</a></li>
  <li><a href="http://www.metanetsoftware.com/technique/tutorialA.html">Collision detection and response</a></li>
  <li><a href="http://gamedevelopment.tutsplus.com/tutorials/collision-detection-using-the-separating-axis-theorem--gamedev-169">Collision detection Using the Separating Axis Theorem</a></li>
- <li><a href="http://www.codezealot.org/archives/55">SAT (Separating Axis Theorem)</a></li>
+ <li><a href="http://www.dyn4j.org/2010/01/sat/">SAT (Separating Axis Theorem)</a></li>
  <li><a href="http://programmerart.weebly.com/separating-axis-theorem.html">Separating Axis Theorem</a></li>
 </ol>
 


### PR DESCRIPTION
The link  http://www.codezealot.org/archives/55 here  
![image](https://user-images.githubusercontent.com/58456527/110730203-e467f480-81d4-11eb-8a86-96fe10b291d3.png)  
is outdated and leads to a 404. Using the [newer link](http://www.dyn4j.org/2010/01/sat/) correctly leads to the page.