### PR TITLE
fix bad brush class on css/@media/-webkit-transition

### DIFF
--- a/files/en-us/web/css/@media/-webkit-transition/index.html
+++ b/files/en-us/web/css/@media/-webkit-transition/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{ CSSRef }} {{deprecated_header}} {{ Non-standard_header }}</div>
 
-<p>The <strong><code>-webkit-transition</code></strong> Boolean <a href="/en-US/docs/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features">media feature</a> is a <a href="/en-US/docs/Web/CSS/Webkit_Extensions">Chrome extension</a> whose value is <code>true</code> if the browsing context supports <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transitions</a>. It was never supported in browsers not based on WebKit or Blink.</p>
+<p>The <strong><code>-webkit-transition</code></strong> Boolean <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features">media feature</a> is a <a href="/en-US/docs/Web/CSS/WebKit_Extensions">Chrome extension</a> whose value is <code>true</code> if the browsing context supports <a href="/en-US/docs/Web/CSS/CSS_Transitions">CSS transitions</a>. It was never supported in browsers not based on WebKit or Blink.</p>
 
 <p>Apple has <a href="https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3">a description in Safari CSS Reference</a>; this is now called <code>transition</code> there.</p>
 
@@ -23,9 +23,9 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: cssline-numbers language-css"><code class="language-css"><span class="atrule token"><span class="rule token">@media</span> <span class="punctuation token">(</span>-webkit-transition<span class="punctuation token">)</span></span> <span class="punctuation token">{</span>
-  <span class="comment token">/* CSS to use if transitions are supported */</span>
-<span class="punctuation token">}</span></code></pre>
+<pre class="brush: css line-numbers language-css">@media (-webkit-transition) {
+  /* CSS to use if transitions are supported */
+}</pre>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Fixed the flaws. In particular, the `<pre>` tag there had the `brush:` set to `cssline-numbers` which is missing a space because there is syntax highlighter called `cssline-numbers`. 