### PR TITLE
Replace broken jsref with jsxref

### DIFF
--- a/files/en-us/web/api/readablestream/cancel/index.html
+++ b/files/en-us/web/api/readablestream/cancel/index.html
@@ -12,7 +12,7 @@ tags:
 <div>{{APIRef("Streams")}}</div>
 
 <p class="summary">The <strong><code>cancel()</code></strong> method of the
-  {{domxref("ReadableStream")}} interface returns a {{jsref("Promise")}} that
+  {{domxref("ReadableStream")}} interface returns a {{jsxref("Promise")}} that
   resolves when the stream is canceled.</p>
 
 <p>Cancel is used when you've completely finished with the stream and don't need any more

--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -36,7 +36,7 @@ tags:
 
 <dl>
 	<dt>{{domxref("ReadableStream.cancel()")}}</dt>
-	<dd>Returns a {{jsref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied <code>reason</code> argument will be given to the underlying source, which may or may not use it.</dd>
+	<dd>Returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied <code>reason</code> argument will be given to the underlying source, which may or may not use it.</dd>
 	<dt>{{domxref("ReadableStream.getReader()")}}</dt>
 	<dd>Creates a reader and locks the stream to it. While the stream is locked, no other reader can be acquired until this one is released.</dd>
 	<dt>{{domxref("ReadableStream.pipeThrough()")}}</dt>

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.html
@@ -13,7 +13,7 @@ tags:
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
 <p class="summary">The <strong><code>cancel()</code></strong> method of the
-  {{domxref("ReadableStreamBYOBReader")}} interface returns a {{jsref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer.</p>
+  {{domxref("ReadableStreamBYOBReader")}} interface returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer.</p>
 
 <div class="note">
   <p><strong>Note</strong>: If the reader is active, the <code>cancel()</code> method

--- a/files/en-us/web/api/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/index.html
@@ -32,9 +32,9 @@ tags:
 
 <dl>
  <dt>{{domxref("ReadableStreamBYOBReader.cancel()")}}</dt>
- <dd>Returns a {{jsref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied <code>reason</code> argument will be given to the underlying source, which may or may not use it.</dd>
+ <dd>Returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer. The supplied <code>reason</code> argument will be given to the underlying source, which may or may not use it.</dd>
  <dt>{{domxref("ReadableStreamBYOBReader.read()")}}</dt>
- <dd>Returns a {{jsref("Promise")}} that resolves with an object indicating the state of the stream: either the next chunk in the stream or an indication that the stream is closed.</dd>
+ <dd>Returns a {{jsxref("Promise")}} that resolves with an object indicating the state of the stream: either the next chunk in the stream or an indication that the stream is closed.</dd>
  <dt>{{domxref("ReadableStreamBYOBReader.releaseLock()")}}</dt>
  <dd>Releases the reader's lock on the stream.</dd>
 </dl>

--- a/files/en-us/web/api/readablestreambyobreader/read/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.html
@@ -13,7 +13,7 @@ tags:
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
 <p class="summary">The <strong><code>read()</code></strong> method of the
-  {{domxref("ReadableStreamBYOBReader")}} interface returns a {{jsref("Promise")}} that resolves with an obect representing the next chunk in the stream's queue.</p>
+  {{domxref("ReadableStreamBYOBReader")}} interface returns a {{jsxref("Promise")}} that resolves with an obect representing the next chunk in the stream's queue.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
@@ -12,7 +12,7 @@ tags:
 <div>{{APIRef("Streams")}}</div>
 
 <p class="summary">The <strong><code>cancel()</code></strong> method of the
-  {{domxref("ReadableStreamDefaultReader")}} interface returns a {{jsref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer.</p>
+  {{domxref("ReadableStreamDefaultReader")}} interface returns a {{jsxref("Promise")}} that resolves when the stream is canceled. Calling this method signals a loss of interest in the stream by a consumer.</p>
 
 <p>Cancel is used when you've completely finished with the stream and don't need any more
   data from it, even if there are chunks enqueued waiting to be read. That data is lost


### PR DESCRIPTION
There are two more instances of `jsref` that I look suspicious, but I am not sure what to do about:

```
files/en-us/web/api/arraybufferview/index.html
11:<p>{{JSRef("Global_Objects", "TypedArray", "Int8Array,Uint8Array,Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array")}}</p>

files/en-us/web/api/buffersource/index.html
11:<div>{{JSRef("Global_Objects", "ArrayBuffer")}}</div>
```
