### PR TITLE
Update fetch() vs jQuery.ajax() list intro in “Using Fetch”

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as {{domxref("Service_Worker_API", "Service Workers")}}. Fetch also provides a single logical place to define other HTTP-related concepts such as CORS and extensions to HTTP.</p>
 
-<p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in two main ways:</p>
+<p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in the following ways:</p>
 
 <ul>
  <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, it will resolve normally (with <code>ok</code> status set to false), and it will only reject on network failure or if anything prevented the request from completing.</li>

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as {{domxref("Service_Worker_API", "Service Workers")}}. Fetch also provides a single logical place to define other HTTP-related concepts such as CORS and extensions to HTTP.</p>
 
-<p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in the following ways:</p>
+<p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in the following significant ways:</p>
 
 <ul>
  <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, it will resolve normally (with <code>ok</code> status set to false), and it will only reject on network failure or if anything prevented the request from completing.</li>

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>This kind of functionality was previously achieved using {{domxref("XMLHttpRequest")}}. Fetch provides a better alternative that can be easily used by other technologies such as {{domxref("Service_Worker_API", "Service Workers")}}. Fetch also provides a single logical place to define other HTTP-related concepts such as CORS and extensions to HTTP.</p>
 
-<p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in three main ways:</p>
+<p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in two main ways:</p>
 
 <ul>
  <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, it will resolve normally (with <code>ok</code> status set to false), and it will only reject on network failure or if anything prevented the request from completing.</li>


### PR DESCRIPTION
The list of main differences in the fetch API was reduced from 3 items to 2 items in this PR- [https://github.com/mdn/content/pull/2558](https://github.com/mdn/content/pull/2558). This changes the description of the list to match the contents of the the list.

This is a small nitpick, but will prevent others from looking for a third difference that does not exist.