### PR TITLE
Fix broken link

### DIFF
--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h2 id="Overview">Overview</h2>
 
-<p>The File and Directory Entries API includes both <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#asynchronous_apis">asynchronous</a> and <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#synchronous_apis">synchronous</a> versions of the interfaces. The asynchronous API can be used in cases where you don't want an outstanding operation to block the UI. The synchronous API, on the other hand, allows for simpler programming model, but it must be used with <a href="/en-US/Using_web_workers">WebWorkers</a>. </p>
+<p>The File and Directory Entries API includes both <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#asynchronous_apis">asynchronous</a> and <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#synchronous_apis">synchronous</a> versions of the interfaces. The asynchronous API can be used in cases where you don't want an outstanding operation to block the UI. The synchronous API, on the other hand, allows for simpler programming model, but it must be used with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">WebWorkers</a>. </p>
 
 <h3 id="Usefulness_of_the_API">Usefulness of the API</h3>
 


### PR DESCRIPTION
Fix broken link on the page _Introduction to the File and Directory Entries API_. The link should take the user to the _Using Web Workers_ page, but it returns a "Page not found" instead.