### PR TITLE
Demix ParentNode.childElementCount

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1348,7 +1348,7 @@
 /en-US/docs/DOM/DocumentTouch.createTouchList	/en-US/docs/Web/API/Document/createTouchList
 /en-US/docs/DOM/DocumentType	/en-US/docs/Web/API/DocumentType
 /en-US/docs/DOM/DynamicsCompressorNode	/en-US/docs/Web/API/DynamicsCompressorNode
-/en-US/docs/DOM/Element.childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/DOM/Element.childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/DOM/Element.children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/DOM/Element.contentEditable	/en-US/docs/Web/API/HTMLElement/contentEditable
 /en-US/docs/DOM/Element.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
@@ -2966,7 +2966,7 @@
 /en-US/docs/Document_Object_Model_(DOM)/DocumentTouch.createTouch	/en-US/docs/Web/API/Document/createTouch
 /en-US/docs/Document_Object_Model_(DOM)/DocumentTouch.createTouchList	/en-US/docs/Web/API/Document/createTouchList
 /en-US/docs/Document_Object_Model_(DOM)/DocumentType	/en-US/docs/Web/API/DocumentType
-/en-US/docs/Document_Object_Model_(DOM)/Element.childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/Document_Object_Model_(DOM)/Element.childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Document_Object_Model_(DOM)/Element.children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Document_Object_Model_(DOM)/Element.contentEditable	/en-US/docs/Web/API/HTMLElement/contentEditable
 /en-US/docs/Document_Object_Model_(DOM)/Element.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
@@ -7507,7 +7507,7 @@
 /en-US/docs/Web/API/Document/baseURI	/en-US/docs/Web/API/Node/baseURI
 /en-US/docs/Web/API/Document/cancelFullscreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Web/API/Document/charset	/en-US/docs/Web/API/document/characterSet
-/en-US/docs/Web/API/Document/childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/Web/API/Document/childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/Document/children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/Document/defaultView/popstate_event	/en-US/docs/Web/API/Window/popstate_event
 /en-US/docs/Web/API/Document/defaultView/resize_event	/en-US/docs/Web/API/Window/resize_event
@@ -7548,7 +7548,7 @@
 /en-US/docs/Web/API/DocumentFragment.DocumentFragment	/en-US/docs/Web/API/DocumentFragment/DocumentFragment
 /en-US/docs/Web/API/DocumentFragment.querySelector	/en-US/docs/Web/API/DocumentFragment/querySelector
 /en-US/docs/Web/API/DocumentFragment.querySelectorAll	/en-US/docs/Web/API/DocumentFragment/querySelectorAll
-/en-US/docs/Web/API/DocumentFragment/childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/Web/API/DocumentFragment/childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/DocumentFragment/children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/DocumentFragment/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/DocumentFragment/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
@@ -7578,7 +7578,7 @@
 /en-US/docs/Web/API/DynamicsCompressorNode.release	/en-US/docs/Web/API/DynamicsCompressorNode/release
 /en-US/docs/Web/API/DynamicsCompressorNode.threshold	/en-US/docs/Web/API/DynamicsCompressorNode/threshold
 /en-US/docs/Web/API/Element.attributes	/en-US/docs/Web/API/Element/attributes
-/en-US/docs/Web/API/Element.childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/Web/API/Element.childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/Element.children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/Element.clientLeft	/en-US/docs/Web/API/Element/clientLeft
 /en-US/docs/Web/API/Element.clientTop	/en-US/docs/Web/API/Element/clientTop
@@ -7617,7 +7617,6 @@
 /en-US/docs/Web/API/Element/animationiteration_event	/en-US/docs/Web/API/HTMLElement/animationiteration_event
 /en-US/docs/Web/API/Element/animationstart_event	/en-US/docs/Web/API/HTMLElement/animationstart_event
 /en-US/docs/Web/API/Element/cancel_event	/en-US/docs/Web/API/HTMLDialogElement/cancel_event
-/en-US/docs/Web/API/Element/childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
 /en-US/docs/Web/API/Element/children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/Element/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/Element/fullscreenchange	/en-US/docs/Web/API/Element/fullscreenchange_event
