### PR TITLE
Adds TrustedTypePolicyFactory

### DIFF
--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -14,7 +14,12 @@ tags:
 
 <h3 id="Default_policy">The default policy</h3>
 
-<p>Creating a policy with a name of "default" creates a special policy that will be used if a string (rather than a Trusted Type object) is passed to an injection sink. This can be used in a transitional phase while moving from an application that inserted strings into injection sinks.</p>
+<p>In Chrome a policy with a name of "default" creates a special policy that will be used if a string (rather than a Trusted Type object) is passed to an injection sink. This can be used in a transitional phase while moving from an application that inserted strings into injection sinks.</p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The above behavior is not yet settled in the specification and may change in future.</p>
+</div>
 
 <div class="notecard warning">
   <h4>Note</h4>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -33,7 +33,7 @@ tags:
 
 <dl>
   <dt>{{jsxref("TypeError")}}</dt>
-  <dd>Thrown if policy names are restricted by the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy `trusted-types` directive</a> and this name is not on the allowlist.</dd>
+  <dd>Thrown if policy names are restricted by the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy <code>trusted-types</code> directive</a> and this name is not on the allowlist.</dd>
   <dt>{{jsxref("TypeError")}}</dt>
   <dd>Thrown if the name is a duplicate and the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy trusted-types directive</a> is not using <code>allow-duplicates</code>.</dd>
 </dl>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -40,7 +40,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The below code creates a policy with the name <code>myEscapePolicy</code> with a function defined for <code>createHTML</code> which sanitizes HTML.</p>
