### PR TITLE
Drop spec table from “Feature-Policy: sync-xhr” article

### DIFF
--- a/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
@@ -26,30 +26,6 @@ tags:
 
 <p>By default the policy is set to <code>*</code>, which means synchronous requests are allowed in all frames.</p>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Feature Policy")}}</td>
-   <td>{{Spec2("Feature Policy")}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td><a href="https://xhr.spec.whatwg.org/#feature-policy-integration">WHATWG Spec</a></td>
-   <td></td>
-   <td>Default policy is <code>*</code>.</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">


### PR DESCRIPTION
https://github.com/whatwg/xhr/pull/322 removed the `sync-xhr` policy-controlled feature from XHR spec — so this change removes the Specifications table from the “Feature-Policy: sync-xhr” article.