### PR TITLE
Removed the missleading [,...]

### DIFF
--- a/files/en-us/web/api/console/table/index.html
+++ b/files/en-us/web/api/console/table/index.html
@@ -126,7 +126,8 @@ console.table([john, jane, emily], ["firstName"]);</pre>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">console.table(data, columns);
+<pre class="brush: js">console.table(data);
+console.table(data, columns);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/api/console/table/index.html
+++ b/files/en-us/web/api/console/table/index.html
@@ -126,7 +126,7 @@ console.table([john, jane, emily], ["firstName"]);</pre>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">console.table(data [, <em>columns</em>]);
+<pre class="brush: js">console.table(data, columns);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>


### PR DESCRIPTION
Fixes #3126 

Here I just wrote it as (param1, param2) because in the paragraph above it is saying that columns(param2) is optional.