### PR TITLE
Update instanceof check to use WebAssembly.RuntimeError

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.html
@@ -55,13 +55,13 @@ tags:
 <pre class="brush: js">try {
   throw new WebAssembly.RuntimeError('Hello', 'someFile', 10);
 } catch (e) {
-  console.log(e instanceof RuntimeError); // true
-  console.log(e.message);                 // "Hello"
-  console.log(e.name);                    // "RuntimeError"
-  console.log(e.fileName);                // "someFile"
-  console.log(e.lineNumber);              // 10
-  console.log(e.columnNumber);            // 0
-  console.log(e.stack);                   // returns the location where the code was run
+  console.log(e instanceof WebAssembly.RuntimeError); // true
+  console.log(e.message);                             // "Hello"
+  console.log(e.name);                                // "RuntimeError"
+  console.log(e.fileName);                            // "someFile"
+  console.log(e.lineNumber);                          // 10
+  console.log(e.columnNumber);                        // 0
+  console.log(e.stack);                               // returns the location where the code was run
 }</pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.html
@@ -40,13 +40,13 @@ tags:
 <pre class="brush: js">try {
   throw new WebAssembly.RuntimeError('Hello', 'someFile', 10);
 } catch (e) {
-  console.log(e instanceof RuntimeError); // true
-  console.log(e.message);                 // "Hello"
-  console.log(e.name);                    // "RuntimeError"
-  console.log(e.fileName);                // "someFile"
-  console.log(e.lineNumber);              // 10
-  console.log(e.columnNumber);            // 0
-  console.log(e.stack);                   // returns the location where the code was run
+  console.log(e instanceof WebAssembly.RuntimeError); // true
+  console.log(e.message);                             // "Hello"
+  console.log(e.name);                                // "RuntimeError"
+  console.log(e.fileName);                            // "someFile"
+  console.log(e.lineNumber);                          // 10
+  console.log(e.columnNumber);                        // 0
+  console.log(e.stack);                               // returns the location where the code was run
 }</pre>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
### Affected pages:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RunTimeError

### Issue:
Code examples on both pages are constructing `RuntimeError` using `WebAssembly.RuntimeError`, however, when performing `instanceof` check, they are using `RuntimeError` directly, which is not available outside of without `WebAssembly` namespace.

### Fix:
Replace `e instanceof RuntimeError` with `e instanceof WebAssembly.RuntimeError`
