### PR TITLE
fix 'timeout' related to requestIdleCallback

### DIFF
--- a/files/en-us/web/api/window/requestidlecallback/index.html
+++ b/files/en-us/web/api/window/requestidlecallback/index.html
@@ -51,7 +51,7 @@ tags:
     <ul>
       <li><code>timeout</code>: If <code>timeout</code> is specified and has a positive
         value, and the callback has not already been called by the time <em>timeout</em>
-        milliseconds have passed, the callback will be called during the next idle period,
+        milliseconds have passed, a task to execute the callback is queued in the event loop,
         even if doing so risks causing a negative performance impact.</li>
     </ul>
   </dd>


### PR DESCRIPTION

Seems to be a small mistake in explain `timeout` about requestIdleCallback
https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [x] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
1. - [x] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [x] Link to any other resources that you think might be useful in reviewing your PR.
