### PR TITLE
fail on unsafe html

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,7 +57,7 @@ jobs:
           # this to "*:error" which means the slightest flaw in the build
           # will break the build.
           # See https://github.com/mdn/yari/issues/715
-          export BUILD_FLAW_LEVELS="*:ignore"
+          export BUILD_FLAW_LEVELS="unsafe_html: error, *:ignore"
 
           # Note, it might be interesting to explore building *some*
           # pages in a PR build if the diff doesn't have any index.html

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -366,6 +366,6 @@ rect2.bind("EnterFrame", function () {
 {{Deprecated_Header}}
 
 <p>Small change</p>
-<img src="iceberg.jpg" alt="Iceberg pic" onerror=alert(1)>
+<img src="iceberg.jpg" alt="Iceberg pic">
 
 <p><code>geckoRelease:</code> {{ geckoRelease("1.9.3") }}</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -366,6 +366,6 @@ rect2.bind("EnterFrame", function () {
 {{Deprecated_Header}}
 
 <p>Small change</p>
-<img src="iceberg.jpg" alt="Iceberg pic">
+<img src="iceberg.jpg" alt="Iceberg pic" onerror=alert(1)>
 
 <p><code>geckoRelease:</code> {{ geckoRelease("1.9.3") }}</p>


### PR DESCRIPTION
As of this change, any touch of any index.html that introduces something that's supposedly "unsafe" should crash CI. 