### PR TITLE
Added RegExp match indices

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -27,6 +27,10 @@ tags:
 
 <h3 id="JavaScript">JavaScript</h3>
 
+<ul>
+  <li>Added support for RegExp match indices ({{bug(1519483)}}).</li>
+</ul>
+
 <h4 id="removals_js">Removals</h4>
 
 <h3 id="HTTP">HTTP</h3>

--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -28,7 +28,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
-  <li>Added support for RegExp match indices ({{bug(1519483)}}).</li>
+  <li>Added support for <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#indices">RegExp match indices</a> ({{bug(1519483)}}).</li>
 </ul>
 
 <h4 id="removals_js">Removals</h4>

--- a/files/en-us/web/javascript/guide/regular_expressions/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.html
@@ -293,6 +293,11 @@ console.log('The value of lastIndex is ' + /d(b+)d/g.lastIndex);
  </thead>
  <tbody>
   <tr>
+   <td><code>d</code></td>
+   <td>Generate indices for substring matches.</td>
+   <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices">RegExp.prototype.hasIndices</a></code></td>
+  </tr>
+  <tr>
    <td><code>g</code></td>
    <td>Global search.</td>
    <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global">RegExp.prototype.global</a></code></td>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.html
@@ -78,6 +78,7 @@ console.log(str2.replace(regex2,'')); // Output: bar
 <ul>
  <li>{{JSxRef("RegExp.lastIndex")}}</li>
  <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
  <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
  <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
  <li>{{JSxRef("RegExp.prototype.source")}}</li>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -104,7 +104,7 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
       <td><code>4</code></td>
     </tr>
     <tr>
-      <td><code>indices</code></td>
+      <td><code id="indices">indices</code></td>
       <td>An array where each entry represents a substring match.
         Each substring match itself is an array where the first entry
         represents its start index and the second entry its end index.<br/>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -47,7 +47,8 @@ tags:
 <h3 id="Return_value">Return value</h3>
 
 <p>If the match succeeds, the <code>exec()</code> method returns an array (with extra
-  properties <code>index</code> and <code>input</code>; see below) and updates the
+  properties <code>index</code>, <code>input</code>, and if the <code>d</code> flag is
+  set, <code>indices</code>; see below) and updates the
   {{jsxref("RegExp.lastIndex", "lastIndex")}} property of the regular expression object.
   The returned array has the matched text as the first item, and then one item for each
   parenthetical capture group of the matched text.</p>
@@ -62,7 +63,7 @@ tags:
 <pre class="brush: js">// Match "quick brown" followed by "jumps", ignoring characters in between
 // Remember "brown" and "jumps"
 // Ignore case
-let re = /quick\s(brown).+?(jumps)/ig;
+let re = /quick\s(brown).+?(jumps)/igd;
 let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
 </pre>
 
@@ -79,7 +80,7 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
   </thead>
   <tbody>
     <tr>
-      <th rowspan="4" scope="row" style="vertical-align: top;"><code>result</code></th>
+      <th rowspan="5" scope="row" style="vertical-align: top;"><code>result</code></th>
       <td><code>[0]</code></td>
       <td>The full string of characters matched</td>
       <td><code>"Quick Brown Fox Jumps"</code></td>
@@ -103,12 +104,28 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
       <td><code>4</code></td>
     </tr>
     <tr>
+      <td><code>indices</code></td>
+      <td>An array where each entry represents a substring match.
+        Each substring match itself is an array where the first entry
+        represents its start index and the second entry its end index.<br/>
+        The <code>indices</code> array additionally has a <code>groups</code>
+        property.
+      </td>
+      <td>
+        <p><code>indices[0] === Array [ 4, 25 ]</code></p>
+        <p><code>indices[1] === Array [ 10, 15 ]</code></p>
+        <p><code>indices[2] === Array [ 20, 25 ]</code></p>
+        <p><code>indices.groups === undefined</code></p>
+        <p><code>indices.length === 3</code></p>
+      </td>
+    </tr>
+    <tr>
       <td><code>input</code></td>
       <td>The original string that was matched against.</td>
       <td><code>The Quick Brown Fox Jumps Over The Lazy Dog</code></td>
     </tr>
     <tr>
-      <th rowspan="5" scope="row" style="vertical-align: top;"><code>re</code></th>
+      <th rowspan="9" scope="row" style="vertical-align: top;"><code>re</code></th>
       <td><code>lastIndex</code></td>
       <td>
         <p>The index at which to start the next match.</p>
@@ -116,6 +133,22 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
         <p>If <code>g</code> is absent, this will always be <code>0</code>.</p>
       </td>
       <td><code>25</code></td>
