### PR TITLE
Fixes Issue with "Recording a media element" #3437

### DIFF
--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.html
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.html
@@ -270,7 +270,7 @@ let recordingTimeMS = 5000;
 
 <p>{{ EmbedLiveSample('Example', 600, 440, "", "", "", "camera;microphone") }}</p>
 
-<p>You can {{LiveSampleLink("Example", "take a look at all the code")}}, including the parts hidden above because they aren't critical to the explanation of how the APIs are being used.</p>
+<p>You can {{LiveSampleLink("Example", "view the full demo here")}}, and use your browsers developer tools to inspect the page and look at all the code, including the parts hidden above because they aren't critical to the explanation of how the APIs are being used.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
In Result Section, a wrong label "take a look at all the code" was attached to a link which is now changed to a more appropriate label.
> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Recording_API/Recording_a_media_element
> Issue number (if there is an associated issue)
Fixes Issue #3437 .
> Anything else that could help us review it
