### PR TITLE
fix: flaws in web/w*

### DIFF
--- a/files/en-us/web/tutorials/index.html
+++ b/files/en-us/web/tutorials/index.html
@@ -74,14 +74,14 @@ tags:
 <div class="row topicpage-table">
 <div class="section">
 <dl>
- <dt><a href="/en-US/docs/Learn/HTML/Forms">HTML forms</a></dt>
+ <dt><a href="/en-US/docs/Learn/Forms">HTML forms</a></dt>
  <dd>Forms are a very important part of the Web — these provide much of the functionality you need for interacting with websites, e.g. registering and logging in, sending feedback, buying products, and more. This module gets you started with creating the client-side parts of forms.</dd>
 </dl>
 </div>
 
 <div class="section">
 <dl>
- <dt><strong><a href="/en-US/docs/Tips_for_Authoring_Fast-loading_HTML_Pages">Tips for authoring fast-loading HTML pages</a></strong></dt>
+ <dt><strong><a href="/en-US/docs/Learn/HTML/Howto/Author_fast-loading_HTML_pages">Tips for authoring fast-loading HTML pages</a></strong></dt>
  <dd>Optimize web pages to provide a more responsive site for visitors and reduce the load on your web server and Internet connection.</dd>
 </dl>
 </div>
@@ -111,7 +111,7 @@ tags:
  </dd>
  <dt><a href="/en-US/docs/Learn/CSS/Styling_text">Styling text</a></dt>
  <dd>Here we look at text styling fundamentals, including setting font, boldness, and italics, line and letter spacing, and drop shadows and other text features. We round off the module by looking at applying custom fonts to your page, and styling lists and links.</dd>
- <dt><strong><a href="/en-US/docs/Common_CSS_Questions">Common CSS Questions</a></strong></dt>
+ <dt><strong><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">Common CSS Questions</a></strong></dt>
  <dd>Common questions and answers for beginners.</dd>
 </dl>
 </div>
@@ -124,7 +124,7 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a></dt>
  <dd>At this point we've already looked at CSS fundamentals, how to style text, and how to style and manipulate the boxes that your content sits inside. Now it's time to look at how to place your boxes in the right place in relation to the viewport, and one another. We have covered the necessary prerequisites so can now dive deep into CSS layout, looking at different display settings, traditional layout methods involving float and positioning, and new fangled layout tools like flexbox.</dd>
- <dt><strong><a href="/en-US/docs/CSS/CSS_Reference">CSS reference</a></strong></dt>
+ <dt><strong><a href="/en-US/docs/Web/CSS/Reference">CSS reference</a></strong></dt>
  <dd>Complete reference to CSS, with details on support by Firefox and other browsers.</dd>
 </dl>
 </div>
@@ -146,7 +146,7 @@ tags:
 <dl>
  <dt><strong><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></strong></dt>
  <dd>Apply rotation, skewing, scaling, and translation using CSS.</dd>
- <dt><strong><a href="/en-US/docs/CSS/CSS_transitions">CSS transitions</a></strong></dt>
+ <dt><strong><a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transitions</a></strong></dt>
  <dd>CSS transitions, part of the draft CSS3 specification, provide a way to animate changes to CSS properties, instead of having the changes take effect instantly.</dd>
 </dl>
 </div>
@@ -210,7 +210,7 @@ tags:
 
 <div class="section">
 <dl>
- <dt><strong><a href="/en-US/docs/A_re-introduction_to_JavaScript">A re-Introduction to JavaScript</a></strong></dt>
+ <dt><strong><a href="/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript">A re-Introduction to JavaScript</a></strong></dt>
  <dd>A recap of the JavaScript programming language aimed at intermediate-level developers.</dd>
  <dt><strong><a href="http://eloquentjavascript.net/" rel="external">Eloquent JavaScript</a></strong></dt>
  <dd>A comprehensive guide to intermediate and advanced JavaScript methodologies.</dd>
@@ -256,7 +256,7 @@ tags:
 <div class="section">
 <dl>
  <dt><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions">WebExtensions</a></dt>
- <dd>WebExtensions is a cross-browser system for developing browser add-ons. To a large extent, the system is compatible with the <a class="external-icon external" href="https://developer.chrome.com/extensions">extension API</a> supported by Google Chrome and Opera. Extensions written for these browsers will in most cases run in Firefox or <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/">Microsoft Edge</a> with <a href="/en-US/Add-ons/WebExtensions/Porting_from_Google_Chrome">just a few changes</a>. The API is also fully compatible with <a href="/en-US/Firefox/Multiprocess_Firefox">multiprocess Firefox</a>.</dd>
+ <dd>WebExtensions is a cross-browser system for developing browser add-ons. To a large extent, the system is compatible with the <a class="external-icon external" href="https://developer.chrome.com/extensions">extension API</a> supported by Google Chrome and Opera. Extensions written for these browsers will in most cases run in Firefox or <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/">Microsoft Edge</a> with <a href="https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/">just a few changes</a>. The API is also fully compatible with <a href="/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox">multiprocess Firefox</a>.</dd>
 </dl>
 </div>
 </div>

