### PR TITLE
Fixes a typo in "Examine and edit CSS":

### DIFF
--- a/files/en-us/tools/page_inspector/how_to/examine_and_edit_css/index.html
+++ b/files/en-us/tools/page_inspector/how_to/examine_and_edit_css/index.html
@@ -40,7 +40,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>This feature is enabled from Firefox 81 by setting the preference <code>devtools.inspector.ruleview.inline-compatibility-warning.enabled</code> to <code>true</code> (open <code>about.config</code> in the URL bar to view/set Firefox preferences).</p>
+  <p>This feature is enabled from Firefox 81 by setting the preference <code>devtools.inspector.ruleview.inline-compatibility-warning.enabled</code> to <code>true</code> (open <code>about:config</code> in the URL bar to view/set Firefox preferences).</p>
 </div>
 
 <p><img alt="Tooltip displayed next to CSS element. Hover to find out browsers with compatibility issues." src="firefox_compatibility_tootips.jpg"></p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
In Examine and edit CSS Page, under Browser compact Warning heading, in (open about.config in the URL bar to view/set Firefox preferences) about.config should be about:config.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS
> Issue number (if there is an associated issue)
Fixes Issue #3441 
> Anything else that could help us review it
