### PR TITLE
Adding the color() functional notation

### DIFF
--- a/files/en-us/web/css/color_value/color()/index.html
+++ b/files/en-us/web/css/color_value/color()/index.html
@@ -1,0 +1,64 @@
+---
+title: color()
+slug: Web/CSS/color_value/color()
+tags:
+  - CSS
+  - CSS Data Type
+  - Data Type
+  - Reference
+  - Web
+  - color
+---
+<div>{{CSSRef}}</div>
+
+<p>The <strong><code>color()</code></strong> functional notation allows a color to be specified in a particular, specified colorspace rather than the implicit sRGB colorspace that most of the other color functions operate in.</p>
+
+<p>Support for a particular colorspace can be detected with the <a href="/en-US/docs/Web/CSS/@media/color-gamut">color-gamut</a> CSS media feature.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css">color(display-p3 1 0.5 0);
+color(display-p3 1 0.5 0 / .5);
+color(rec2020 0.42053 0.979780 0.00579, color(display-p3(0 1 0)));
+</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+  <dt>Functional notation: <code>color( [ [&lt;ident&gt; | &lt;dashed-ident&gt;]? [ &lt;number-percentage&gt;+ | &lt;string&gt; ] [ / &lt;alpha-value&gt; ]? ]# , &lt;color&gt;? )</code></dt>
+  <dd><code>[&lt;ident&gt; | &lt;dashed-ident&gt;]</code> is an optional {{cssxref("ident")}} or {{cssxref("dashed-ident")}} denoting the colorspace. If this is an <code>&lt;ident&gt;</code> it denotes one of the predefined colorspaces (such as display-p3); if it is a &lt;dashed-ident&gt; it denotes a custom colorspace, defined by a @color-profile rule.</dd>
+  <dd><code>[ &lt;number-percentage&gt;+ | &lt;string&gt; ]</code> is either one or more {{cssxref("number")}} or {{cssxref("percentage")}} values providing the parameter values that the colorspace takes, or a {{cssxref("string")}} giving the name of a color defined by the colorspace.</dd>
+  <dd><code> / &lt;alpha-value&gt;</code> (alpha) can be a {{cssxref("&lt;number&gt;")}} between <code>0</code> and <code>1</code>, or a {{cssxref("&lt;percentage&gt;")}}, where the number <code>1</code> corresponds to <code>100%</code> (full opacity).</dd>
+ </dl>
+
+ <div class="notecard note">
+   <h4>Note:</h4>
+   <p>The string identifying the colorspace and values may be repeated, separated by a comma. This enables the addition of fallback values in case the first colorspace is unsupported.</p>
+ </div>
+
+ <table class="standard-table">
+  <thead>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <td>{{SpecName('CSS4 Colors', '#funcdef-color')}}</td>
+    <td>{{Spec2('CSS4 Colors')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.types.color.color")}}</p>
+
+<h2>See also</h2>
+
+<ul>
+  <li><a href="https://webkit.org/blog/10042/wide-gamut-color-in-css-with-display-p3/">Wide Gamut Color in CSS with Display-p3</a></li>
+</ul>


### PR DESCRIPTION
More work on color functional notation. This PR adds the `color()` value. 