+<p>The below code creates a policy with the name <code>"myEscapePolicy"</code> with a function defined for <code>createHTML()</code> which sanitizes HTML.</p>
 
 <pre class="brush: js">const escapeHTMLPolicy = trustedTypes.createPolicy("myEscapePolicy", {
   createHTML: (string) =&gt; string.replace(/\&gt;/g, "&lt;")

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -12,6 +12,15 @@ tags:
 
 <p class="summary">The <strong><code>createPolicy()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface creates a {{domxref("TrustedTypePolicy")}} object that implements the rules passed as <code>policyOptions</code>.</p>
 
+<h3 id="Default_policy">The default policy</h3>
+
+<p>Creating a policy with a name of "default" creates a special policy that will be used if a string (rather than a Trusted Type object) is passed to an injection sink. This can be used in a transitional phase while moving from an application that inserted strings into injection sinks.</p>
+
+<div class="notecard warning">
+  <h4>Note</h4>
+  <p>A lax default policy could defeat the purpose of using Trusted Types, and therefore should be defined with strict rules to ensure it cannot be used to run dangerous code.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>policy</var> = <var>TrustedTypePolicyFactory</var>.createPolicy(<var>policyName</var>,<var>policyOptions</var>);</pre>
@@ -22,7 +31,16 @@ tags:
   <dt><code>policyName</code></dt>
   <dd>A {{domxref("DOMString")}} with the name of the policy.</dd>
   <dt><code>policyOptions</code>{{optional_inline}}</dt>
-  <dd>A {{domxref("TrustedTypePolicyOptions")}} dictionary of user-defined functions for converting strings into trusted values.</dd>
+  <dd>User-defined functions for converting strings into trusted values.
+    <dl>
+      <dt><code>CreateHTML(<var>input</var>[,<var>args</var>])</code></dt>
+      <dd>A callback function in the form of a {{domxref("DOMString", "string")}} that contains code to run when creating a {{domxref("TrustedHTML")}} object.</dd>
+      <dt><code>CreateScript(<var>input</var>[,<var>args</var>])</code></dt>
+      <dd>A callback function in the form of a {{domxref("DOMString", "string")}} that contains code to run when creating a {{domxref("TrustedScript")}} object.</dd>
+      <dt><code>CreateScriptURL(<var>input</var>[,<var>args</var>])</code></dt>
+      <dd>A callback function in the form of a {{domxref("DOMString", "string")}} that contains code to run when creating a {{domxref("TrustedScriptURL")}} object.</dd>
+    </dl>
+  </dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>
@@ -44,6 +62,20 @@ tags:
 
 <pre class="brush: js">const escapeHTMLPolicy = trustedTypes.createPolicy("myEscapePolicy", {
   createHTML: (string) =&gt; string.replace(/\&gt;/g, "&lt;")
+});</pre>
+
+<h3>Creating a default policy</h3>
+
+<p>On a site where Trusted Types are enforced via a Content Security Policy with the <code><a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for">require-trusted-types-for</a></code> directive set to <code>script</code>, any injection script that accepts a script expects a Trusted Type object. In the case that a string is inserted instead, the following default policy will be used.</p>
+
+<p>The policy logs a message to the console to remind the developer to refactor this part of the application to use a Trusted Type object. It also appends details of the use of the default policy, type, and injection sink to the returned value.</p>
+
+<pre class="brush: js">trustedTypes.createPolicy('default', {
+  createScriptURL: (s, type, sink) => {
+    console.log("Please refactor.");
+    return s + '?default-policy-used&type=' + encodeURIComponent(type) +
+          '&sink=' + encodeURIComponent(sink);
+  }
 });</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -33,7 +33,7 @@ tags:
 
 <dl>
   <dt>{{jsxref("TypeError")}}</dt>
-  <dd>Thrown if policy names are restricted by the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy trusted-types directive</a> and this name is not on the allowlist.</dd>
+  <dd>Thrown if policy names are restricted by the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy `trusted-types` directive</a> and this name is not on the allowlist.</dd>
   <dt>{{jsxref("TypeError")}}</dt>
   <dd>Thrown if the name is a duplicate and the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy trusted-types directive</a> is not using <code>allow-duplicates</code>.</dd>
 </dl>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -1,0 +1,70 @@
+---
+title: TrustedTypePolicyFactory.createPolicy()
+slug: Web/API/TrustedTypePolicyFactory/createPolicy
+tags:
+  - API
+  - Method
+  - Reference
+  - createPolicy
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>createPolicy()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface creates a {{domxref("TrustedTypePolicy")}} object that implements the rules passed as <code>policyOptions</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>policy</var> = <var>TrustedTypePolicyFactory</var>.createPolicy(<var>policyName</var>,<var>policyOptions</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>policyName</code></dt>
+  <dd>A {{domxref("DOMString")}} with the name of the policy.</dd>
+  <dt><code>policyOptions</code>{{optional_inline}}</dt>
+  <dd>A {{domxref("TrustedTypePolicyOptions")}} dictionary of user-defined functions for converting strings into trusted values.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("TrustedTypePolicy")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{jsxref("TypeError")}}</dt>
+  <dd>Thrown if policy names are restricted by the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy trusted-types directive</a> and this name is not on the allowlist.</dd>
+  <dt>{{jsxref("TypeError")}}</dt>
+  <dd>Thrown if the name is a duplicate and the <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types">Content Security Policy trusted-types directive</a> is not using <code>allow-duplicates</code>.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The below code creates a policy with the name <code>myEscapePolicy</code> with a function defined for <code>createHTML</code> which sanitizes HTML.</p>
+
+<pre class="brush: js">const escapeHTMLPolicy = trustedTypes.createPolicy("myEscapePolicy", {
+  createHTML: (string) =&gt; string.replace(/\&gt;/g, "&lt;")
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-createpolicy','TrustedTypePolicyFactory.createPolicy()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.createPolicy")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -12,6 +12,11 @@ tags:
 
 <p class="summary">The <strong><code>defaultPolicy</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.</p>
 
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Information about the creation and use of default policies can be found in the <code><a href="/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#default_policy">createPolicy()</a></code> documentation.</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>defaultPolicy</var> = <var>TrustedTypePolicyFactory</var>.defaultPolicy;</pre>

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -1,0 +1,51 @@
+---
+title: TrustedTypePolicyFactory.defaultPolicy
+slug: Web/API/TrustedTypePolicyFactory/defaultPolicy
+tags:
+  - API
+  - Property
+  - Reference
+  - defaultPolicy
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>defaultPolicy</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>defaultPolicy</var> = <var>TrustedTypePolicyFactory</var>.defaultPolicy;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("TrustedTypePolicy")}} or null.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The first line below returns null as no default policy has been created. Once a default policy is created, calling <code>defaultPolicy</code> returns that policy object.</p>
+
+<pre class="brush: js">console.log(trustedTypes.defaultPolicy); // null
+const dp = trustedTypes.createPolicy('default', {});
+console.log(trustedTypes.defaultPolicy); // a TrustedTypePolicy object</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-defaultpolicy','TrustedTypePolicyFactory.defaultPolicy')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.defaultPolicy")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
@@ -1,0 +1,49 @@
+---
+title: TrustedTypePolicyFactory.emptyHTML
+slug: Web/API/TrustedTypePolicyFactory/emptyHTML
+tags:
+  - API
+  - Property
+  - Reference
+  - emptyHTML
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>emptyHTML</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedHTML")}} object containing an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>emptyHTML</var> = <var>TrustedTypePolicyFactory</var>.emptyHTML;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("TrustedHTML")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example an empty string is to be inserted into the element. Therefore there is no need to create a policy, and the <code>emptyHTML</code> property can be used to insert the empty element when a Trusted Types object is expected.</p>
+
+<pre class="brush: js">el.innerHTML = trustedTypes.emptyHTML;</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-emptyhtml','TrustedTypePolicyFactory.emptyHTML')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.emptyHTML")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
@@ -12,6 +12,8 @@ tags:
 
 <p class="summary">The <strong><code>emptyHTML</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedHTML")}} object containing an empty string.</p>
 
+<p>This object can be used when the application requires an empty string to be inserted into an injection sink.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>emptyHTML</var> = <var>TrustedTypePolicyFactory</var>.emptyHTML;</pre>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -23,7 +23,7 @@ tags:
 
 <p>The <a href="https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-emptyscript">specification</a> explains that the <code>emptyScript</code> object can be used to detect support for dynamic code compilation.</p>
 
-<p>Native Trusted Types implementations can support <code>eval(TrustedScript)</code>, therefore in the below example in a native implementation will return false for <code>eval(trustedTypes.emptyScript)</code>. A polyfill will return a truthy object.</p>
+<p>Native Trusted Types implementations can support <code>eval(TrustedScript)</code>, therefore in the below example a native implementation will return false for <code>eval(trustedTypes.emptyScript)</code>. A polyfill will return a truthy object.</p>
 
 <pre class="brush: js">const supportsTS = !eval(trustedTypes.emptyScript);
 eval(supportsTS ? myTrustedScriptObj : myTrustedScriptObj.toString());</pre>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -12,6 +12,8 @@ tags:
 
 <p class="summary">The <strong><code>emptyScript</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedScript")}} object containing an empty string.</p>
 
+<p>This object can be used when the application requires an empty string to be inserted into an injection sink which is expecting a <code>TrustedScript</code> object.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">var <var>emptyScript</var> = <var>TrustedTypePolicyFactory</var>.emptyScript;</pre>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -1,0 +1,52 @@
+---
+title: TrustedTypePolicyFactory.emptyScript
+slug: Web/API/TrustedTypePolicyFactory/emptyScript
+tags:
+  - API
+  - Property
+  - Reference
+  - emptyScript
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>emptyScript</code></strong> read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns a {{domxref("TrustedScript")}} object containing an empty string.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>emptyScript</var> = <var>TrustedTypePolicyFactory</var>.emptyScript;</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("TrustedScript")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <a href="https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-emptyscript">specification</a> explains that the <code>emptyScript</code> object can be used to detect support for dynamic code compilation.</p>
+
+<p>Native Trusted Types implementations can support <code>eval(TrustedScript)</code>, therefore in the below example in a native implementation will return false for <code>eval(trustedTypes.emptyScript)</code>. A polyfill will return a truthy object.</p>
+
+<pre class="brush: js">const supportsTS = !eval(trustedTypes.emptyScript);
+eval(supportsTS ? myTrustedScriptObj : myTrustedScriptObj.toString());</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-emptyscript','TrustedTypePolicyFactory.emptyScript')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.emptyScript")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -33,9 +33,9 @@ tags:
 
 <p>A {{domxref("DOMString","string")}} with one of:</p>
 <ul>
-  <li>"TrustedHTML"</li>
-  <li>"TrustedScript"</li>
-  <li>"TrustedScriptURL</li>
+  <li><code>"TrustedHTML"</code></li>
+  <li><code>"TrustedScript"</code></li>
+  <li><code>"TrustedScriptURL"</code></li>
 </ul>
 
 <p>Or, null.</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -1,0 +1,70 @@
+---
+title: TrustedTypePolicyFactory.getAttributeType()
+slug: Web/API/TrustedTypePolicyFactory/getAttributeType
+tags:
+  - API
+  - Method
+  - Reference
+  - getAttributeType
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>getAttributeType()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface allows web developers to check if a Trusted Type is required for an element, and if so which Trusted Type is used.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>attributeType</var> = <var>TrustedTypePolicyFactory</var>.getAttributeType(<var>tagName</var>,<var>attribute</var>[,<var>elementNs</var>,<var>attrNs</var>]);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>tagName</code></dt>
+  <dd>A {{domxref("DOMString","string")}} containing the name of an HTML tag.</dd>
+  <dt><code>attribute</code></dt>
+  <dd>A {{domxref("DOMString","string")}} containing an attribute.</dd>
+  <dt><code>elementNs</code>{{optional_inline}}</dt>
+  <dd>A {{domxref("DOMString","string")}} containing a namespace.</dd>
+  <dt><code>attrNs</code>{{optional_inline}}</dt>
+  <dd>A {{domxref("DOMString","string")}} containing a namespace.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("DOMString","string")}} with one of:</p>
+<ul>
+  <li>"TrustedHTML"</li>
+  <li>"TrustedScript"</li>
+  <li>"TrustedScriptURL</li>
+</ul>
+
+<p>Or, null.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example, passing the {{htmlelement("script")}} element and {{htmlattrxref("src")}} attribute to <code>getAttributeType</code> returns "TrustedScriptURL".</p>
+
+<pre class="brush: js">console.log(trustedTypes.getAttributeType('script', 'src')); // "TrustedScriptURL"</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-getattributetype','TrustedTypePolicyFactory.getAttributeType()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.getAttributeType")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -24,9 +24,9 @@ tags:
   <dt><code>attribute</code></dt>
   <dd>A {{domxref("DOMString","string")}} containing an attribute.</dd>
   <dt><code>elementNs</code>{{optional_inline}}</dt>
