### PR TITLE
unsafe HTML should be breaking CI

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,7 +57,7 @@ jobs:
           # this to "*:error" which means the slightest flaw in the build
           # will break the build.
           # See https://github.com/mdn/yari/issues/715
-          export BUILD_FLAW_LEVELS="*:ignore"
+          export BUILD_FLAW_LEVELS="unsafe_html: error, *:ignore"
 
           # Note, it might be interesting to explore building *some*
           # pages in a PR build if the diff doesn't have any index.html

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -13,7 +13,9 @@ tags:
     <a href="https://github.com/mdn/yari">mdn/yari</a> for its automation.</p>
 </div>
 
-<h2>About this page</h2>
+<script>alert(1)</script>
+
+<h2 OnError=alert(1)>About this page</h2>
 
 <p>The <b>kitchensink</b> is a page that <i>attempts</i> to incorporate every possible content element and Yari macro.</p>
 


### PR DESCRIPTION
This relates to https://github.com/mdn/yari/issues/3177 and using that new flaw checker in the content CI. 