### PR TITLE
Fix note at top of HTTP Origin header doc

### DIFF
--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <strong><code>Origin</code></strong> request header indicates where a fetch originates from. It doesn't include any path information, but only the server name. It is sent with {{Glossary("CORS")}} requests, and some same-origin requests. It is similar to the {{HTTPHeader("Referer")}} header, but, unlike this header, it doesn't disclose the whole path.</p>
+<p>The <strong><code>Origin</code></strong> request header indicates where a request originates from. It doesn't include any path information. It is similar to the {{HTTPHeader("Referer")}} header, but, unlike that header, it doesn't disclose the whole path.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -14,7 +14,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>Browsers add the {{httpheader("Origin")}} request header to:</p>
+  <p>Basically, browsers add the {{httpheader("Origin")}} request header to:</p>
   <ul>
     <li>all {{Glossary("CORS", "cross origin")}} requests.</li>
     <li><a href="/en-US/docs/Web/Security/Same-origin_policy">same-origin</a> requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).</li>

--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -10,10 +10,15 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <strong><code>Origin</code></strong> request header indicates where a fetch originates from. It doesn't include any path information, but only the server name. It is sent with {{Glossary("CORS")}} requests, as well as with {{HTTPMethod("POST")}} requests. It is similar to the {{HTTPHeader("Referer")}} header, but, unlike this header, it doesn't disclose the whole path.</p>
+<p>The <strong><code>Origin</code></strong> request header indicates where a fetch originates from. It doesn't include any path information, but only the server name. It is sent with {{Glossary("CORS")}} requests, and some same-origin requests. It is similar to the {{HTTPHeader("Referer")}} header, but, unlike this header, it doesn't disclose the whole path.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The {{httpheader("Origin")}} header is not set on <a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch">Fetch requests</a> with a method of {{HTTPMethod("HEAD")}} or {{HTTPMethod("GET")}} (this behavior was corrected in Firefox 65 — see {{bug(1508661)}}).</p>
+  <h4>Note</h4>
+  <p>Browsers add the {{httpheader("Origin")}} request header to:</p>
+  <ul>
+    <li>all {{Glossary("CORS", "cross origin")}} requests.</li>
+    <li><a href="/en-US/docs/Web/Security/Same-origin_policy">same-origin</a> requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).</li>
+  </ul>
 </div>
 
 <table class="properties">

--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -19,6 +19,7 @@ tags:
     <li>all {{Glossary("CORS", "cross origin")}} requests.</li>
     <li><a href="/en-US/docs/Web/Security/Same-origin_policy">same-origin</a> requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).</li>
   </ul>
+  <p>There are some exceptions to the above rules; for example if a cross-origin request is made in <a href="/en-US/docs/Web/API/Request/mode#value">no-cors mode</a> the <code>Origin</code> header will not be added.</p>
 </div>
 
 <table class="properties">


### PR DESCRIPTION
Partial fix to HTTP Header "Origin" docs as suggested by @sideshowbarker in #3239 (that will remain open, in case he wishes to do further updates to integrate more information).

Note, the compatibility information that has been removed. I was going to add back into BCD, but it is already present.