### PR TITLE
Remove rogue body tag in CSS offset page

### DIFF
--- a/files/en-us/web/css/offset/index.html
+++ b/files/en-us/web/css/offset/index.html
@@ -97,7 +97,6 @@ offset: url(arc.svg) 30deg / 50px 100px;
 
 <h2 id="Specifications">Specifications</h2>
 
- &lt;body&gt;
   <table class="standard-table">
  <thead>
   <tr>


### PR DESCRIPTION
Hi 👋 

I stumbled upon a rogue `<body>` tag on the [`offset`](https://developer.mozilla.org/en-US/docs/Web/CSS/offset#specifications) property page on the specifications section

There are no issues related as far as I'm aware