### PR TITLE
Clarify speechSynthesis.getVoices examples

### DIFF
--- a/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.html
+++ b/files/en-us/web/api/speechsynthesis/onvoiceschanged/index.html
@@ -40,7 +40,8 @@ tags:
   With Chrome however, you have to wait for the event to fire before populating the list,
   hence the bottom if statement seen below.</p>
 
-<pre class="brush: js">var voices = [];
+<pre class="brush: js">var synth = window.speechSynthesis;
+var voices = [];
 
 function populateVoiceList() {
   voices = synth.getVoices();

--- a/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.html
+++ b/files/en-us/web/api/speechsynthesis/voiceschanged_event/index.html
@@ -50,7 +50,8 @@ synth.addEventListener('voiceschanged', function() {
 
 <p>Or use the <code><a href="/en-US/docs/Web/API/SpeechSynthesis/onvoiceschanged">onvoiceschanged</a></code> event handler property:</p>
 
-<pre class="brush: js">synth.onvoiceschanged = function() {
+<pre class="brush: js">var synth = window.speechSynthesis;
+synth.onvoiceschanged = function() {
   var voices = synth.getVoices();
   for(i = 0; i &lt; voices.length ; i++) {
     var option = document.createElement('option');

--- a/files/en-us/web/api/speechsynthesisvoice/index.html
+++ b/files/en-us/web/api/speechsynthesisvoice/index.html
@@ -34,7 +34,8 @@ tags:
 
 <p>The following snippet is excerpted from our <a class="external external-icon" href="https://github.com/mdn/web-speech-api/tree/master/speak-easy-synthesis">Speech synthesiser demo</a>.</p>
 
-<pre class="brush: js">function populateVoiceList() {
+<pre class="brush: js">var synth = window.speechSynthesis;
+function populateVoiceList() {
   voices = synth.getVoices();
 
   for(i = 0; i &lt; voices.length ; i++) {


### PR DESCRIPTION
Hi all 👋 

I was playing around with the `SpeechSynthesis` API and saw some unclear examples on MDN. If you look a the page https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/onvoiceschanged a `synth` variable is referenced but never defined.

It seems that the example has been copy pasted from another page and the variable declaration was omitted. 

There are couple more things I would like to improve regarding the quirks of the `SpeechSynthesis` but that will be the subject of another PR