@@ -7641,7 +7640,7 @@
 /en-US/docs/Web/API/Element/pointerup_event	/en-US/docs/Web/API/HTMLElement/pointerup_event
 /en-US/docs/Web/API/Element/remove	/en-US/docs/Web/API/ChildNode/remove
 /en-US/docs/Web/API/Element/resourcetimingbufferfull_event	/en-US/docs/Web/API/Performance/resourcetimingbufferfull_event
-/en-US/docs/Web/API/ElementTraversal.childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/Web/API/ElementTraversal.childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/ElementTraversal.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/ElementTraversal.lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/ElementTraversal.nextElementSibling	/en-US/docs/Web/API/Element/nextElementSibling
@@ -8465,10 +8464,11 @@
 /en-US/docs/Web/API/PannerNode.setOrientation	/en-US/docs/Web/API/PannerNode/setOrientation
 /en-US/docs/Web/API/PannerNode.setPosition	/en-US/docs/Web/API/PannerNode/setPosition
 /en-US/docs/Web/API/PannerNode.setVelocity	/en-US/docs/Web/API/PannerNode/setVelocity
-/en-US/docs/Web/API/ParentNode.childElementCount	/en-US/docs/Web/API/ParentNode/childElementCount
+/en-US/docs/Web/API/ParentNode.childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/ParentNode.children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/ParentNode.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/ParentNode.lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
+/en-US/docs/Web/API/ParentNode/childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/PasswordCredential/additionalData	/en-US/docs/Web/API/PasswordCredential
 /en-US/docs/Web/API/PasswordCredential/idName	/en-US/docs/Web/API/PasswordCredential
 /en-US/docs/Web/API/PasswordCredential/passwordName	/en-US/docs/Web/API/PasswordCredential

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7547,7 +7547,6 @@
 /en-US/docs/Web/API/DocumentFragment.DocumentFragment	/en-US/docs/Web/API/DocumentFragment/DocumentFragment
 /en-US/docs/Web/API/DocumentFragment.querySelector	/en-US/docs/Web/API/DocumentFragment/querySelector
 /en-US/docs/Web/API/DocumentFragment.querySelectorAll	/en-US/docs/Web/API/DocumentFragment/querySelectorAll
-/en-US/docs/Web/API/DocumentFragment/childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/DocumentFragment/children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/DocumentFragment/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/DocumentFragment/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7507,7 +7507,6 @@
 /en-US/docs/Web/API/Document/baseURI	/en-US/docs/Web/API/Node/baseURI
 /en-US/docs/Web/API/Document/cancelFullscreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Web/API/Document/charset	/en-US/docs/Web/API/document/characterSet
-/en-US/docs/Web/API/Document/childElementCount	/en-US/docs/Web/API/Element/childElementCount
 /en-US/docs/Web/API/Document/children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/Document/defaultView/popstate_event	/en-US/docs/Web/API/Window/popstate_event
 /en-US/docs/Web/API/Document/defaultView/resize_event	/en-US/docs/Web/API/Window/resize_event

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -71118,29 +71118,6 @@
       "fscholz"
     ]
   },
-  "Web/API/ParentNode/childElementCount": {
-    "modified": "2020-10-15T21:05:55.635Z",
-    "contributors": [
-      "sideshowbarker",
-      "mfluehr",
-      "adyouri",
-      "ExE-Boss",
-      "K-Gun",
-      "jszhou",
-      "uxfed",
-      "Alhadis",
-      "fscholz",
-      "jsx",
-      "411911.ca",
-      "Kartik_Chadha",
-      "teoli",
-      "ethertank",
-      "Sheppy",
-      "trevorh",
-      "ziyunfei",
-      "Jürgen Jeka"
-    ]
-  },
   "Web/API/ParentNode/children": {
     "modified": "2020-10-15T21:05:52.672Z",
     "contributors": [
@@ -165769,6 +165746,29 @@
       "chrisdavidmills",
       "david_ross",
       "jpmedley"
+    ]
+  },
+  "Web/API/Element/childElementCount": {
+    "modified": "2020-10-15T21:05:55.635Z",
+    "contributors": [
+      "sideshowbarker",
+      "mfluehr",
+      "adyouri",
+      "ExE-Boss",
+      "K-Gun",
+      "jszhou",
+      "uxfed",
+      "Alhadis",
+      "fscholz",
+      "jsx",
+      "411911.ca",
+      "Kartik_Chadha",
+      "teoli",
+      "ethertank",
+      "Sheppy",
+      "trevorh",
+      "ziyunfei",
+      "Jürgen Jeka"
     ]
   }
 }

