### PR TITLE
Remove obsolete property and methods

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.html
@@ -93,8 +93,6 @@ tags:
  <dd>Specifies the function that creates an object's prototype.</dd>
  <dt>{{jsxref("Object.prototype.__proto__")}}</dt>
  <dd>Points to the object which was used as prototype when the object was instantiated.</dd>
- <dt>{{jsxref("Object.prototype.__noSuchMethod__")}}</dt>
- <dd>Allows a function to be defined that will be executed when an undefined object member is called as a method.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
@@ -118,12 +116,8 @@ tags:
  <dd>Calls {{jsxref("Object.toString", "toString()")}}.</dd>
  <dt>{{jsxref("Object.prototype.toString()")}}</dt>
  <dd>Returns a string representation of the object.</dd>
- <dt>{{jsxref("Object.prototype.unwatch()")}}</dt>
- <dd>Removes a watchpoint from a property of the object.</dd>
  <dt>{{jsxref("Object.prototype.valueOf()")}}</dt>
  <dd>Returns the primitive value of the specified object.</dd>
- <dt>{{jsxref("Object.prototype.watch()")}}</dt>
- <dd>Adds a watchpoint to a property of the object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
In my opinion, [`Object.prototype.__noSuchMethod__`](https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/Object.noSuchMethod), [`Object.prototype.unwatch()`](https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/Object.unwatch), and [`Object.prototype.watch()`](https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript/Object.watch) in [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) page should be removed.

Reasons being that the links are broken due to the pages being archived, there is a better alternative like [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), and they still can access the pages at [`Archived JavaScript Reference`](https://developer.mozilla.org/en-US/docs/Archive/Web/JavaScript).

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
2. - [ ] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
3. - [x] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
4. - [x] Link to any other resources that you think might be useful in reviewing your PR.
