### PR TITLE
Clarify return value of String.matchAll

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.html
@@ -49,7 +49,12 @@ tags:
 <h3 id="Return_value">Return value</h3>
 
 <p>An <a href="/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">iterator</a>
-  (which is not a restartable iterable).</p>
+  (which is not a restartable iterable) of matches.</p>
+
+<p>Each match is an array (with extra properties <code>index</code> and
+  <code>input</code>; see the return value for {{jsxref("RegExp.exec")}}). The match
+  array has the matched text as the first item, and then one item for each
+  parenthetical capture group of the matched text.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
The return value section of the `String.matchAll` page is really vague right now. The examples hint at what it is, but it never actually says it anywhere explicitly.