### PR TITLE
Update colon encoding in "Time value format" section.

### DIFF
--- a/files/en-us/web/html/element/input/time/index.html
+++ b/files/en-us/web/html/element/input/time/index.html
@@ -119,7 +119,7 @@ startTime.addEventListener("input", function() {
 
 <p>{{EmbedLiveSample("Time_value_format", 600, 80)}}</p>
 
-<p>When a form including a <code>time</code> input is submitted, the value is encoded before being included in the form's data. The form's data entry for a time input will always be in the form <code>name=hh%3Amm</code>, or <code>name=hh%3Amm%3ass</code> if seconds are included (see {{anch("Using the step attribute")}}).</p>
+<p>When a form including a <code>time</code> input is submitted, the value is encoded before being included in the form's data. The form's data entry for a time input will always be in the form <code>name=hh%3Amm</code>, or <code>name=hh%3Amm%3Ass</code> if seconds are included (see {{anch("Using the step attribute")}}).</p>
 
 <h2 id="Additional_attributes">Additional attributes</h2>
 


### PR DESCRIPTION
Typo: Updated `name=hh%3Amm%3ass` to `name=hh%3Amm%3Ass` on page HTML Input "\<input type="time">" section: "Time value format"