+    </tr>
+    <tr>
+      <td><code>dotAll</code></td>
+      <td>
+        Indicates if the <code>s</code> flag was used to let <code>.</code>
+        match newlines.
+      </td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
+      <td><code>hasIndices</code></td>
+      <td>
+        Indicates if the <code>d</code> flag was used to generate an
+        <code>indices</code> property in the returned value containing
+        start and end indices of the substring matches.</td>
+      <td><code>true</code></td>
     </tr>
     <tr>
       <td><code>ignoreCase</code></td>
@@ -137,6 +170,23 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
       <td><code>source</code></td>
       <td>The text of the pattern.</td>
       <td><code>quick\s(brown).+?(jumps)</code></td>
+    </tr>
+    <tr>
+      <td><code>sticky</code></td>
+      <td>
+        Indicates if the <code>y</code> flag was used to match
+        only from the index indicated by the <code>lastIndex</code>
+        property.
+      </td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
+      <td><code>unicode</code></td>
+      <td>
+        Indicates if the <code>u</code> flag was used to
+        treat the pattern as a sequence of Unicode code points.
+      </td>
+      <td><code>false</code></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -109,7 +109,11 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
         Each substring match itself is an array where the first entry
         represents its start index and the second entry its end index.<br/>
         The <code>indices</code> array additionally has a <code>groups</code>
-        property.
+        property which holds an object of all named capturing groups. The keys
+        are the names of the capturing groups and each value is an array with
+        the first item being the start entry and the second entry being the
+        end index of the capturing group. If the regular expression doesn't
+        contain any capturing groups, <code>groups</code> is <code>undefined</code>.
       </td>
       <td>
         <p><code>indices[0] === Array [ 4, 25 ]</code></p>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/global/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/global/index.html
@@ -68,8 +68,11 @@ console.log(str2);  // Output: examplefoo</pre>
 
 <ul>
  <li>{{jsxref("RegExp.lastIndex")}}</li>