-  <dd>A {{domxref("DOMString","string")}} containing a namespace.</dd>
+  <dd>A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to the HTML namespace.</dd>
   <dt><code>attrNs</code>{{optional_inline}}</dt>
-  <dd>A {{domxref("DOMString","string")}} containing a namespace.</dd>
+  <dd>A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to null.</dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -31,9 +31,9 @@ tags:
 
 <p>A {{domxref("DOMString","string")}} with one of:</p>
 <ul>
-  <li>"TrustedHTML"</li>
-  <li>"TrustedScript"</li>
-  <li>"TrustedScriptURL</li>
+  <li><code>"TrustedHTML"</code></li>
+  <li><code>"TrustedScript"</code></li>
+  <li><code>"TrustedScriptURL"</code></li>
 </ul>
 
 <p>Or, null.</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -24,7 +24,7 @@ tags:
   <dt><code>property</code></dt>
   <dd>A {{domxref("DOMString","string")}} containing a property, for example <code>"innerHTML"</code>.</dd>
   <dt><code>elementNs</code>{{optional_inline}}</dt>
-  <dd>A {{domxref("DOMString","string")}} containing a namespace.</dd>
+  <dd>A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to the HTML namespace.</dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -1,0 +1,68 @@
+---
+title: TrustedTypePolicyFactory.getPropertyType()
+slug: Web/API/TrustedTypePolicyFactory/getPropertyType
+tags:
+  - API
+  - Method
+  - Reference
+  - getPropertyType
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>getPropertyType()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface allows web developers to check if a Trusted Type is required for an element's property.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>null</var> = TrustedTypePolicyFactory.getPropertyType(<var>tagName</var>,<var>property</var>[, <var>elementNS</var>]);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>tagName</code></dt>
+  <dd>A {{domxref("DOMString","string")}} containing the name of an HTML tag.</dd>
+  <dt><code>property</code></dt>
+  <dd>A {{domxref("DOMString","string")}} containing a property, for example <code>"innerHTML"</code>.</dd>
+  <dt><code>elementNs</code>{{optional_inline}}</dt>
+  <dd>A {{domxref("DOMString","string")}} containing a namespace.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{domxref("DOMString","string")}} with one of:</p>
+<ul>
+  <li>"TrustedHTML"</li>
+  <li>"TrustedScript"</li>
+  <li>"TrustedScriptURL</li>
+</ul>
+
+<p>Or, null.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example, passing the {{htmlelement("div")}} element and <code>innerHTML</code> property to <code>getPropertyType</code> returns "TrustedHTML".</p>
+
+<pre class="brush: js">console.log(trustedTypes.getPropertyType('div', 'innerHTML')); // "TrustedHTML"</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-getpropertytype','TrustedTypePolicyFactory.getPropertyType()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.getPropertyType")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.html
@@ -42,7 +42,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The below code creates a policy with the name <code>myEscapePolicy</code> with a function defined for <code>createHTML</code> which sanitizes HTML.</p>
+<p>The below code creates a policy with the name <code>"myEscapePolicy"</code> with a function defined for <code>createHTML()</code> which sanitizes HTML.</p>
 
 <p>We then use the policy to sanitize a string, creating a {{domxref("TrustedHTML")}} object, <code>escaped</code>. This object can be tested with {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}} to ensure that it was created by one of our policies.</p>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.html