--- a/files/en-us/web/api/document/childelementcount/index.html
+++ b/files/en-us/web/api/document/childelementcount/index.html
@@ -1,0 +1,54 @@
+---
+title: Document.childElementCount
+slug: Web/API/Document/childElementCount
+tags:
+  - API
+  - DOM
+  - Property
+  - Reference
+---
+<div>{{ APIRef("DOM") }}</div>
+
+<p>The <code><strong>Document.childElementCount</strong></code> read-only property
+returns the number of child elements of the document.</p>
+
+<p>To get the number of children of a specific element, see {{domxref("Element.childElementCount")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js"><em>document</em>.childElementCount;
+</pre>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush:js">
+document.children;
+// HTMLCollection, usually containing an &lt;html&gt; element, the document's only child
+
+document.childElementCount;
+// 1
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-childelementcount', 'ParentNode.childElementCount')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.Document.childElementCount")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("Element.childElementCount")}}</li>
+  <li>{{domxref("DocumentFragment.childElementCount")}}</li>
+</ul>

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -34,6 +34,8 @@ tags:
  <dd>Returns the {{HTMLElement("body")}} or {{htmlelement("frameset")}} node of the current document.</dd>
  <dt>{{DOMxRef("Document.characterSet")}}{{ReadOnlyInline}}</dt>
  <dd>Returns the character set being used by the document.</dd>
+ <dt>{{domxref("Document.childElementCount")}} {{readonlyInline}}</dt>
+ <dd>Returns the number of child elements of the current document.</dd>
  <dt>{{DOMxRef("Document.compatMode")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Indicates whether the document is rendered in <em>quirks</em> or <em>strict</em> mode.</dd>
  <dt>{{DOMxRef("Document.contentType")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
@@ -87,10 +89,6 @@ tags:
  <dt>{{DOMxRef("Document.visibilityState")}}{{ReadOnlyInline}}</dt>
  <dd>Returns a <code>string</code> denoting the visibility state of the document. Possible values are <code>visible</code>, <code>hidden</code>, <code>prerender</code>, and <code>unloaded</code>.</dd>
 </dl>
-
-<p>The <code>Document</code> interface is extended with the {{DOMxRef("ParentNode")}} interface:</p>
-
-<p>{{page("/en-US/docs/Web/API/ParentNode","Properties")}}</p>
 
 <h3 id="Extensions_for_HTMLDocument">Extensions for HTMLDocument</h3>
 

--- a/files/en-us/web/api/documentfragment/childelementcount/index.html
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.html
@@ -52,5 +52,5 @@ fragment.childElementCount; // 1
 
 <ul>
   <li>{{domxref("Element.childElementCount")}}</li>
-  <li>{{domxref("DocumentFragment.childElementCount")}}</li>
+  <li>{{domxref("Document.childElementCount")}}</li>
 </ul>

--- a/files/en-us/web/api/documentfragment/childelementcount/index.html
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.html
@@ -1,0 +1,56 @@
+---
+title: DocumentFragment.childElementCount
+slug: Web/API/DocumentFragment/childElementCount
+tags:
+  - API
+  - DOM
+  - Property
+  - Reference
+---
+<div>{{ APIRef("DOM") }}</div>
+
+<p>The <code><strong>Document.childElementCount</strong></code> read-only property
+returns the number of child elements of a <code>DocumentFragment</code>.</p>
+
+<p>To get the number of children of a specific element, see {{domxref("Element.childElementCount")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js"><em>fragment</em>.childElementCount;
+</pre>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush:js">
+let fragment = new DocumentFragment()
+fragment.childElementCount; // 0
+
+let paragraph = document.createElement('p')
+fragment.appendChild(paragraph)
+
+fragment.childElementCount; // 1
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-childelementcount', 'ParentNode.childElementCount')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.DocumentFragment.childElementCount")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("Element.childElementCount")}}</li>
+  <li>{{domxref("DocumentFragment.childElementCount")}}</li>
+</ul>

--- a/files/en-us/web/api/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/index.html
@@ -26,14 +26,14 @@ tags:
 <p><em>This interface has no specific properties, but inherits those of its parent, {{domxref("Node")}}, and implements those of the {{domxref("ParentNode")}} interface.</em></p>
 
 <dl>
+ <dt>{{ domxref("DocumentFragment.childElementCount") }} {{readonlyInline}} </dt>
+ <dd>Returns the amount of child {{domxref("Element","elements")}} the <code>DocumentFragment</code> has.</dd>
  <dt>{{ domxref("ParentNode.children") }} {{readonlyInline}}{{experimental_inline}}</dt>
  <dd>Returns a live {{domxref("HTMLCollection")}} containing all objects of type {{domxref("Element")}} that are children of the <code>DocumentFragment</code> object.</dd>
  <dt>{{ domxref("ParentNode.firstElementChild") }} {{readonlyInline}}{{experimental_inline}}</dt>
  <dd>Returns the {{domxref("Element")}} that is the first child of the <code>DocumentFragment</code> object, or <code>null</code> if there is none.</dd>
  <dt>{{ domxref("ParentNode.lastElementChild") }} {{readonlyInline}}{{experimental_inline}}</dt>
  <dd>Returns the {{domxref("Element")}} that is the last child of the <code>DocumentFragment</code> object, or <code>null</code> if there is none.</dd>
- <dt>{{ domxref("ParentNode.childElementCount") }} {{readonlyInline}}{{experimental_inline}}</dt>
- <dd>Returns an <code>unsigned long</code> giving the amount of child {{domxref("Element","elements")}} the <code>DocumentFragment</code> has.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/element/childelementcount/index.html
+++ b/files/en-us/web/api/element/childelementcount/index.html
@@ -1,12 +1,12 @@
 ---
 title: ParentNode.childElementCount
-slug: Web/API/ParentNode/childElementCount
+slug: Web/API/Element/childElementCount
 tags:
-- API
-- DOM
-- ParentNode
-- Property
-- Reference
+  - API
+  - DOM
+  - ParentNode
+  - Property
+  - Reference
 ---
 <div>{{ APIRef("DOM") }}</div>
 

--- a/files/en-us/web/api/element/childelementcount/index.html
+++ b/files/en-us/web/api/element/childelementcount/index.html
@@ -1,70 +1,27 @@
 ---
-title: ParentNode.childElementCount
+title: Element.childElementCount
 slug: Web/API/Element/childElementCount
 tags:
   - API
   - DOM
-  - ParentNode
   - Property
   - Reference
 ---
 <div>{{ APIRef("DOM") }}</div>
 
-<p>The <code><strong>ParentNode.childElementCount</strong></code> read-only property
-  returns an <code>unsigned long</code> representing the number of child elements of the
-  given element.</p>
-
-<div class="note">
-  <p>This property was initially defined in the {{domxref("ElementTraversal")}} pure
-    interface. As this interface contained two distinct set of properties, one aimed at
-    {{domxref("Node")}} that have children, one at those that are children, they have been
-    moved into two separate pure interfaces, {{domxref("ParentNode")}} and
-    {{domxref("ChildNode")}}. In this case, <code>childElementCount</code> moved to
-    {{domxref("ParentNode")}}. This is a fairly technical change that shouldn't affect
-    compatibility.</p>
-</div>
+<p>The <code><strong>Element.childElementCount</strong></code> read-only property
+returns the number of child elements of this element.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <var>count</var> = <em>node</em>.childElementCount;
-</pre>
-
-<dl>
-  <dt><code>count</code></dt>
-  <dd>The return value, which is an <code>unsigned long</code> (an integer) type.</dd>
-  <dt><code>node</code></dt>
-  <dd>An object representing a {{domxref("Document")}}, {{domxref("DocumentFragment")}},
-    or {{domxref("Element")}}.</dd>
-</dl>
+<pre class="brush: js">element.childElementCount;</pre>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush:js">var foo = document.getElementById('foo');
-if (foo.childElementCount &gt; 0) {
+<pre class="brush:js">let sidebar = document.getElementById('sidebar');
+if (sidebar.childElementCount &gt; 0) {
   // Do something
 }
-</pre>
-
-<h2 id="Polyfill_for_IE8_IE9_Safari">Polyfill for IE8 &amp; IE9 &amp; Safari</h2>
-
-<p>This property is completely unsupported prior to IE9. In IE9 and Safari, it is
-  unsupported in the <code>Document</code> and <code>DocumentFragment</code> objects.</p>
-
-<pre class="brush:js">;(function(constructor) {
-  if (constructor &amp;&amp;
-      constructor.prototype &amp;&amp;
-      constructor.prototype.childElementCount == null) {
-    Object.defineProperty(constructor.prototype, 'childElementCount', {
-      get: function() {
-        var i = 0, count = 0, node, nodes = this.childNodes;
-        while (node = nodes[i++]) {
-          if (node.nodeType === 1) count++;
-        }
-        return count;
-      }
-    });
-  }
-})(window.Node || window.Element);
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
@@ -73,39 +30,20 @@ if (foo.childElementCount &gt; 0) {
   <tbody>
     <tr>
       <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-childelementcount',
-        'ParentNode.childElementCount')}}</td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Split the <code>ElementTraversal</code> interface in {{domxref("ChildNode")}}
-        and <code>ParentNode</code>. This method is now defined on the latter.<br>
-        The {{domxref("Document")}} and {{domxref("DocumentFragment")}} implemented the
-        new interfaces.</td>
-    </tr>
-    <tr>
-      <td>{{SpecName('Element Traversal', '#attribute-childElementCount',
-        'ElementTraversal.childElementCount')}}</td>
-      <td>{{Spec2('Element Traversal')}}</td>
-      <td>Added its initial definition to the <code>ElementTraversal</code> pure interface
-        and use it on {{domxref("Element")}}.</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-childelementcount', 'ParentNode.childElementCount')}}</td>
     </tr>
   </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ParentNode.childElementCount")}}</p>
+<p>{{Compat("api.Element.childElementCount")}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{domxref("ParentNode")}} and {{domxref("ChildNode")}} pure interfaces.</li>
-  <li>
-    Object types implementing this pure interface:
-      {{domxref("Document")}}, {{domxref("Element")}}, and
-      {{domxref("DocumentFragment")}}.
-  </li>
+  <li>{{domxref("Document.childElementCount")}}</li>
+  <li>{{domxref("DocumentFragment.childElementCount")}}</li>
 </ul>

--- a/files/en-us/web/api/element/index.html
+++ b/files/en-us/web/api/element/index.html
@@ -27,6 +27,8 @@ tags:
  <dd>Returns a {{DOMxRef("HTMLSlotElement")}} representing the {{htmlelement("slot")}} the node is inserted in.</dd>
  <dt>{{DOMxRef("Element.attributes")}} {{readOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef("NamedNodeMap")}} object containing the assigned attributes of the corresponding HTML element.</dd>
+ <dt>{{domxref("Element.childElementCount")}} {{readonlyInline}}</dt>
+ <dd>Returns the number of child elements of this element.</dd>
  <dt>{{DOMxRef("Element.classList")}} {{readOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef("DOMTokenList")}} containing the list of class attributes.</dd>
  <dt>{{DOMxRef("Element.className")}}</dt>


### PR DESCRIPTION
The IDL for childElementCount is this:

```WebIDL
interface mixin ParentNode {
  readonly attribute unsigned long childElementCount;
};

Document includes ParentNode;
DocumentFragment includes ParentNode;
Element includes ParentNode;
```

Therefore we need these pages (created in this PR):
http://localhost:3000/en-US/docs/Web/API/Document/childElementCount
http://localhost:3000/en-US/docs/Web/API/DocumentFragment/childElementCount
http://localhost:3000/en-US/docs/Web/API/Element/childElementCount

Currently existing is: https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/childElementCount
(I made that a redirect to http://localhost:3000/en-US/docs/Web/API/Element/childElementCount which is the oldest/original API.)

This note was fun (I removed it). ElementTraversal seems to be the old mixin here. Neither ElementTraversal nor ParentNode are really interesting to readers as the note points out.

> This property was initially defined in the ElementTraversal pure interface. As this interface contained two distinct set of properties, one aimed at Node that have children, one at those that are children, they have been moved into two separate pure interfaces, ParentNode and ChildNode. In this case, childElementCount moved to ParentNode. This is a fairly technical change that shouldn't affect compatibility.