### PR TITLE
Added missing attribute name references (#1712)

### DIFF
--- a/files/en-us/web/html/attributes/index.html
+++ b/files/en-us/web/html/attributes/index.html
@@ -34,7 +34,7 @@ tags:
    <td>List of types the server accepts, typically a file type.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/accept-charset">accept-charset</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/form#attr-accept-charset">accept-charset</a></code></td>
    <td>{{ HTMLElement("form") }}</td>
    <td>List of supported charsets.</td>
   </tr>
@@ -54,7 +54,7 @@ tags:
    <td>Specifies the horizontal alignment of the element.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/allow">allow</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/iframe#attr-allow">allow</a></code></td>
    <td>{{ HTMLElement("iframe") }}</td>
    <td>Specifies a feature-policy for the iframe.</td>
   </tr>
@@ -64,7 +64,7 @@ tags:
    <td>Alternative text in case an image can't be displayed.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/async">async</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/script#attr-async">async</a></code></td>
    <td>{{ HTMLElement("script") }}</td>
    <td>Executes the script asynchronously.</td>
   </tr>
@@ -128,7 +128,7 @@ tags:
    <td>From the {{SpecName('HTML Media Capture', '#the-capture-attribute','media capture')}}spec, specifies a new file can be captured.</td>
   </tr>
   <tr>
-   <td><code>challenge</code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/keygen#attr-challenge">challenge</a></code></td>
    <td>{{ HTMLElement("keygen") }}</td>
    <td>A challenge string that is submitted along with the public key.</td>
   </tr>
@@ -153,12 +153,12 @@ tags:
    <td>Often used with CSS to style elements with common properties.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/code">code</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/applet#attr-code">code</a></code></td>
    <td>{{ HTMLElement("applet") }}</td>
    <td>Specifies the URL of the applet's class file to be loaded and executed.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/codebase">codebase</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/applet#attr-codebase">codebase</a></code></td>
    <td>{{ HTMLElement("applet") }}</td>
    <td>This attribute gives the absolute or relative URL of the directory where applets' .class files referenced by the code attribute are stored.</td>
   </tr>
@@ -174,7 +174,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/cols">cols</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/textarea#attr-cols">cols</a></code></td>
    <td>{{ HTMLElement("textarea") }}</td>
    <td>Defines the number of columns in a textarea.</td>
   </tr>
@@ -184,7 +184,7 @@ tags:
    <td>The colspan attribute defines the number of columns a cell should span.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/content">content</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/meta#attr-content">content</a></code></td>
    <td>{{ HTMLElement("meta") }}</td>
    <td>A value associated with <code>http-equiv</code> or <code>name</code> depending on the context.</td>
   </tr>
@@ -204,7 +204,7 @@ tags:
    <td>Indicates whether the browser should show playback controls to the user.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/coords">coords</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/area#attr-coords">coords</a></code></td>
    <td>{{ HTMLElement("area") }}</td>
    <td>A set of values specifying the coordinates of the hot-spot region.</td>
   </tr>
@@ -219,7 +219,7 @@ tags:
    <td>Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/data">data</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/object#attr-data">data</a></code></td>
    <td>{{ HTMLElement("object") }}</td>
    <td>Specifies the URL of the resource.</td>
   </tr>
@@ -234,17 +234,17 @@ tags:
    <td>Indicates the date and time associated with the element.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/decoding">decoding</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/img#attr-decoding">decoding</a></code></td>
    <td>{{ HTMLElement("img") }}</td>
    <td>Indicates the preferred method to decode the image.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/default">default</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/track#attr-default">default</a></code></td>
    <td>{{ HTMLElement("track") }}</td>
    <td>Indicates that the track should be enabled unless the user's preferences indicate something different.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/defer">defer</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/script#attr-defer">defer</a></code></td>
    <td>{{ HTMLElement("script") }}</td>
    <td>Indicates that the script should be executed after the page has been parsed.</td>
   </tr>
@@ -274,7 +274,7 @@ tags:
    <td>Defines whether the element can be dragged.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/enctype">enctype</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/form#attr-enctype">enctype</a></code></td>
    <td>{{ HTMLElement("form") }}</td>
    <td>Defines the content type of the form data when the <code>method</code> is POST.</td>
   </tr>
@@ -340,7 +340,7 @@ tags:
    <td>Prevents rendering of given element, while keeping child elements, e.g. script elements, active.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/high">high</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/meter#attr-high">high</a></code></td>
    <td>{{ HTMLElement("meter") }}</td>
    <td>Indicates the lower bound of the upper range.</td>
   </tr>
@@ -355,12 +355,12 @@ tags:
    <td>Specifies the language of the linked resource.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/http-equiv">http-equiv</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/meta#attr-http-equiv">http-equiv</a></code></td>
    <td>{{ HTMLElement("meta") }}</td>
    <td>Defines a pragma directive.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/icon">icon</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/command#attr-icon">icon</a></code></td>
    <td>{{ HTMLElement("command") }}</td>
    <td>Specifies a picture which represents the command.</td>
   </tr>
@@ -392,7 +392,7 @@ tags:
    <td>Provides a hint as to the type of data that might be entered by the user while editing the element or its contents. The attribute can be used with form controls (such as the value of <code>textarea</code> elements), or in elements in an editing host (e.g., using <code>contenteditable</code> attribute).</td>
   </tr>
   <tr>
-   <td><code>ismap</code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/img#attr-ismap">ismap</a></code></td>
    <td>{{ HTMLElement("img") }}</td>
    <td>Indicates that the image is part of a server-side image map.</td>
   </tr>
@@ -402,12 +402,12 @@ tags:
    <td></td>
   </tr>
   <tr>
-   <td><code>keytype</code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/keygen#attr-keytype">keytype</a></code></td>
    <td>{{ HTMLElement("keygen") }}</td>
    <td>Specifies the type of key generated.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/kind">kind</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/track#attr-kind">kind</a></code></td>
    <td>{{ HTMLElement("track") }}</td>
    <td>Specifies the kind of text track.</td>
   </tr>
@@ -422,7 +422,7 @@ tags:
    <td>Defines the language used in the element.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/language">language</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/script#attr-language">language</a></code> {{deprecated_inline}}</td>
    <td>{{ HTMLElement("script") }}</td>
    <td>Defines the script language used in the element.</td>
   </tr>
@@ -434,7 +434,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/list">list</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/input#attr-list">list</a></code></td>
    <td>{{ HTMLElement("input") }}</td>
    <td>Identifies a list of pre-defined options to suggest to the user.</td>
   </tr>
@@ -444,12 +444,12 @@ tags:
    <td>Indicates whether the media should start playing from the start when it's finished.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/low">low</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/meter#attr-low">low</a></code></td>
    <td>{{ HTMLElement("meter") }}</td>
    <td>Indicates the upper bound of the lower range.</td>
   </tr>
   <tr>
-   <td><code>manifest</code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/html#attr-manifest">manifest</a></code> {{obsolete_inline}}</td>
    <td>{{ HTMLElement("html") }}</td>
    <td>Specifies the URL of the document's cache manifest.
     <div class="note"><strong>Note:</strong> This attribute is obsolete, use <a href="/en-US/docs/Web/Manifest"><code>&lt;link rel="manifest"&gt;</code></a> instead.</div>
@@ -476,7 +476,7 @@ tags:
    <td>Specifies a hint of the media for which the linked resource was designed.</td>
   </tr>
   <tr>
-   <td><a href="/en-US/docs/Web/HTML/Attributes/method">method</a></td>
+   <td><a href="/en-US/docs/Web/HTML/Element/form#attr-method">method</a></td>
    <td>{{ HTMLElement("form") }}</td>
    <td>Defines which <a href="/en-US/docs/Web/HTTP">HTTP</a> method to use when submitting the form. Can be <code>GET</code> (default) or <code>POST</code>.</td>
   </tr>
@@ -501,17 +501,17 @@ tags:
    <td>Name of the element. For example used by the server to identify the fields in form submits.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/novalidate">novalidate</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/form#attr-novalidate">novalidate</a></code></td>
    <td>{{ HTMLElement("form") }}</td>
    <td>This attribute indicates that the form shouldn't be validated when submitted.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/open">open</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/details#attr-open">open</a></code></td>
    <td>{{ HTMLElement("details") }}</td>
    <td>Indicates whether the details will be shown on page load.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/optimum">optimum</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/meter#attr-optimum">optimum</a></code></td>
    <td>{{ HTMLElement("meter") }}</td>
    <td>Indicates the optimal numeric value.</td>
   </tr>
@@ -531,7 +531,7 @@ tags:
    <td>Provides a hint to the user of what can be entered in the field.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/poster">poster</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/video#attr-poster">poster</a></code></td>
    <td>{{ HTMLElement("video") }}</td>
    <td>A URL indicating a poster frame to show until the user plays or seeks.</td>
   </tr>
@@ -541,7 +541,7 @@ tags:
    <td>Indicates whether the whole resource, parts of it or nothing should be preloaded.</td>
   </tr>
   <tr>
-   <td><code>radiogroup</code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/command#attr-radiogroup">radiogroup</a></code></td>
    <td>{{ HTMLElement("command") }}</td>
    <td></td>
   </tr>
@@ -566,12 +566,12 @@ tags:
    <td>Indicates whether this element is required to fill out or not.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/reversed">reversed</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/ol#attr-reversed">reversed</a></code></td>
    <td>{{ HTMLElement("ol") }}</td>
    <td>Indicates whether the list should be displayed in a descending order instead of a ascending.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/rows">rows</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/textarea#attr-rows">rows</a></code></td>
    <td>{{ HTMLElement("textarea") }}</td>
    <td>Defines the number of rows in a text area.</td>
   </tr>
@@ -586,17 +586,17 @@ tags:
    <td>Stops a document loaded in an iframe from using certain features (such as submitting forms or opening new windows).</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/scope">scope</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/th#attr-scope">scope</a></code></td>
    <td>{{ HTMLElement("th") }}</td>
    <td>Defines the cells that the header test (defined in the <code>th</code> element) relates to.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/scoped">scoped</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/style#attr-scoped">scoped</a></code> {{non-standard_inline}} {{deprecated_inline}}</td>
    <td>{{ HTMLElement("style") }}</td>
    <td></td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/selected">selected</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/option#attr-selected">selected</a></code></td>
    <td>{{ HTMLElement("option") }}</td>
    <td>Defines a value which will be selected on page load.</td>
   </tr>
@@ -616,7 +616,7 @@ tags:
    <td></td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/slot">slot</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Global_attributes/slot">slot</a></code></td>
    <td><a href="/en-US/docs/Web/HTML/Global_attributes">Global attribute</a></td>
    <td>Assigns a slot in a shadow DOM shadow tree to an element.</td>
   </tr>
@@ -636,12 +636,12 @@ tags:
    <td>The URL of the embeddable content.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/srcdoc">srcdoc</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/iframe#attr-srcdoc">srcdoc</a></code></td>
    <td>{{ HTMLElement("iframe") }}</td>
    <td></td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/srclang">srclang</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/track#attr-srclang">srclang</a></code></td>
    <td>{{ HTMLElement("track") }}</td>
    <td></td>
   </tr>
@@ -651,7 +651,7 @@ tags:
    <td>One or more responsive image candidates.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/start">start</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/ol#attr-start">start</a></code></td>
    <td>{{ HTMLElement("ol") }}</td>
    <td>Defines the first number if other than 1.</td>
   </tr>
@@ -666,7 +666,7 @@ tags:
    <td>Defines CSS styles which will override styles previously set.</td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/summary">summary</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/table#attr-summary">summary</a></code> {{deprecated_inline}}</td>
    <td>{{ HTMLElement("table") }}</td>
    <td></td>
   </tr>
@@ -717,7 +717,7 @@ tags:
    </td>
   </tr>
   <tr>
-   <td><code><a href="/en-US/docs/Web/HTML/Attributes/wrap">wrap</a></code></td>
+   <td><code><a href="/en-US/docs/Web/HTML/Element/textarea#attr-wrap">wrap</a></code></td>
    <td>{{ HTMLElement("textarea") }}</td>
    <td>Indicates whether the text should be wrapped.</td>
   </tr>


### PR DESCRIPTION
This PR aims to resolve a few missing attributes from #1712 until separate pages for these attributes have been created.

----

1. Attributes with a single related element have been anchor linked to the details page of said element. 

> It is likely that some of these are documented but within details of the element they relate to
\- https://github.com/mdn/content/issues/1712#issue-793298658

2. Previously unlinked (single element) attributes have also been linked.

3. Global attribute references have been linked.

4. Inline flairs were carried over (`{{deprecated_inline}}` etc.)

## Updated list from https://github.com/mdn/content/issues/1712#issue-793298658

* [x]  `accept-charset`
* [ ]  `action`
* [ ]  `align`
* [x]  `allow`
* [ ]  `alt`
* [x]  `async`
* [ ]  `autofocus`
* [ ]  `autoplay`
* [ ]  `buffered`
* [x]  `challenge` <- 🔗 New reference
* [ ]  `charset`
* [ ]  `checked`
* [ ]  `cite`
* [x]  `code`
* [x]  `codebase`
* [x]  `cols`
* [ ]  `colspan`
* [x]  `content`
* [ ]  `contextmenu`
* [ ]  `controls`
* [x]  `coords`
* [x]  `data`
* [ ]  `datetime`
* [x]  `decoding`
* [x]  `default`
* [x]  `defer`
* [ ]  `dirname`
* [ ]  `download`
* [x]  `enctype`
* [ ]  `enterkeyhint`
* [x]  ~`for`~ <- Already fixed
* [ ]  `form`
* [ ]  `formaction`
* [ ]  `formenctype`
* [ ]  `formmethod`
* [ ]  `formnovaliddate`
* [ ]  `formtarget`
* [ ]  `headers`
* [x]  `high`
* [ ]  `href`
* [ ]  `hreflang`
* [x]  `http-equiv`
* [x]  `icon`
* [ ]  `importance`
* [x] `ismap` <- 🔗 New reference
* [x] `keytype` <- 🔗 New reference
* [x]  `kind`
* [ ]  `label`
* [x]  `language`
* [ ]  `loading`
* [x]  `list`
* [ ]  `loop`
* [x]  `low`
* [x] `manifest`
* [ ]  `media`
* [x]  `method`
* [ ]  `muted`
* [ ]  `name`
* [x]  `novalidate`
* [x]  `open`
* [x]  `optimum`
* [ ]  `placeholder`
* [x]  `poster`
* [ ]  `preload`
* [x] `radiogroup` <- 🔗 New reference
* [ ]  `referrer-policy`
* [x]  `reversed`
* [x]  `rows`
* [ ]  `rowspan`
* [x]  `scope`
* [x]  `scoped`
* [x]  `selected`
* [ ]  `shape`
* [ ]  `sizes`
* [x]  `slot`
* [ ]  `span`
* [ ]  `src`
* [x]  `srcdoc`
* [x]  `srclang`
* [ ]  `srcset`
* [x]  `start`
* [x]  `summary`
* [ ]  `target`
* [ ]  `type`
* [ ]  `usemap`
* [ ]  `value`
* [ ]  `width`
* [x]  `wrap`

41 references modified