### PR TITLE
Add a BCD table to the Subgrid page

### DIFF
--- a/files/en-us/web/css/css_grid_layout/subgrid/index.html
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.html
@@ -111,6 +111,11 @@ tags:
  </tbody>
 </table>
 
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.properties.grid-template-columns.subgrid")}}</p>
+
 <h2 id="See_also">See also</h2>
 
 <ul>


### PR DESCRIPTION
There's also a "css.properties.grid-template-rows.subgrid" entry in BCD,
but its status should be the same.