### PR TITLE
Persian & Arabic examples

### DIFF
--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -156,7 +156,7 @@ list-style-type: unset;
  <dt><code>-moz-arabic-indic</code></dt>
  <dd>
  <ul>
-  <li>Example</li>
+  <li>E.g. ١, ٢, ٣, ٤, ٥, ٦</li>
  </ul>
  </dd>
  <dt><code>armenian</code></dt>
@@ -362,7 +362,7 @@ list-style-type: unset;
  <dt><code>-moz-persian</code></dt>
  <dd>
  <ul>
-  <li>Example</li>
+  <li>E.g. ۱, ۲, ۳, ۴, ۵, ۶</li>
  </ul>
  </dd>
  <dt><code>simp-chinese-formal</code> {{experimental_inline}}</dt>

--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -155,7 +155,7 @@ list-style-type: unset;
  <dt><code>arabic-indic</code></dt>
  <dt><code>-moz-arabic-indic</code></dt>
  <dd>
- <ul>
+ <ul style="list-style-type: arabic-indic;"> 
   <li>E.g. ١, ٢, ٣, ٤, ٥, ٦</li>
  </ul>
  </dd>
@@ -361,7 +361,7 @@ list-style-type: unset;
  <dt><code>persian</code> {{experimental_inline}}</dt>
  <dt><code>-moz-persian</code></dt>
  <dd>
- <ul>
+ <ul style="list-style-type: persian;"> 
   <li>E.g. ۱, ۲, ۳, ۴, ۵, ۶</li>
  </ul>
  </dd>


### PR DESCRIPTION

> Added persian & arabic-indic list style types example from 1 to 6.

> https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type

