### PR TITLE
Fix two jsref calls to apiref

### DIFF
--- a/files/en-us/web/api/arraybufferview/index.html
+++ b/files/en-us/web/api/arraybufferview/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - Typed Arrays
 ---
-<p>{{JSRef("Global_Objects", "TypedArray", "Int8Array,Uint8Array,Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array")}}</p>
+<p>{{APIRef}}</p>
 
 <p><code><strong>ArrayBufferView</strong></code> is a helper type representing any of the following JavaScript {{jsxref("TypedArray")}} types:</p>
 

--- a/files/en-us/web/api/buffersource/index.html
+++ b/files/en-us/web/api/buffersource/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - Typed Arrays
 ---
-<div>{{JSRef("Global_Objects", "ArrayBuffer")}}</div>
+<div>{{APIRef}}</div>
 
 <p><code><strong>BufferSource</strong></code> is a typedef used to represent objects that are either themselves an {{jsxref("ArrayBuffer")}}, or which are a {{jsxref("TypedArray")}} providing an {{domxref("ArrayBufferView")}}.</p>
 


### PR DESCRIPTION
Closes https://github.com/mdn/content/issues/3407

There are JS sidebars on these pages
https://developer.mozilla.org/en-US/docs/Web/API/buffersource
https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView

As this lives under API/, the sidebar is usually `APIRef`. 

I could have given APIRef a group like `{{APIRef("WebGL")}}`, so that the sidebar isn't empty, but ArrayBufferView and BufferSource aren't just WebGL types, so I went with no group. Will render an empty sidebar but at least not a JS sidebar.