### PR TITLE
add ru team to localization page

### DIFF
--- a/files/en-us/mdn/contribute/localize/index.html
+++ b/files/en-us/mdn/contribute/localize/index.html
@@ -41,6 +41,13 @@ tags:
  <li>Current contributors: <a href="https://github.com/mfuji09">mfuji09</a>, <a href="https://github.com/hmatrjp">hmatrjp</a>, <a href="https://github.com/potappo">potappo</a>, <a href="https://github.com/dynamis">dynamis</a>, <a href="https://github.com/kenji-yamasaki">kenji-yamasaki</a></li>
 </ul>
 
+<h3 id="Russian_ru">Russian (ru)</h3>
+
+<ul>
+ <li>Discussions: <a href="https://chat.mozilla.org/#/room/#mdn-l10n-ru:mozilla.org">Matrix (#mdn-l10n-ru channel)</a></li>
+ <li>Current contributors: <a href="https://github.com/armanpwnz">armanpwnz</a>, <a href="https://github.com/captainspring">captainspring</a>, <a href="https://github.com/mpstv">mpstv</a>, <a href="https://github.com/myshov">myshov</a>, <a href="https://github.com/Saionaro">Saionaro</a>, <a href="https://github.com/lex111">lex111</a></li>
+</ul>
+
 <h2 id="Other_MDN_localization">Other MDN localization</h2>
 
 <p>For the moment, the new MDN platform UI will only be in English. This is a problem that we are going to get to later on.</p>


### PR DESCRIPTION
Our ru localization team started work recently on the translated-content repo; this PR adds their details to the MDN Localization page.