### PR TITLE
Add: section on component files order

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -68,6 +68,24 @@ tags:
 	<li>The browser assembles the small chunks into a complete web page and displays it to you (the goods arrive at your door — new shiny stuff, awesome!).</li>
 </ol>
 
+<h2 id="Order_in_which_component_files_are_parsed">Order in which component files are parsed</h2>
+
+<p>Once the client’s request is approved, the server firstly sends back the HTML file - this is also why it is commonly called index.html: index files are the first to be parsed by the server.</p>
+
+<p>The HTML file links CSS and JavaScript together via two elements called tags: link for CSS (see <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/How_CSS_works#how_does_css_actually_work">How does CSS actually work</a>for reference) and script for JavaScript (see <a href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript">What is JavaScript</a>for reference).</p>
+
+<p>CSS and JavaScript could be written internally to the HTML file or externally in a separate file but linked up to it via the tags mentioned above.</p>
+
+<p>From a server standpoint it is important to know the order in which these files are parsed: when sending back the approved request, the HTML file is parsed first and, by looking inside that file, the server recognises which CSS and JavaScript files are linked in there.</p>
+
+<p>After the HTML has been parsed and a DOM-tree structure has been generated from it, the linked CSS is then parsed, and applied to the appropriate parts of the DOM tree.</p>
+
+<p>At this point, the visual representation of the page is painted to the screen, and the user sees the page.</p>
+
+<p>The JavaScript usually gets parsed and applied to the page after this point.</p>
+
+<p>This is how the structure of a website is put together.</p>
+
 <h2 id="DNS_explained">DNS explained</h2>
 
 <p>Real web addresses aren't the nice, memorable strings you type into your address bar to find your favorite websites. They are special numbers that look like this: <code>63.245.215.20</code>.</p>

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -70,21 +70,17 @@ tags:
 
 <h2 id="Order_in_which_component_files_are_parsed">Order in which component files are parsed</h2>
 
-<p>Once the client’s request is approved, the server firstly sends back the HTML file - this is also why it is commonly called index.html: index files are the first to be parsed by the server.</p>
+<p>Once the client’s request is approved, the server first sends back the HTML (index) file — index.html is commonly named as such, as it is the first file of a website to be parsed by the server.</p>
 
-<p>The HTML file links CSS and JavaScript together via two elements called tags: link for CSS (see <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/How_CSS_works#how_does_css_actually_work">How does CSS actually work</a>for reference) and script for JavaScript (see <a href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript">What is JavaScript</a>for reference).</p>
+<p>The HTML file can reference <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS">CSS</a> and <a href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript">JavaScript</a>, either in external files via <code>&lt;link&gt;</code> and <code>&lt;script&gt;</code> elements respectively, or embedded in the HTML page via <code>&lt;style&gt;</code> and <code>&lt;script&gt;</code> elements.</p>
 
-<p>CSS and JavaScript could be written internally to the HTML file or externally in a separate file but linked up to it via the tags mentioned above.</p>
+<p>From a server standpoint it is important to know the order in which these files are parsed when the response is sent back:</p>
 
-<p>From a server standpoint it is important to know the order in which these files are parsed: when sending back the approved request, the HTML file is parsed first and, by looking inside that file, the server recognises which CSS and JavaScript files are linked in there.</p>
-
-<p>After the HTML has been parsed and a DOM-tree structure has been generated from it, the linked CSS is then parsed, and applied to the appropriate parts of the DOM tree.</p>
-
-<p>At this point, the visual representation of the page is painted to the screen, and the user sees the page.</p>
-
-<p>The JavaScript usually gets parsed and applied to the page after this point.</p>
-
-<p>This is how the structure of a website is put together.</p>
+<ul>
+  <li>The HTML file is parsed first and, by looking inside that file, the server recognises which CSS and JavaScript files are referenced.</li>
+  <li>After the HTML has been parsed and a DOM tree structure has been generated from it, the linked CSS is then parsed, and styles are applied to the appropriate parts of the DOM tree. At this point, the visual representation of the page is painted to the screen, and the user sees the page.</p>
+  <li>The JavaScript usually gets parsed and applied to the page after the HTML and CSS.</li>
+</ul>
 
 <h2 id="DNS_explained">DNS explained</h2>
 


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There was nothing wrong. I've just added some content I thought could be useful for the reader. Before the "DNS explained" section, I've added a section explaining the order in which the component files are parsed by the server. While the user is really studying frontend tech with these chapters, I think it's important to figure out how the server processes these files.

> MDN URL of main page changed: https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works

> Issue number (if there is an associated issue): none 

> Anything else that could help us review it
