### PR TITLE
Clarify removeListener backward-compatibility note

### DIFF
--- a/files/en-us/web/api/mediaquerylist/addlistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.html
@@ -17,10 +17,10 @@ tags:
   <code>MediaQueryListener</code> that will run a custom callback function in response to
   the media query status changing.</p>
 
-<p>This is basically an alias of {{DOMxRef("EventTarget.addEventListener()")}}, retained for
-  backwards compatibility purposes. Older browsers should use <code>addListener</code>
-  instead of <code>addEventListener</code> since <code>MediaQueryList</code> only inherits
-  from <code>EventTarget</code> in newer browsers.</p>
+<p>In older browsers <code>MediaQueryList</code> did not yet inherit from {{DOMxRef("EventTarget")}},
+  so this method was provided as an alias of {{DOMxRef("EventTarget.addEventListener()")}}.
+  Use <code>addEventListener()</code> instead of <code>addListener()</code> if it is
+  available in the browsers you need to support.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.html
@@ -16,9 +16,10 @@ tags:
   {{DOMxRef("MediaQueryList")}} interface removes a listener from the
   <code>MediaQueryListener</code>.</p>
 
-<p>This is basically an alias of {{DOMxRef("EventTarget.removeEventListener()")}}, for
-  backwards compatibility purposes — in older browsers you could use
-  <code>removeEventListener()</code> instead.</p>
+<p>This is basically an alias of {{DOMxRef("EventTarget.removeEventListener()")}}, retained for
+  backwards compatibility purposes. Older browsers should use <code>removeListener</code>
+  instead of <code>removeEventListener</code> since <code>MediaQueryList</code> only inherits
+  from <code>EventTarget</code> in newer browsers.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.html
@@ -16,10 +16,10 @@ tags:
   {{DOMxRef("MediaQueryList")}} interface removes a listener from the
   <code>MediaQueryListener</code>.</p>
 
-<p>This is basically an alias of {{DOMxRef("EventTarget.removeEventListener()")}}, retained for
-  backwards compatibility purposes. Older browsers should use <code>removeListener</code>
-  instead of <code>removeEventListener</code> since <code>MediaQueryList</code> only inherits
-  from <code>EventTarget</code> in newer browsers.</p>
+<p>In older browsers <code>MediaQueryList</code> did not yet inherit from {{DOMxRef("EventTarget")}},
+  so this method was provided as an alias of {{DOMxRef("EventTarget.removeEventListener()")}}.
+  Use <code>removeEventListener()</code> instead of <code>removeListener()</code> if it is
+  available in the browsers you need to support.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Affected page: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/removeListener

The previous text was unclear as to whether `removeEventListener` could be used in older browsers:

> This is basically an alias of EventTarget.removeEventListener(), for backwards compatibility purposes — in older browsers you could use removeEventListener() instead.

This PR clarifies the backwards-compatibility message to be consistent with [addListener](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener)'s page. New text:

> This is basically an alias of EventTarget.removeEventListener(), retained for backwards compatibility purposes. Older browsers should use removeListener instead of removeEventListener since MediaQueryList only inherits from EventTarget in newer browsers.