### PR TITLE
Fixed some flaws in JavaScript/Reference/Global_Objects

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/index.html
@@ -15,9 +15,9 @@ tags:
 
 <p>The <strong>global object</strong> itself can be accessed using the {{JSxRef("Operators/this", "this")}} operator in the global scope. In fact, the global scope <strong>consists of</strong> the properties of the global object, including inherited properties, if any.</p>
 
-<p>Other objects in the global scope are either <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Creating_new_objects">created by the user script</a> or provided by the host application. The host objects available in browser contexts are documented in the <a href="/en-US/docs/Web/API/Reference">API reference</a>.</p>
+<p>Other objects in the global scope are either <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#creating_new_objects">created by the user script</a> or provided by the host application. The host objects available in browser contexts are documented in the <a href="/en-US/docs/Web/API">API reference</a>.</p>
 
-<p>For more information about the distinction between the <a href="/en-US/docs/DOM/DOM_Reference">DOM</a> and core <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, see <a href="/en-US/docs/Web/JavaScript/JavaScript_technologies_overview">JavaScript technologies overview</a>.</p>
+<p>For more information about the distinction between the <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> and core <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, see <a href="/en-US/docs/Web/JavaScript/JavaScript_technologies_overview">JavaScript technologies overview</a>.</p>
 
 <h2 id="Standard_objects_by_category">Standard objects by category</h2>
 
@@ -177,13 +177,13 @@ tags:
 <div class="twocolumns">
 <ul>
  <li>{{JSxRef("Intl")}}</li>
- <li>{{JSxRef("Global_Objects/Collator", "Intl.Collator")}}</li>
- <li>{{JSxRef("Global_Objects/DateTimeFormat", "Intl.DateTimeFormat")}}</li>
- <li>{{JSxRef("Global_Objects/ListFormat", "Intl.ListFormat")}}</li>
- <li>{{JSxRef("Global_Objects/NumberFormat", "Intl.NumberFormat")}}</li>
- <li>{{JSxRef("Global_Objects/PluralRules", "Intl.PluralRules")}}</li>
- <li>{{JSxRef("Global_Objects/RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
- <li>{{JSxRef("Global_Objects/Locale", "Intl.Locale")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/Collator", "Intl.Collator")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/DateTimeFormat", "Intl.DateTimeFormat")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/ListFormat", "Intl.ListFormat")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/NumberFormat", "Intl.NumberFormat")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/PluralRules", "Intl.PluralRules")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/RelativeTimeFormat", "Intl.RelativeTimeFormat")}}</li>
+ <li>{{JSxRef("Global_Objects/Intl/Locale", "Intl.Locale")}}</li>
 </ul>
 </div>
 


### PR DESCRIPTION
There were some broken JSxRef and other links on JavaScript/Reference/Global_Objects.  The fixes here are entirely of the “click the ‘Fix fixable flaws’ button” variety.  There are still two broken links outstanding on the page; they were not fixed by clicking the button, and I was reluctant to slow down the extant fixes while trying to figure out how to fix the other two. 

If there’s an issue relating to any of this, I don’t know about it.  I just happened across the flaws while preparing to do other work.