### PR TITLE
Re-word stuff about integers in JS intro doc

### DIFF
--- a/files/en-us/web/javascript/a_re-introduction_to_javascript/index.html
+++ b/files/en-us/web/javascript/a_re-introduction_to_javascript/index.html
@@ -61,7 +61,9 @@ tags:
 
 <h2 id="Numbers">Numbers</h2>
 
-<p>Numbers in JavaScript are "double-precision 64-bit format IEEE 754 values", according to the spec —  There's <strong><em>no such thing as an integer</em></strong> in JavaScript (except {{jsxref("BigInt")}}), so you have to be a little careful. See this example:</p>
+<p>ECMAScript has two built-in numeric types: <strong>Number</strong> and <strong>BigInt</strong>.</p>
+
+<p>The Number type is a <a href="https://en.wikipedia.org/wiki/Double_precision_floating-point_format">double-precision 64-bit binary format IEEE 754 value</a> (numbers between -(2<sup>53</sup> − 1) and 2<sup>53</sup> − 1). And where this article and other MDN articles refer to “integers”, what’s usually meant is a <em>representation</em> of an integer using a Number value. But because such Number values aren’t real integers, you have to be a little careful. For example:</p>
 
 <pre class="brush: js">console.log(3 / 2);             // 1.5, <em>not</em> 1
 console.log(Math.floor(3 / 2)); // 1</pre>


### PR DESCRIPTION
Replace emphatic “There's no such thing as an integer in JavaScript” statement with explanation that in MDN, “integer” usually means a representation of an integer using a Number value. Fixes https://github.com/mdn/content/issues/3391