### PR TITLE
Skipping indentation on the first paragraph

### DIFF
--- a/files/en-us/web/css/text-indent/index.html
+++ b/files/en-us/web/css/text-indent/index.html
@@ -84,6 +84,61 @@ text-indent: unset;
 
 <p>{{ EmbedLiveSample('Simple_indent','100%','100%') }}</p>
 
+<h3 id="Skipping_indentation_on_the_first_paragraph">Skipping indentation on the first paragraph</h3>
+
+<p>A common typographic practice when paragraph indentation is present is to skip the indentation for the first paragraph. As the <em>The Chicago Manual of Style</em> puts it, &ldquo;the first line of text following a subhead may begin flush left or be indented by the usual paragraph indention.&rdquo;</p>
+
+<p>Treating differently first paragraphs from the other paragraphs can be done using the <a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">adjacent sibling combinator</a>, as in the following example:</p>
+
+<h4 id="HTML">HTML</h4>
+
+<pre class="brush: html">&lt;h2&gt;Lorem ipsum&lt;/h2&gt;
+
+&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse eu
+venenatis quam. Vivamus euismod eleifend metus vitae pharetra. In vel tempor metus.
+Donec dapibus feugiat euismod. Vivamus interdum tellus dolor. Vivamus blandit eros
+et imperdiet auctor. Mauris sapien nunc, condimentum a efficitur non, elementum ac
+sapien. Cras consequat turpis non augue ullamcorper, sit amet porttitor dui
+interdum.&lt;/p&gt;
+
+&lt;p&gt;Sed laoreet luctus erat at rutrum. Proin velit metus, luctus in sapien in,
+tincidunt mattis ex. Praesent venenatis orci at sagittis eleifend. Nulla facilisi.
+In feugiat vehicula magna iaculis vehicula. Nulla suscipit tempor odio a semper.
+Donec vitae dapibus ipsum. Donec libero purus, convallis eu efficitur id, pulvinar
+elementum diam. Maecenas mollis blandit placerat. Ut gravida pellentesque nunc, in
+eleifend ante convallis sit amet.&lt;/p&gt;
+
+&lt;h2&gt;Donec ullamcorper elit nisl&lt;/h2&gt;
+
+&lt;p&gt;Donec ullamcorper elit nisl, sagittis bibendum massa gravida in. Fusce
+tempor in ante gravida iaculis. Integer posuere tempor metus. Vestibulum lacinia,
+nunc et dictum viverra, urna massa aliquam tellus, id mollis sem velit vestibulum
+nulla. Pellentesque habitant morbi tristique senectus et netus et malesuada fames
+ac turpis egestas. Donec vulputate leo ut iaculis ultrices. Cras egestas rhoncus
+lorem. Nunc blandit tempus lectus, rutrum hendrerit orci eleifend id. Ut at quam
+velit.&lt;/p&gt;
+
+&lt;p&gt;Aenean rutrum tempor ligula, at luctus ligula auctor vestibulum. Sed
+sollicitudin velit in leo fringilla sollicitudin. Proin eu gravida arcu. Nam
+iaculis malesuada massa, eget aliquet turpis sagittis sed. Sed mollis tellus ac
+dui ullamcorper, nec lobortis diam pellentesque. Quisque dapibus accumsan libero,
+sed euismod ipsum ullamcorper sed.&lt;/p&gt;</pre>
+
+<h4 id="CSS">CSS</h4>
+
+<pre class="brush: css">p {
+&nbsp;&nbsp;&nbsp;&nbsp;text-align: justify;
+&nbsp;&nbsp;&nbsp;&nbsp;margin: 1em 0 0 0;
+}</p>
+<p>p + p {
+&nbsp;&nbsp;&nbsp;&nbsp;text-indent: 1em;
+&nbsp;&nbsp;&nbsp;&nbsp;margin: 0;
+}</pre>
+
+<h4 id="Result">Result</h4>
+
+<p>{{ EmbedLiveSample('Skipping_indentation_on_the_first_paragraph','100%','100%') }}</p>
+
 <h3 id="Percentage_indent">Percentage indent</h3>
 
 <h4 id="HTML_2">HTML</h4>

--- a/files/en-us/web/css/text-indent/index.html
+++ b/files/en-us/web/css/text-indent/index.html
@@ -88,7 +88,7 @@ text-indent: unset;
 
 <p>A common typographic practice when paragraph indentation is present is to skip the indentation for the first paragraph. As the <em>The Chicago Manual of Style</em> puts it, &ldquo;the first line of text following a subhead may begin flush left or be indented by the usual paragraph indention.&rdquo;</p>
 
-<p>Treating differently first paragraphs from the other paragraphs can be done using the <a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">adjacent sibling combinator</a>, as in the following example:</p>
+<p>Treating first paragraphs differently from subsequent paragraphs can be done using the <a href="/en-US/docs/Web/CSS/Adjacent_sibling_combinator">adjacent sibling combinator</a>, as in the following example:</p>
 
 <h4 id="HTML">HTML</h4>
 
@@ -127,17 +127,17 @@ sed euismod ipsum ullamcorper sed.&lt;/p&gt;</pre>
 <h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">p {
-&nbsp;&nbsp;&nbsp;&nbsp;text-align: justify;
-&nbsp;&nbsp;&nbsp;&nbsp;margin: 1em 0 0 0;
+    text-align: justify;
+    margin: 1em 0 0 0;
 }</p>
 <p>p + p {
-&nbsp;&nbsp;&nbsp;&nbsp;text-indent: 1em;
-&nbsp;&nbsp;&nbsp;&nbsp;margin: 0;
+    text-indent: 1em;
+    margin: 0;
 }</pre>
 
 <h4 id="Result">Result</h4>
 
-<p>{{ EmbedLiveSample('Skipping_indentation_on_the_first_paragraph','100%','100%') }}</p>
+<p>{{ EmbedLiveSample('Skipping_indentation_on_the_first_paragraph','','500px') }}</p>
 
 <h3 id="Percentage_indent">Percentage indent</h3>
 

--- a/files/en-us/web/css/text-indent/index.html
+++ b/files/en-us/web/css/text-indent/index.html
@@ -131,7 +131,7 @@ sed euismod ipsum ullamcorper sed.&lt;/p&gt;</pre>
     margin: 1em 0 0 0;
 }</p>
 <p>p + p {
-    text-indent: 1em;
+    text-indent: 2em;
     margin: 0;
 }</pre>
 


### PR DESCRIPTION
Added a sample usage of

``` css
p {
	text-align: justify;
	margin: 1em 0 0 0;
}

p + p {
	text-indent: 1em;
	margin: 0;
}
```