### PR TITLE
Link types: noopener - add note about new default

### DIFF
--- a/files/en-us/web/html/link_types/noopener/index.html
+++ b/files/en-us/web/html/link_types/noopener/index.html
@@ -13,6 +13,11 @@ tags:
 
 <p>Note that when <code>noopener</code> is used, nonempty target names other than <code>_top</code>, <code>_self</code>, and <code>_parent</code> are all treated like <code>_blank</code> in terms of deciding whether to open a new window/tab.</p>
 
+<div class="notecard note">
+ <h4>Note</h4>
+ <p>Setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements now implicitly provides the same <code>rel</code> behavior as setting <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> which does not set <code>window.opener</code>. See <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#browser_compatibility">browser compatibility</a> for support status.</p>
+</div>
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">


### PR DESCRIPTION
This PR adds the note about the new default `rel=noopener` behaviour (https://github.com/whatwg/html/pull/4330), under the rel link_type documentation

noopener is now implicitly set on `_blank` by default 

There is still a lot of out-of-date security information out there saying `target="_blank"` by itself is bad, when the default behaviour has changed to be securely `noopener` (fairly recently).
