### PR TITLE
add rfc for modernizing learn js

### DIFF
--- a/files/en-us/mdn/guidelines/code_guidelines/javascript/index.html
+++ b/files/en-us/mdn/guidelines/code_guidelines/javascript/index.html
@@ -22,7 +22,7 @@ tags:
   <ul>
    <li><a href="#use_expanded_syntax">Use expanded syntax</a></li>
    <li><a href="#javascript_comments">JavaScript comments</a></li>
-   <li><a href="#use_es6_features">Use ES6 features</a></li>
+   <li><a href="#use_modern_js_features">Use modern JS features</a></li>
   </ul>
  </li>
  <li><a href="#variables">Variables</a>
@@ -128,14 +128,13 @@ tags:
 
 <p>Also note that you should leave a space between the slashes and the comment, in each case.</p>
 
-<h3 id="Use_ES6_features">Use ES6 features</h3>
+<h3 id="Use_modern_JS_features">Use modern JS features</h3>
 
-<p>For general usage*, you can use common ES6 features (such as <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/const">const</a></code>, <a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>, and <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax">spread syntax</a>) in MDN examples. We include them in many places in these guidelines, as we believe the web industry has generally gotten to the point where such features are familiar enough to be understandable. And for those that don't use them yet, we'd like to play our part in helping people to evolve their skills.</p>
-
-<p>However, we don't yet recommend the general use of newer ES features such as <a href="/en-US/docs/Web/JavaScript/Reference/Statements/async_function">async</a>/<a href="/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a>, trailing commas on argument lists, etc. We’d prefer you not to use those unless strictly necessary, and if you do use them, include explanation in your example to say what they are doing, with a link to appropriate reference material.</p>
+<p>For general usage*, you can use modern well-supported JS features (such as <a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow functions</a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promises</a>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/async_function">async</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></code>/<code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/const">const</a></code>, <a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>, and <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax">spread syntax</a>) in MDN examples. We include them in many places in these guidelines, as we believe the web industry has generally gotten to the point where such features are familiar enough to be understandable. And for those that don't use them yet, we'd like to play our part in helping people to evolve their skills.</p>
 
 <div class="notecard note">
-<p>* By "general usage", we mean general example writing. Reference pages covering specific modern ES features obviously need to use the features they are documenting!</p>
+  <h4>Note</h4>
+  <p>* By "general usage", we mean general example writing. Reference pages covering specific JS features obviously need to use the features they are documenting!</p>
 </div>
 
 <h2 id="Variables">Variables</h2>
@@ -158,7 +157,8 @@ let s = d/t;
 </pre>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using <code>i</code>, <code>j</code>, etc. for loop iterators.</p>
+  <h4>Note</h4>
+  <p>The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using <code>i</code>, <code>j</code>, etc. for loop iterators.</p>
 </div>
 
 <h3 id="Declaring_variables">Declaring variables</h3>
@@ -353,7 +353,8 @@ function notVeryObviousName() {
 </pre>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using <code>i</code>, <code>j</code>, etc. for loop iterators.</p>
+  <h4>Note</h4>
+  <p>The only place where it is OK to not use human-readable semantic names is where a very common recognized convention exists, such as using <code>i</code>, <code>j</code>, etc. for loop iterators.</p>
 </div>
 
 <h3 id="Defining_functions">Defining functions</h3>

--- a/rfcs/modernize-learn-js.md
+++ b/rfcs/modernize-learn-js.md
@@ -1,0 +1,67 @@
+# MDN content project: Modernizing the Learning Area JavaScript modules
+
+This RFC proposes that we work on modernizing the [Learning Area JavaScript modules](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
+available on MDN.
+
+## Problem statement
+
+The JavaScript learning area modules are pretty good as they stand, and still
+helpful to aspiring web developers. The main problem is that many of the
+component articles were written before the time that MDN's JS policy was
+changed (from "don't use ES6 features, they are too modern" to "use modern
+features").
+
+As a result, a number of articles are a bit out of date, or teach the old way
+of doing something first, with the new way added in as a new section at the end.
+
+Examples:
+
+- In the [Handling text — strings in JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings)
+  article, old-school string concatenation is introduced centrally,
+  whereas template literals are introduced at the end as a newer syntax that
+  you'll also come across. This should really be done the other way round.
+- In the [arrays introduction](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Arrays),
+  the basics are explained just fine, but there is no coverage of modern array
+  methods that are very commonplace in JS these days, such as `map()` or `filter()`.
+- In the [JS objects module](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects),
+  old-school constructors and prototypes are introduced first, and ES class
+  syntax is tacked on the end as an afterthought. This should be the other way
+  round.
+
+## Priority assessment
+
+This list checks this project against the [OWD prioritization criteria](https://github.com/openwebdocs/project/blob/main/steering-committee/prioritization-criteria.md).
+
+- **Effort**: Medium/High: There are over 40 JavaScript articles in the
+  learning area, and each one needs to be audited, a decision made about what we
+  should do with it, and then rewriting work done. Related examples also need
+  to be updated.
+- **Dependencies**: Not much to mention here.
+- **Community enablement**: Yes. Each page rewrite is a self-contained task, so
+  we could get community to help out here.
+- **Momentum**: Medium. A lot of features we'd be writing about are pretty
+  stable, but the technology is very popular.
+- **Enabling learners**: Yes!!
+- **Enabling professionals**: Yes, somewhat. Even professional web developers
+  can often benefit greatly from an authoritative source of information show
+  the modern way to write JS. We should aim to keep this pretty up-to-date.
+- **Underrepresented topics / Ethical web**: n/a
+- **Operational necessities**: n/a
+- **Addressing the needs of the web industry**: n/a
+
+## Proposed solutions
+
+Audit existing articles, work out how to update them, get them rewritten.
+
+## Task list
+
+- Agree on an overall strategy for the updates. For example, is there a
+  particular set of ECMAScript that we want to stick to documenting in this
+  resource? How new is too new? Do we gate it on what is supported in at least
+  two rendering engines, or somesuchthing? How do we deal with
+  backwards-compatibility? Show examples of how to support older browsers, or
+  just teach everyone how to use Babel.js to begin with?
+- Audit each page. For each one, write a list of what needs to be done to get
+  that page updated in line with the above strategy.
+- Find writers to help do this work.
+- Divide the writing and reviewing work up between the available writers.

--- a/rfcs/modernize-learn-js.md
+++ b/rfcs/modernize-learn-js.md
@@ -27,6 +27,14 @@ Examples:
   old-school constructors and prototypes are introduced first, and ES class
   syntax is tacked on the end as an afterthought. This should be the other way
   round.
+- We did some work on making sure that `const`/`let` is used in appropriate
+  Places instead of `var`. We should check to see if there is any more work to
+  do here.
+- We should include a guide early on about targeting browsers, where we could
+  cover things like considering which browsers/non-browser runtimes you need to
+  support, making it clear that we only support modern browsers in these guides,
+  and setting up tools like Babel.js if you want to support ancient engines.
+
 
 ## Priority assessment
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This is an RFC to describe what should be done about modernizing the [JavaScript modules](https://developer.mozilla.org/en-US/docs/Learn/JavaScript) in the learning area.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/JavaScript

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

n/a
