### PR TITLE
Fixed typo for wrong aria attribute in example

### DIFF
--- a/files/en-us/web/api/element/ariakeyshortcuts/index.html
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example the <code>aria-disabled</code> attribute on the element with an ID of <code>skip-link</code> is set to "Alt+Shift+A". Using <code>ariaKeyShortcuts</code> we update the value to "Alt+Shift+M".</p>
+<p>In this example the <code>aria-keyshortcuts</code> attribute on the element with an ID of <code>skip-link</code> is set to "Alt+Shift+A". Using <code>ariaKeyShortcuts</code> we update the value to "Alt+Shift+M".</p>
 
 <pre class="brush: html">&lt;a id="skip-link" href="#content" aria-keyshortcuts="Alt+Shift+A"&gt;Skip to content&lt;/a&gt;</pre>
 


### PR DESCRIPTION
Fixes a typo in the examples (https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaKeyShortcuts#examples). The example had the wrong aria attribute `aria-disabled` mentioned and not `aria-keyshortcuts`.