### PR TITLE
moving another CSS example

### DIFF
--- a/files/en-us/web/css/mask-mode/index.html
+++ b/files/en-us/web/css/mask-mode/index.html
@@ -58,7 +58,7 @@ mask-mode: unset;
 
 <h3 id="Using_alpha_mask_mode">Using alpha mask mode</h3>
 
-<p>{{EmbedGHLiveSample("css-examples/masking/mask-clip.html", '100%', 760)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-mode.html", '100%', 760)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/mask-position/index.html
+++ b/files/en-us/web/css/mask-position/index.html
@@ -58,56 +58,10 @@ mask-position: unset;
 
 <h3 id="Setting_mask_position">Setting mask position</h3>
 
-<h4 id="CSS">CSS</h4>
+<p>Change the <code>mask-position</code> value to any of the allowed values detailed above.
+  If viewing the example in a Chromium-based browser change the value of <code>-webkit-mask-position</code>.
 
-<pre class="brush: css; highlight[13]">#wrapper {
-  border: 1px solid black;
-  width: 250px;
-  height: 250px;
-}
-
-#masked {
-  width: 250px;
-  height: 250px;
-  background: blue linear-gradient(red, blue);
-  mask-image: url(https://mdn.mozillademos.org/files/12676/star.svg);
-  mask-repeat: no-repeat;
-  mask-position: top right; /* Can be changed in the live sample */
-  margin-bottom: 10px;
-}
-</pre>
-
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="wrapper"&gt;
-  &lt;div id="masked"&gt;
-  &lt;/div&gt;
-&lt;/div&gt;
-&lt;select id="maskPosition"&gt;
-  &lt;option value="top"&gt;top&lt;/option&gt;
-  &lt;option value="center"&gt;center&lt;/option&gt;
-  &lt;option value="bottom"&gt;bottom&lt;/option&gt;
-  &lt;option value="top right" selected&gt;top right&lt;/option&gt;
-  &lt;option value="center center"&gt;center center&lt;/option&gt;
-  &lt;option value="bottom left"&gt;bottom left&lt;/option&gt;
-  &lt;option value="10px 20px"&gt;10px 20px&lt;/option&gt;
-  &lt;option value="60% 20%"&gt;60% 20%&lt;/option&gt;
-&lt;/select&gt;
-</pre>
-
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var maskPosition = document.getElementById("maskPosition");
-maskPosition.addEventListener("change", function (evt) {
-  document.getElementById("masked").style.maskPosition = evt.target.value;
-});
-</pre>
-</div>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Setting_mask_position", 290, 290)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-position.html", '100%', 760)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes #3518 by moving an example into the css examples repo.

Also spotted one of the other mask pages was linking to the wrong example so changed that.