### PR TITLE
Switch to different svg compat data (mdn/browser-compat-data#9402)

### DIFF
--- a/files/en-us/web/svg/attribute/stop-opacity/index.html
+++ b/files/en-us/web/svg/attribute/stop-opacity/index.html
@@ -66,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stop-opacity")}}</p>
+<p>{{Compat("svg.elements.stop.stop-opacity")}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
# Summary of changes
Changed compatibility data source on [this page](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/stop) from `svg.attributes.presentation.stop-opacity` to `svg.elements.stop.stop-opacity`.

This is following the suggestion that SVG compatibility data should be organized the same way HTML is: https://github.com/mdn/browser-compat-data/issues/9462

Which in turn is following discussion here about missing compatibility data for `stop-opacity`: https://github.com/mdn/browser-compat-data/issues/9402

