### PR TITLE
BatteryManager: Incorporate methods rather than include

### DIFF
--- a/files/en-us/web/api/batterymanager/index.html
+++ b/files/en-us/web/api/batterymanager/index.html
@@ -46,7 +46,14 @@ tags:
 
 <p>Inherited from {{domxref("EventTarget")}}:</p>
 
-<p>{{page("/en-US/docs/Web/API/EventTarget","Methods")}}</p>
+<dl>
+	<dt>{{domxref("EventTarget.addEventListener()", "<var>EventTarget</var>.addEventListener()")}}</dt>
+	<dd>Registers an event handler of a specific event type on the <code><var>EventTarget</var></code>.</dd>
+	<dt>{{domxref("EventTarget.removeEventListener()", "<var>EventTarget</var>.removeEventListener()")}}</dt>
+	<dd>Removes an event listener from the <code><var>EventTarget</var></code>.</dd>
+	<dt>{{domxref("EventTarget.dispatchEvent()", "<var>EventTarget</var>.dispatchEvent()")}}</dt>
+	<dd>Dispatches an event to this <code><var>EventTarget</var></code>.</dd>
+</dl>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/batterymanager/index.html
+++ b/files/en-us/web/api/batterymanager/index.html
@@ -44,16 +44,7 @@ tags:
 
 <h2 id="Methods">Methods</h2>
 
-<p>Inherited from {{domxref("EventTarget")}}:</p>
-
-<dl>
-	<dt>{{domxref("EventTarget.addEventListener()", "<var>EventTarget</var>.addEventListener()")}}</dt>
-	<dd>Registers an event handler of a specific event type on the <code><var>EventTarget</var></code>.</dd>
-	<dt>{{domxref("EventTarget.removeEventListener()", "<var>EventTarget</var>.removeEventListener()")}}</dt>
-	<dd>Removes an event listener from the <code><var>EventTarget</var></code>.</dd>
-	<dt>{{domxref("EventTarget.dispatchEvent()", "<var>EventTarget</var>.dispatchEvent()")}}</dt>
-	<dd>Dispatches an event to this <code><var>EventTarget</var></code>.</dd>
-</dl>
+<p><em>Inherits methods from its parent interface:</em> {{domxref("EventTarget")}}.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/eventtarget/index.html
+++ b/files/en-us/web/api/eventtarget/index.html
@@ -36,16 +36,6 @@ tags:
 	<dd>Dispatches an event to this <code><var>EventTarget</var></code>.</dd>
 </dl>
 
-<h3 id="Additional_methods_in_Mozilla_chrome_codebase">Additional methods in Mozilla chrome codebase</h3>
-
-<p>Mozilla includes a couple of extensions for use by JS-implemented event targets to implement <code>on<var>event</var></code> properties.</p>
-
-<p>See also <a href="/en-US/docs/Mozilla/WebIDL_bindings">WebIDL bindings</a>.</p>
-
-<ul>
-	<li><code>void <strong>setEventHandler</strong>(DOMString <var>type</var>, EventHandler <var>handler</var>)</code> {{non-standard_inline}}</li>
-	<li><code>EventHandler <strong>getEventHandler</strong>(DOMString <var>type</var>)</code> {{non-standard_inline}}</li>
-</ul>
 
 <h2 id="Example">Example</h2>
 


### PR DESCRIPTION
Fixes #3316

Copy-paste of methods from EventTarget, and removal of additional chrome/mozilla methods. 

@wbamberg Set you as reviewer for this first one.