### PR TITLE
AriaRoles: Remove pagemacro

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.html
@@ -8,7 +8,6 @@ tags:
   - ARIA widget
   - Reference
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
 
 <p class="summary"><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria-1.1/#alert">alert</a> role can be used to tell the user an element has been dynamically updated. Screen readers will instantly start reading out the updated content when the role is added. If the user is expected to close the alert, then the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Alertdialog_Role">alertdialog</a> role should be used instead.</span></p>
 
@@ -71,3 +70,11 @@ function triggerAlert() {
  <li><a href="https://developer.paciellogroup.com/blog/2017/04/aria-alert-support/">ARIA alert support - The Paciello Group</a></li>
  <li>ARIA Live Regions</li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+   <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>
+  

--- a/files/en-us/web/accessibility/aria/roles/application_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/application_role/index.html
@@ -8,8 +8,6 @@ tags:
   - Reference
   - Role application
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The <code>application</code> role indicates to assistive technologies that an element <em>and all of its children</em> should be treated similar to a desktop application, and no traditional HTML interpretation techniques should be used. This role should only be used to define very dynamic and desktop-like web applications.</span></p>
 
 <pre class="brush: html">&lt;div role="application"&gt;...&lt;/div&gt;
@@ -109,3 +107,9 @@ tags:
 <ul>
  <li><a href="https://www.marcozehe.de/2012/02/06/if-you-use-the-wai-aria-role-application-please-do-so-wisely/">If you use the WAI-ARIA role "application", please do so wisely</a> - blog post by Marco Zehe</li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/aria_timer_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/aria_timer_role/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - Role Timer
 ---
-<p>{{draft}}{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
+<p>{{draft}}</p>
 
 <p><span class="seoSummary">The timer role indicates to assistive technologies that an element is a numerical counter listing the amount of elapsed time from a starting point or the remaining time until an end point.</span></p>
 
@@ -113,3 +113,11 @@ function startTimer(timerName) {
 <h2 id="Precedence_order">Precedence order</h2>
 
 <p>Applying the <code>timer</code> role will cause this and all of the descendant elements of this element to be treated like XXX</p>
+
+
+<section id="Quick_links">
+  <ol>
+   <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>
+  

--- a/files/en-us/web/accessibility/aria/roles/article_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/article_role/index.html
@@ -9,8 +9,6 @@ tags:
   - Article role
   - Reference
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p class="summary"><span class="seoSummary">The <code>article</code> role indicates a section of a page that could easily stand on its own on a page, in a document, or on a website. It is usually set on related content items such as comments, forum posts, newspaper articles or other items grouped together on one page.</span></p>
 
 <pre class="brush: html">&lt;div role="article"&gt;
@@ -114,5 +112,12 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Feed_Role">feed role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Section_Role">section role</a></li>
  <li><a href="/en-US/docs/Web/HTML/Element/article">&lt;article&gt; element</a></li>
- <li><a href="/en-US/docs/Web/RSS/Article">RSS Article</a></li>
+ <li>{{Glossary("RSS")}}</li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+   <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>
+  

--- a/files/en-us/web/accessibility/aria/roles/banner_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/banner_role/index.html
@@ -92,3 +92,9 @@ tags:
  <li><a href="/en-US/docs/Web/HTML/Element/header">HTML <code>header</code> element</a></li>
  <li><a href="https://w3c.github.io/aria-practices/examples/landmarks/banner.html">WC3 Landmarks Example</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+   <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/button_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.html
@@ -278,3 +278,10 @@ function toggleButton(element) {
  <li><a href="https://www.w3.org/TR/wai-aria-practices/examples/button/button.html">Official WAI-ARIA example code</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/menubutton_role">ARIA menubutton role</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+   <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/cell_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/cell_role/index.html
@@ -7,8 +7,6 @@ tags:
   - cell
   - table
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The <code>cell</code> value of the ARIA <em>role</em> attribute identifies an element as being a cell in a tabular container that does not contain column or row header information. To be supported, the cell must be nested in an element with the role of <code>row</code>.</p>
 
 <pre class="brush: html">&lt;div role="row"&gt;
@@ -190,3 +188,9 @@ tags:
  <li><a href="/en-US/docs/Learn/HTML/Tables/Advanced">HTML table advanced features and accessibility</a></li>
  <li><a href="/en-US/docs/Learn/HTML/Tables/Basics">HTML table basics</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+   <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.html
@@ -7,8 +7,6 @@ tags:
   - NeedsContent
   - Role
 ---
-<p>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
 <p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria-1.1/#checkbox">checkbox role</a> is used for checkable interactive controls. Elements containing <code>role="checkbox"</code> must also include the <code>aria-checked</code> attribute to expose the checkbox's state to assistive technology.</span></p>
 
 <pre class="brush: html">&lt;span role="checkbox" aria-checked="false" tabindex="0" aria-labelledby="chk1-label"&gt;
@@ -143,3 +141,10 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Switch_role">ARIA: switch role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Option_role">ARIA: option role</a></li>
 </ul>
+
+
+<section id="Quick_links">
+    <ol>
+        <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+    </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/comment_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/comment_role/index.html
@@ -8,8 +8,6 @@ tags:
   - Reference
   - annotations
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The <code>comment</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> semantically denotes a comment/reaction to some content on the page, or to a previous comment.</p>
 
 <h2 id="Examples">Examples</h2>
@@ -84,3 +82,10 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Annotations">ARIA annotations</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+      <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/complementary_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/complementary_role/index.html
@@ -7,8 +7,6 @@ tags:
   - Reference
   - role-complementary
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The <code>complementary</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> is used to designate a supporting section that relates to the main content, yet can stand alone when separated. These sections are frequently presented as sidebars or call-out boxes. If possible, use the <a href="/en-US/docs/Web/HTML/Element/aside">HTML &lt;aside&gt; element</a> instead.</span></p>
 
 <pre class="brush: html">&lt;div role="complementary"&gt;
@@ -114,3 +112,9 @@ tags:
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="http://html5doctor.com/aside-revisited/">Aside Revisited | HTML5 Doctor</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+      <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/contentinfo_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/contentinfo_role/index.html
@@ -7,8 +7,6 @@ tags:
   - Reference
   - role-contentinfo
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The <code>contentinfo</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> is used to identify information repeated at the end of every page of a website, including copyright information, navigation links, and privacy statements. This section is commonly called a footer.</p>
 
 <pre class="brush: html">&lt;div role="contentinfo"&gt;
@@ -145,3 +143,9 @@ tags:
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="http://html5doctor.com/the-footer-element-update/">The Footer Element Update | HTML5 Doctor</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+      <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/dialog_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/dialog_role/index.html
@@ -7,8 +7,6 @@ tags:
   - NeedsContent
   - Web Development
 ---
-<p>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
 <p><span class="seoSummary">The <code><a href="https://www.w3.org/TR/2009/WD-wai-aria-20091215/roles#dialog">dialog</a></code> role is used to mark up an HTML based application dialog or window that separates content or UI from the rest of the web application or page. Dialogs are generally placed on top of the rest of the page content using an overlay. Dialogs can be either non-modal (it's still possible to interact with content outside of the dialog) or modal (only the content in the dialog can be interacted with).</span></p>
 
 <pre class="brush: html">&lt;div <strong>role="dialog" aria-labelledby="dialog1Title" aria-describedby="dialog1Desc"</strong>&gt;
@@ -143,3 +141,10 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Alertdialog_Role">ARIA: alertdialog role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role">Using the alertdialog role</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+      <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/document_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/document_role/index.html
@@ -7,7 +7,6 @@ tags:
   - Document
   - Reference
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
 <p><span class="seoSummary">Generally used in complex composite <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/widget_Role">widgets</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Application_Role">applications</a>, the <code>document</code> role can inform assistive technologies to switch context to a reading mode: The <code>document</code> role tells assistive technologies with reading or browse modes to use the document mode to read the content contained within this element.</span></p>
 
 <pre class="brush: html">&lt;div role="dialog"&gt;
@@ -20,7 +19,7 @@ tags:
 &lt;/div&gt;
 </pre>
 
-<p>This example shows a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/diialog_Role">dialog</a> widget with some controls and a section with some informational text that the assistive technology user can read when tabbing to it.</p>
+<p>This example shows a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a> widget with some controls and a section with some informational text that the assistive technology user can read when tabbing to it.</p>
 
 <h2 id="Description">Description</h2>
 
@@ -88,3 +87,9 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/widget_Role">ARIA:widget role</a> </li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Application_Role">ARIA: application role</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+      <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/feed_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/feed_role/index.html
@@ -7,8 +7,6 @@ tags:
   - Reference
   - feed
 ---
-<p>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
 <p><span class="seoSummary">A <code>feed</code> is a dynamic scrollable <code>list</code> of <code>articles</code> in which articles are added to or removed from either end of the list as the user scrolls. A <code>feed</code> enables screen readers to use the browse mode reading cursor to both read and scroll through a stream of rich content that may continue scrolling infinitely by loading more content as the user reads.</span></p>
 
 <pre class="brush: html">&lt;section role="feed" <a class="state-reference" href="https://w3c.github.io/aria/#aria-busy">aria-busy</a>="false"&gt;
@@ -113,3 +111,9 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/List_role">ARIA: list role</a></li>
  <li><cite><a href="https://www.w3.org/TR/wai-aria-practices-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> Authoring Practices</a></cite> - additional details on implementing a feed design pattern.</li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/figure_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/figure_role/index.html
@@ -10,8 +10,6 @@ tags:
   - Role
   - figure
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The ARIA <code>figure</code> role can be used to identify a figure inside page content where appropriate semantics do not already exist. A figure is generally considered to be one or more images, code snippets, or other content that puts across information in a different way to a regular flow of text.</p>
 
 <pre class="brush: html">&lt;div role="figure" aria-labelledby="caption"&gt;
@@ -145,3 +143,9 @@ tags:
  <li><a href="/en-US/docs/Web/HTML/Element/figure">HTML &lt;figure&gt; element</a></li>
  <li><a href="/en-US/docs/Web/HTML/Element/figcaption">HTML &lt;figcaption&gt; element</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/form_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/form_role/index.html
@@ -10,8 +10,6 @@ tags:
   - Role
   - form
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The <code>form</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> can be used to identify a group of elements on a page that provide equivalent functionality to an HTML form.</p>
 
 <pre class="brush: html">&lt;div role="form" id="contact-info" aria-label="Contact information"&gt;
@@ -153,3 +151,9 @@ tags:
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.html
@@ -5,8 +5,6 @@ tags:
   - ARIA
   - HTML
 ---
-<p>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
 <p><span class="seoSummary">The grid role is for a widget that contains one or more rows of cells. The position of each cell is significant and can be focused using keyboard input.</span></p>
 
 <pre class="brush: html">&lt;table role="grid" aria-labelledby="id-select-your-seat"&gt;
@@ -45,7 +43,7 @@ tags:
 
 <p>A grid widget contains one or more rows with one or more cells of thematically related interactive content. While it does not imply a specific visual presentation, it implies a relationship among elements. Uses fall into two categories: presenting tabular information (data grids) and grouping other widgets (layout grids). Even though both data grids and layout grids employ the same ARIA roles, states, and properties, differences in their content and purpose surface factors that are important to consider in keyboard interaction design. See <a href="https://www.w3.org/TR/wai-aria-practices-1.2/#grid">ARIA Authoring practices</a> for more details</p>
 
-<p>Cell elements have the role <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">gridcell</a></code>, unless they are a row or column header. Then the elements are <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowheader_Role">rowheader</a></code> and <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role">columnheader</a></code>, respectively. Cell elements need to be owned by elements with a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role">row</a></code> role. Rows can be grouped using <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">rowgroup</a>s</code>.</p>
+<p>Cell elements have the role <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">gridcell</a></code>, unless they are a row or column header. Then the elements are <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role">rowheader</a></code> and <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_Role">columnheader</a></code>, respectively. Cell elements need to be owned by elements with a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role">row</a></code> role. Rows can be grouped using <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">rowgroup</a>s</code>.</p>
 
 <p>If the grid is used as an interactive widget, <a href="#keyboard-use">keyboard</a> interactions need to be implemented.</p>
 
@@ -54,7 +52,7 @@ tags:
 <h4 id="Roles">Roles</h4>
 
 <dl>
- <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Treegrid_Role">treegrid</a> (subclass)</dt>
+ <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role">treegrid</a> (subclass)</dt>
  <dd>If a grid has columns that can expanded or collapsed, a treegrid can be used.</dd>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role">row</a></dt>
  <dd>A row inside the grid.</dd>
@@ -687,16 +685,22 @@ document.querySelector('table').addEventListener("keydown", function(event) {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/composite_Role">ARIA composite role</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/composite_role">ARIA composite role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">ARIA table role</a></li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_Role">ARIA treegrid role</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role">ARIA treegrid role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role">ARIA row role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">ARIA rowgroup role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">ARIA: gridcell role</a></li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowheader_Role">ARIA: rowheader role</a></li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role">ARIA: columnheader role</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role">ARIA: rowheader role</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role">ARIA: columnheader role</a></li>
  <li>HTML table element</li>
  <li>aria-level</li>
  <li>aria-multiselectable</li>
  <li>aria-readonly</li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/gridcell_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/gridcell_role/index.html
@@ -5,8 +5,6 @@ tags:
   - ARIA
   - HTML
 ---
-<p>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
 <p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria-1.1/#gridcell">gridcell role</a> is used to make a cell in a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Treegrid_role">treegrid</a>. It is intended to mimic the functionality of the <a href="/en-US/docs/Web/HTML/Element/td">HTML <code>td</code> element</a> for table-style grouping of information.</span></p>
 
 <pre class="brush: html">&lt;div role="gridcell"&gt;Potato&lt;/div&gt;
@@ -174,3 +172,9 @@ tags:
  <li><a href="https://www.w3.org/TR/wai-aria-1.1/#gridcell">gridcell: Accessible Rich Internet Applications (WAI-ARIA) 1.1</a></li>
  <li><a href="http://www.maxability.co.in/wai-aria-overview/gridcell-role/">Gridcell Role - Maxability</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/heading_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/heading_role/index.html
@@ -7,8 +7,6 @@ tags:
   - ARIA heading
   - Reference
 ---
-<div> {{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The heading role defines this element as a heading to a page or section. To give the page more structure, a level should also be provided to indicate relationships between sections.</span></p>
 
 <pre class="brush: html">&lt;div role="heading" aria-level="1"&gt;This is a main page heading&lt;/div&gt;
@@ -112,3 +110,9 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt; thru &lt;h6&gt;: The HTML Section Heading elements</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/index.html
+++ b/files/en-us/web/accessibility/aria/roles/index.html
@@ -78,7 +78,6 @@ tags:
 
 
 
-
 <section id="Quick_links">
 <ol>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>

--- a/files/en-us/web/accessibility/aria/roles/list_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.html
@@ -10,8 +10,6 @@ tags:
   - Role
   - list
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The ARIA <code>list</code> role can be used to identify a list of items. It is normally used in conjunction with the <code>listitem</code> role, which is used to identify a list item contained inside the list.</span></p>
 
 <pre class="brush: html">&lt;section role="list"&gt;
@@ -27,8 +25,9 @@ tags:
 
 <p>There are no hard and fast rules about which elements you should use to markup the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.</p>
 
-<div class="warning">
-<p><strong>Warning</strong>:<span class="ILfuVd yZ8quc"> If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{htmlelement("ul")}}/{{htmlelement("ol")}} and {{htmlelement("li")}}. See {{anch("Best practices")}} for a full example.</span></p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{htmlelement("ul")}}/{{htmlelement("ol")}} and {{htmlelement("li")}}. See {{anch("Best practices")}} for a full example.</p>
 </div>
 
 <h3 id="Associated_WAI-ARIA_Roles_States_and_Properties">Associated WAI-ARIA Roles, States, and Properties</h3>
@@ -38,7 +37,7 @@ tags:
  <dd>
  <p>A single item in a list or directory. Elements with role listitem can only be found in an element with the role <code>list</code> or <code>group</code>.</p>
  </dd>
- <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Group_role">group</a></dt>
+ <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></dt>
  <dd>
  <p>A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a pages table of contents.</p>
  </dd>
@@ -114,5 +113,11 @@ tags:
  <li><span class="ILfuVd yZ8quc">{{htmlelement("ol")}}</span></li>
  <li><span class="ILfuVd yZ8quc">{{htmlelement("li")}}</span></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Listitem_role">ARIA: listitem role</a></li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Group_role">ARIA: group role</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role">ARIA: group role</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.html
@@ -6,14 +6,6 @@ tags:
   - Accessibility
   - NeedsContent
 ---
-<p>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
-<ul class="ul1">
-</ul>
-
-<ul class="ul1">
-</ul>
-
 <p><span class="seoSummary">The <code>listbox</code> role is used for lists from which a user may select one or more items which are static and, unlike HTML &lt;select&gt; elements, may contain images.</span></p>
 
 <h2 id="Description">Description</h2>
@@ -33,7 +25,7 @@ tags:
 <h4 id="Associated_Roles">Associated Roles</h4>
 
 <dl>
-	<dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Option_Role">option</a></dt>
+	<dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></dt>
 	<dd>One or more nested options are required. All selected options have <code>aria-selected</code> set to <code>true</code>. All options that are not selected have <code>aria-selected</code> set to <code>false</code>.  If an option is not selectable, omit the <code>aria-selected</code>.</dd>
 	<dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/List_role">list</a></dt>
 	<dd>A section containing <code>listitem</code> elements</dd>
@@ -180,7 +172,7 @@ tags:
 	<li class="li3">It is recommended that authors use different styling for the selection when the list is not focused, e.g. a non-active selection is often shown with a lighter background color.</li>
 	<li class="li3">If the listbox is not part of another widget, it should have the <code><span class="s1">aria-labelledby</span></code> property set.</li>
 	<li class="li3">If one or more entries are not DOM children of listbox, additional <span class="s1">aria-*</span> properties will need to be set (see <a href="https://www.w3.org/TR/wai-aria-practices/#listbox_div">ARIA Best Practices</a>).</li>
-	<li class="li3">If there is a valid reason to <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-expanded">expand</a> the listbox, the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Combobox_Role"><code>combobox</code></a> role may be more appropriate.</li>
+	<li class="li3">If there is a valid reason to <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-expanded">expand</a> the listbox, the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role"><code>combobox</code></a> role may be more appropriate.</li>
 </ul>
 
 <h2 id="Specifications">Specifications</h2>
@@ -212,10 +204,16 @@ tags:
 	<li><a href="/en-US/docs/Web/HTML/Element/select">HTML <code>&lt;select&gt;</code> element</a></li>
 	<li><a href="/en-US/docs/Web/HTML/Element/label">HTML <code>&lt;label&gt;</code> element</a></li>
 	<li><a href="/en-US/docs/Web/HTML/Element/option">HTML <code>&lt;option&gt;</code> element</a></li>
-	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Combobox_Role">ARIA: <code>combobox</code> role</a></li>
-	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Option_Role">ARIA: <code>option</code> role</a></li>
+	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role">ARIA: <code>combobox</code> role</a></li>
+	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/option_role">ARIA: <code>option</code> role</a></li>
 	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/List_role">ARIA: <code>list</code> role</a></li>
 	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Listitem_role">ARIA: <code>listitem</code> role</a></li>
 	<li class="li2"><a href="https://www.w3.org/TR/wai-aria-practices/#Listbox">ARIA Best Practices – Listbox</a></li>
 	<li class="li2"><a href="https://www.w3.org/TR/wai-aria-1.1/#listbox">ARIA Role Model – Listbox</a></li>
 </ul>
+
+<section id="Quick_links">
+	<ol>
+	  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+	</ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/listitem_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/listitem_role/index.html
@@ -10,8 +10,6 @@ tags:
   - Role
   - listitem
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p class="summary">The ARIA <code>listitem</code> role can be used to identify an item inside a list of items. It is normally used in conjunction with the <code>list</code> role, which is used to identify a list container.</p>
 
 <pre class="brush: html">&lt;section role="list"&gt;
@@ -38,7 +36,7 @@ tags:
  <dd>
  <p>A list of items. Elements with role <code>list</code> must have one or more elements with the role <code>listitem</code> as children, a one or more elements with the role of <code>group</code> that have one or more elements with the <code>listitem</code> role as children.</p>
  </dd>
- <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Group_role" rel="nofollow">group</a></dt>
+ <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role" rel="nofollow">group</a></dt>
  <dd>
  <p>A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a pages table of contents.</p>
  </dd>
@@ -112,5 +110,11 @@ tags:
  <li><a href="/en-US/docs/Web/HTML/Element/ul">HTML <code>&lt;ul&gt;</code> element</a></li>
  <li><a href="/en-US/docs/Web/HTML/Element/ol">HTML <code>&lt;ol&gt;</code> element</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/List_role">ARIA: list role</a></li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Group_role" rel="nofollow">ARIA: group role</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/group_role" rel="nofollow">ARIA: group role</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/main_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/main_role/index.html
@@ -7,8 +7,6 @@ tags:
   - Reference
   - role-main
 ---
-<p>{{draft}}{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</p>
-
 <p>The <code>main</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> is used to indicate the primary content of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.</p>
 
 <pre class="brush: html">&lt;div id="main" role="main"&gt;
@@ -129,3 +127,9 @@ tags:
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="http://html5doctor.com/the-main-element/">The main element | HTML5 Doctor</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/mark_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/mark_role/index.html
@@ -8,8 +8,6 @@ tags:
   - annotations
   - mark
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The <code>mark</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> semantically denotes HTML elements containing text that is marked/highlighted for reference purposes. This is semantically equivalent to the HTML <a href="/en-US/docs/Web/HTML/Element/mark">&lt;mark&gt;</a> element. If possible, you should use this element instead.</p>
 
 <h2 id="Examples">Examples</h2>
@@ -52,3 +50,9 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Annotations">ARIA annotations</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/navigation_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/navigation_role/index.html
@@ -7,8 +7,6 @@ tags:
   - Reference
   - role-navigation
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The <code>navigation</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> is used to identify major groups of links used for navigating through a website or page content.</span></p>
 
 <pre class="brush: html">&lt;div role="navigation" aria-label="Main"&gt;
@@ -149,3 +147,10 @@ tags:
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="http://html5doctor.com/nav-element/">Semantic navigation with the nav element | HTML5 Doctor</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/region_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/region_role/index.html
@@ -9,8 +9,6 @@ tags:
   - landmark role
   - role-region
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The <strong><code>region</code></strong> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> is used to identify an area in the document that the author has identified as significant. It is used to provide a generic landmark for people to be able to navigate to easily when none of the other landmark roles are appropriate.</span></p>
 
 <pre class="brush: html">&lt;div role="region" aria-label="Example"&gt;
@@ -134,3 +132,10 @@ tags:
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
  <li><a href="http://html5doctor.com/the-section-element/">The section element | HTML5 Doctor</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/role_img/index.html
+++ b/files/en-us/web/accessibility/aria/roles/role_img/index.html
@@ -10,8 +10,6 @@ tags:
   - Role
   - figure
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The ARIA <code>img</code> role can be used to identify multiple elements inside page content that should be considered as a single image. These elements could be images, code snippets, text, emojis, or other content that can be combined to deliver information in a visual manner.</p>
 
 <pre class="brush: html">&lt;div role="img" aria-label="Description of the overall image"&gt;
@@ -119,3 +117,10 @@ tags:
  <li><a href="https://wicg.github.io/aom/spec/">Accessibility Object Model</a></li>
  <li><a href="https://w3c.github.io/html-aria/">ARIA in HTML</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/row_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/row_role/index.html
@@ -10,9 +10,7 @@ tags:
   - Reference
   - Row Role
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
-<p>An element with <code>role="row"</code> is a row of cells within a tabular structure. A row contains one or more cells,  grid cells or column headers, and possibly a row header, within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a></code>, <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">table</a></code> or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Treegrid_Role">treegrid</a></code>, and optionally within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">rowgroup</a></code>.</p>
+<p>An element with <code>role="row"</code> is a row of cells within a tabular structure. A row contains one or more cells,  grid cells or column headers, and possibly a row header, within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a></code>, <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">table</a></code> or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role">treegrid</a></code>, and optionally within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">rowgroup</a></code>.</p>
 
 <pre class="brush: html">&lt;div role="table" aria-label="Populations" aria-describedby="country_population_desc"&gt;
    &lt;div id="country_population_desc"&gt;World Populations by Country&lt;/div&gt;
@@ -37,7 +35,7 @@ tags:
 
 <h2 id="Description">Description</h2>
 
-<p>The element <code>role="row"</code> is a row within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a></code>, <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">table</a></code> or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Treegrid_Role">treegrid</a></code>, and optionally within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">rowgroup</a></code>, that is a container for one or more <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_Role">cells</a></code>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role"><code>gridcells</code></a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role"><code>columnheaders</code></a>, or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowheader_Role"><code>rowheaders</code></a> within a static tabular structure. Using native <a href="/en-US/docs/Web/HTML/Element/tr">HTML <code>&lt;tr&gt;</code></a> elements, whenever possible, is strongly encouraged.</p>
+<p>The element <code>role="row"</code> is a row within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a></code>, <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">table</a></code> or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role">treegrid</a></code>, and optionally within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Rowgroup_Role">rowgroup</a></code>, that is a container for one or more <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_Role">cells</a></code>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role"><code>gridcells</code></a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role"><code>columnheaders</code></a>, or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role"><code>rowheaders</code></a> within a static tabular structure. Using native <a href="/en-US/docs/Web/HTML/Element/tr">HTML <code>&lt;tr&gt;</code></a> elements, whenever possible, is strongly encouraged.</p>
 
 <p>To create an ARIA row, add <code>role="row"</code> to the container element. That row should be nested within a grid, table or treegrid. A group of rows can be nested within a grid, table or treegrid directly, or within a rowgroup in one of those containers. Each row contains child cells. These cells can be of different types, depending on whether they are column or row headers, or grid or regular cells.</p>
 
@@ -45,7 +43,7 @@ tags:
 
 <p>If the row is within a treegrid, rows can include the <code>aria-expanded</code> attribute, using the attribute to indicate the present status. This is not the case for an ordinary table or grid, in which the aria-expanded attribute is not present.</p>
 
-<p>To create an interactive widget that has a tabular structure, use the grid pattern instead. If the interaction provides for the selection state of individual cells, if left to right and top to bottom navigation is provided, or if the user interface allows the rearranging of cell order or otherwise changing individual cell order such as through drag and drop, use <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Treegrid_Role">treegrid</a> instead.</p>
+<p>To create an interactive widget that has a tabular structure, use the grid pattern instead. If the interaction provides for the selection state of individual cells, if left to right and top to bottom navigation is provided, or if the user interface allows the rearranging of cell order or otherwise changing individual cell order such as through drag and drop, use <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role">treegrid</a> instead.</p>
 
 <div class="note">
 <p>Note: Using the native HTML table element (&lt;table&gt;) along with the table row element (&lt;tr&gt;) whenever possible is strongly encouraged.</p>
@@ -62,7 +60,7 @@ tags:
  <dd>One of the three possible contexts (along with grid and treegrid) in which you'll find a row, it identifies the row as being part of a non-interactive table structure containing data arranged in rows and columns, similar to the native &lt;table&gt; HTML element. </dd>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">role="grid"</a></dt>
  <dd>One of the three possible contexts (along with table and treegrid) in which you'll find a row, it identifies the row as being part of a non-interactive table structure containing data arranged in rows and columns, similar to the native &lt;table&gt; HTML element.</dd>
- <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridtree_Role">role="treegrid"</a></dt>
+ <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/gridtree_role">role="treegrid"</a></dt>
  <dd>Similar to a grid, but with rows that can be expanded and collapsed in the same manner as for a tree.</dd>
 </dl>
 
@@ -71,7 +69,7 @@ tags:
 <dl>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_Role">role="cell"</a></dt>
  <dd>A cell in a row within a tabular container.</dd>
- <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_Role">role="gridcell"</a></dt>
+ <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">role="gridcell"</a></dt>
  <dd>A cell in a row within a grid or treegrid.</dd>
  <dt>role="columnheader"</dt>
  <dd>A header cell that is the structural equivalent of the HTML &lt;th&gt; element with a column scope. Unlike a plain cell, the columnheader role establishes a relationship between it and all cells in the corresponding column. </dd>
@@ -126,7 +124,7 @@ tags:
 
 <h3 id="Required_JavaScript_features">Required JavaScript features</h3>
 
-<p>None. For sortable columns, see the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role">columnheader</a> aria role.</p>
+<p>None. For sortable columns, see the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role">columnheader</a> aria role.</p>
 
 <div class="note">
 <p><span class="ILfuVd yZ8quc">The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and <strong>adding</strong> an ARIA role, state or property to make it accessible, then do so. Employ the HTML &lt;table&gt; element instead of the ARIA role of table whenever possible.</span></p>
@@ -227,3 +225,10 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/HTML/Element/tr">HTML table row</a></li>
 </ul>
+
+
+<section id="Quick_links">
+   <ol>
+     <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+   </ol>
+ </section>

--- a/files/en-us/web/accessibility/aria/roles/rowgroup_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/rowgroup_role/index.html
@@ -8,8 +8,6 @@ tags:
   - rowgroup
   - table
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>An element with <code>role="rowgroup"</code> is a group of <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role">rows</a> within a tabular structure. A <code>rowgroup</code> contains one or more rows of <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_Role">cells</a>,  <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">grid cells</a>, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role">column headers</a>, or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_Role">row headers</a> within a <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">grid</a></code>, <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">table</a></code> or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Treegrid_Role" rel="nofollow">treegrid</a></code>.</p>
 
 <pre class="brush: html">&lt;div role="table" aria-label="Populations" aria-describedby="country_population_desc"&gt;
@@ -60,7 +58,7 @@ tags:
 
 <dl>
  <dt><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Row_Role">role="row"</a></dt>
- <dd>A row of cells within a tabular structure. A row contains one or more <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_Role">cells</a>,  <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_Role">gridcell</a>, or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role">column headers</a>, and sometimes a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_Role">row header</a>.</dd>
+ <dd>A row of cells within a tabular structure. A row contains one or more <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Cell_Role">cells</a>,  <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role">gridcell</a>, or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Columnheader_Role">column headers</a>, and sometimes a <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_Role">row header</a>.</dd>
 </dl>
 
 <h3 id="Keyboard_interactions">Keyboard interactions</h3>
@@ -161,3 +159,9 @@ tags:
  <li><a href="/en-US/docs/Web/HTML/Element/tfoot">HTML table footer</a></li>
  <li><a href="/en-US/docs/Web/HTML/Element/thead">HTML table header</a></li>
 </ul>
+
+<section id="Quick_links">
+   <ol>
+     <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+   </ol>
+ </section>

--- a/files/en-us/web/accessibility/aria/roles/search_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/search_role/index.html
@@ -7,8 +7,6 @@ tags:
   - Reference
   - role-search
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The <code>search</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> is used to identify a section of the page used to search the page, site, or collection of sites.</span></p>
 
 <pre class="brush: html">&lt;form role="search"&gt;
@@ -120,3 +118,9 @@ tags:
  <li><a href="https://developer.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013 | The Paciello Group</a></li>
  <li><a href="https://www.scottohara.me/blog/2018/03/03/landmarks.html">Accessible Landmarks | scottohara.me</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/suggestion_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/suggestion_role/index.html
@@ -8,8 +8,6 @@ tags:
   - annotations
   - suggestion
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The <code>suggestion</code> <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles">landmark role</a> semantically denotes a single proposed change to an editable document. This should be used on an element that wraps an element with an <code>insertion</code> role, and one with a <code>deletion</code> role.</p>
 
 <h2 id="Examples">Examples</h2>
@@ -59,3 +57,10 @@ tags:
 <ul>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Annotations">ARIA annotations</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.html
@@ -11,8 +11,6 @@ tags:
   - a11y
   - toggle
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The ARIA <strong><code>switch</code></strong> role is functionally identical to the <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a> role, except that instead of representing "checked" and "unchecked" states, which are fairly generic in meaning, the <code>switch</code> role represents the states "on" and "off."</span></p>
 
 <p>This example creates a widget and assigns the ARIA <code>switch</code> role to it.</p>
@@ -191,3 +189,10 @@ label.switch {
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role">ARIA: checkbox role</a></li>
  <li><code><a href="en-US/docs/Web/HTML/Element/input/checkbox">&lt;input type="checkbox"&gt;</a></code></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/tab_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/tab_role/index.html
@@ -8,8 +8,6 @@ tags:
   - ARIA widget
   - Reference
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The ARIA <code>tab</code> role indicates an interactive element inside a <code>tablist</code> that, when activated, displays its associated <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Tabpanel_Role"><code>tabpanel</code></a>.</span></p>
 
 <pre class="brush: html">&lt;button role="tab" aria-selected="true" aria-controls="tabpanel-id" id="tab-id"&gt;Tab label&lt;/button&gt;</pre>
@@ -232,3 +230,11 @@ function changeTabs(e) {
 <h2 id="Screen_reader_support">Screen reader support</h2>
 
 <p>TBD</p>
+
+
+<section id="Quick_links">
+	<ol>
+	  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+	</ol>
+</section>
+

--- a/files/en-us/web/accessibility/aria/roles/table_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/table_role/index.html
@@ -10,8 +10,6 @@ tags:
   - Reference
   - Table Role
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>The table value of the ARIA role attribute identifies the element containing the role as having a non-interactive table structure containing data arranged in rows and columns, similar to the native <a href="/en-US/docs/Web/HTML/Element/table"><code>&lt;table&gt;</code></a> HTML element.</p>
 
 <pre class="brush: html">&lt;div role="table" aria-label="Semantic Elements" aria-describedby="semantic_elements_table_desc" aria-rowcount="81"&gt;
@@ -160,3 +158,10 @@ tags:
  <li><a href="/en-US/docs/Learn/HTML/Tables/Advanced">HTML table element</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Grid_Role">ARIA: grid role</a></li>
 </ul>
+
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.html
@@ -9,13 +9,11 @@ tags:
   - ARIA widget
   - Reference
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p>{{draft}}</p>
 
 <p>The ARIA tabpanel role indicates</p>
 
-<pre class="brush: html"> </pre>
+<pre class="brush: html">TBD</pre>
 
 <h2 id="Description">Description</h2>
 
@@ -109,3 +107,9 @@ id="tab-id" tabindex="0"&gt;Tab label&lt;/div&gt; </pre>
 <h2 id="Screen_reader_support">Screen reader support</h2>
 
 <p>TBD</p>
+
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/textbox_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/textbox_role/index.html
@@ -6,8 +6,6 @@ tags:
   - Accessibility
   - NeedsContent
 ---
-<div>{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}</div>
-
 <p><span class="seoSummary">The <code>textbox</code> role is used to identify an element that allows the input of free-form text. </span>Whenever possible, rather than using this role, use an {{HTMLElement("input")}} element with <a href="/en-US/docs/Web/HTML/Element/input/text">type="text"</a>, for single-line input, or a {{HTMLElement("textarea")}} element for multi-line input.</p>
 
 <h2 id="Description">Description</h2>
@@ -120,5 +118,12 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox">ARIA: search role</a></li>
+	<li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role">ARIA: search role</a></li>
 </ul>
+
+
+<section id="Quick_links">
+	<ol>
+	  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+	</ol>
+  </section>

--- a/files/en-us/web/xpath/comparison_with_css_selectors/index.html
+++ b/files/en-us/web/xpath/comparison_with_css_selectors/index.html
@@ -9,7 +9,7 @@ tags:
   - Selectors
   - XPath
 ---
-<p>{{XSLTRef}}{{Page("/en-US/docs/Web/XPath", "Subnav")}}{{Draft}}</p>
+<p>{{XSLTRef}}{{Draft}}</p>
 
 <p class="summary">This article seeks to document the difference between CSS Selectors and XPath for web developers to be able to better choose the right tool for the right job.</p>
 
@@ -47,3 +47,26 @@ tags:
   </tr>
  </tbody>
 </table>
+
+
+<section id="Quick_links">
+  <ol>
+   <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
+   <li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
+   <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
+   <li class="toggle">
+    <details open><summary>Guides</summary>
+    <ol>
+     <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li>
+     <li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li>
+    </ol>
+    </details>
+   </li>
+   <li class="toggle">
+    <details open><summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}</details>
+   </li>
+   <li class="toggle">
+    <details open><summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}</details>
+   </li>
+  </ol>
+  </section>


### PR DESCRIPTION
Fixes up sidebar on all 37 AriaRoles docs (as part of removing `{{Page}}` macro (FYI @wbamberg).

In summary, all the aria role docs had `{{Page("/en-US/docs/Web/Accessibility/ARIA/Roles", "Subnav")}}` which was supposed to generate the sidebar from the Subnav heading in parent doc. However "Subnav" sections got removed at some point as sidebars are done differently. 

Instead, this now uses the "Quick_links" section to generate the intended effect. 

It also fixes a few broken links, and changes the names of some broken links to lower case (which may not have been necessary, but seemed consistent when I started, and is non harmful).


EDITED. Also added XPath comparison doc fix (only other case ofa page import of a subnav). I took the quicklinks from the XPath page - so it matches the expected sidebar.