### PR TITLE
Fix typo in stroke-linejoin

### DIFF
--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.html
@@ -100,7 +100,7 @@ tags:
 
 <h3 id="arcs">arcs</h3>
 
-<div class="notecard note"><strong>Note:</strong> the <code>arcs</code> value as been introduced in SVG2 and it isn't widely supported yet, see <a href="#browser_compatibility">Browser compatibility</a> bellow for details.</div>
+<div class="notecard note"><strong>Note:</strong> the <code>arcs</code> value as been introduced in SVG2 and it isn't widely supported yet, see <a href="#browser_compatibility">Browser compatibility</a> below for details.</div>
 
 <p>The <code>arcs</code> value indicates that an arcs corner is to be used to join path segments. The arcs shape is formed by extending the outer edges of the stroke at the join point with arcs that have the same curvature as the outer edges at the join point.</p>
 
@@ -204,7 +204,7 @@ tags:
 
 <h3 id="miter-clip">miter-clip</h3>
 
-<div class="notecard note"><strong>Note:</strong> the <code>miter-clip</code> value as been introduced in SVG2 and it isn't widely supported yet, see <a href="#browser_compatibility">Browser compatibility</a> bellow for details.</div>
+<div class="notecard note"><strong>Note:</strong> the <code>miter-clip</code> value as been introduced in SVG2 and it isn't widely supported yet, see <a href="#browser_compatibility">Browser compatibility</a> below for details.</div>
 
 <p>The <code>miter-clip</code> value indicates that a sharp corner is to be used to join path segments. The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect.</p>
 


### PR DESCRIPTION
Fixes a typo in https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linejoin#miter-clip and https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linejoin#arcs

below vs bellow

I checked to make sure this wasn't an English vs American spelling - and am pretty certain it's just a mistake.

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [ ] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
1. - [x] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [ ] Link to any other resources that you think might be useful in reviewing your PR.