--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -63,7 +63,7 @@ tags:
  <dd>Contains functionality related to custom elements, most notably the {{domxref("CustomElementRegistry.define()")}} method used to register new custom elements so they can then be used in your document.</dd>
  <dt>{{domxref("Window.customElements")}}</dt>
  <dd>Returns a reference to the <code>CustomElementRegistry</code> object.</dd>
- <dt><a href="/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks">Life cycle callbacks</a></dt>
+ <dt><a href="/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks">Life cycle callbacks</a></dt>
  <dd>Special callback functions defined inside the custom element's class definition, which affect its behavior:
  <ul>
   <li><code>connectedCallback</code>: Invoked when the custom element is first connected to the document's DOM.</li>
@@ -133,8 +133,8 @@ tags:
  <dd>A placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together. The associated DOM interface is {{domxref("HTMLSlotElement")}}.</dd>
  <dt>The <code><a href="/en-US/docs/Web/HTML/Global_attributes/slot">slot</a></code> global HTML attribute</dt>
  <dd>Assigns a slot in a shadow DOM shadow tree to an element.</dd>
- <dt>{{domxref("Slotable")}}</dt>
- <dd>A mixin implemented by both {{domxref("Element")}} and {{domxref("Text")}} nodes, defining features that allow them to become the contents of an {{htmlelement("slot")}} element. The mixin defines one attribute, {{domxref("Slotable.assignedSlot")}}, which returns a reference to the slot the node is inserted in.</dd>
+ <dt>{{domxref("Element", "Slotable")}}</dt>
+ <dd>A mixin implemented by both {{domxref("Element")}} and {{domxref("Text")}} nodes, defining features that allow them to become the contents of an {{htmlelement("slot")}} element. The mixin defines one attribute, {{domxref("Element.assignedSlot")}}, which returns a reference to the slot the node is inserted in.</dd>
  <dt>{{domxref("Element")}} extensions</dt>
  <dd>Extensions to the <code>Element</code> interface related to slots:
  <ul>

--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -133,8 +133,10 @@ tags:
  <dd>A placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together. The associated DOM interface is {{domxref("HTMLSlotElement")}}.</dd>
  <dt>The <code><a href="/en-US/docs/Web/HTML/Global_attributes/slot">slot</a></code> global HTML attribute</dt>
  <dd>Assigns a slot in a shadow DOM shadow tree to an element.</dd>
- <dt>{{domxref("Element", "Slotable")}}</dt>
- <dd>A mixin implemented by both {{domxref("Element")}} and {{domxref("Text")}} nodes, defining features that allow them to become the contents of an {{htmlelement("slot")}} element. The mixin defines one attribute, {{domxref("Element.assignedSlot")}}, which returns a reference to the slot the node is inserted in.</dd>
+ <dt>{{domxref("Element.assignedSlot")}}</dt>
+ <dd>A read-only attribute which returns a reference to the {{htmlelement("slot")}} in which this element is inserted.</dd>
+<dt>{{domxref("Text.assignedSlot")}}</dt>
+ <dd>A read-only attribute which returns a reference to the {{htmlelement("slot")}} in which this text node is inserted.</dd>
  <dt>{{domxref("Element")}} extensions</dt>
  <dd>Extensions to the <code>Element</code> interface related to slots:
  <ul>

--- a/files/en-us/web/web_components/using_templates_and_slots/index.html
+++ b/files/en-us/web/web_components/using_templates_and_slots/index.html
@@ -102,7 +102,7 @@ document.body.appendChild(templateContent);</pre>
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: Elements that can be inserted into slots are known as {{domxref("Element", "Slotable")}}; when an element has been inserted in a slot, it is said to be <em>slotted</em>.</p>
+<p><strong>Note</strong>: Nodes that can be inserted into slots are known as <em>Slotable</em> nodes; when an node has been inserted in a slot, it is said to be <em>slotted</em>.</p>
 </div>
 
 <div class="notecard note">

--- a/files/en-us/web/web_components/using_templates_and_slots/index.html
+++ b/files/en-us/web/web_components/using_templates_and_slots/index.html
@@ -102,7 +102,7 @@ document.body.appendChild(templateContent);</pre>
 </pre>
 
 <div class="note">
