### PR TITLE
Fix typo: aria-colcount → aria-rowcount in ARIA table role docs

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/table_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/table_role/index.html
@@ -79,7 +79,7 @@ tags:
  <p>This attribute is only required if the columns are not present in the DOM all the time. It provides an explicit indication of the number of columns in the full table. Set the value to the total number of columns in the full table. If unknown, set <code>aria-colcount="-1"</code>.</p>
  </dd>
  <dt>aria-rowcount attribute</dt>
- <dd>This attribute is only required if the rows are not present in the DOM all the time, such as scrollable tables that reuse rows to minimize the number of DOM nodes. It provides an explicit indication of the number of rows in the full table. Set the value to the total number of rows in the full table. If unknown, set <code>aria-colcount="-1"</code>.</dd>
+ <dd>This attribute is only required if the rows are not present in the DOM all the time, such as scrollable tables that reuse rows to minimize the number of DOM nodes. It provides an explicit indication of the number of rows in the full table. Set the value to the total number of rows in the full table. If unknown, set <code>aria-rowcount="-1"</code>.</dd>
 </dl>
 
 <h3 id="Keyboard_interactions">Keyboard interactions</h3>


### PR DESCRIPTION
# Summary
On the [ARIA: table role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role) docs, the section for "Associated WAI-ARIA roles, states, and properties" provides guidance on setting the correct attribute if the row  count is unknown.

Currently the docs state to set `aria-colcount="-1"`. This appears to be a typo, since the section is describing the `aria-rowcount` specifically.

I couldn't find an example with `-1` specifically on the w3c docs, but it appears to set the `aria-rowcount` in the other instances:
https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html

## Checklist

- [x]  Provide a summary of your changes
- [x] ~Provide a link to the issue(s) you are fixing~ not applicable
- [x]  Review the results of the automated checks
- [x]  Link to any other resources that you think might be useful in reviewing your PR.