### PR TITLE
FF86 relnote: EventTarget.addEventListener() signal option

### DIFF
--- a/files/en-us/mozilla/firefox/releases/86/index.html
+++ b/files/en-us/mozilla/firefox/releases/86/index.html
@@ -64,6 +64,7 @@ currencyNames.of('EUR'); // "Euro"</pre>
 
 <ul>
   <li><a href="/en-US/docs/Web/API/Window/name"><code>Window.name</code></a> is now reset to an empty string if a tab loads a page from a different domain, and restored if the original page is reloaded (e.g. by selecting the "back" button). This prevents an untrusted page from accessing any information that the previous page might have stored in the property (potentially the new page might also modify such data, which might then be read by the original page if it was reloaded). For more information see {{bug(1685089)}}.</li>
+  <li><a href="/en-US/docs/Web/API/EventTarget/addEventListener"><code>EventTarget.addEventListener()</code></a> now supports the <code>signal</code> option. This option allows an <a href="/en-US/docs/Web/API/AbortSignal"><code>AbortSignal</code></a> to be passed to the method. The <code>AbortSignal</code> can later be used to remove the listener by calling <code>abort()</code>. For more information see {{bug(1679204)}}.</li>
 </ul>
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>


### PR DESCRIPTION
Adds FF86 release note for bug https://bugzilla.mozilla.org/show_bug.cgi?id=1679204

Discussed in https://github.com/mdn/browser-compat-data/issues/9555#issuecomment-804722926