### PR TITLE
Fix typo in open source etiquette article

### DIFF
--- a/files/en-us/mdn/contribute/open_source_etiquette/index.html
+++ b/files/en-us/mdn/contribute/open_source_etiquette/index.html
@@ -123,7 +123,7 @@ tags:
 
 <ul>
   <li>Discuss one topic per issue — it is easy to keep issues focused and productive.</li>
-  <li>Fix one issue per PR — it my be slightly more work for you, but it is much easier to review a single clear fix.</li>
+  <li>Fix one issue per PR — it may be slightly more work for you, but it is much easier to review a single clear fix.</li>
   <li>Contribute to other threads if you have a useful point to make or can answer some else's question.</li>
   <li>Ask questions using other mechanisms like chat rooms or forums if you are not sure whether something is useful or have a simple question.</li>
   <li>Read the manual first to try to answer the question yourself before asking it.</li>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/MDN/Contribute/Open_source_etiquette