### PR TITLE
Move DocumentOrShadowRoot.getSelection to Document.getSelection

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1928,7 +1928,7 @@
 /en-US/docs/DOM/document.getElementsByName	/en-US/docs/Web/API/Document/getElementsByName
 /en-US/docs/DOM/document.getElementsByTagName	/en-US/docs/Web/API/Document/getElementsByTagName
 /en-US/docs/DOM/document.getElementsByTagNameNS	/en-US/docs/Web/API/Document/getElementsByTagNameNS
-/en-US/docs/DOM/document.getSelection	/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection
+/en-US/docs/DOM/document.getSelection	/en-US/docs/Web/API/Document/getSelection
 /en-US/docs/DOM/document.hasFocus	/en-US/docs/Web/API/Document/hasFocus
 /en-US/docs/DOM/document.head	/en-US/docs/Web/API/Document/head
 /en-US/docs/DOM/document.height	/en-US/docs/Web/API/Document/height
@@ -3297,7 +3297,7 @@
 /en-US/docs/Document_Object_Model_(DOM)/document.getElementsByName	/en-US/docs/Web/API/Document/getElementsByName
 /en-US/docs/Document_Object_Model_(DOM)/document.getElementsByTagName	/en-US/docs/Web/API/Document/getElementsByTagName
 /en-US/docs/Document_Object_Model_(DOM)/document.getElementsByTagNameNS	/en-US/docs/Web/API/Document/getElementsByTagNameNS
-/en-US/docs/Document_Object_Model_(DOM)/document.getSelection	/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection
+/en-US/docs/Document_Object_Model_(DOM)/document.getSelection	/en-US/docs/Web/API/Document/getSelection
 /en-US/docs/Document_Object_Model_(DOM)/document.hasFocus	/en-US/docs/Web/API/Document/hasFocus
 /en-US/docs/Document_Object_Model_(DOM)/document.head	/en-US/docs/Web/API/Document/head
 /en-US/docs/Document_Object_Model_(DOM)/document.height	/en-US/docs/Web/API/Document/height
@@ -7516,7 +7516,6 @@
 /en-US/docs/Web/API/Document/elementFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot/elementFromPoint
 /en-US/docs/Web/API/Document/elementsFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot/elementsFromPoint
 /en-US/docs/Web/API/Document/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
-/en-US/docs/Web/API/Document/getSelection	/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection
 /en-US/docs/Web/API/Document/inputEncoding	/en-US/docs/Web/API/document/characterSet
 /en-US/docs/Web/API/Document/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/Document/mozCancelFullScreen	/en-US/docs/Web/API/Document/exitFullscreen
@@ -7558,6 +7557,7 @@
 /en-US/docs/Web/API/DocumentOrShadowRoot/activeElement	/en-US/docs/Web/API/Document/activeElement
 /en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/Web/API/DocumentOrShadowRoot/getAnimations	/en-US/docs/Web/API/Document/getAnimations
+/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection	/en-US/docs/Web/API/Document/getSelection
 /en-US/docs/Web/API/DocumentOrShadowRoot/nodeFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot
 /en-US/docs/Web/API/DocumentOrShadowRoot/nodesFromPoint	/en-US/docs/Web/API/DocumentOrShadowRoot
 /en-US/docs/Web/API/DocumentOrShadowRoot/pictureInPictureElement	/en-US/docs/Web/API/Document/pictureInPictureElement
@@ -9307,7 +9307,7 @@
 /en-US/docs/Web/API/document.getElementsByName	/en-US/docs/Web/API/Document/getElementsByName
 /en-US/docs/Web/API/document.getElementsByTagName	/en-US/docs/Web/API/Document/getElementsByTagName
 /en-US/docs/Web/API/document.getElementsByTagNameNS	/en-US/docs/Web/API/Document/getElementsByTagNameNS
-/en-US/docs/Web/API/document.getSelection	/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection
+/en-US/docs/Web/API/document.getSelection	/en-US/docs/Web/API/Document/getSelection
 /en-US/docs/Web/API/document.hasFocus	/en-US/docs/Web/API/Document/hasFocus
 /en-US/docs/Web/API/document.head	/en-US/docs/Web/API/Document/head
 /en-US/docs/Web/API/document.height	/en-US/docs/Web/API/Document/height

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -44334,19 +44334,6 @@
       "jpmedley"
     ]
   },