-<p><strong>Note</strong>: Elements that can be inserted into slots are known as {{domxref("Slotable")}}; when an element has been inserted in a slot, it is said to be <em>slotted</em>.</p>
+<p><strong>Note</strong>: Elements that can be inserted into slots are known as {{domxref("Element", "Slotable")}}; when an element has been inserted in a slot, it is said to be <em>slotted</em>.</p>
 </div>
 
 <div class="notecard note">

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.html
@@ -87,7 +87,7 @@ tags:
 
 <p>Base64-encoded ZIP of a profile directory to use for the Firefox instance. This may be used to e.g. install
   extensions or custom certificates, but for setting custom preferences we recommend using the <code>prefs</code> (<a
-    href="#Prefs">Preferences Object</a>) entry instead.</p>
+    href="#prefs">Preferences Object</a>) entry instead.</p>
 <p>Profiles are created in the systems temporary folder. This is also where the encoded profile is extracted when
   <code>profile</code> is provided. By default geckodriver will create a new profile in this location.</p>
 
@@ -229,8 +229,8 @@ tags:
 <span class="p">}</span></pre>
 
 <p><span class="p">The <code><a href="#firefoxoptions">moz:firefoxOptions</a></code> must be placed—as above—inside
-    <code><a href="/en-US/docs/Web/WebDriver/Capabilities#alwaysMatch">alwaysMatch</a></code>, or in one of the
-  </span><code><a href="/en-US/docs/Web/WebDriver/Capabilities#firstMatch">firstMatch</a></code> <a
+    <code><a href="/en-US/docs/Web/WebDriver/Capabilities#alwaysmatch">alwaysMatch</a></code>, or in one of the
+  </span><code><a href="/en-US/docs/Web/WebDriver/Capabilities#firstmatch">firstMatch</a></code> <a
     href="/en-US/docs/Web/WebDriver/Capabilities">capabilities objects</a> as seen here:</p>
 
 <pre class="brush: json">{

--- a/files/en-us/web/webdriver/commands/gettimeouts/index.html
+++ b/files/en-us/web/webdriver/commands/gettimeouts/index.html
@@ -7,7 +7,7 @@ tags:
   - Reference
   - WebDriver
 ---
-<p>The <em>Get Timeouts</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the timeouts associated with the current session. The <a href="/en-US/docs/Web/WebDriver/Timeouts">session timeout</a> durations control such behavior as timeouts on <a href="/en-US/docs/Web/WebDriver/Timeouts#script">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageLoad">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit">element retrieval</a>.</p>
+<p>The <em>Get Timeouts</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the timeouts associated with the current session. The <a href="/en-US/docs/Web/WebDriver/Timeouts">session timeout</a> durations control such behavior as timeouts on <a href="/en-US/docs/Web/WebDriver/Timeouts#script">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageload">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit">element retrieval</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/webdriver/commands/settimeouts/index.html
+++ b/files/en-us/web/webdriver/commands/settimeouts/index.html
@@ -7,7 +7,7 @@ tags:
   - Reference
   - WebDriver
 ---
-<p>The <em>Set Timeouts</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API sets the timeouts associated with the current session. The <a href="/en-US/docs/Web/WebDriver/Timeouts">session timeout</a> durations control such behavior as timeouts on <a href="/en-US/docs/Web/WebDriver/Timeouts#script">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageLoad">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit">element retrieval</a>.</p>
+<p>The <em>Set Timeouts</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API sets the timeouts associated with the current session. The <a href="/en-US/docs/Web/WebDriver/Timeouts">session timeout</a> durations control such behavior as timeouts on <a href="/en-US/docs/Web/WebDriver/Timeouts#script">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageload">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit">element retrieval</a>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/webdriver/timeouts/index.html
+++ b/files/en-us/web/webdriver/timeouts/index.html
@@ -5,7 +5,7 @@ tags:
   - WebDriver
   - timeouts
 ---
-<p>Associated with a <a href="/en-US/docs/Web/WebDriver">WebDriver</a> session are various timeout definitions that control behavior for <a href="/en-US/docs/Web/WebDriver/Timeouts#script" rel="nofollow">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageLoad" rel="nofollow">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit" rel="nofollow">element retrieval</a>.</p>
+<p>Associated with a <a href="/en-US/docs/Web/WebDriver">WebDriver</a> session are various timeout definitions that control behavior for <a href="/en-US/docs/Web/WebDriver/Timeouts#script" rel="nofollow">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageload" rel="nofollow">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit" rel="nofollow">element retrieval</a>.</p>
 
 <p>You will find the <em><a href="#payload">timeouts object</a></em> used in a few different contexts. It can be used as configuration when <a href="/en-US/docs/Web/WebDriver/Commands/NewSession">creating a new session</a> through <a href="/en-US/docs/Web/WebDriver/Capabilities">capabilities</a>, it is returned as part of the matched, effective capabilities after the session has been created, and it is used as input and output for the <a href="/en-US/docs/Web/WebDriver/Commands/SetTimeouts">Set Timeouts</a> and <a href="/en-US/docs/Web/WebDriver/Commands/GetTimeouts">Get Timeouts</a> commands.</p>
 


### PR DESCRIPTION
Kept the "Slotable" name but left the re-writes to Element