### PR TITLE
Replace polyfill link in “Detecting device orientation” doc

### DIFF
--- a/files/en-us/web/api/detecting_device_orientation/index.html
+++ b/files/en-us/web/api/detecting_device_orientation/index.html
@@ -23,7 +23,7 @@ tags:
 <p>All you need to do in order to begin receiving orientation change is to listen to the {{event("deviceorientation")}} event:</p>
 
 <div class="note">
-<p><strong>Note</strong>: <a href="https://github.com/dorukeker/gyronorm.js">gyronorm.js</a> is a polyfill for normalizing the accelerometer and gyroscope data on mobile devices. This is useful for overcoming some of the differences in device support for device orientation.</p>
+<p><strong>Note</strong>: <a href="https://github.com/wagerfield/parallax">parallax</a> is a polyfill for normalizing the accelerometer and gyroscope data on mobile devices. This is useful for overcoming some of the differences in device support for device orientation.</p>
 </div>
 
 <pre class="brush: js">window.addEventListener("deviceorientation", handleOrientation, true);


### PR DESCRIPTION
[gyronorm.js](https://github.com/dorukeker/gyronorm.js
) is not maintained anymore, so replaced it with [parallax](https://github.com/wagerfield/parallax).


> Dear All, It has been almost 5 years since I first wrote this library. In the mean time JS evolved a lot; and parallel to this I grow apart from the JS world. Therefore I dont have the resources to go on maintaining this library and make sure it runs as expercted on latest devices. Gyronorm library will stay opensource in GitHub however I wont be merging any PR; and I wont look actively into any issues. I created an issue for alternatives here: https://github.com/dorukeker/gyronorm.js/issues/61 So if any one finds an up-to-date alternative please feel free to share it. Cheers!