-  "Web/API/DocumentOrShadowRoot/getSelection": {
-    "modified": "2020-10-15T21:49:28.182Z",
-    "contributors": [
-      "mfuji09",
-      "chrisdavidmills",
-      "ExE-Boss",
-      "nmaxcom",
-      "jpmedley",
-      "fscholz",
-      "bede",
-      "david_ross"
-    ]
-  },
   "Web/API/DocumentTimeline": {
     "modified": "2020-10-15T21:45:09.763Z",
     "contributors": [
@@ -165786,6 +165773,19 @@
       "Sheppy",
       "chrisdavidmills",
       "rachelnabors"
+    ]
+  },
+  "Web/API/Document/getSelection": {
+    "modified": "2020-10-15T21:49:28.182Z",
+    "contributors": [
+      "mfuji09",
+      "chrisdavidmills",
+      "ExE-Boss",
+      "nmaxcom",
+      "jpmedley",
+      "fscholz",
+      "bede",
+      "david_ross"
     ]
   }
 }

--- a/files/en-us/mozilla/firefox/releases/57/index.html
+++ b/files/en-us/mozilla/firefox/releases/57/index.html
@@ -94,7 +94,7 @@ tags:
  <li>The {{DOMxRef("Selection.type")}} property of the <a href="/en-US/docs/Web/API/Selection">Selection API</a> is now implemented ({{bug(1359157)}}).</li>
  <li>{{DOMxRef("Document.createEvent", "Document.createEvent('FocusEvent')")}} is now supported ({{bug(1388069)}}).</li>
  <li>The <code>files</code> property of the {{DOMxRef("HTMLInputElement")}} interface is now settable ({{bug(1384030)}}).</li>
- <li>The <code>HTMLDocument.getSelection()</code> method has been moved to the {{DOMxRef("DocumentOrShadowRoot/getSelection","Document")}} interface so it is available to XML documents ({{bug(718711)}}).</li>
+ <li>The <code>HTMLDocument.getSelection()</code> method has been moved to the {{DOMxRef("Document/getSelection","Document")}} interface so it is available to XML documents ({{bug(718711)}}).</li>
  <li>The {{Event("messageerror")}} event is now implemented, and can have code run in response to it firing via event handlers implemented on message targets — see {{DOMxRef("MessagePort.onmessageerror")}}, {{DOMxRef("DedicatedWorkerGlobalScope.onmessageerror")}}, {{DOMxRef("Worker.onmessageerror")}}, {{DOMxRef("BroadcastChannel.onmessageerror")}}, and {{DOMxRef("Window.onmessageerror")}} ({{bug(1359017)}}).</li>
  <li>When {{DOMxRef("Headers")}} values are iterated over, they are automatically sorted in lexicographical order, and values from duplicate header names are combined ({{bug(1396848)}}).</li>
 </ul>

--- a/files/en-us/mozilla/firefox/releases/8/index.html
+++ b/files/en-us/mozilla/firefox/releases/8/index.html
@@ -35,7 +35,7 @@ tags:
  <li>When editing {{ domxref("element.contenteditable") }} areas, exiting a heading by pressing return, or exiting list editing mode by pressing return twice, now returns to paragraph entry mode (that is, paragraphs inside {{ HTMLElement("p") }} blocks) instead of separating lines by {{ HTMLElement("br") }} elements.</li>
  <li>Fixed a bug that prevents justification from taking effect properly when applied to the first line in a {{ domxref("element.contenteditable") }} area.</li>
  <li>Fixed a bug that caused pressing delete or backspace at the beginning of a {{ domxref("element.contenteditable") }} area to affect the previous <code>contenteditable</code> block if one is present.</li>
- <li>{{ domxref("DocumentOrShadowRoot/getSelection", "document.getSelection()") }} now returns the same <code>Selection</code> object as {{ domxref("window.getSelection()") }}, instead of <em>stringifying</em> it.</li>
+ <li>{{ domxref("Document.getSelection()") }} now returns the same <code>Selection</code> object as {{ domxref("window.getSelection()") }}, instead of <em>stringifying</em> it.</li>
  <li>The HTML5 <code>selectionDirection</code> property makes it possible to define the direction of the selection in an editable text.</li>
  <li>{{ domxref("HTMLMediaElement") }} now have a <code>seekable</code> property that return a {{ domxref("TimeRanges") }} object.</li>
  <li>The {{ domxref("HTMLMediaElement") }}<code>.preload</code> attribute now correctly reflects as an <em>enumerated value</em>.</li>

--- a/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.html
+++ b/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.html
@@ -28,7 +28,7 @@ tags:
 <h2 id="DOM_changes">DOM changes</h2>
 <p>There have been a couple of changes in the DOM that impact add-ons:</p>
 <h3 id="Selection_changes">Selection changes</h3>
