### PR TITLE
fix typo: model/vml -> model/vrml

### DIFF
--- a/files/en-us/web/http/basics_of_http/mime_types/index.html
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.html
@@ -121,7 +121,7 @@ tags:
       href="https://www.iana.org/assignments/media-types/media-types.xhtml#model"
       style="float: right;">List at IANA</a></dt>
   <dd>Model data for a 3D object or scene. Examples include <code>model/3mf</code> and
-    <code>model/vml</code>.</dd>
+    <code>model/vrml</code>.</dd>
   <dt><code>text</code> <a
       href="https://www.iana.org/assignments/media-types/media-types.xhtml#text"
       style="float: right;">List at IANA</a></dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`model/vml` does not exist

should be `model/vrml`

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

["Not to be confused with VML."](https://en.wikipedia.org/wiki/VRML#firstHeading)