### PR TITLE
WebExtensions update for Firefox 87 release notes.

### DIFF
--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -73,7 +73,7 @@ tags:
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
   <ul>
-    <li><a href="en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">nativeMessaging</a> is now an <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a>({{bug(1630415)}}).</li>
+    <li><a href="en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">nativeMessaging</a> is now an <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a> ({{bug(1630415)}}).</li>
   </ul>
 
 <h4 id="Removals_9">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -73,7 +73,7 @@ tags:
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
   <ul>
-    <li> <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">nativeMessaging</a> is now an <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a>.</li>
+    <li><a href="en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">nativeMessaging</a> is now an <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a>({{bug(1630415)}}).</li>
   </ul>
 
 <h4 id="Removals_9">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/87/index.html
+++ b/files/en-us/mozilla/firefox/releases/87/index.html
@@ -72,6 +72,9 @@ tags:
 <h4 id="webdriver_removals">Removals</h4>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
+  <ul>
+    <li> <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging">nativeMessaging</a> is now an <a href="en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions">optional permission</a>.</li>
+  </ul>
 
 <h4 id="Removals_9">Removals</h4>
 


### PR DESCRIPTION
Adds note to the Firefox 87 [release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/87) about nativeMessaging moving to optional permissions. 
