### PR TITLE
Worker API postMessage fixes

### DIFF
--- a/files/en-us/web/api/worker/postmessage/index.html
+++ b/files/en-us/web/api/worker/postmessage/index.html
@@ -6,7 +6,6 @@ tags:
   - JavaScript
   - Method
   - Reference
-  - Référence(2)
   - Web Workers
   - Worker
   - postMessage

--- a/files/en-us/web/api/worker/postmessage/index.html
+++ b/files/en-us/web/api/worker/postmessage/index.html
@@ -54,7 +54,7 @@ second.onchange = function() {
 }
 </pre>
 
-<p>For a full example, see our<a class="external external-icon" href="https://github.com/mdn/simple-web-worker">Basic dedicated worker example</a> (<a class="external external-icon" href="https://mdn.github.io/simple-web-worker/">run dedicated worker</a>).</p>
+<p>For a full example, see our <a class="external external-icon" href="https://github.com/mdn/simple-web-worker">Basic dedicated worker example</a> (<a class="external external-icon" href="https://mdn.github.io/simple-web-worker/">run dedicated worker</a>).</p>
 
 <div class="note">
 <p><strong>Note</strong>: <code>postMessage()</code> can only send a single object at once. As seen above, if you want to pass multiple values you can send an array.</p>

--- a/files/en-us/web/api/worker/postmessage/index.html
+++ b/files/en-us/web/api/worker/postmessage/index.html
@@ -54,7 +54,7 @@ second.onchange = function() {
 }
 </pre>
 
-<p>For a full example, see our <a class="external external-icon" href="https://github.com/mdn/simple-web-worker">Basic dedicated worker example</a> (<a class="external external-icon" href="https://mdn.github.io/simple-web-worker/">run dedicated worker</a>).</p>
+<p>For a full example, see our <a class="external external-icon" href="https://github.com/mdn/simple-web-worker">simple worker example</a> (<a class="external external-icon" href="https://mdn.github.io/simple-web-worker/">run example</a>).</p>
 
 <div class="note">
 <p><strong>Note</strong>: <code>postMessage()</code> can only send a single object at once. As seen above, if you want to pass multiple values you can send an array.</p>


### PR DESCRIPTION
Changes:
 - added a missing space
 - removed a non-English tag
 - changed the wording referring to the example (now uses the GitHub repo title)