### PR TITLE
Replace link to CSP2 spec in CSP frame-ancestors doc

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
@@ -64,7 +64,7 @@ Content-Security-Policy: frame-ancestors &lt;source&gt; &lt;source&gt;;
  </ul>
 
  <div class="notecard warning">
- <p>If no URL scheme is specified for a <code>host-source</code> and the iframe is loaded from an <code>https</code> URL, the URL for the page loading the iframe must also be <code>https</code>, per the W3C spec on <a href="https://w3c.github.io/webappsec-csp/2/#match-source-expression">matching source expressions</a>.</p>
+ <p>If no URL scheme is specified for a <code>host-source</code> and the iframe is loaded from an <code>https</code> URL, the URL for the page loading the iframe must also be <code>https</code>, per the W3C spec on <a href="https://www.w3.org/TR/CSP2/#match-source-expression">matching source expressions</a>.</p>
  </div>
  </dd>
  <dt>&lt;scheme-source&gt;</dt>

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
@@ -64,7 +64,7 @@ Content-Security-Policy: frame-ancestors &lt;source&gt; &lt;source&gt;;
  </ul>
 
  <div class="notecard warning">
- <p>If no URL scheme is specified for a <code>host-source</code> and the iframe is loaded from an <code>https</code> URL, the URL for the page loading the iframe must also be <code>https</code>, per the W3C spec on <a href="https://www.w3.org/TR/CSP2/#match-source-expression">matching source expressions</a>.</p>
+ <p>If no URL scheme is specified for a <code>host-source</code> and the iframe is loaded from an <code>https</code> URL, the URL for the page loading the iframe must also be <code>https</code>, per the <a href="https://w3c.github.io/webappsec-csp/#match-url-to-source-expression">Does url match expression in origin with redirect count?</a> section of the CSP spec.</p>
  </div>
  </dd>
  <dt>&lt;scheme-source&gt;</dt>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Using the published link instead of editors link which is removed.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