-<p>In the past, {{ domxref("DocumentOrShadowRoot/getSelection", "document.getSelection()") }} was returning a stringified version of the selection instead of the {{ domxref("Selection") }} object itself. This was non-standard behavior, and has been corrected.</p>
+<p>In the past, {{ domxref("Document.getSelection()") }} was returning a stringified version of the selection instead of the {{ domxref("Selection") }} object itself. This was non-standard behavior, and has been corrected.</p>
 <h3 id="Potential_name_conflicts">Potential name conflicts</h3>
 <p>When the DOM File API was added, a new global called {{ domxref("File") }} was added; this can conflict with objects in your scripts. If you have any globals called <code>File</code>, you should rename them.</p>
 <p>Similarly, a new global, {{ domxref("ChromeWorker") }}, was introduced to support allowing Workers to be used from chrome code. If by some chance you have any globals with this name, you should rename them.</p>

--- a/files/en-us/web/api/document/getselection/index.html
+++ b/files/en-us/web/api/document/getselection/index.html
@@ -1,28 +1,23 @@
 ---
-title: DocumentOrShadowRoot.getSelection()
+title: Document.getSelection()
 slug: Web/API/Document/getSelection
 tags:
   - API
-  - DocumentOrShadowRoot
   - Document
   - Method
   - Reference
-  - ShadowRoot
   - getSelection
-  - getSelection()
-  - shadow dom
 ---
-<div>{{APIRef("DOM")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("DOM")}}</div>
 
 <p><span class="seoSummary">The <strong><code>getSelection()</code></strong> property of
-    the {{DOMxRef("DocumentOrShadowRoot")}} interface returns a {{DOMxRef("Selection")}}
+    the {{DOMxRef("Document")}} interface returns a {{DOMxRef("Selection")}}
     object representing the range of text selected by the user, or the current position of
     the caret.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var selection = documentOrShadowRootInstance.getSelection()</pre>
+<pre class="brush: js">getSelection()</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -34,44 +29,30 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush:js">function foo() {
-    var selObj = document.getSelection();
-    alert(selObj);
-    var selRange = selObj.getRangeAt(0);
-    // do stuff with the range
-}</pre>
+<h3 id="Getting_a_Selection_object">Getting a Selection object</h3>
 
-<h2 id="Notes">Notes</h2>
+<pre class="brush:js">
+let selection = document.getSelection();
+let selRange = selection.getRangeAt(0);
+// do stuff with the range
 
-<h3 id="String_representation_of_the_Selection_object">String representation of the
-  Selection object</h3>
+console.log(selection); // Selection object
+</pre>
 
-<p>In JavaScript, when an object is passed to a function expecting a string (like
-  {{DOMxRef("Window.alert()")}}), the object's {{JSxRef("Object.toString", "toString()")}}
-  method is called and the returned value is passed to the function. This can make the
-  object appear to be a string when used with other functions when it is really an object
-  with properties and methods.</p>
+<h3 id="String_representation_of_the_Selection_object">String representation of the Selection object</h3>
 
-<p>In the above example, <code>selObj.toString()</code> is automatically called when it is
-  passed to {{DOMxRef("Window.alert()")}}. However, attempting to use a JavaScript <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> property
-  or method such as
-  <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length">length</a></code>
-  or
-  <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr">substr</a></code>
-  directly on a {{DOMxRef("Selection")}} object results in an error if it does not have
-  that property or method and may return unexpected results if it does. To use a
-  <code>Selection</code> object as a string, call its <code>toString()</code> method
-  directly:</p>
+<p>Some functions (like {{DOMxRef("Window.alert()")}}) call {{JSxRef("Object.toString", "toString()")}}
+  automatically and the returned value is passed to the function. As a consequence, this will return the selected text
+  and not the <code>Selection</code> object:</p>
 
-<pre class="brush:js;gutter:false;">var selectedText = selObj.toString();</pre>
+<pre class="brush:js;">alert(selection);</pre>
 
-<ul>
-  <li><code>selObj</code> is a <code>Selection</code> object.</li>
-  <li><code>selectedText</code> is a string (Selected text).</li>
-</ul>
+<p>However, not all functions call <code>toString()</code> automatically.
+  To use a <code>Selection</code> object as a string, call its <code>toString()</code> method directly:</p>
 
-<h3 id="Related_objects">Related objects</h3>
+<pre class="brush:js;">let selectedText = selection.toString();</pre>
+
+<h2 id="Related_objects">Related objects</h3>
 
 <p>You can call {{domxref("Window.getSelection()")}}, which works identically to
   <code>Document.getSelection()</code>.</p>
