### PR TITLE
Adding "Formal Definition" heading above cssinfo

### DIFF
--- a/files/en-us/web/css/margin/index.html
+++ b/files/en-us/web/css/margin/index.html
@@ -156,6 +156,8 @@ margin: auto;               /* top and bottom: 0 margin     */
  </tbody>
 </table>
 
+<h2 id="Formal_definition">Formal definition</h2>
+
 <p>{{cssinfo}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/css/margin/index.html
+++ b/files/en-us/web/css/margin/index.html
@@ -9,15 +9,20 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>margin</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">margin area</a> on all four sides of an element. It is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand</a> for {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}.</p>
+<p>The <strong><code>margin</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> shorthand property sets the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">margin area</a> on all four sides of an element.
 
 <div>{{EmbedInteractiveExample("pages/css/margin.html")}}</div>
 
-<p>The top and bottom margins have no effect on <em>non-<a href="/en-US/docs/Web/CSS/Replaced_element">replaced</a></em> inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.</p>
+<h2 id="Constituent_properties">Constituent properties</h2>
 
-<div class="note">
-<p><strong>Note:</strong> Margins create extra space around an element. In contrast, {{cssxref("padding")}} creates extra space <em>within</em> an element.</p>
-</div>
+<p>This property is a shorthand for the following CSS properties:</p>
+
+<ul>
+ <li>{{cssxref("margin-bottom")}}</li>
+ <li>{{cssxref("margin-left")}}</li>
+ <li>{{cssxref("margin-right")}}</li>
+ <li>{{cssxref("margin-top")}}</li>
+</ul>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -60,7 +65,27 @@ margin: unset;
  <dd>The browser selects a suitable margin to use. For example, in certain cases this value can be used to center an element.</dd>
 </dl>
 
-<h3 id="Formal_syntax">Formal syntax</h3>
+<h2 id="Description">Description</h2>
+
+<p>This property can be used to set a margin on all four sides of an element. Margins create extra space <em>around</em> an element, unlike {{cssxref("padding")}}, which creates extra space <em>within</em> an element.</p>
+
+<p>The top and bottom margins have no effect on <em>non-<a href="/en-US/docs/Web/CSS/Replaced_element">replaced</a></em> inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.</p>
+
+<h3 id="Horizontal_centering">Horizontal centering</h3>
+
+<p>To center something horizontally in modern browsers, you can use {{cssxref("display")}}<code>: flex; </code>{{cssxref("justify-content")}}<code>: center;</code> .</p>
+
+<p>However, in older browsers like IE8-9 that do not support Flexible Box Layout, these are not available. In order to center an element inside its parent, use <code>margin: 0 auto;</code>.</p>
+
+<h3 id="Margin_collapsing">Margin collapsing</h3>
+
+<p>Elements' top and bottom margins are sometimes collapsed into a single margin that is equal to the larger of the two margins. See <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">Mastering margin collapsing</a> for more information.</p>
+
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Formal syntax</h2>
 
 {{csssyntax}}
 
@@ -115,18 +140,6 @@ margin: auto;               /* top and bottom: 0 margin     */
                             /* Box is horizontally centered */
 </pre>
 
-<h2 id="Notes">Notes</h2>
-
-<h3 id="Horizontal_centering">Horizontal centering</h3>
-
-<p>To center something horizontally in modern browsers, you can use {{cssxref("display")}}<code>: flex; </code>{{cssxref("justify-content")}}<code>: center;</code> .</p>
-
-<p>However, in older browsers like IE8-9 that do not support Flexible Box Layout, these are not available. In order to center an element inside its parent, use <code>margin: 0 auto;</code>.</p>
-
-<h3 id="Margin_collapsing">Margin collapsing</h3>
-
-<p>Elements' top and bottom margins are sometimes collapsed into a single margin that is equal to the larger of the two margins. See <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">Mastering margin collapsing</a> for more information.</p>
-
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
@@ -155,10 +168,6 @@ margin: auto;               /* top and bottom: 0 margin     */
   </tr>
  </tbody>
 </table>
-
-<h2 id="Formal_definition">Formal definition</h2>
-
-<p>{{cssinfo}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
This PR adds a "Formal Definition" heading above cssinfo in the margin web/css doc.

I noticed this heading on other property docs and it appeared to be missing here.

Let me know if this is buttery or not.

Love MDN!!! Thanks!!!

Checklist — To help your pull request get merged faster, please do the following:

1. - [ ] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [ ] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
1. - [ ] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [ ] Link to any other resources that you think might be useful in reviewing your PR.
