### PR TITLE
Clarify what BigInt.asIntN() and BigInt.asUintN() really do

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.html
@@ -10,8 +10,7 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>BigInt.asIntN</code></strong> static method is used to wrap a BigInt
-  value to a signed integer between -2<sup>width-1</sup> and 2<sup>width-1</sup>-1.</p>
+<p>The <strong><code>BigInt.asIntN</code></strong> static method clamps a BigInt value to a signed integer value, and returns that value.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/bigint-asintn.html", "taller")}}</div>
 
@@ -24,21 +23,21 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">BigInt.asIntN(<var>width</var>, <var>bigint</var>);</pre>
+  class="brush: js">BigInt.asIntN(<var>bits</var>, <var>bigint</var>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>width</var></code></dt>
+  <dt><code><var>bits</var></code></dt>
   <dd>The amount of bits available for the integer size.</dd>
   <dt><code><var>bigint</var></code></dt>
-  <dd>The integer to clamp to fit into the supplied bits.</dd>
+  <dd>The BigInt value to clamp to fit into the supplied bits.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>
 
 <p>The value of <code><var>bigint</var></code> modulo
-  2<sup><code><var>width</var></code></sup> as a signed integer.</p>
+  2<sup><code><var>bits</var></code></sup>, as a signed integer.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.html
@@ -10,8 +10,7 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>BigInt.asUintN</code></strong> static method is used to wrap a BigInt
-  value to an unsigned integer between 0 and 2<sup>width</sup>-1.</p>
+<p>The <strong><code>BigInt.asUintN</code></strong> static method clamps a BigInt value to an unsigned integer value, and returns that value.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/bigint-asuintn.html", "taller")}}</div>
 
@@ -24,21 +23,21 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js">BigInt.asUintN(<var>width</var>, <var>bigint</var>);</pre>
+  class="brush: js">BigInt.asUintN(<var>bits</var>, <var>bigint</var>);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>width</var></code></dt>
+  <dt><code><var>bits</var></code></dt>
   <dd>The amount of bits available for the integer size.</dd>
   <dt><code><var>bigint</var></code></dt>
-  <dd>The integer to clamp to fit into the supplied bits.</dd>
+  <dd>The BigInt value to clamp to fit into the supplied bits.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>
 
 <p>The value of <code><var>bigint</var></code> modulo
-  2<sup><code><var>width</var></code></sup> as an unsigned integer.</p>
+  2<sup><code><var>bits</var></code></sup>, as an unsigned integer.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.html
@@ -198,9 +198,9 @@ Boolean(12n)
 
 <dl>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN"><code>BigInt.asIntN()</code></a></dt>
- <dd>Wraps a <code>BigInt</code> value to a signed integer between <code>-2<var><sup>width</sup></var><sup>-1</sup></code> and <code>2<var><sup>width</sup></var><sup>-1</sup> - 1</code>.</dd>
+ <dd>Clamps a BigInt value to a signed integer value, and returns that value.</dd>
  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN"><code>BigInt.asUintN()</code></a></dt>
- <dd>Wraps a <code>BigInt</code> value to an unsigned integer between <code>0</code> and <code>2<var><sup>width</sup></var> - 1</code>.</dd>
+ <dd>Clamps a BigInt value to an unsigned integer value, and returns that value.</dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>


### PR DESCRIPTION
This change updates the descriptions of the `BigInt.asIntN()` and `BigInt.asUintN()` methods to describe them by saying they “clamp” a BigInt value to a signed/unsigned integer of the number of bits given, and then return that value — rather than describing them by saying they “wrap” a BigInt value (the meaning of which is unclear and potentially misleading).