### PR TITLE
Add link for non-FIPS functions

### DIFF
--- a/files/en-us/mozilla/projects/nss/reference/nss_cryptographic_module/index.html
+++ b/files/en-us/mozilla/projects/nss/reference/nss_cryptographic_module/index.html
@@ -18,7 +18,7 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/Reference/NSS_cryptographic_module/Data_types">PKCS #11 data types</a></li>
- <li><a href="/en-US/docs/Mozilla/Projects/NSS/Reference/NSS_cryptographic_module/Non-FIPS_mode_of_operation">PKCS #11 functions in the non-FIPS (default) mode of operation</a></li>
+ <li><a href="/en-US/docs/Mozilla/Projects/NSS/PKCS11_Functions">PKCS #11 functions in the non-FIPS (default) mode of operation</a></li>
  <li><a href="/en-US/docs/Mozilla/Projects/NSS/Reference/NSS_cryptographic_module/FIPS_mode_of_operation">PKCS #11 functions in the FIPS mode of operation</a></li>
  <li>NSC_ModuleDBFunc</li>
 </ul>


### PR DESCRIPTION
Fixes link as discussed in https://github.com/mdn/content/issues/2669#issuecomment-804741620