### PR TITLE
changed selector from font to p

### DIFF
--- a/files/en-us/web/css/inheritance/index.html
+++ b/files/en-us/web/css/inheritance/index.html
@@ -55,13 +55,13 @@ tags:
 
 <p>You can control inheritance for all properties at once using the {{cssxref("all")}} shorthand property, which applies its value to all properties. For example:</p>
 
-<pre class="brush: css">font {
+<pre class="brush: css">p {
   all: revert;
   font-size: 200%;
   font-weight: bold;
 }</pre>
 
-<p>This reverts the style of the {{cssxref("font")}} property to the user agent's default unless a user stylesheet exists, in which case that is used instead. Then it doubles the font size and applies a {{cssxref("font-weight")}} of <code>"bold"</code>.</p>
+<p>This reverts the style of the paragraphs' {{cssxref("font")}} property to the user agent's default unless a user stylesheet exists, in which case that is used instead. Then it doubles the font size and applies a {{cssxref("font-weight")}} of <code>"bold"</code>.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
changed selector from `font` to `p`, then updated the text to go along with that.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only) 

font is deprecated, and likely not what was meant

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance

> Issue number (if there is an associated issue)

> Anything else that could help us review it
