### PR TITLE
Use “BigInt values” to clarify they’re not objects

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.html
@@ -33,7 +33,7 @@ const hugeBin = BigInt("0b11111111111111111111111111111111111111111111111111111"
 // ↪ 9007199254740991n
 </pre>
 
-<p>BigInt values are similar to Number values in some ways, but also differ in a few key matters: a BigInt value cannot be used with methods in the built-in <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a> object and cannot be mixed with a Number value in operations; they must be coerced to the same type. Be careful coercing values back and forth, however, as the precision of a BigInt value may be lost when it is coerced to a Number value.</p>
+<p>BigInt values are similar to Number values in some ways, but also differ in a few key matters: A BigInt value cannot be used with methods in the built-in <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a> object and cannot be mixed with a Number value in operations; they must be coerced to the same type. Be careful coercing values back and forth, however, as the precision of a BigInt value may be lost when it is coerced to a Number value.</p>
 
 <h3 id="Type_information">Type information</h3>
 
@@ -50,7 +50,7 @@ typeof BigInt('1') === 'bigint'  // true
 
 <h3 id="Operators">Operators</h3>
 
-<p>The following operators may be used with a BigInt values or object-wrapped BigInt values:</p>
+<p>The following operators may be used with BigInt values or object-wrapped BigInt values:</p>
 
 <pre>+ * - **</pre>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.html
@@ -9,11 +9,11 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p><strong><code>BigInt</code></strong> is a built-in object that provides a way to represent whole numbers larger than 2<sup>53</sup> - 1, which is the largest number JavaScript can reliably represent with the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a> {{Glossary("Primitive", "primitive")}} and represented by the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER"><code>Number.MAX_SAFE_INTEGER</code></a> constant. <strong><code>BigInt</code></strong> can be used for arbitrarily large integers.</p>
+<p><strong><code>BigInt</code></strong> is a built-in object whose constructor returns a <code>bigint</code> {{Glossary("Primitive", "primitive")}} — also called a <strong>BigInt value</strong>, or sometimes just a <strong>BigInt</strong> — to represent whole numbers larger than  2<sup>53</sup> - 1 (<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER"><code>Number.MAX_SAFE_INTEGER</code></a>), which is the largest number JavaScript can represent with a <code>number</code> {{Glossary("Primitive", "primitive")}} (or <em>Number value</em>). BigInt values can be used for arbitrarily large integers.</p>
 
 <h2 id="Description">Description</h2>
 
-<p>A <code>BigInt</code> is created by appending <code>n</code> to the end of an integer literal — <code>10n</code> — or by calling the function <code>BigInt()</code>.</p>
+<p>A <strong>BigInt value</strong>, also sometimes just called a <strong>BigInt</strong>, is a <code>bigint</code> {{Glossary("Primitive", "primitive")}}, created by appending <code>n</code> to the end of an integer literal, or by calling the {{jsxref("Global_Objects/BigInt/BigInt", "BigInt()")}} constructor (but without the <code>new</code> operator) and giving it an integer value or string value.</p>
 
 <pre class="brush: js">const previouslyMaxSafeInteger = 9007199254740991n
 
@@ -33,26 +33,28 @@ const hugeBin = BigInt("0b11111111111111111111111111111111111111111111111111111"
 // ↪ 9007199254740991n
 </pre>
 
-<p><code>BigInt</code> is similar to <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a> in some ways, but also differs in a few key matters — it cannot be used with methods in the built-in <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a> object and cannot be mixed with instances of <code>Number</code> in operations; they must be coerced to the same type. Be careful coercing values back and forth, however, as the precision of a <code>BigInt</code> may be lost when it is coerced to a <code>Number</code>.</p>
+<p>BigInt values are similar to Number values in some ways, but also differ in a few key matters: a BigInt value cannot be used with methods in the built-in <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a> object and cannot be mixed with a Number value in operations; they must be coerced to the same type. Be careful coercing values back and forth, however, as the precision of a BigInt value may be lost when it is coerced to a Number value.</p>
 
 <h3 id="Type_information">Type information</h3>
 
-<p>When tested against <code>typeof</code>, a <code>BigInt</code> will give "bigint":</p>
+<p>When tested against <code>typeof</code>, a BigInt value (<code>bigint</code> primitive) will give "<code>bigint</code>":</p>
 
 <pre class="brush: js">typeof 1n === 'bigint'           // true
 typeof BigInt('1') === 'bigint'  // true
 </pre>
 
-<p>When wrapped in an <code>Object</code>, a <code>BigInt</code> will be considered as a normal "object" type:</p>
+<p>A BigInt value can also be wrapped in an <code>Object</code>:</p>
 
 <pre class="brush: js">typeof Object(1n) === 'object'  // true
 </pre>
 
 <h3 id="Operators">Operators</h3>
 
-<p>The following operators may be used with <code>BigInt</code>s (or object-wrapped <code>BigInt</code>s): <code>+</code>, <code>*</code>, <code>-</code>, <code>**</code>, <code>%</code>.</p>
+<p>The following operators may be used with a BigInt values or object-wrapped BigInt values:</p>
 
-<p><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Bitwise operators</a> are supported as well, except <code>&gt;&gt;&gt;</code> (zero-fill right shift) as all BigInts are signed.</p>
+<pre>+ * - **</pre>
+
+<p><a href="/en-US/docs/Web/JavaScript/Reference/Operators">Bitwise operators</a> are supported as well, except <code>&gt;&gt;&gt;</code> (zero-fill right shift), as every BigInt value is signed.</p>
 
 <p>Also unsupported is the unary operator (<code>+</code>), <a href="https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs">in order to not break asm.js</a>.</p>
 
@@ -81,13 +83,7 @@ bigN * -1n
 // ↪ –18014398509481984n
 </pre>
 
-<p>The <code>/</code> operator also works as expected with whole numbers.</p>
-
-<p>However, since these are <code>BigInt</code>s and not <code>BigDecimal</code>s, this operation will round towards <code>0</code> (which is to say, it will not return any fractional digits).</p>
-
-<div class="notecard warning">
-<p>An operation with a fractional result will be truncated when used with a <code>BigInt</code>.</p>
-</div>
+<p>The <code>/</code> operator also works as expected with whole numbers — but operations with a fractional result will be truncated when used with a BigInt value — they won’t return any fractional digits.</p>
 
 <pre class="brush: js">const expected = 4n / 2n
 // ↪ 2n
@@ -99,7 +95,7 @@ const rounded = 5n / 2n
 
 <h3 id="Comparisons">Comparisons</h3>
 
-<p>A <code>BigInt</code> is not strictly equal to a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a>, but it <em>is</em> loosely so:</p>
+<p>A BigInt value is not strictly equal to a Number value, but it <em>is</em> loosely so:</p>
 
 <pre class="brush: js">0n === 0
 // ↪ false
@@ -107,7 +103,7 @@ const rounded = 5n / 2n
 0n == 0
 // ↪ true</pre>
 
-<p>A <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a> and a <code>BigInt</code> may be compared as usual:</p>
+<p>A Number value and a BigInt value may be compared as usual:</p>
 
 <pre class="brush: js">1n &lt; 2
 // ↪ true
@@ -124,7 +120,7 @@ const rounded = 5n / 2n
 2n &gt;= 2
 // ↪ true</pre>
 
-<p>They may be mixed in arrays and sorted:</p>
+<p>BigInt values and Number values may be mixed in arrays and sorted:</p>
 
 <pre class="brush: js">const mixed = [4n, 6, -12n, 10, 4, 0, 0n]
 // ↪  [4n, 6, -12n, 10, 4, 0, 0n]
@@ -134,14 +130,14 @@ mixed.sort() // default sorting behavior
 
 mixed.sort((a, b) =&gt; a - b)
 // won't work since subtraction will not work with mixed types
-// TypeError: can't convert BigInt to number
+// TypeError: can't convert BigInt value to Number value
 
 // sort with an appropriate numeric comparator
 mixed.sort((a, b) =&gt; (a &lt; b) ? -1 : ((a &gt; b) ? 1 : 0))
 // ↪  [ -12n, 0, 0n, 4n, 4, 6, 10 ]
 </pre>
 
-<p>Note that comparisons with <code>Object</code>-wrapped <code>BigInt</code>s act as with other objects, only indicating equality when the same object instance is compared:</p>
+<p>Note that comparisons with <code>Object</code>-wrapped BigInt values act as with other objects, only indicating equality when the same object instance is compared:</p>
 
 <pre class="brush: js">0n === Object(0n)          // false
 Object(0n) === Object(0n)  // false
@@ -152,11 +148,11 @@ o === o                    // true
 
 <h3 id="Conditionals">Conditionals</h3>
 
-<p>A <code>BigInt</code> behaves like a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a> in cases where:</p>
+<p>A BigInt value behaves like a Number value in cases where:</p>
 
 <ul>
  <li>it is converted to a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean"><code>Boolean</code></a>: via the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean"><code>Boolean</code></a> function;</li>
- <li>when used with <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators">logical operators</a> <code>||</code>, <code>&amp;&amp;</code>, and <code>!</code>; or</li>
+ <li>when used with <a href="/en-US/docs/Web/JavaScript/Reference/Operators">logical operators</a> <code>||</code>, <code>&amp;&amp;</code>, and <code>!</code>; or</li>
  <li>within a conditional test like an <a href="/en-US/docs/Web/JavaScript/Reference/Statements/if...else"><code>if</code></a> statement.</li>
 </ul>
 
@@ -191,42 +187,46 @@ Boolean(12n)
 
 <dl>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt"><code>BigInt()</code></a></dt>
- <dd>Creates a new <code>bigint</code> value.</dd>
+ <dd>Creates a new BigInt value.</dd>
 </dl>
 
 <h2 id="Static_methods">Static methods</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN"><code>BigInt.asIntN()</code></a></dt>
- <dd>Wraps a <code>BigInt</code> value to a signed integer between <code>-2<var><sup>width</sup></var><sup>-1</sup></code> and <code>2<var><sup>width</sup></var><sup>-1</sup> - 1</code>.</dd>
+ <dd>Clamps a BigInt value to a signed integer value, and returns that value.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN"><code>BigInt.asUintN()</code></a></dt>
- <dd>Wraps a <code>BigInt</code> value to an unsigned integer between <code>0</code> and <code>2<var><sup>width</sup></var> - 1</code>.</dd>
+ <dd>Clamps a BigInt value to an unsigned integer value, and returns that value.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString"><code>BigInt.prototype.toLocaleString()</code></a></dt>
- <dd>Returns a string with a language-sensitive representation of this number. Overrides the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString"><code>Object.prototype.toLocaleString()</code></a> method.</dd>
+ <dd>Returns a string with a language-sensitive representation of this BigInt value. Overrides the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString"><code>Object.prototype.toLocaleString()</code></a> method.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString"><code>BigInt.prototype.toString()</code></a></dt>
- <dd>Returns a string representing the specified object in the specified radix (base). Overrides the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString"><code>Object.prototype.toString()</code></a> method.</dd>
+ <dd>Returns a string representing this BigInt value in the specified radix (base). Overrides the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString"><code>Object.prototype.toString()</code></a> method.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf"><code>BigInt.prototype.valueOf()</code></a></dt>
- <dd>Returns the primitive value of the specified object. Overrides the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf"><code>Object.prototype.valueOf()</code></a> method.</dd>
+ <dd>Returns this BigInt value. Overrides the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf"><code>Object.prototype.valueOf()</code></a> method.</dd>
 </dl>
 
 <h2 id="Usage_recommendations">Usage recommendations</h2>
 
 <h3 id="Coercion">Coercion</h3>
 
-<p>Because coercing between <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a> and <code>BigInt</code> can lead to loss of precision, it is recommended to only use <code>BigInt</code> when values greater than 2<sup>53</sup> are reasonably expected and not to coerce between the two types.</p>
+<p>Because coercing between Number values and BigInt values can lead to loss of precision, the following are recommended:</p>
+<ul>
+  <li>Only use a BigInt value when values greater than 2<sup>53</sup> are reasonably expected.</li>
+  <li>Don’t coerce between BigInt values and Number values.</li>
+</ul>
 
 <h3 id="Cryptography">Cryptography</h3>
 
-<p>The operations supported on <code>BigInt</code>s are not constant time. <code>BigInt</code> is therefore <a href="https://www.chosenplaintext.ca/articles/beginners-guide-constant-time-cryptography.html">unsuitable for use in cryptography</a>.</p>
+<p>The operations supported on BigInt values are not constant-time. BigInt values are therefore <a href="https://www.chosenplaintext.ca/articles/beginners-guide-constant-time-cryptography.html">unsuitable for use in cryptography</a>.</p>
 
 <h3 id="Use_within_JSON">Use within JSON</h3>
 
-<p>Using <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify"><code>JSON.stringify()</code></a> with any <code>BigInt</code> value will raise a <code>TypeError</code> as <code>BigInt</code> values aren't serialized in JSON by default. However, you can implement your own <code>toJSON</code> method if needed:</p>
+<p>Using <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify"><code>JSON.stringify()</code></a> with any BigInt value will raise a <code>TypeError</code>, as BigInt values aren't serialized in JSON by default. However, you can implement your own <code>toJSON</code> method:</p>
 
 <pre class="brush: js">BigInt.prototype.toJSON = function() { return this.toString()  }</pre>
 
@@ -239,7 +239,7 @@ Boolean(12n)
 
 <h3 id="Calculating_Primes">Calculating Primes</h3>
 
-<pre class="brush: js">// Returns true if passed BigInt is a prime number
+<pre class="brush: js">// Returns true if the passed BigInt value is a prime number
 function isPrime(p) {
   for (let i = 2n; i * i &lt;= p; i++) {
     if (p % i === 0n) return false;
@@ -247,7 +247,7 @@ function isPrime(p) {
   return true
 }
 
-// Takes a BigInt as an argument, returns nth prime number as BigInt
+// Takes a BigInt value as an argument, returns nth prime number as a BigInt value
 function nthPrime(nth) {
   let maybePrime = 2n
   let prime = 0n


### PR DESCRIPTION
This change updates the BigInt article to clarify that code does not operate on BigInt objects but instead on bigint primitive values. The ECMAScript spec uses the term “BigInt value” to refer to bigint primitives — and the shorthand “BigInt” to refer to BigInt values — and normatively defines what a BigInt value is:

https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-value
> ### 4.4.28 BigInt value
> primitive value corresponding to an arbitrary-precision integer value

…so this change follows that, and updates the BigInt article to consistently use “BigInt value”, in normal type — non-monospaced, without `<code></code>` markup — to make clear that what’s being operated on in code is not a BigInt *object*, but instead a primitive value.

Fixes https://github.com/mdn/content/issues/3336