### PR TITLE
Flex shorthand links and HTML entities inside IDs

### DIFF
--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -99,11 +99,11 @@ flex: unset;
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties, but grows to absorb any extra free space in the flex container, and shrinks to its minimum size to fit the container. This is equivalent to setting "<code>flex: 1 1 auto</code>".</dd>
  <dt id="none"><code>none</code></dt>
  <dd>The item is sized according to its <code>width</code> and <code>height</code> properties. It is fully inflexible: it neither shrinks nor grows in relation to the flex container. This is equivalent to setting "<code>flex: 0 0 auto</code>".</dd>
- <dt id="&lt;'flex-grow'&gt;"><code>&lt;'flex-grow'&gt;</code></dt>
+ <dt id="flex-grow"><code>&lt;'flex-grow'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-grow")}} of the flex item. Negative values are considered invalid. Defaults to <code>1</code> when omitted. (initial is <code>0</code>)</dd>
- <dt id="&lt;'flex-shrink'&gt;"><code>&lt;'flex-shrink'&gt;</code></dt>
+ <dt id="flex-shrink"><code>&lt;'flex-shrink'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-shrink")}} of the flex item. Negative values are considered invalid. Defaults to <code>1</code> when omitted. (initial is <code>1</code>)</dd>
- <dt id="&lt;'flex-basis'&gt;"><code>&lt;'flex-basis'&gt;</code></dt>
+ <dt id="flex-basis"><code>&lt;'flex-basis'&gt;</code></dt>
  <dd>Defines the {{cssxref("flex-basis")}} of the flex item. A preferred size of <code>0</code> must have a unit to avoid being interpreted as a flexibility. Defaults to <code>0</code> when omitted. (initial is <code>auto</code>)</dd>
 </dl>
 

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -70,7 +70,7 @@ flex: unset;
   <ul>
    <li>The first value must be:
     <ul>
-     <li>a {{cssxref("&lt;number&gt;")}} and it is interpreted as <code><a href="flex-grow">&lt;flex-grow&gt;</a></code>.</li>
+     <li>a {{cssxref("&lt;number&gt;")}} and it is interpreted as <code><a href="#flex-grow">&lt;flex-grow&gt;</a></code>.</li>
     </ul>
    </li>
    <li>The second value must be one of:
@@ -83,8 +83,8 @@ flex: unset;
  </li>
  <li><strong>Three-value syntax:</strong> the values must be in the following order:
   <ol>
-   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="flex-grow">&lt;flex-grow&gt;</a></code>.</li>
-   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="flex-shrink">&lt;flex-shrink&gt;</a></code>.</li>
+   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="#flex-grow">&lt;flex-grow&gt;</a></code>.</li>
+   <li>a {{cssxref("&lt;number&gt;")}} for <code><a href="#flex-shrink">&lt;flex-shrink&gt;</a></code>.</li>
    <li>a valid value for {{cssxref("width")}} for <code><a href="#flex-basis">&lt;flex-basis&gt;</a></code>.</li>
   </ol>
  </li>

--- a/files/en-us/web/css/font/index.html
+++ b/files/en-us/web/css/font/index.html
@@ -66,19 +66,19 @@ tags:
 <h3 id="Values">Values</h3>
 
 <dl>
- <dt id="&lt;'font-style'&gt;"><code>&lt;'font-style'&gt;</code></dt>
+ <dt id="font-style"><code>&lt;'font-style'&gt;</code></dt>
  <dd>See the {{cssxref("font-style")}} CSS property.</dd>
- <dt id="&lt;'font-variant'&gt;"><code>&lt;'font-variant'&gt;</code></dt>
+ <dt id="font-variant"><code>&lt;'font-variant'&gt;</code></dt>
  <dd>See the {{cssxref("font-variant")}} CSS property.</dd>
- <dt id="&lt;'font-weight'&gt;"><code>&lt;'font-weight'&gt;</code></dt>
+ <dt id="font-weight"><code>&lt;'font-weight'&gt;</code></dt>
  <dd>See the {{cssxref("font-weight")}} CSS property.</dd>
- <dt id="&lt;'font-stretch'&gt;"><code>&lt;'font-stretch'&gt;</code></dt>
+ <dt id="font-stretch"><code>&lt;'font-stretch'&gt;</code></dt>
  <dd>See the {{cssxref("font-stretch")}} CSS property.</dd>
- <dt id="&lt;'font-size'&gt;"><code>&lt;'font-size'&gt;</code></dt>
+ <dt id="font-size"><code>&lt;'font-size'&gt;</code></dt>
  <dd>See the {{cssxref("font-size")}} CSS property.</dd>
- <dt id="&lt;'line-height'&gt;"><code>&lt;'line-height'&gt;</code></dt>
+ <dt id="line-height"><code>&lt;'line-height'&gt;</code></dt>
  <dd>See the {{cssxref("line-height")}} CSS property.</dd>
- <dt id="&lt;'font-family'&gt;"><code>&lt;'font-family'&gt;</code></dt>
+ <dt id="font-family"><code>&lt;'font-family'&gt;</code></dt>
  <dd>See the {{cssxref("font-family")}} CSS property.</dd>
 </dl>
 


### PR DESCRIPTION
Remove less than (`&lt;`) and greater than (`&gt;`) HTML entities from ids.
This change was initially implemented with #920, but the changes were incomplete in the flex and font documents.

#920 additionally introduced the broken/inconsistent links for the CSS property values on the flex property page. 
Today, some of the links are going to the primary page for the CSS property associated with the shorthand, and some are linking to the definitions on the same page. 

This PR consistently links to the value definitions within the flex page (as appears to have been originally intended). 
Additionally, the existing same page links are broken today, but are fixed by in this PR by cleaning up and removing the HTML entities from the ids.
