### PR TITLE
adding RFCs explainer readme

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,45 @@
+# MDN RFCs
+
+MDN RFC (Request for Comment) documents are intended to concisely summarize a
+proposal for a larger work item that we should consider doing on MDN. This
+includes what problems are being solved by the work, what benefits it brings to
+MDN and the wider web industry, how much effort it will take, and what the
+work involves.
+
+Once submitted, RFCs are used to assess and prioritize upcoming MDN work. They
+are considered as part of our [Content opportunity assessment](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Processes/Workstream_assessment_project#content_opportunity_assessment)
+process.
+
+## What should the RFC contain?
+
+The RFC should contain the following:
+
+- A title and opening paragraph that summarizes the work proposed by the RFC.
+- Problem statement: A paragraph that explains why we should do this work, in
+  the form of a problem statement — a problem that MDN/the web industry
+  currently faces, and what we should do about it.
+- Priority assessment: A list of criteria that each RFC is assessed against,
+  with a description of how the RFC scores against each one. This section uses
+  the [OWD prioritization criteria](https://github.com/openwebdocs/project/blob/main/steering-committee/prioritization-criteria.md).
+- Proposed solutions: At a high level, what solution or solutions are being
+  proposed to fix the problem stated earlier?
+- Task list: A lower-level set of tasks that would need to be completed to
+  implement the solution(s) detailed above. This obviously can't be 100%
+  accurate at the planning stage; rough ideas are fine for now.
+
+When creating a new RFC, use an existing RFC as a template.
+
+## Submitting an RFC
+
+Submit your RFC as a markdown file in this directory of the `content` repo,
+as a PR.
+
+## Getting feedback
+
+Once written, an RFC document should be sent around to key stakeholders that
+can provide the most valuable feedback on the document, for example MDN core
+writers or engineers, [MDN PAB](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board)
+members, [Open Web Docs](https://github.com/openwebdocs/) members, writers of
+associated technology specifications, etc.
+
+The MDN team are happy to help you with this; feel free to ask on submission.


### PR DESCRIPTION
Adding README to the RFCs folder, to explain the process of submitting them, what they are for, etc. Fixes https://github.com/mdn/pab/issues/82