### PR TITLE
CSS 'display': fix a typo

### DIFF
--- a/files/en-us/web/css/display/index.html
+++ b/files/en-us/web/css/display/index.html
@@ -38,7 +38,7 @@ display: block flow;
 display: inline flow;
 display: inline flow-root;
 display: block flex;
-display: inline-flex;
+display: inline flex;
 display: block grid;
 display: inline grid;
 display: block flow-root;


### PR DESCRIPTION

**What is wrong:** In the list of examples of the two-value `display` syntax, `inline-flex` is given. Presumably `inline flex` was intended as this is the two-value version of that display value.

This PR simply fixes that. (Note: `inline-flex` is still present nearby in the list of legacy values, where it should be).

**MDN URL of main page changed**: https://developer.mozilla.org/en-US/docs/Web/CSS/display