@@ -1,0 +1,79 @@
+---
+title: TrustedTypePolicyFactory
+slug: Web/API/TrustedTypePolicyFactory
+tags:
+  - API
+  - Interface
+  - Reference
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>TrustedTypePolicyFactory</code></strong> interface of the {{domxref('Trusted Types API')}} creates policies and allows the verification of Trusted Type objects against created policies.</p>
+
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+  <dt>{{domxref("TrustedTypePolicyFactory.emptyHTML")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns a {{domxref("TrustedHTML")}} object containing an empty string.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.emptyScript")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns a {{domxref("TrustedScript")}} object containing an empty string.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.defaultPolicy")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("TrustedTypePolicyFactory.createPolicy()")}}</dt>
+  <dd>Creates a {{domxref("TrustedTypePolicy")}} object that implements the rules passed as <code>policyOptions</code>.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.isHTML()")}}</dt>
+  <dd>When passed a value checks that it is a valid {{domxref("TrustedHTML")}} object.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.isScript()")}}</dt>
+  <dd>When passed a value checks that it is a valid {{domxref("TrustedScript")}} object.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.isScriptURL()")}}</dt>
+  <dd>When passed a value checks that it is a valid {{domxref("TrustedScriptURL")}} object.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.getAttributeType()")}}</dt>
+  <dd>Allows web developers to check whether a Trusted Type is required for an element and attribute, and if so which one.</dd>
+  <dt>{{domxref("TrustedTypePolicyFactory.getPropertyType()")}}</dt>
+  <dd>Allows web developers to check whether a Trusted Type is required for a property, and if so which one.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The below code creates a policy with the name <code>myEscapePolicy</code> with a function defined for <code>createHTML</code> which sanitizes HTML.</p>
+
+<p>We then use the policy to sanitize a string, creating a {{domxref("TrustedHTML")}} object, <code>escaped</code>. This object can be tested with {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}} to ensure that it was created by one of our policies.</p>
+
+<pre class="brush: js">const escapeHTMLPolicy = trustedTypes.createPolicy("myEscapePolicy", {
+  createHTML: (string) =&gt; string.replace(/\&gt;/g, "&lt;")
+});
+
+const escaped = escapeHTMLPolicy.createHTML("&lt;img src=x onerror=alert(1)&gt;");
+
+console.log(trustedTypes.isHTML(escaped)) // true;
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#trusted-type-policy-factory','TrustedTypePolicyFactory')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note:</h4>
-  <p>The purpose of the functions <code>isHTML</code>, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+  <p>The purpose of the functions <code>isHTML()</code>, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h3 id="Returns">Return value</h3>
 
