### PR TITLE
adds color-contrast()

### DIFF
--- a/files/en-us/web/css/color_value/color-contrast()/index.html
+++ b/files/en-us/web/css/color_value/color-contrast()/index.html
@@ -24,7 +24,7 @@ color-contrast(#008080 vs olive, var(--myColor), #d2691e)
 <dl>
   <dt>Functional notation: <code>color-contrast( &lt;color&gt; vs &lt;color&gt;#{2,}  )</code></dt>
   <dd><code>&lt;color&gt;</code> is any valid {{cssxref("color_value","color")}}.</dd>
-  <dd><code>&lt;color&gt;#{2,}</code> is a comma separated list of color values to compare with the first value.</dd>
+  <dd><code>&lt;color&gt;#{2,}</code> is a comma-separated list of color values to compare with the first value.</dd>
 </dl>
 
  <table class="standard-table">

--- a/files/en-us/web/css/color_value/color-contrast()/index.html
+++ b/files/en-us/web/css/color_value/color-contrast()/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>color-contrast()</code></strong> functional notation takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values selecting the one with the highest contrast from the list.</p>
+<p>The <strong><code>color-contrast()</code></strong> functional notation takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values, selecting the one with the highest contrast from the list.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/color_value/color-contrast()/index.html
+++ b/files/en-us/web/css/color_value/color-contrast()/index.html
@@ -1,0 +1,49 @@
+---
+title: color-contrast()
+slug: Web/CSS/color_value/color-contrast()
+tags:
+  - CSS
+  - CSS Data Type
+  - Data Type
+  - Reference
+  - Web
+  - color-contrast
+---
+<div>{{CSSRef}}</div>
+
+<p>The <strong><code>color-contrast()</code></strong> functional notation takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values selecting the one with the highest contrast from the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css">color-contrast(wheat vs tan, sienna, #d2691e)
+color-contrast(#008080 vs olive, var(--myColor), #d2691e)
+</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+  <dt>Functional notation: <code>color-contrast( &lt;color&gt; vs &lt;color&gt;#{2,}  )</code></dt>
+  <dd><code>&lt;color&gt;</code> is any valid {{cssxref("color_value","color")}}.</dd>
+  <dd><code>&lt;color&gt;#{2,}</code> is a comma separated list of color values to compare with the first value.</dd>
+</dl>
+
+ <table class="standard-table">
+  <thead>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <td>{{SpecName('CSS5 Colors', '#colorcontrast')}}</td>
+    <td>{{Spec2('CSS5 Colors')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.types.color.color-contrast")}}</p>

--- a/files/en-us/web/css/css_functions/index.html
+++ b/files/en-us/web/css/css_functions/index.html
@@ -161,7 +161,7 @@ tags:
   <dt>{{cssxref("color_value/color-mix()", "color-mix()")}} {{Experimental_Inline}}</dt>
   <dd>Takes two {{cssxref("color_value","color")}} values and returns the result of mixing them in a given colorspace by a given amount.</dd>
   <dt>{{cssxref("color_value/color-contrast()", "color-contrast()")}} {{Experimental_Inline}}</dt>
-  <dd>Takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values selecting the one with the highest contrast from the list.</dd>
+  <dd>Takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values, selecting the one with the highest contrast from the list.</dd>
   <dt>{{cssxref("color_value/device-cmyk()", "device-cmyk()")}}  {{Experimental_Inline}}</dt>
   <dd>Used to express CMYK colors in a device-independent way.</dd>
   <dt>{{cssxref("color_value/hsl()", "hsl()")}} </dt>

--- a/files/en-us/web/css/css_functions/index.html
+++ b/files/en-us/web/css/css_functions/index.html
@@ -160,6 +160,8 @@ tags:
   <dd>Allows a color to be specified in a particular, specified colorspace (rather than the implicit sRGB colorspace that most of the other color functions operate in). </dd>
   <dt>{{cssxref("color_value/color-mix()", "color-mix()")}} {{Experimental_Inline}}</dt>
   <dd>Takes two {{cssxref("color_value","color")}} values and returns the result of mixing them in a given colorspace by a given amount.</dd>
+  <dt>{{cssxref("color_value/color-contrast()", "color-contrast()")}} {{Experimental_Inline}}</dt>
+  <dd>Takes a {{cssxref("color_value","color")}} value and compares it to a list of other {{cssxref("color_value","color")}} values selecting the one with the highest contrast from the list.</dd>
   <dt>{{cssxref("color_value/device-cmyk()", "device-cmyk()")}}  {{Experimental_Inline}}</dt>
   <dd>Used to express CMYK colors in a device-independent way.</dd>
   <dt>{{cssxref("color_value/hsl()", "hsl()")}} </dt>


### PR DESCRIPTION
Adding the `color-contrast()` function. As this currently only has support in Safari TP this is a short page, I'll revisit it and add examples when I do the BCD as browsers implement.

https://drafts.csswg.org/css-color-5/#colorcontrast
