### PR TITLE
Fix Title in Book Detail View

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.html
@@ -58,7 +58,7 @@ exports.book_detail = function(req, res, <strong>next</strong>) {
 <pre>extends layout
 
 block content
-  h1 #{title}: #{book.title}
+  h1 Title: #{book.title}
 
   p #[strong Author:]
     a(href=book.author.url) #{book.author.name}


### PR DESCRIPTION
# Description
This change fixes a typo in the templating. It currently shows the title of the book twice.
<img width="1176" alt="Screen Shot 2021-03-16 at 8 03 46 PM" src="https://user-images.githubusercontent.com/66457042/111408600-c0078e80-8692-11eb-9f91-e0954d44e141.png">

I changed the template so it shows `Title` instead like the screenshot in the tutorial.
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Book_detail_page/locallibary_express_book_detail.png

# Summary of Changes
Changed `#{title}: #{book.title}` to `Title: #{book.title}`

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [ ] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
1. - [x] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [x] Link to any other resources that you think might be useful in reviewing your PR.
