### PR TITLE
Fix spec URL in Cross-Origin-Opener-Policy doc

### DIFF
--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.html
@@ -75,7 +75,7 @@ Cross-Origin-Embedder-Policy: require-corp
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('HTML WHATWG', '#the-cross-origin-opener-policy-header', 'Cross-Origin-Opener-Policy header')}}</td>
+   <td>{{SpecName('HTML WHATWG', '#the-headers', 'Cross-Origin-Opener-Policy header')}}</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
There is no `the-cross-origin-opener-policy-header` anchor in the HTML spec; instead the best place for the MDN article to link to is the [`the-headers`](https://html.spec.whatwg.org/multipage/origin.html#the-headers) anchor, which has the following text:

> A Document's cross-origin opener policy is derived from the `Cross-Origin-Opener-Policy` and the `Cross-Origin-Opener-Policy-Report-Only` HTTP response headers. These headers are structured headers whose value must be a token.