-<p>A {{jsxref("boolean")}}, true if the object is a valid {{domxref("TrustedHTML")}} object.</p>
+<p>A {{jsxref("boolean")}} that is true if the object is a valid {{domxref("TrustedHTML")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -34,7 +34,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the below example the constant <code>html</code> was created by a policy, and therefore <code>isHTML</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isHTML</code>.</p>
+<p>In the below example the constant <code>html</code> was created by a policy, and therefore <code>isHTML()</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isHTML()</code>.</p>
 
 <pre class="brush: js">const html = policy.createHTML('<div>');
 console.log(trustedTypes.isHTML(html)) // true;

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -1,0 +1,68 @@
+---
+title: TrustedTypePolicyFactory.isHTML()
+slug: Web/API/TrustedTypePolicyFactory/isHTML
+tags:
+  - API
+  - Method
+  - Reference
+  - isHTML
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>isHTML()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedHTML")}} object.</p>
+
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>The purpose of the functions <code>isHTML</code>, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>isHTML</var> = <var>TrustedTypePolicyFactory</var>.isHTML(<var>value</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("TrustedHTML")}} object.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("boolean")}}, true if the object is a valid {{domxref("TrustedHTML")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example the constant <code>html</code> was created by a policy, and therefore <code>isHTML</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isHTML</code>.</p>
+
+<pre class="brush: js">const html = policy.createHTML('<div>');
+console.log(trustedTypes.isHTML(html)) // true;
+
+const fake = Object.create(TrustedHTML.prototype);
+console.log(trustedTypes.isHTML(fake)); // false
+
+console.log(trustedTypes.isHTML("<div>plain string</div>")); // false</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-ishtml','TrustedTypePolicyFactory.isHTML()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.isHTML")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h3 id="Returns">Return value</h3>
 
-<p>A {{jsxref("boolean")}}, true if the object is a valid {{domxref("TrustedScript")}} object.</p>
+<p>A {{jsxref("boolean")}} that is true if the object is a valid {{domxref("TrustedScript")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -34,7 +34,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the below example the constant <code>url</code> was created by a policy, and therefore <code>isScriptURL</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isScriptURL</code>.</p>
+<p>In the below example the constant <code>url</code> was created by a policy, and therefore <code>isScriptURL()</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isScriptURL()</code>.</p>
 
 <pre class="brush: js">const myScript = policy.createScript("eval('2 + 2')");
 console.log(trustedTypes.isScript(myScript)) // true;

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -1,0 +1,68 @@
+---
+title: TrustedTypePolicyFactory.isScript()
+slug: Web/API/TrustedTypePolicyFactory/isScript
+tags:
+  - API
+  - Method
+  - Reference
+  - isScript
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>isScript()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScript")}} object.</p>
+
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>The purpose of the functions <code>isScript</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>isScript</var> = <var>TrustedTypePolicyFactory</var>.isScript(<var>value</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("TrustedScript")}} object.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("boolean")}}, true if the object is a valid {{domxref("TrustedScript")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example the constant <code>url</code> was created by a policy, and therefore <code>isScriptURL</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isScriptURL</code>.</p>
+
+<pre class="brush: js">const myScript = policy.createScript("eval('2 + 2')");
+console.log(trustedTypes.isScript(myScript)) // true;
+
+const fake = Object.create(TrustedScript.prototype);
+console.log(trustedTypes.isScript(fake)); // false
+
+console.log(trustedTypes.isScript("eval('2 + 2')")); // false</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-isscript','TrustedTypePolicyFactory.isScript()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.isScript")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note:</h4>
-  <p>The purpose of the functions <code>isScript</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+  <p>The purpose of the functions <code>isScript()</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -34,7 +34,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the below example the constant <code>url</code> was created by a policy, and therefore <code>isScriptURL</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isScriptURL</code>.</p>
+<p>In the below example the constant <code>url</code> was created by a policy, and therefore <code>isScriptURL()</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isScriptURL()</code>.</p>
 
 <pre class="brush: js">const url = policy.createScriptURL('https://example.com/myscript.js');
 console.log(trustedTypes.isScriptURL(url)) // true;

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note:</h4>
-  <p>The purpose of the functions <code>isScriptURL</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+  <p>The purpose of the functions <code>isScriptURL()</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h3 id="Returns">Return value</h3>
 
-<p>A {{jsxref("boolean")}}, true if the object is a valid {{domxref("TrustedScriptURL")}} object.</p>
+<p>A {{jsxref("boolean")}}that is true if the object is a valid {{domxref("TrustedScriptURL")}} object.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -1,0 +1,68 @@
+---
+title: TrustedTypePolicyFactory.isScriptURL()
+slug: Web/API/TrustedTypePolicyFactory/isScriptURL
+tags:
+  - API
+  - Method
+  - Reference
+  - isScriptURL
+  - TrustedTypePolicyFactory
+---
+<div>{{DefaultAPISidebar("Trusted Types API")}}</div>
+
+<p class="summary">The <strong><code>isScriptURL()</code></strong> method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScriptURL")}} object.</p>
+
+<div class="notecard note">
+  <h4>Note:</h4>
+  <p>The purpose of the functions <code>isScriptURL</code>, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.</p>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">var <var>isScriptURL</var> = <var>TrustedTypePolicyFactory</var>.isScriptURL(<var>value</var>);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>value</code></dt>
+  <dd>A {{domxref("TrustedScriptURL")}} object.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A {{jsxref("boolean")}}, true if the object is a valid {{domxref("TrustedScriptURL")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example the constant <code>url</code> was created by a policy, and therefore <code>isScriptURL</code> returns true. The second example is an attempt to fake an object, and the third is a string. Both of these will return false when passed to <code>isScriptURL</code>.</p>
+
+<pre class="brush: js">const url = policy.createScriptURL('https://example.com/myscript.js');
+console.log(trustedTypes.isScriptURL(url)) // true;
+
+const fake = Object.create(TrustedScriptURL.prototype);
+console.log(trustedTypes.isScriptURL(fake)); // false
+
+console.log(trustedTypes.isScriptURL("https://example.com/myscript.js")); // false</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Trusted Types','#dom-trustedtypepolicyfactory-isscripturl','TrustedTypePolicyFactory.isScriptURL()')}}</td>
+    <td>{{Spec2('Trusted Types')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TrustedTypePolicyFactory.isScriptURL")}}</p>


### PR DESCRIPTION
Adds the TrustedTypePolicyFactory interface and subpages.

Spec: https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-type-policy-factory

Reviewer: @jpmedley 

Joe: the MDN helper returned some odd things for this one and didn't create one page, however the spec matches BCD in terms of which pages should exist. So I've followed that.