### PR TITLE
Fix up link to PaymentRequestChangeEvent.updateWith()

### DIFF
--- a/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
@@ -71,7 +71,7 @@ paymentRequest.show()
 
 <p>This begins by looking at the event's {{domxref("PaymentMethodChangeEvent.methodName", "methodName")}} property; if that indicates that the user is trying to use Apple Pay, we pass the {{domxref("PaymentMethodChangeEvent.methodDetails", "methodDetails")}} into a function called <code>calculateServiceFee()</code>, which we might create to take the information about the transaction, such as the underlying credit card being used to service the Apple Pay request, and compute and return an {{domxref("PaymentDetailsUpdate")}} object that specifies changes to be applied to the {{domxref("PaymentRequest")}} in order to add any service fees that the payment method might require.</p>
 
-<p>Before the event handler returns, it calls the event's {{domxref("PaymentMethodChangeEvent.updateWith")}} method to integrate the changes into the request.</p>
+<p>Before the event handler returns, it calls the event's {{domxref("PaymentMethodChangeEvent.updateWith()")}} method to integrate the changes into the request.</p>
 
 
 <h2 id="Related_events">Related events</h2>

--- a/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
@@ -71,7 +71,8 @@ paymentRequest.show()
 
 <p>This begins by looking at the event's {{domxref("PaymentMethodChangeEvent.methodName", "methodName")}} property; if that indicates that the user is trying to use Apple Pay, we pass the {{domxref("PaymentMethodChangeEvent.methodDetails", "methodDetails")}} into a function called <code>calculateServiceFee()</code>, which we might create to take the information about the transaction, such as the underlying credit card being used to service the Apple Pay request, and compute and return an {{domxref("PaymentDetailsUpdate")}} object that specifies changes to be applied to the {{domxref("PaymentRequest")}} in order to add any service fees that the payment method might require.</p>
 
-<p>Before the event handler returns, it calls the event's {{domxref("PaymentRequestUpdateEvent.updateWith", "PaymentMethodChangeEvent.updateWith", "updateWith()")}} method to integrate the changes into the request.</p>
+<p>Before the event handler returns, it calls the event's {{domxref("PaymentMethodChangeEvent.updateWith")}} method to integrate the changes into the request.</p>
+
 
 <h2 id="Related_events">Related events</h2>
 


### PR DESCRIPTION
Fixes #3313

`domxref` macro was being used incorrectly. What we want is a link to the method `PaymentMethodChangeEvent.updateWith()`, which I have created with `{{domxref("PaymentMethodChangeEvent.updateWith")}}`. Note that this link ends up being shown as  broken because the method do not exist - that's why I make sure the full event is listed rather than just the method name(

Note that this was a bit confusing because the macro previously included a non-working link to  [PaymentRequestUpdateEvent.updatewith()](https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequestUpdateEvent/updateWith) as well. This does work but which **seems** not relevant to the the page - may be worth a sanity check.
