### PR TITLE
Remove deprecated String.prototype.substr()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.html
@@ -370,9 +370,6 @@ otherwise my code is unreadable."
     "String.prototype.startsWith(<var>searchString</var> [, <var>length</var>])")}}</dt>
   <dd>Determines whether the calling string begins with the characters of string
     <code><var>searchString</var></code>.</dd>
-  <dt>{{jsxref("String.prototype.substr()")}}</dt>
-  <dd>Returns the characters in a string beginning at the specified location through the
-    specified number of characters.</dd>
   <dt>{{jsxref("String.prototype.substring()",
     "String.prototype.substring(<var>indexStart</var> [, <var>indexEnd</var>])")}}</dt>
   <dd>Returns a new string containing characters of the calling string from (or between)


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The Instance methods section does not generally list methods marked with a "thumbs down" elsewhere in the String documentation (like in the browser compatibility table at the bottom). However, `substr()` is still listed. This may be an oversight, and if so, this listing should be removed.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String

> Issue number (if there is an associated issue)
N/A

> Anything else that could help us review it
N/A