### PR TITLE
Adds TrustedTypePolicy API

### DIFF
--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
@@ -1,0 +1,66 @@
+---
+title: TrustedTypePolicy.createHTML()
+slug: Web/API/TrustedTypePolicy/createHTML
+tags:
+  - API
+  - Method
+  - Reference
+  - createHTML
+  - TrustedTypePolicy
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>createHTML()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface  creates a {{domxref("TrustedHTML")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>str</var> = <var>TrustedTypePolicy</var>.createHTML(<var>input</var>[,<var>args</var>]);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>input</code></dt>
+  <dd>A {{domxref("DOMString")}} containing the string to be sanitized by the policy.</dd>
+  <dt><code>args</code>{{optional_inline}}</dt>
+  <dd>Additional arguments to be passed to the function represented by {{domxref("TrustedTypePolicy")}}.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("TrustedHTML")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{jsxref("TypeError")}}</dt>
+  <dd>Thrown if {{domxref("TrustedTypePolicy")}} does not contain a function to run on the input.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example a string containing a potentially dangerous script is used as the input for <code>createHTML()</code>. Dangerous code inserted by a user could then be sanitized before insertion into any injection sink.</p>
+
+<pre class="brush: js">const escaped = escapeHTMLPolicy.createHTML("&lt;img src=x onerror=alert(1)&gt;");</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-createhtml','TrustedTypePolicy.createHTML()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicy.createHTML")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>createHTML()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface  creates a {{domxref("TrustedHTML")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+<p class="summary">The <strong><code>createHTML()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedHTML")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.html
@@ -1,0 +1,66 @@
+---
+title: TrustedTypePolicy.createScript()
+slug: Web/API/TrustedTypePolicy/createScript
+tags:
+  - API
+  - Method
+  - Reference
+  - createScript
+  - TrustedTypePolicy
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>createScript()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedScript")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>str</var> = <var>TrustedTypePolicy</var>.createScript(<var>input</var>[,<var>args</var>]);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>input</code></dt>
+  <dd>A {{domxref("DOMString")}} containing the string to be sanitized by the policy.</dd>
+  <dt><code>args</code>{{optional_inline}}</dt>
+  <dd>Additional arguments to be passed to the function represented by {{domxref("TrustedTypePolicy")}}.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("TrustedScript")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{jsxref("TypeError")}}</dt>
+  <dd>Thrown if {{domxref("TrustedTypePolicy")}} does not contain a function to run on the input.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example a string containing a potentially risky script is used as the input for <code>createScript()</code>. The policy can sanitize this script before inserting it into an injection sink that could cause it to be executed.</p>
+
+<pre class="brush: js">const sanitized = scriptPolicy.createScript("eval('2 + 2')");</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-createscript','TrustedTypePolicy.createScript()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicy.createScript")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
@@ -1,0 +1,66 @@
+---
+title: TrustedTypePolicy.createScriptURL()
+slug: Web/API/TrustedTypePolicy/createScriptURL
+tags:
+  - API
+  - Method
+  - Reference
+  - createScriptURL
+  - TrustedTypePolicy
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>createScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicy")}} interface creates a {{domxref("TrustedScriptURL")}} object using a policy created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>str</var> = <var>TrustedTypePolicy</var>.createScriptURL(<var>input</var>[,<var>args</var>]);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>input</code></dt>
+  <dd>A {{domxref("DOMString")}} containing the string to be sanitized by the policy.</dd>
+  <dt><code>args</code>{{optional_inline}}</dt>
+  <dd>Additional arguments to be passed to the function represented by {{domxref("TrustedTypePolicy")}}.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("TrustedScriptURL")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{jsxref("TypeError")}}</dt>
+  <dd>Thrown if {{domxref("TrustedTypePolicy")}} does not contain a function to run on the input.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example a string containing the URL to an external resource is used as the input for <code>createScriptURL()</code>. The policy can check that this is an allowed URL before inserting it into an injection sink that could cause this external script to be executed.</p>
+
+<pre class="brush: js">const escaped = escapeURLPolicy.createScriptURL("https://example.com/my-script.js");</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-createscripturl','TrustedTypePolicy.createScriptURL()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicy.createScriptURL")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
-<p class="summary">The <strong><code>TrustedTypePolicy</code></strong> interface of the {{domxref('Trusted Types API')}} defines a group of functions which create TrustedType objects.</p>
+<p class="summary">The <strong><code>TrustedTypePolicy</code></strong> interface of the {{domxref('Trusted Types API')}} defines a group of functions which create {{domxref('TrustedType')}} objects.</p>
 
 <p>A <code>TrustedTypePolicy</code> object is created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}} to define a policy for enforcing security rules on input. Therefore, <code>TrustedTypePolicy</code> has no constructor.</p>
 
