### PR TITLE
Updated Typo on HTML Date and Time Formats from o8 to 08 for August

### DIFF
--- a/files/en-us/web/html/date_and_time_formats/index.html
+++ b/files/en-us/web/html/date_and_time_formats/index.html
@@ -168,7 +168,7 @@ tags:
    <td>31</td>
   </tr>
   <tr>
-   <th scope="row">o8</th>
+   <th scope="row">08</th>
    <td>August</td>
    <td>31</td>
   </tr>


### PR DESCRIPTION
Typo: In the "The months of the year and their lengths in days" table the month representation for August reads "oh eight" instead of "zero eight".

https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats