### PR TITLE
Fix link from MediaQueryList's `media` to `matches`

### DIFF
--- a/files/en-us/web/api/window/matchmedia/index.html
+++ b/files/en-us/web/api/window/matchmedia/index.html
@@ -73,7 +73,7 @@ document.querySelector(".mq-value").innerText = mql.matches;
 <p>The JavaScript code passes the media query to match into {{domxref("Window.matchMedia",
   "matchMedia()")}} to compile it, then sets the <code>&lt;span&gt;</code>'s
   {{domxref("HTMLElement.innerText", "innerText")}} to the value of the results'
-  {{domxref("MediaQueryList.media", "matches")}} property, so that it indicates whether or
+  {{domxref("MediaQueryList.matches", "matches")}} property, so that it indicates whether or
   not the document matches the media query at the moment the page was loaded.</p>
 
 <h3 id="HTML">HTML</h3>


### PR DESCRIPTION
Fixes an incorrect link on https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia