### PR TITLE
Fix renamed JavaScript compat features' identifiers

### DIFF
--- a/files/en-us/web/javascript/reference/operators/async_function/index.html
+++ b/files/en-us/web/javascript/reference/operators/async_function/index.html
@@ -91,7 +91,7 @@ add(10).then(v =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.operators.async_function_expression")}}</p>
+<p>{{Compat("javascript.operators.async_function")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.html
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.html
@@ -82,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.operators.function_star")}}</p>
+<p>{{Compat("javascript.operators.generator_function")}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

For improved clarity and consistency, a few JS compat features have been renamed in https://github.com/mdn/browser-compat-data/pull/9592.

> MDN URL of main page changed

[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function*](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function*)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/async_function

> Issue number (if there is an associated issue)

https://github.com/mdn/browser-compat-data/pull/9592

> Anything else that could help us review it

Please don't merge this until Friday, March 26 (after the next BCD release).
