### PR TITLE
Deprecate BluetoothRemoteGATTCharacteristic.writeValue

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
@@ -11,7 +11,9 @@ tags:
 - Web Bluetooth API
 - writeValue
 ---
-<p>{{SeeCompatTable}}</p>
+<p>{{Deprecated_header}}</p>
+
+<p>Use <code>writeValueWithResponse()</code> and <code>writeValueWithoutResponse()</code> instead.</p>
 
 <p>The <strong><code>BluetoothRemoteGATTCharacteristic.writeValue()</code></strong> method
   sets the value property to the bytes contained in an {{jsxref("ArrayBuffer")}} and


### PR DESCRIPTION
See https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
See https://github.com/WebBluetoothCG/web-bluetooth/issues/238

Related: https://github.com/mdn/browser-compat-data/pull/9572

Fixes https://github.com/mdn/content/issues/3382