### PR TITLE
add useful PR file deletion tip

### DIFF
--- a/files/en-us/mdn/contribute/github_beginners/index.html
+++ b/files/en-us/mdn/contribute/github_beginners/index.html
@@ -450,6 +450,13 @@ To github.com:chrisdavidmills/content.git
 
 <p>If you look at your remote fork's github.com page again, you'll see the commit that you wanted to reverse, plus the commit that reverses it.</p>
 
+<div class="note notecard">
+  <h4>Note</h4>
+  <p>Another way to handle getting rid of files that have ended up in pull requests that you don't want to be there is to use the GitHub UI. Go to your pull request's page on github.com, go to the "Files changed" tab, and find the file you want to remove from the pull request. At the top right of the file's box in the page there will be a "three dot" (<code>...</code>) menu. Press this button and choose "Delete file". In the confirmation page, enter a title for the new commit, make sure the "Commit directly..." checkbox is selected, and press the "Commit changes" button.</p>
+
+  <p>It is usually a good idea to get the rest of the pull request looking exactly how you want it before you make changes via the GitHub UI. If you do something like this and then end up having to make more changes, you'll need to remember to pull the changes you made to your remote branch down to your local branch (e.g. with <code>git pull</code>) before you can push more commits.</p>
+</div>
+
 <h3 id="want_to_see_more">Want to see more?</h3>
 
 <p>If you think this troubleshooting guide should contain more information, please <a href="https://github.com/mdn/content/issues/new">create an issue</a> to suggest what you think we should include.</p>

--- a/files/en-us/mdn/contribute/github_cheatsheet/index.html
+++ b/files/en-us/mdn/contribute/github_cheatsheet/index.html
@@ -72,6 +72,11 @@ git push</pre>
 <pre class="brush: bash">git revert HEAD
 git push</pre>
 
+<div class="note notecard">
+  <h4>Note</h4>
+  <p>Another way to handle getting rid of files that have ended up in pull requests that you don't want to be there is to use the GitHub UI. Go to your pull request's page on github.com, go to the "Files changed" tab, and find the file you want to remove from the pull request. At the top right of the file's box in the page there will be a "three dot" (<code>...</code>) menu. Press this button and choose "Delete file". In the confirmation page, enter a title for the new commit, make sure the "Commit directly..." checkbox is selected, and press the "Commit changes" button.</p>
+</div>
+
 <h2 id="want_to_see_more">Want to see more?</h2>
 
 <p>If you think this cheatsheet should contain more commands, please <a href="https://github.com/mdn/content/issues/new">create an issue</a> to suggest what you think we should include.</p>


### PR DESCRIPTION
I realised that you can delete files out of your PRs using the GitHub UI "Delete file" option, which is much easier than trying to do it via the command line. So I've added a note to each file about this.