### PR TITLE
fix(ReadableStreamDefaultReader): jsref -> jsxref

### DIFF
--- a/files/en-us/web/api/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.html
@@ -31,7 +31,7 @@ tags:
 
 <dl>
  <dt>{{domxref("ReadableStreamDefaultReader.cancel()")}}</dt>
- <dd>Returns a {{jsref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied <code>reason</code> argument will be given to the underlying source, which may or may not use it.</dd>
+ <dd>Returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied <code>reason</code> argument will be given to the underlying source, which may or may not use it.</dd>
  <dt>{{domxref("ReadableStreamDefaultReader.read()")}}</dt>
  <dd>Returns a promise providing access to the next chunk in the stream's internal queue.</dd>
  <dt>{{domxref("ReadableStreamDefaultReader.releaseLock()")}}</dt>


### PR DESCRIPTION
In ReadableStreamDefaultReader page, the description of `.cancel()` API look like the below:

```
Returns a that resolves when the stream is canceled.
```

(The word `promise` is missing). This PR tries to fix it.