### PR TITLE
Remove Page macro DataTransfer

### DIFF
--- a/files/en-us/web/api/datatransfer/addelement/index.html
+++ b/files/en-us/web/api/datatransfer/addelement/index.html
@@ -17,7 +17,10 @@ tags:
   {{event("dragend")}} events are fired, and not the default target (the node that was
   dragged).</p>
 
-<div class="note"><strong>Note:</strong> This method is Gecko-specific.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This method is Firefox-specific.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -59,4 +62,10 @@ tags:
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/cleardata/index.html
+++ b/files/en-us/web/api/datatransfer/cleardata/index.html
@@ -196,4 +196,10 @@ tags:
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/dropeffect/index.html
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.html
@@ -151,4 +151,10 @@ function dragover_handler(ev) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/effectallowed/index.html
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.html
@@ -151,4 +151,11 @@ function dragover_handler(ev) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>
+

--- a/files/en-us/web/api/datatransfer/getdata/index.html
+++ b/files/en-us/web/api/datatransfer/getdata/index.html
@@ -130,4 +130,10 @@ function drop(dropevent) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/items/index.html
+++ b/files/en-us/web/api/datatransfer/items/index.html
@@ -120,4 +120,10 @@ function dragover_handler(ev) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.html
@@ -68,3 +68,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozClearDataAt")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozcursor/index.html
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.html
@@ -63,4 +63,10 @@ tags:
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.html
@@ -78,3 +78,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozGetDataAt")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.html
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.html
@@ -49,3 +49,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozItemCount")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
-<p>{{ Non-standard_header() }}{{deprecated_header}}</p>
+<p>{{deprecated_header}}{{Non-standard_header()}}</p>
 
 <p>The <strong><code>DataTransfer.mozSetDataAt()</code></strong> method is used to add
   data to a specific index in the drag event's {{domxref("DataTransfer","data transfer")}}
@@ -28,15 +28,16 @@ tags:
   is replaced in the same position as the old data.</p>
 
 <p>The data should be either a {{domxref("DOMString","string")}}, a {{jsxref("Boolean")}}
-  or number type (which will be converted into a string) or an {{ interface("nsISupports")
-  }}.</p>
+  or number type (which will be converted into a string) or an {{ interface("nsISupports") }}.</p>
 
-<div class="note"><strong>Note:</strong> This method is Gecko-specific.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This method is Firefox-specific.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">void <em>dataTransfer</em>.mozSetDataAt([type], data, index);
-</pre>
+<pre class="brush: js">void <em>dataTransfer</em>.mozSetDataAt([type], data, index);</pre>
 
 <h3 id="Arguments">Arguments</h3>
 
@@ -82,3 +83,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozSetDataAt")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.html
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.html
@@ -18,7 +18,10 @@ tags:
   external drags or if the calling function cannot reach the node, <code>null</code> is
   returned.</p>
 
-<div class="note"><strong>Note:</strong> This property is Gecko-specific.</div>
+<div class="notecard note">
+  <h4>Note</h4>>
+  <p>This property is Firefox-specific.</p>
+</div>
 
 <p>This property is {{readonlyInline}}.</p>
 
@@ -55,3 +58,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozSourceNode")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/moztypesat/index.html
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.html
@@ -10,19 +10,21 @@ tags:
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
-<p>{{ Non-standard_header() }}{{deprecated_header}}</p>
+<p>{{deprecated_header}}{{Non-standard_header()}}</p>
 
 <p>The <strong><code>DataTransfer.mozTypesAt()</code></strong> method returns a list of
   the format types that are stored for an item at the specified index. If the index is not
   in the range from 0 to the number of items minus one, an empty string list is returned.
 </p>
 
-<div class="note"><strong>Note:</strong> This method is Gecko-specific.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This method is Firefox-specific.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">nsIVariant <em>dataTransfer</em>.mozTypesAt(index);
-</pre>
+<pre class="brush: js">mozTypesAt(index);</pre>
 
 <h3 id="Arguments">Arguments</h3>
 
@@ -76,3 +78,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozTypesAt")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.html
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.html
@@ -18,7 +18,10 @@ tags:
   <code>false</code> otherwise. This property only applies to the {{event("dragend")}}
   event.</p>
 
-<div class="note"><strong>Note:</strong> This property is Gecko-specific.</div>
+  <div class="notecard note">
+    <h4>Note</h4>>
+    <p>This property is Firefox-specific.</p>
+  </div>
 
 <p>This property is {{readonlyInline}}.</p>
 
@@ -51,3 +54,13 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.DataTransfer.mozUserCancelled")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/setdata/index.html
+++ b/files/en-us/web/api/datatransfer/setdata/index.html
@@ -133,4 +133,10 @@ function drop_handler(ev) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/setdragimage/index.html
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.html
@@ -146,20 +146,10 @@ function drop_handler(ev) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
-
-<div class="jfk-bubble gtx-bubble"
-  style="left: -1px; top: 27px; opacity: 1; transition: opacity 0.218s ease-out 0s;">
-  <div class="jfk-bubble-content-id" id="bubble-4">
-    <div id="gtx-host" style="max-width: 400px;"></div>
-  </div>
-
-  <div class="jfk-bubble-closebtn-id jfk-bubble-closebtn"></div>
-
-  <div class="jfk-bubble-arrow-id jfk-bubble-arrow jfk-bubble-arrowup"
-    style="left: 15px;">
-    <div class="jfk-bubble-arrowimplbefore"></div>
-
-    <div class="jfk-bubble-arrowimplafter"></div>
-  </div>
-</div>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransfer/types/index.html
+++ b/files/en-us/web/api/datatransfer/types/index.html
@@ -125,4 +125,10 @@ function dragover_handler(ev) {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/datatransferitem/kind/index.html
+++ b/files/en-us/web/api/datatransferitem/kind/index.html
@@ -92,4 +92,10 @@ tags:
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>

--- a/files/en-us/web/api/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/index.html
@@ -59,7 +59,7 @@ tags:
  <dd>A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragend')}} event.</dd>
  <dt>{{domxref('GlobalEventHandlers.ondragenter')}}</dt>
  <dd>A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragenter')}} event.</dd>
- <dt>{{domxref('GlobalEventHandlers.ondragexit')}}</dt>
+ <dt>{{domxref('GlobalEventHandlers.ondragleave')}}</dt>
  <dd>A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragexit')}} event.</dd>
  <dt>{{domxref('GlobalEventHandlers.ondragleave')}}</dt>
  <dd>A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragleave')}} event.</dd>
@@ -103,4 +103,10 @@ tags:
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/DataTransfer", "See also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API">Drag and drop</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations">Drag Operations</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types">Recommended Drag Types</a></li>
+ <li><a href="/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Multiple_items">Dragging and Dropping Multiple Items</a></li>
+ <li><a href="https://codepen.io/tech_query/pen/MqGgap">DataTransfer test - Paste or Drag</a></li>
+</ul>


### PR DESCRIPTION
Removes the `Page` macro from DragTransfer sub topics as part of fixing #3196

This is to explore what to do when Page macro is used to include **See also** sections into methods, properties etc from the top level (as queried in https://github.com/mdn/content/pull/3008#issuecomment-804606895). In this case some, but not all, elements like  [DataTransfer.addElement](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/addElement) included the section from [DataTransfer](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/addElement). 

What I have done is deleted the inclusion. My thinking is that there is already a link to the parent where the see also information is provided. In method doc I don't expect a see also, and it isn't worth maintaining one that can get out of sync with the parent. 

If this approach is OK I will extend it to the similar examples.
