### PR TITLE
Django - remove incorrect comment using os.path

### DIFF
--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -410,7 +410,7 @@ pip3 install psycopg2-binary
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 # The absolute path to the directory where collectstatic will collect static files for deployment.
-STATIC_ROOT = BASE_DIR / 'staticfiles'  #. os.path.join(BASE_DIR, 'staticfiles')
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # The URL to use when referring to static files (where they will be served from)
 STATIC_URL = '/static/'


### PR DESCRIPTION
Fixes #3480 (just removes a comment). This should NOT cause a problem, but for some reason it does.