### PR TITLE
clarifying grid shorthand

### DIFF
--- a/files/en-us/web/css/grid/index.html
+++ b/files/en-us/web/css/grid/index.html
@@ -12,11 +12,13 @@ tags:
 
 <p>The <strong><code>grid</code></strong> CSS property is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> that sets all of the explicit and implicit grid properties in a single declaration.</p>
 
+<p>Using <code>grid</code> you specify one axis using {{cssxref("grid-template-rows")}} or {{cssxref("grid-template-columns")}}, you then specify how content should auto-repeat in the other axis using the implicit grid properties: {{cssxref("grid-auto-rows")}}, {{cssxref("grid-auto-columns")}}, and {{cssxref("grid-auto-flow")}}.</p>
+
 <div>{{EmbedInteractiveExample("pages/css/grid.html")}}</div>
 
 <div class="notecard note">
   <h4>Note</h4>
-<p>You can only specify the explicit <em>or</em> the implicit grid properties in a single <code>grid</code> declaration. The sub-properties you don’t specify are set to their initial value, as normal for shorthands. Also, the gutter properties are NOT reset by this shorthand.</p>
+<p>The sub-properties you don’t specify are set to their initial value, as normal for shorthands. Also, the gutter properties are NOT reset by this shorthand.</p>
 </div>
 
 <h2 id="Constituent_properties">Constituent properties</h2>


### PR DESCRIPTION
Fixes #3415 

I've added a paragraph explaining that the `grid` shorthand lets you specify the explicit grid on one axis and the implicit for the other, and removed a line from the note which was potentially confusing.