@@ -71,4 +71,3 @@ el.innerHTML = escaped;
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.TrustedTypePolicy")}}</p>
-

--- a/files/en-us/web/api/trustedtypepolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/index.html
@@ -1,0 +1,74 @@
+---
+title: TrustedTypePolicy
+slug: Web/API/TrustedTypePolicy
+tags:
+  - API
+  - Interface
+  - Reference
+  - TrustedTypePolicy
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>TrustedTypePolicy</code></strong> interface of the {{domxref('Trusted Types API')}} defines a group of functions which create TrustedType objects.</p>
+
+<p>A <code>TrustedTypePolicy</code> object is created by {{domxref("TrustedTypePolicyFactory.createPolicy","TrustedTypePolicyFactory.createPolicy()")}} to define a policy for enforcing security rules on input. Therefore, <code>TrustedTypePolicy</code> has no constructor.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+  <dt>{{domxref("TrustedTypePolicy.name")}}{{ReadOnlyInline}}</dt>
+  <dd>A {{domxref("DOMString")}} containing the name of the policy.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("TrustedTypePolicy.createHTML","TrustedTypePolicy.createHTML()")}}</dt>
+  <dd>Creates a {{domxref("TrustedHTML")}} object.</dd>
+  <dt>{{domxref("TrustedTypePolicy.createScript","TrustedTypePolicy.createScript()")}}</dt>
+  <dd>Creates a {{domxref("TrustedScript")}} object.</dd>
+  <dt>{{domxref("TrustedTypePolicy.createScriptURL","TrustedTypePolicy.createScriptURL()")}}</dt>
+  <dd>Creates a {{domxref("TrustedScriptURL")}} object.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example we create a policy that will create {{domxref("TrustedHTML")}} objects using {{domxref("TrustedTypePolicyFactory.createPolicy()")}}. We can then use {{domxref("TrustedTypePolicy.createHTML")}} to create a sanitized HTML string to be inserted into the document.</p>
+
+<p>The sanitized value can then be used with {{domxref("Element.innerHTML")}} to ensure that no new HTML elements can be injected.</p>
+
+<pre class="brush: html">&lt;div id="myDiv"&gt;&lt;/div&gt;</pre>
+
+<pre class="brush: js">const escapeHTMLPolicy = trustedTypes.createPolicy("myEscapePolicy", {
+  createHTML: (string) =&gt; string.replace(/\&gt;/g, "&lt;")
+});
+
+let el = document.getElementById("myDiv");
+const escaped = escapeHTMLPolicy.createHTML("&lt;img src=x onerror=alert(1)&gt;");
+console.log(escaped instanceof TrustedHTML); // true
+el.innerHTML = escaped;
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#trustedtypepolicy',"TrustedTypePolicy")}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicy")}}</p>
+

--- a/files/en-us/web/api/trustedtypepolicy/name/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.html
@@ -1,0 +1,53 @@
+---
+title: TrustedTypePolicy.name
+slug: Web/API/TrustedTypePolicy/name
+tags:
+  - API
+  - Property
+  - Reference
+  - name
+  - TrustedTypePolicy
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>name</code></strong> read-only property of the {{domxref("TrustedTypePolicy")}} interface returns the name of the policy.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>name</var> = <var>TrustedTypePolicy</var>.name;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString")}} containing the name of the policy.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example a policy called <code>myEscapePolicy</code> is created using {{domxref("TrustedTypePolicyFactory.createPolicy()")}} and is represented by the object <code>escapeHTMLPolicy</code>. Calling <code>name</code> on this object returns the string "myEscapePolicy".</p>
+
+<pre class="brush:js">const escapeHTMLPolicy = trustedTypes.createPolicy("myEscapePolicy", {
+  createHTML: (string) =&gt; string.replace(/\&gt;/g, "&lt;")
+});
+
+console.log(escapeHTMLPolicy.name); /* "myEscapePolicy" */</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicy-name',"TrustedTypePolicy.name")}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicy.name")}}</p>


### PR DESCRIPTION
Another of the Trusted Type API interfaces. This time TrustedTypePolicy.

Spec: https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-type-policy

Reviewer: @jpmedley 
