### PR TITLE
Drop historic window.close() behavior

### DIFF
--- a/files/en-us/web/api/window/close/index.html
+++ b/files/en-us/web/api/window/close/index.html
@@ -49,20 +49,6 @@ function closeOpenedWindow() {
 }
 </pre>
 
-<h3 id="Closing_the_current_window">Closing the current window</h3>
-
-<p>In the past, when you called the <code>window</code> object's <code>close()</code>
-  method directly, rather than calling <code>close()</code> on a <code>window</code>
-  <strong>instance</strong>, the browser closed the frontmost window, whether your script
-  created that window or not. This is no longer the case; for security reasons, scripts
-  are no longer allowed to close windows they didn't open. (Firefox 46.0.1: scripts can
-  not close windows, they had not opened)</p>
-
-<pre class="brush: js">function closeCurrentWindow() {
-  window.close();
-}
-</pre>
-
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">


### PR DESCRIPTION
This drops some compat information from the page content that's in BCD already, plus some stuff that's basically historical trivia now.

Related to: https://github.com/mdn/browser-compat-data/issues/9270, https://github.com/mdn/browser-compat-data/pull/9492