### PR TITLE
Fix incorrect references in markerUnits docs

### DIFF
--- a/files/en-us/web/svg/attribute/markerunits/index.html
+++ b/files/en-us/web/svg/attribute/markerunits/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{SVGRef}}</div>
 
-<p>The <strong><code>markerUnits</code></strong> attribute defines the coordinate system for the {{SVGAttr("markerWidth")}} and {{SVGAttr("markerUnits")}} attributes and the contents of the {{SVGElement("marker")}}.</p>
+<p>The <strong><code>markerUnits</code></strong> attribute defines the coordinate system for the {{SVGAttr("markerWidth")}} and {{SVGAttr("markerHeight")}} attributes and the contents of the {{SVGElement("marker")}}.</p>
 
 <h2 id="Usage_notes">Usage notes</h2>
 
@@ -31,9 +31,9 @@ tags:
 
 <dl>
  <dt><code>userSpaceOnUse</code></dt>
- <dd>This value specifies that the <code>markerWidth</code> and <code>markerUnits</code> attributes and the contents of the <code>&lt;marker&gt;</code> element represent values in the current user coordinate system in place for the graphic object referencing the marker (i.e., the user coordinate system for the element referencing the <code>&lt;marker&gt;</code> element via a {{SVGAttr("marker")}}, <code>marker-start</code>, <code>marker-mid</code>, or <code>marker-end</code> property).</dd>
+ <dd>This value specifies that the <code>markerWidth</code> and <code>markerHeight</code> attributes and the contents of the <code>&lt;marker&gt;</code> element represent values in the current user coordinate system in place for the graphic object referencing the marker (i.e., the user coordinate system for the element referencing the <code>&lt;marker&gt;</code> element via a {{SVGAttr("marker")}}, <code>marker-start</code>, <code>marker-mid</code>, or <code>marker-end</code> property).</dd>
  <dt><code>strokeWidth</code></dt>
- <dd>This value specifies that the <code>markerWidth</code> and <code>markerUnits</code> attributes and the contents of the <code>&lt;marker&gt;</code> element represent values in a coordinate system which has a single unit equal the size in user units of the current stroke width (see the {{SVGAttr("stroke-width")}} attribute) in place for the graphic object referencing the marker.</dd>
+ <dd>This value specifies that the <code>markerWidth</code> and <code>markerHeight</code> attributes and the contents of the <code>&lt;marker&gt;</code> element represent values in a coordinate system which has a single unit equal the size in user units of the current stroke width (see the {{SVGAttr("stroke-width")}} attribute) in place for the graphic object referencing the marker.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>
@@ -69,6 +69,6 @@ tags:
 <ul>
  <li>{{SVGElement("marker")}}</li>
  <li>{{SVGAttr("markerWidth")}}</li>
- <li>{{SVGAttr("markerUnits")}}</li>
+ <li>{{SVGAttr("markerHeight")}}</li>
  <li>{{SVGAttr("stroke-width")}}</li>
 </ul>


### PR DESCRIPTION
The markerUnits attribute defines the coordinate system for the markerWidth and **markerHeight** attributes, not markerWidth and **markerUnits** as is currently reflected in the docs. This commit changes the docs to match the [SVG 1.1](https://www.w3.org/TR/SVG11/painting.html#MarkerUnitsAttribute) and [SVG 2](https://svgwg.org/svg2-draft/painting.html#MarkerUnitsAttribute) specs.

Checklist — To help your pull request get merged faster, please do the following:

1. - [x] Provide a summary of your changes — say what problem you are fixing, what files are changed, and what you've done. This doesn't need to be hugely detailed, as we can see exact changes in the "Files changed" tab.
1. - [x] Provide a link to the issue(s) you are fixing, if appropriate, in the form "Fixes _url-of-issue_". GitHub will render this in the form "Fixes #1234", with the issue number linked to the issue. Doing this allows us to figure out what issues you are fixing, as well as helping to automate things (for example the issue will be closed once the PR that fixed it has been merged).
1. - [x] Review the results of the automated checking we run on every PR and fix any problems reported (see the list of checks near the bottom of the PR page). If you need help, please ask in a comment!
1. - [x] Link to any other resources that you think might be useful in reviewing your PR.
