### PR TITLE
Normalized Set format and clarified set vs array

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -137,7 +137,7 @@ mySet1.has(document.querySelector('body')) // true
 // converting between Set and Array
 const mySet2 = new Set([1, 2, 3, 4])
 mySet2.size                    // 4
-[...mySet2]                    // [1, 2, 3, 4]
+mySet2                         // {1, 2, 3, 4}
 
 // intersect can be simulated via
 const intersection = new Set([...mySet1].filter(x =&gt; mySet2.has(x)))
@@ -209,11 +209,11 @@ const setA = new Set([1, 2, 3, 4])
 const setB = new Set([2, 3])
 const setC = new Set([3, 4, 5, 6])
 
-isSuperset(setA, setB)          // =&gt; true
-union(setA, setC)               // =&gt; Set [1, 2, 3, 4, 5, 6]
-intersection(setA, setC)        // =&gt; Set [3, 4]
-symmetricDifference(setA, setC) // =&gt; Set [1, 2, 5, 6]
-difference(setA, setC)          // =&gt; Set [1, 2]
+isSuperset(setA, setB)          // returns true
+union(setA, setC)               // returns {1, 2, 3, 4, 5, 6}
+intersection(setA, setC)        // returns {3, 4}
+symmetricDifference(setA, setC) // returns {1, 2, 5, 6}
+difference(setA, setC)          // returns {1, 2}
 
 </pre>
 
@@ -226,6 +226,9 @@ let mySet = new Set(myArray)
 
 mySet.has('value1')     // returns true
 
+// Log the set in its standard format
+console.log(mySet) // eill log the sets normal format which looks similar to an object {...}
+
 // Use the spread operator to transform a set into an Array.
 console.log([...mySet]) // Will show you exactly the same Array as myArray
 </pre>
@@ -236,6 +239,9 @@ console.log([...mySet]) // Will show you exactly the same Array as myArray
 
 const numbers = [2,3,4,4,2,3,3,4,4,5,5,6,6,7,5,32,3,4,5]
 
+console.log(new Set(numbers)])
+// Set(7) {2, 3, 4, 5, 6, 7, 32}
+
 console.log([...new Set(numbers)])
 
 // [2, 3, 4, 5, 6, 7, 32]</pre>
@@ -244,12 +250,12 @@ console.log([...new Set(numbers)])
 
 <pre class="brush: js">let text = 'India'
 
-const mySet = new Set(text)  // Set ['I', 'n', 'd', 'i', 'a']
+const mySet = new Set(text)  // Set(5) {'I', 'n', 'd', 'i', 'a'}
 mySet.size  // 5
 
 //case sensitive &amp; duplicate ommision
-new Set("Firefox")  // Set(7) [ "F", "i", "r", "e", "f", "o", "x" ]
-new Set("firefox")  // Set(6) [ "f", "i", "r", "e", "o", "x" ]
+new Set("Firefox")  // Set(7) { "F", "i", "r", "e", "f", "o", "x" }
+new Set("firefox")  // Set(6) { "f", "i", "r", "e", "o", "x" }
 </pre>
 
 <h3 id="Use_Set_to_ensure_the_uniqueness_of_a_list_of_values">Use Set to ensure the uniqueness of a list of values</h3>

--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -137,7 +137,7 @@ mySet1.has(document.querySelector('body')) // true
 // converting between Set and Array
 const mySet2 = new Set([1, 2, 3, 4])
 mySet2.size                    // 4
-mySet2                         // {1, 2, 3, 4}
+[...mySet2]                    // [1, 2, 3, 4]
 
 // intersect can be simulated via
 const intersection = new Set([...mySet1].filter(x =&gt; mySet2.has(x)))

--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -210,10 +210,10 @@ const setB = new Set([2, 3])
 const setC = new Set([3, 4, 5, 6])
 
 isSuperset(setA, setB)          // returns true
-union(setA, setC)               // returns {1, 2, 3, 4, 5, 6}
-intersection(setA, setC)        // returns {3, 4}
-symmetricDifference(setA, setC) // returns {1, 2, 5, 6}
-difference(setA, setC)          // returns {1, 2}
+union(setA, setC)               // returns Set {1, 2, 3, 4, 5, 6}
+intersection(setA, setC)        // returns Set {3, 4}
+symmetricDifference(setA, setC) // returns Set {1, 2, 5, 6}
+difference(setA, setC)          // returns Set {1, 2}
 
 </pre>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -226,9 +226,6 @@ let mySet = new Set(myArray)
 
 mySet.has('value1')     // returns true
 
-// Log the set in its standard format
-console.log(mySet) // eill log the sets normal format which looks similar to an object {...}
-
 // Use the spread operator to transform a set into an Array.
 console.log([...mySet]) // Will show you exactly the same Array as myArray
 </pre>

--- a/files/en-us/web/javascript/reference/global_objects/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.html
@@ -236,9 +236,6 @@ console.log([...mySet]) // Will show you exactly the same Array as myArray
 
 const numbers = [2,3,4,4,2,3,3,4,4,5,5,6,6,7,5,32,3,4,5]
 
-console.log(new Set(numbers)])
-// Set(7) {2, 3, 4, 5, 6, 7, 32}
-
 console.log([...new Set(numbers)])
 
 // [2, 3, 4, 5, 6, 7, 32]</pre>


### PR DESCRIPTION
I was reading the docs on this today and was very confused by how and why the docs were doing things. After spending some time testing the examples, I realized that they simply were not consistent in how they were written and were type casting in someplace for no reason. These changes settle on representing the `Set` according to the standard unless explicitly showing how to convert from a set to an array.

This should help devs not already familiar with Set to better understand it and its uniqueness at first glance and reduce confusion like I had by utilizing the standards for Set when applicable

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [x] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
1. - [x] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [x] Link to any other resources that you think might be useful in reviewing your PR.
