### PR TITLE
Make ::selection allowed-properties list match spec

### DIFF
--- a/files/en-us/web/css/_doublecolon_selection/index.html
+++ b/files/en-us/web/css/_doublecolon_selection/index.html
@@ -23,11 +23,9 @@ tags:
 <ul>
  <li>{{CSSxRef("color")}}</li>
  <li>{{CSSxRef("background-color")}}</li>
- <li>{{CSSxRef("caret-color")}}</li>
- <li>{{CSSxRef("outline")}} and its longhands</li>
  <li>{{CSSxRef("text-decoration")}} and its associated properties</li>
- <li>{{CSSxRef("text-emphasis-color")}}</li>
  <li>{{CSSxRef("text-shadow")}}</li>
+ <li>{{CSSxRef("stroke-color")}}, {{CSSxRef("fill-color")}} and {{CSSxRef("stroke-width")}}</li>
 </ul>
 
 <div class="warning">

--- a/files/en-us/web/css/_doublecolon_selection/index.html
+++ b/files/en-us/web/css/_doublecolon_selection/index.html
@@ -23,7 +23,6 @@ tags:
 <ul>
  <li>{{CSSxRef("color")}}</li>
  <li>{{CSSxRef("background-color")}}</li>
- <li>{{CSSxRef("cursor")}}</li>
  <li>{{CSSxRef("caret-color")}}</li>
  <li>{{CSSxRef("outline")}} and its longhands</li>
  <li>{{CSSxRef("text-decoration")}} and its associated properties</li>


### PR DESCRIPTION
Replaced the list of the accepted properties to use with ::selection as described in spec 
https://drafts.csswg.org/css-pseudo-4/#highlight-styling