### PR TITLE
Fix incorrectly placed note in rel attribute page

### DIFF
--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -238,11 +238,10 @@ tags:
 &lt;link rel=alternate href="/fr/pdf" hreflang=fr type=application/pdf title="French PDF"&gt;</pre>
 		</li>
 	</ul>
+  <p class="note">Note: The obsolete <code>rev="made"</code> is treated as <code>rel="alternate"</code></p>
 	</dd>
 	<dt>{{htmlattrdef("author")}}</dt>
-	<dd>Indicates the author of the current document or article. Relevant for {{htmlelement('link')}}, {{htmlelement('a')}}, and {{htmlelement('area')}} elements, the <code>author</code> keyword creates a hyperlink. With {{htmlelement('a')}} and {{htmlelement('area')}}, it indicates the linked document (or <code>mailto:</code>) provides information about the author of the nearest {{htmlelement('article')}} ancestor if there is one, otherwise the entire document. For {{htmlelement('link')}}, it represents the author of the entire document.
-	<p class="note">Note: The obsolete <code>rev="made"</code> is treated as <code>rel="alternate"</code></p>
-	</dd>
+	<dd>Indicates the author of the current document or article. Relevant for {{htmlelement('link')}}, {{htmlelement('a')}}, and {{htmlelement('area')}} elements, the <code>author</code> keyword creates a hyperlink. With {{htmlelement('a')}} and {{htmlelement('area')}}, it indicates the linked document (or <code>mailto:</code>) provides information about the author of the nearest {{htmlelement('article')}} ancestor if there is one, otherwise the entire document. For {{htmlelement('link')}}, it represents the author of the entire document.</dd>
 	<dt>{{htmlattrdef("bookmark")}}</dt>
 	<dd>Relevant as the <code>rel</code> attribute value for the {{htmlelement('a')}} and {{htmlelement('area')}} elements, the bookmark provides a permalink for ancestor section, which is the nearest ancestor {{htmlelement('article')}} or {{htmlelement('section')}}, if there is at least one, otherwise, the nearest heading sibling or ancestor descendant, to the next..</dd>
 	<dt>{{htmlattrdef("canonical")}}</dt>


### PR DESCRIPTION
A note about rel="alternate" was placed under the definition for rel="author" instead.