### PR TITLE
Fix dead link to mdn.github.io page

### DIFF
--- a/files/en-us/web/api/performance_timeline/index.html
+++ b/files/en-us/web/api/performance_timeline/index.html
@@ -66,7 +66,7 @@ tags:
  <li>Performance Observers {{experimental_inline}}: As shown in the {{domxref("PerformanceObserver")}} interface's <a href="/Web/API/PerformanceObserver#Browser_compatibility">Browser Compatibility</a> table, this interface has no shipping implementations.</li>
 </ul>
 
-<p>To test your browser's support for these interfaces, run the <code><a href="https://mdn.github.io/web-performance/perf-api-support.html">perf-api-support</a></code> application.</p>
+<p>To test your browser's support for these interfaces, run the <code><a href="https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html">perf-api-support</a></code> application.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
## Summary

Fix dead link on page https://developer.mozilla.org/en-US/docs/Web/API/Performance_Timeline

>To test your browser's support for these interfaces, run the [**perf-api-support**](https://mdn.github.io/web-performance/perf-api-support.html) application.

Before, linked to: https://mdn.github.io/web-performance/perf-api-support.html

Now, links to: https://mdn.github.io/dom-examples/performance-apis/perf-api-support.html

(I don't think there was an issue for this)

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [ ] N/A (There's no issue) ~Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).~
1. - [ ] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [ ] Link to any other resources that you think might be useful in reviewing your PR.