@@ -90,18 +71,13 @@ tags:
   <tbody>
     <tr>
       <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName("Shadow DOM", "#extensions-to-the-documentorshadowroot-mixin",
-        "DocumentOrShadowRoot")}}</td>
-      <td>{{Spec2("Shadow DOM")}}</td>
-      <td>Initial definition.</td>
+      <td>{{SpecName("Selection API", "#extensions-to-document-interface", "Document.getSelection")}}</td>
     </tr>
   </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentOrShadowRoot.getSelection")}}</p>
+<p>{{Compat("api.Document.getSelection")}}</p>

--- a/files/en-us/web/api/document/getselection/index.html
+++ b/files/en-us/web/api/document/getselection/index.html
@@ -1,16 +1,16 @@
 ---
 title: DocumentOrShadowRoot.getSelection()
-slug: Web/API/DocumentOrShadowRoot/getSelection
+slug: Web/API/Document/getSelection
 tags:
-- API
-- DocumentOrShadowRoot
-- Document
-- Method
-- Reference
-- ShadowRoot
-- getSelection
-- getSelection()
-- shadow dom
+  - API
+  - DocumentOrShadowRoot
+  - Document
+  - Method
+  - Reference
+  - ShadowRoot
+  - getSelection
+  - getSelection()
+  - shadow dom
 ---
 <div>{{APIRef("DOM")}}{{SeeCompatTable}}</div>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -256,6 +256,8 @@ tags:
  <dd>Returns a list of elements with the given tag name.</dd>
  <dt>{{DOMxRef("Document.getElementsByTagNameNS()")}}</dt>
  <dd>Returns a list of elements with the given tag name and namespace.</dd>
+ <dt>{{DOMxRef("Document.getSelection()")}}</dt>
+ <dd>Returns a {{DOMxRef('Selection')}} object representing the range of text selected by the user, or the current position of the caret.</dd>
  <dt>{{DOMxRef("Document.hasStorageAccess()")}} {{Experimental_Inline}}</dt>
  <dd>Returns a {{jsxref("Promise")}} that resolves with a boolean value indicating whether the document has access to its first-party storage.</dd>
  <dt>{{DOMxRef("Document.importNode()")}}</dt>
@@ -340,8 +342,6 @@ tags:
  <dd>Returns the topmost element at the specified coordinates.</dd>
  <dt>{{DOMxRef("DocumentOrShadowRoot.elementsFromPoint()")}}</dt>
  <dd>Returns an array of all elements at the specified coordinates.</dd>
- <dt>{{DOMxRef("DocumentOrShadowRoot.getSelection()")}}</dt>
- <dd>Returns a {{DOMxRef('Selection')}} object representing the range of text selected by the user, or the current position of the caret.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>

--- a/files/en-us/web/api/document/selectionchange_event/index.html
+++ b/files/en-us/web/api/document/selectionchange_event/index.html
@@ -74,6 +74,6 @@ document.onselectionchange = () =&gt; {
 
 <ul>
  <li>{{domxref("Document/selectstart_event", "selectstart")}}</li>
- <li>{{domxref("DocumentOrShadowRoot/getSelection", "Document.getSelection")}}</li>
+ <li>{{domxref("Document.getSelection")}}</li>
  <li>{{domxref("Selection", "Selection")}}</li>
 </ul>

--- a/files/en-us/web/api/document/selectionchange_event/index.html
+++ b/files/en-us/web/api/document/selectionchange_event/index.html
@@ -74,6 +74,6 @@ document.onselectionchange = () =&gt; {
 
 <ul>
  <li>{{domxref("Document/selectstart_event", "selectstart")}}</li>
- <li>{{domxref("Document.getSelection")}}</li>
+ <li>{{domxref("Document.getSelection()")}}</li>
  <li>{{domxref("Selection", "Selection")}}</li>
 </ul>


### PR DESCRIPTION
This PR is the gold example for why the mixin work matters.
The current page is this: https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection

There are so many things wrong here:
- This API is an old school Document API. It is supported since forever.
- The spec defines it just for Document. https://w3c.github.io/selection-api/#extensions-to-document-interface
- No spec defines it under DocumentOrShadowRoot. This is not under any mixin!
- It is surely not experimental
- It has nothing to do with Shadow DOM!

So basically, we warn about a perfect API that's been around forever as experimental and we document it weirdly under DocumentOrShadowRoot. Such a shame :(

I therefore moved it back to Document, cleaned up the page, and updated links to it. 