### PR TITLE
fix[tools]:list elements order (minor)

### DIFF
--- a/files/en-us/tools/page_inspector/how_to/examine_event_listeners/index.html
+++ b/files/en-us/tools/page_inspector/how_to/examine_event_listeners/index.html
@@ -20,7 +20,7 @@ tags:
  <li>a right-pointing arrowhead; click to expand the row and show the listener function source code</li>
  <li>the name of the event for which a handler was attached to this element</li>
  <li>the name and line number for the listener; you can also click here to expand the row and view the listener function source code</li>
-  <li>a curved arrow pointing to a stack; click it to show the code for the handler in the debugger</li>
+ <li>a curved arrow pointing to a stack; click it to show the code for the handler in the debugger</li>
  <li>a label indicating whether the event bubbles</li>
  <li>a label indicating the system that defines the event. Firefox can display:
   <ul>

--- a/files/en-us/tools/page_inspector/how_to/examine_event_listeners/index.html
+++ b/files/en-us/tools/page_inspector/how_to/examine_event_listeners/index.html
@@ -18,9 +18,9 @@ tags:
 
 <ul>
  <li>a right-pointing arrowhead; click to expand the row and show the listener function source code</li>
- <li>a curved arrow pointing to a stack; click it to show the code for the handler in the debugger</li>
  <li>the name of the event for which a handler was attached to this element</li>
  <li>the name and line number for the listener; you can also click here to expand the row and view the listener function source code</li>
+  <li>a curved arrow pointing to a stack; click it to show the code for the handler in the debugger</li>
  <li>a label indicating whether the event bubbles</li>
  <li>a label indicating the system that defines the event. Firefox can display:
   <ul>


### PR DESCRIPTION
Change the order of elements describing the pop-up to reflect whats shown in the image.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The description list order doesn't reflect whats shown in the example image.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Examine_event_listeners
> Issue number (if there is an associated issue)

> Anything else that could help us review it