- <li>{{jsxref("RegExp.prototype.ignoreCase")}}</li>
- <li>{{jsxref("RegExp.prototype.multiline")}}</li>
- <li>{{jsxref("RegExp.prototype.source")}}</li>
- <li>{{jsxref("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
+ <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
+ <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.unicode")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.html
@@ -69,6 +69,7 @@ console.log(regex2.exec(str2).indices); // Output: undefined
 
 <ul>
  <li>{{JSxRef("RegExp.lastIndex")}}</li>
+ <li>{{JSxRef("RegExp.prototype.exec()")}}</li>
  <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
  <li>{{JSxRef("RegExp.prototype.global")}}</li>
  <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.html
@@ -1,0 +1,79 @@
+---
+title: RegExp.prototype.hasIndices
+slug: Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices
+tags:
+  - Draft
+  - JavaScript
+  - Property
+  - Prototype
+  - Reference
+  - RegExp
+  - Regular Expressions
+---
+<p>{{JSRef}}</p>
+
+<p>The <strong><code>hasIndices</code></strong> property indicates whether or not the "<code>d</code>" flag is used with the regular expression. <code>hasIndices</code> is a read-only property of an individual regular expression instance.</p>
+
+<div>{{EmbedInteractiveExample("pages/js/regexp-prototype-hasindices.html")}}</div>
+
+<p>{{JS_Property_Attributes(0, 0, 1)}}</p>
+
+<h2 id="Description">Description</h2>
+
+<p>The value of <code>hasIndices</code> is a {{JSxRef("Boolean")}} and <code>true</code> if the "<code>d</code>" flag was used; otherwise, <code>false</code>. The "<code>d</code>" flag indicates that the result of a regular expression match should contain the start and end indices of the substrings of each capture group.</p>
+
+<p>You cannot change this property directly.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Using_hasIndices">Using <code>hasIndices</code></h3>
+
+<pre class="brush: js">const str1 = 'foo bar foo';
+
+const regex1 = new RegExp('foo', 'gd');
+
+console.log(regex1.hasIndices); // Output: true
+
+console.log(regex1.exec(str1).indices[0]); // Output: Array [0, 3]
+console.log(regex1.exec(str1).indices[0]); // Output: Array [8, 11]
+
+const str2 = 'foo bar foo';
+
+const regex2 = new RegExp('foo');
+
+console.log(regex2.hasIndices); // Output: false
+
+console.log(regex2.exec(str2).indices); // Output: undefined
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('ESDraft', '#sec-get-regexp.prototype.hasIndices', 'RegExp.prototype.hasIndices')}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("javascript.builtins.RegExp.hasIndices")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{JSxRef("RegExp.lastIndex")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
+ <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.unicode")}}</li>
+</ul>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.html
@@ -57,8 +57,11 @@ console.log(regex.ignoreCase); // true
 
 <ul>
  <li>{{jsxref("RegExp.lastIndex")}}</li>
- <li>{{jsxref("RegExp.prototype.global")}}</li>
- <li>{{jsxref("RegExp.prototype.multiline")}}</li>
- <li>{{jsxref("RegExp.prototype.source")}}</li>
- <li>{{jsxref("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
+ <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.unicode")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.html
@@ -75,6 +75,8 @@ let re = new RegExp('\\w+')
  <dd>Whether <code>.</code> matches newlines or not.</dd>
  <dt>{{JSxRef("RegExp.prototype.global")}}</dt>
  <dd>Whether to test the regular expression against all possible matches in a string, or only against the first.</dd>
+ <dt>{{JSxRef("RegExp.prototype.hasIndices")}}</dt>
+ <dd>Whether the regular expression result exposes the start and end indices of captured substrings.</dd>
  <dt>{{JSxRef("RegExp.prototype.ignoreCase")}}</dt>
  <dd>Whether to ignore case while attempting a match in a string.</dd>
  <dt>{{JSxRef("RegExp.prototype.multiline")}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastindex/index.html
@@ -74,9 +74,12 @@ console.log(re.lastIndex);
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("RegExp.prototype.ignoreCase")}}</li>
- <li>{{jsxref("RegExp.prototype.global")}}</li>
- <li>{{jsxref("RegExp.prototype.multiline")}}</li>
- <li>{{jsxref("RegExp.prototype.source")}}</li>
- <li>{{jsxref("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
+ <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
+ <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.unicode")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.html
@@ -57,8 +57,11 @@ console.log(regex.multiline); // true
 
 <ul>
  <li>{{jsxref("RegExp.lastIndex")}}</li>
- <li>{{jsxref("RegExp.prototype.global")}}</li>
- <li>{{jsxref("RegExp.prototype.ignoreCase")}}</li>
- <li>{{jsxref("RegExp.prototype.source")}}</li>
- <li>{{jsxref("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
+ <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.unicode")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
@@ -60,6 +60,8 @@ RegExp(<var>pattern</var>[, <var>flags</var>])
       characters:</p>
 
     <dl>
+      <dt><code>d</code> (indices)</dt>
+      <dd>Generate indices for substring matches.</dd>
       <dt><code>g</code> (global match)</dt>
       <dd>Find all matches rather than stopping after the first match.</dd>
       <dt><code>i</code> (ignore case)</dt>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/sticky/index.html
@@ -80,8 +80,11 @@ regex2.test('.\nfoo'); // true - index 2 is the beginning of a line
 
 <ul>
  <li>{{jsxref("RegExp.lastIndex")}}</li>
- <li>{{jsxref("RegExp.prototype.global")}}</li>
- <li>{{jsxref("RegExp.prototype.ignoreCase")}}</li>
- <li>{{jsxref("RegExp.prototype.multiline")}}</li>
- <li>{{jsxref("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
+ <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
+ <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.unicode")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.html
@@ -58,9 +58,11 @@ console.log(regex.unicode); // true
 
 <ul>
  <li>{{jsxref("RegExp.lastIndex")}}</li>
- <li>{{jsxref("RegExp.prototype.global")}}</li>
- <li>{{jsxref("RegExp.prototype.ignoreCase")}}</li>
- <li>{{jsxref("RegExp.prototype.multiline")}}</li>
- <li>{{jsxref("RegExp.prototype.source")}}</li>
- <li>{{jsxref("RegExp.prototype.sticky")}}</li>
+ <li>{{JSxRef("RegExp.prototype.dotAll")}}</li>
+ <li>{{JSxRef("RegExp.prototype.global")}}</li>
+ <li>{{JSxRef("RegExp.prototype.hasIndices")}}</li>
+ <li>{{JSxRef("RegExp.prototype.ignoreCase")}}</li>
+ <li>{{JSxRef("RegExp.prototype.multiline")}}</li>
+ <li>{{JSxRef("RegExp.prototype.source")}}</li>
+ <li>{{JSxRef("RegExp.prototype.sticky")}}</li>
 </ul>


### PR DESCRIPTION
This adds the [RegExp match indices](https://github.com/tc39/proposal-regexp-match-indices) feature, which got [recently implemented in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1519483) and also [in Chrome](https://bugs.chromium.org/p/v8/issues/detail?id=9548).

The precise changes include:
* A new page for the `RegExp.prototype.hasIndices` property
* References to the property page
* Descriptions of the `d` flag for the `RegExp` constructor
* Extended example for `RegExp.prototype.exec()` plus description of other `RegExp` properties
* Release note for Firefox 88

Related PRs:
BCD: https://github.com/mdn/browser-compat-data/pull/9508
Live example: https://github.com/mdn/interactive-examples/pull/1782

Sebastian