### PR TITLE
fixing a bunch of 'sectioning' flaws

### DIFF
--- a/files/en-us/learn/css/howto/index.html
+++ b/files/en-us/learn/css/howto/index.html
@@ -70,6 +70,6 @@ tags:
  </ul>
 
 <div class="notecard note">
-  <h3>The CSS Layout Cookbook</h3>
+  <h4>The CSS Layout Cookbook</h4>
   <p>We have a cookbook dedicated to <a href="/en-US/docs/Web/CSS/Layout_cookbook">CSS Layout solutions</a>, with fully worked examples and explanations of common layout tasks.</p>
 </div>

--- a/files/en-us/mdn/structures/compatibility_tables/index.html
+++ b/files/en-us/mdn/structures/compatibility_tables/index.html
@@ -128,7 +128,6 @@ tags:
  <li>The top level object structure for JS built-in objects is <code>javascript.builtins</code>; see <a href="https://github.com/mdn/browser-compat-data/blob/master/javascript/builtins/Array.json">Array.json</a> for an example.</li>
 </ul>
 
-<div>
 <p>In HTML, CSS, and JS pages, you'll normally only need one feature. API interfaces work slightly differently — they always have multiple sub-features (see {{anch("Sub-features")}}, below).</p>
 
 <h3 id="Basic_structure_inside_a_feature">Basic structure inside a feature</h3>
@@ -283,7 +282,6 @@ tags:
 }</pre>
 
 <p>See <a href="https://github.com/mdn/browser-compat-data/blob/master/api/VRDisplay.json">VRDisplay.json</a> for a full example.</p>
-</div>
 
 <h2 id="Adding_data_Advanced_cases">Adding data: Advanced cases</h2>
 

--- a/files/en-us/mozilla/developer_guide/articles_for_new_developers/index.html
+++ b/files/en-us/mozilla/developer_guide/articles_for_new_developers/index.html
@@ -9,8 +9,6 @@ tags:
 
 <p>Also, before you go any further, we'd like to welcome you to the Mozilla community of developers! We look forward to your input!</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt class="landingPageList"><a href="/en-US/docs/Mozilla/Developer_guide/Introduction">Contributing to the Mozilla code base</a></dt>
  <dd class="landingPageList">This page should guide you through the initial steps of contributing to Mozilla. Welcome, we're delighted to see you! :)</dd>
@@ -18,11 +16,6 @@ tags:
  <dd class="landingPageList">Submitting a patch, getting it reviewed, and committed to the Mozilla source tree involves several steps. This article explains how.</dd>
 </dl>
 
-</div>
-
-<div class="section">
-</div>
-</div>
 
 <p>To add pages to the list above, open the page you'd like to add in the <a href="/en-US/docs/MDN/Contribute/Editor">MDN editor</a> by clicking the Edit button near the top of the page. Scroll to the bottom of the page to the <a href="/en-US/docs/MDN/Contribute/Editor/Basics#The_tags_box">tags list</a> and add the tag "Introduction". After a short while, the page will automatically appear in the list above.</p>
 

--- a/files/en-us/mozilla/developer_guide/index.html
+++ b/files/en-us/mozilla/developer_guide/index.html
@@ -8,8 +8,6 @@ tags:
 ---
 <p><span class="seoSummary">There are lots of ways to contribute to the Mozilla project: coding, testing, improving the build process and tools, or contributing to the documentation. This guide provides information that will not only help you get started as a Mozilla contributor, but that you'll find useful to refer to even if you are already an experienced contributor.</span></p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Documentation" id="Documentation_topics">Documentation topics</h2>
 
 <dl>
@@ -62,9 +60,7 @@ tags:
  <dt><a href="https://firefox-source-docs.mozilla.org/">Firefox Source Docs</a></dt>
  <dd>Web-hosted documentation built from the mozilla-central source code.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 id="Tools">Tools</h2>
 
 <dl>
@@ -93,5 +89,3 @@ tags:
  <dt><a class="external" href="http://www.codefirefox.com/videos/">Firefox development video tutorials</a></dt>
  <dd>Brian Bondy's video tutorials on Firefox development.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/mozilla/developer_guide/source_code/index.html
+++ b/files/en-us/mozilla/developer_guide/source_code/index.html
@@ -10,8 +10,6 @@ tags:
 ---
 <p>The articles below will help you get your hands on the Mozilla source code, learn to navigate the code, and how to get the changes you propose checked into the tree.</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a class="external" href="https://firefox-source-docs.mozilla.org/contributing/vcs/mercurial.html">Mercurial Overview</a></dt>
  <dd>If you plan to contribute to the Mozilla project, the best way to get the code is to check it out from the version control repository. Learn how to do that here.</dd>
@@ -24,9 +22,7 @@ tags:
  href="https://bugzilla.mozilla.org/buglist.cgi?query_format=advanced&product=Core&product=DevTools&product=Firefox&resolution=---&keywords=good-first-bug&keywords_type=allwords">Good first bugs</a></dt>
  <dd>If you are new to the project and want something to work on, look here.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><a class="external" href="https://firefox-source-docs.mozilla.org/code-quality/coding-style/index.html">Firefox coding style</a></dt>
  <dd>The code style guide provides information about how you should format your source code to ensure that you don't get mocked by the reviewers.</dd>
@@ -45,5 +41,3 @@ tags:
  <dt><a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Source_Code/CVS">Getting older Mozilla code from CVS</a></dt>
  <dd>Older versions of the Mozilla source code, as well as the current versions of NSS and NSPR, are kept in a CVS repository. Learn about that in this article.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/mozilla/developer_guide/svg_guidelines/index.html
+++ b/files/en-us/mozilla/developer_guide/svg_guidelines/index.html
@@ -39,7 +39,6 @@ tags:
 
 <h3 id="Whitespace_and_line_breaks">Whitespace and line breaks</h3>
 
-<div id="magicdomid5">
 <h4 id="Whitespace">Whitespace</h4>
 
 <p>In addition to trailing whitespace at the end of lines, there are a few more cases more specific to SVGs:</p>
@@ -72,7 +71,6 @@ tags:
 <p>You should only use line breaks for logical separation or if they help make the file readable. You should avoid line breaks between every single element or within attribute values. It's recommended to put the attributes on the same line as their tag names, if possible. You should also put the shortest attributes first, so they are easier to spot.</p>
 
 <h3 id="Unused_tags_and_attributes">Unused tags and attributes</h3>
-</div>
 
 <h4 id="Editor_metadata">Editor metadata</h4>
 

--- a/files/en-us/plugins/index.html
+++ b/files/en-us/plugins/index.html
@@ -11,8 +11,6 @@ tags:
 <p><strong>Important</strong>: plugins are a legacy technology that are a security and performance problem for Firefox (and other browser) users. They may not be supported in the future. New content should not be written using Flash or any other plugin technology.</p>
 </div>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 id="Roadmap">Roadmap</h2>
 
 <dl>
@@ -29,9 +27,7 @@ tags:
  <li>Starting with Firefox 56 in September 2017, Firefox for Android will remove all support for plugins (<a class="external external-icon" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1381916" title="FIXED: Remove support for plugins (flash)">bug 1381916</a>).</li>
  <li>Since <a href="/en-US/docs/Mozilla/Firefox/Releases/85">Firefox 85</a>, Flash support is no longer available in Firefox.</li>
 </ul>
-</div>
 
-<div class="section">
 <h2 id="Tutorials_and_references">Tutorials and references</h2>
 
 <p>The articles below are developer information about the  developing for click-to-play, and plugin blocking.</p>
@@ -44,5 +40,3 @@ tags:
  <dt><a href="/en-US/docs/Archive/Plugins">Archived Information</a></dt>
  <dd>Legacy documentation about developing NPAPI plugins.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.html
@@ -29,7 +29,6 @@ tags:
 
 <p>The <code>&lt;canvas&gt;</code> element can be styled just like any normal image ({{cssxref("margin")}}, {{cssxref("border")}}, {{cssxref("background")}}…). These rules, however, don't affect the actual drawing on the canvas. We'll see how this is done in a <a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors">dedicated chapter</a> of this tutorial. When no styling rules are applied to the canvas it will initially be fully transparent.</p>
 
-<div id="section_2">
 <h3 id="Fallback_content">Fallback content</h3>
 
 <p>The <code>&lt;canvas&gt;</code> element differs from an {{HTMLElement("img")}} tag in that, like for {{HTMLElement("video")}}, {{HTMLElement("audio")}}, or {{HTMLElement("picture")}} elements, it is easy to define some fallback content, to be displayed in older browsers not supporting it, like versions of Internet Explorer earlier than version 9 or textual browsers. You should always provide fallback content to be displayed by those browsers.</p>
@@ -67,7 +66,6 @@ var ctx = canvas.getContext('2d');
 
 <p>The first line in the script retrieves the node in the DOM representing the {{HTMLElement("canvas")}} element by calling the {{domxref("document.getElementById()")}} method. Once you have the element node, you can access the drawing context using its <code>getContext()</code> method.</p>
 
-<div id="section_5">
 <h2 id="Checking_for_support">Checking for support</h2>
 
 <p>The fallback content is displayed in browsers which do not support {{HTMLElement("canvas")}}. Scripts can also check for support programmatically by testing for the presence of the <code>getContext()</code> method. Our code snippet from above becomes something like this:</p>
@@ -81,7 +79,6 @@ if (canvas.getContext) {
   // canvas-unsupported code here
 }
 </pre>
-</div>
 </div>
 
 <h2 id="A_skeleton_template">A skeleton template</h2>

--- a/files/en-us/web/api/elementcssinlinestyle/index.html
+++ b/files/en-us/web/api/elementcssinlinestyle/index.html
@@ -17,7 +17,7 @@ tags:
 <p><strong>Note</strong>: <code>ElementCSSInlineStyle</code> is a mixin and not an interface; you can't actually create an object of type <code>ElementCSSInlineStyle</code>.</p>
 </div>
 
-<div>{{InterfaceOverview("CSSOM")}}</div>
+{{InterfaceOverview("CSSOM")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlorforeignelement/index.html
+++ b/files/en-us/web/api/htmlorforeignelement/index.html
@@ -22,7 +22,7 @@ tags:
 <p><strong>Note</strong>: <code>HTMLOrForeignElement</code> is a mixin and not an interface; you can't actually create an object of type <code>HTMLOrForeignElement</code>.</p>
 </div>
 
-<div>{{InterfaceOverview("HTML DOM")}}</div>
+{{InterfaceOverview("HTML DOM")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
@@ -115,7 +115,6 @@ div {
  <li><a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3">Stacking context example 3</a>: 3-level HTML hierarchy, z-index on the second level</li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
@@ -123,4 +122,3 @@ div {
  <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: November 3, 2014</li>
 </ul>
-</div>

--- a/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.html
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.html
@@ -229,7 +229,6 @@ h1 {
  <li><a href="/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3">Stacking context example 3</a>: 3-level HTML hierarchy, <code>z-index</code> on the second level</li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
@@ -237,4 +236,3 @@ h1 {
  <li>This article is the English translation of an article I wrote in Italian for <a href="http://www.yappy.it">YappY</a>. I grant the right to share all the content under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative Commons: Attribution-Sharealike license</a>.</li>
  <li>Last Updated Date: July 9, 2005</li>
 </ul>
-</div>

--- a/files/en-us/web/guide/index.html
+++ b/files/en-us/web/guide/index.html
@@ -9,8 +9,6 @@ tags:
 ---
 <p><strong>These articles provide how-to information to help make use of specific web technologies and APIs.</strong></p>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt class="landingPageList"><a href="/en-US/docs/Learn/HTML">HTML learning area</a></dt>
  <dd class="landingPageList"><strong>HyperText Markup Language (HTML)</strong> is the core language of nearly all web content. Most of what you see on screen in your browser is described, fundamentally, using HTML.</dd>
@@ -37,7 +35,6 @@ tags:
 </dl>
 </div>
 
-<div class="section">
 <dl>
  <dt class="landingPageList"><a href="/en-US/docs/Web/Progressive_web_apps#core_pwa_guides">Progressive web apps</a></dt>
  <dd class="landingPageList">Progressive web apps (PWAs) use modern web APIs along with traditional progressive enhancement strategy to create cross-platform web applications. These apps work everywhere and provide several features that give them the same user experience advantages as native apps. This set of guides tells you all you need to know about PWAs.</dd>
@@ -56,8 +53,6 @@ tags:
  <dt class="landingPageList"><a href="/en-US/docs/Glossary">Glossary</a></dt>
  <dd class="landingPageList">Defines numerous technical terms related to the Web and the Internet.</dd>
 </dl>
-</div>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/index.html
+++ b/files/en-us/web/mathml/index.html
@@ -14,8 +14,6 @@ tags:
 
 <p>Here you'll find links to documentation, examples, and tools to help you work with this powerful technology. For a quick overview, see the <a href="https://fred-wang.github.io/MozSummitMathML/index.html">slides for the innovation fairs at Mozilla Summit 2013</a>.</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 id="MathML_reference">MathML reference</h2>
 
 <dl>
@@ -29,9 +27,6 @@ tags:
  <dd>Suggestions and tips for writing MathML, including suggested MathML editors and how to integrate their output into Web content.</dd>
 </dl>
 
-</div>
-
-<div class="section">
 <h2 id="Getting_help_from_the_community">Getting help from the community</h2>
 
 <ul>
@@ -60,8 +55,6 @@ tags:
  <li><a href="/en-US/docs/Web/HTML">HTML</a></li>
  <li><a href="/en-US/docs/Web/SVG">SVG</a></li>
 </ul>
-</div>
-</div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/media/images/index.html
+++ b/files/en-us/web/media/images/index.html
@@ -9,8 +9,6 @@ tags:
 ---
 <p>The {{Glossary("HTML")}} {{HTMLElement("img")}} element lets you embed images into an HTML document, while the {{HTMLElement("picture")}} element enables <a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images">responsive images</a>. In this guide you'll find links to resources that deal with adding images to websites.</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Documentation" id="References">References</h2>
 
 <p>These articles cover some of the HTML elements and CSS properties that are used to control how images are displayed on the web.</p>
@@ -34,9 +32,7 @@ tags:
  <dt>{{cssxref("background-image")}}</dt>
  <dd>The <strong><code>background-image</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets one or more background images for an element.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 class="Documentation" id="Guides">Guides</h2>
 
 <p>These articles provide guidance on selecting and configuring image types.</p>
@@ -56,5 +52,3 @@ tags:
  <dt><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images">Learn HTML: Responsive Images</a></dt>
  <dd>In this article, we'll learn about the concept of responsive images — images that work well on devices with widely differing screen sizes, resolutions, and other such features — and look at what tools HTML provides to help implement them.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/web/progressive_web_apps/developer_guide/index.html
+++ b/files/en-us/web/progressive_web_apps/developer_guide/index.html
@@ -19,8 +19,6 @@ tags:
 
 <p><strong>---&gt;&gt;&gt; Titles below are just for the list; give articles good SEO names and feel free to tweak those and this as needed... &lt;&lt;&lt;---</strong></p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 class="Basics" id="Web_app_basics">Web app basics</h2>
 
 <dl>
@@ -50,9 +48,7 @@ tags:
  <dt>Gaming topics for web app developers</dt>
  <dd>description</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 class="Polishing" id="Polishing_web_apps">Polishing web apps</h2>
 
 <dl>
@@ -72,5 +68,3 @@ tags:
  <dt>some topic</dt>
  <dd>some description</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/web/security/same-origin_policy/index.html
+++ b/files/en-us/web/security/same-origin_policy/index.html
@@ -270,10 +270,8 @@ tags:
  <li>{{httpheader("Cross-Origin-Embedder-Policy")}}</li>
 </ul>
 
-<div class="originaldocinfo">
 <h2 id="Original_Document_Information">Original Document Information</h2>
 
 <ul>
  <li>Author(s): Jesse Ruderman</li>
 </ul>
-</div>

--- a/files/en-us/web/tutorials/index.html
+++ b/files/en-us/web/tutorials/index.html
@@ -31,77 +31,55 @@ tags:
 
 <h3 id="Introductory_level">Introductory level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">Introduction to HTML</a></dt>
  <dd>This module sets the stage, getting you used to important concepts and syntax, looking at applying HTML to text, how to create hyperlinks, and how to use HTML to structure a webpage.</dd>
  <dt><strong><a href="/en-US/docs/Web/HTML/Element">MDN HTML element reference</a></strong></dt>
  <dd>A comprehensive reference for HTML elements, and how the different browsers support them.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><strong><a href="https://www.theblogstarter.com/html-for-beginners">Creating a Simple Web Page with HTML</a> </strong></dt>
  <dd>An HTML guide for beginners that includes explanations of common tags, including HTML5 tags. Also includes a step-by-step guide to creating a basic web page with code examples.</dd>
  <dt><strong><a href="http://wikiversity.org/wiki/Web_Design/HTML_Challenges" rel="external">HTML Challenges</a> </strong></dt>
  <dd>Use these challenges to hone your HTML skills (for example, "Should I use an &lt;h2&gt; element or a &lt;strong&gt; element?"), focusing on meaningful markup.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Intermediate_level">Intermediate level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding">Multimedia and embedding</a></dt>
  <dd>This module explores how to use HTML to include multimedia in your web pages, including the different ways that images can be included, and how to embed video, audio, and even entire other webpages.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/HTML/Tables">HTML tables</a></dt>
  <dd>Representing tabular data on a webpage in an understandable, {{glossary("Accessibility", "accessible")}} way can be a challenge. This module covers basic table markup, along with more complex features such as implementing captions and summaries.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Advanced_level">Advanced level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/Forms">HTML forms</a></dt>
  <dd>Forms are a very important part of the Web — these provide much of the functionality you need for interacting with websites, e.g. registering and logging in, sending feedback, buying products, and more. This module gets you started with creating the client-side parts of forms.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><strong><a href="/en-US/docs/Learn/HTML/Howto/Author_fast-loading_HTML_pages">Tips for authoring fast-loading HTML pages</a></strong></dt>
  <dd>Optimize web pages to provide a more responsive site for visitors and reduce the load on your web server and Internet connection.</dd>
 </dl>
-</div>
-</div>
 
 <h2 class="Documentation" id="CSS-Tutorials">CSS Tutorials</h2>
 
 <h3 id="Introductory_level_2">Introductory level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/Getting_started_with_the_web/CSS_basics">CSS basics</a></dt>
  <dd>CSS (Cascading Style Sheets) is the code you use to style your webpage. <em>CSS Basics</em> takes you through what you need to get started. We'll answer questions like: How do I make my text black or red? How do I make my content show up in such-and-such a place on the screen? How do I decorate my webpage with background images and colors?</dd>
  <dt><a href="/en-US/docs/Learn/CSS/First_steps">CSS first steps</a></dt>
  <dd>CSS (Cascading Style Sheets) is used to style and lay out web pages — for example, to alter the font, color, size, and spacing of your content, split it into multiple columns, or add animations and other decorative features. This module provides a gentle beginning to your path towards CSS mastery with the basics of how it works, what the syntax looks like, and how you can start using it to add styling to HTML.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/CSS/Building_blocks">CSS building blocks</a></dt>
  <dd>
@@ -114,22 +92,16 @@ tags:
  <dt><strong><a href="/en-US/docs/Learn/CSS/Howto/CSS_FAQ">Common CSS Questions</a></strong></dt>
  <dd>Common questions and answers for beginners.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Intermediate_level_2">Intermediate level</h3>
 
-<div class="row topicpage-table" style="width: 100%;">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/CSS/CSS_layout">CSS layout</a></dt>
  <dd>At this point we've already looked at CSS fundamentals, how to style text, and how to style and manipulate the boxes that your content sits inside. Now it's time to look at how to place your boxes in the right place in relation to the viewport, and one another. We have covered the necessary prerequisites so can now dive deep into CSS layout, looking at different display settings, traditional layout methods involving float and positioning, and new fangled layout tools like flexbox.</dd>
  <dt><strong><a href="/en-US/docs/Web/CSS/Reference">CSS reference</a></strong></dt>
  <dd>Complete reference to CSS, with details on support by Firefox and other browsers.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><strong><a href="http://www.alistapart.com/articles/fluidgrids/" rel="external">Fluid Grids</a></strong></dt>
  <dd>Design layouts that fluidly resize with the browser window, while still using a typographic grid.</dd>
@@ -141,50 +113,38 @@ tags:
 
 <h3 id="Advanced_level_2">Advanced level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><strong><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></strong></dt>
  <dd>Apply rotation, skewing, scaling, and translation using CSS.</dd>
  <dt><strong><a href="/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions">CSS transitions</a></strong></dt>
  <dd>CSS transitions, part of the draft CSS3 specification, provide a way to animate changes to CSS properties, instead of having the changes take effect instantly.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><strong><a href="http://www.html5rocks.com/tutorials/webfonts/quick/" rel="external">Quick Guide to Implement Web Fonts  (with @font-face)</a> </strong></dt>
  <dd>The @font-face feature from CSS3 allows you to use custom typefaces on the web in an accessible, manipulatable, and scalable way.</dd>
  <dt><strong><a href="http://davidwalsh.name/starting-css" rel="external">Starting to Write CSS</a> </strong></dt>
  <dd>An introduction to tools and methodologies to write more succinct, maintainable, and scalable CSS.</dd>
 </dl>
-</div>
-</div>
 
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Web/API/Canvas_API/Tutorial">Canvas tutorial</a></dt>
  <dd>Learn how to draw graphics using scripting using the canvas element.</dd>
  <dt><strong><a href="http://html5doctor.com/" rel="external">HTML5 Doctor</a></strong></dt>
  <dd>Articles about using HTML5 right now.</dd>
 </dl>
-</div>
 
 <h2 class="Documentation" id="JavaScript-Tutorials">JavaScript Tutorials</h2>
 
 <h3 id="Introductory_level_3">Introductory level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/JavaScript/First_steps">JavaScript first steps</a></dt>
  <dd>In our first JavaScript module, we first answer some fundamental questions such as "what is JavaScript?", "what does it look like?", and "what can it do?", before moving on to taking you through your first practical experience of writing JavaScript. After that, we discuss some key JavaScript features in detail, such as variables, strings, numbers and arrays.</dd>
  <dt><a href="/en-US/docs/Learn/JavaScript/Building_blocks">JavaScript building blocks</a></dt>
  <dd>In this module, we continue our coverage of all JavaScript's key fundamental features, turning our attention to commonly-encountered types of code block such as conditional statements, loops, functions, and events. You've seen this stuff already in the course, but only in passing — here we'll discuss it all explicitly.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics">Getting started with JavaScript</a></dt>
  <dd>What is JavaScript and how can it help you?</dd>
@@ -193,22 +153,16 @@ tags:
  <dt><a href="https://learn.freecodecamp.org/">freeCodeCamp</a></dt>
  <dd>freeCodeCamp teaches a variety of languages and frameworks for web development. It also has a <a href="https://freecodecamp.org/forum">forum</a>, an <a href="https://coderadio.freecodecamp.org">internet radio station</a>, and a <a href="https://freecodecamp.org/news">blog</a>.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Intermediate_level_3">Intermediate level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Learn/JavaScript/Objects">Introducing JavaScript objects</a></dt>
  <dd>In JavaScript, most things are objects, from core JavaScript features like strings and arrays to the browser APIs built on top of JavaScript. You can even create your own objects to encapsulate related functions and variables into efficient packages. The object-oriented nature of JavaScript is important to understand if you want to go further with your knowledge of the language and write more efficient code, therefore we've provided this module to help you. Here we teach object theory and syntax in detail, look at how to create your own objects, and explain what JSON data is and how to work with it.</dd>
  <dt><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs">Client-side web APIs</a></dt>
  <dd>When writing client-side JavaScript for websites or applications, you won't go very far before you start to use APIs — interfaces for manipulating different aspects of the browser and operating system the site is running on, or even data from other websites or services. In this module, we will explore what APIs are, and how to use some of the most common APIs you'll come across often in your development work. </dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><strong><a href="/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript">A re-Introduction to JavaScript</a></strong></dt>
  <dd>A recap of the JavaScript programming language aimed at intermediate-level developers.</dd>
@@ -219,13 +173,9 @@ tags:
  <dt><strong><a href="http://www.addyosmani.com/resources/essentialjsdesignpatterns/book/" rel="external">Essential JavaScript Design Patterns</a> </strong></dt>
  <dd>An introduction to essential JavaScript design patterns.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Advanced_level_3">Advanced level</h3>
 
-<div class="row topicpage-table">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Web/JavaScript/Guide">JavaScript Guide</a></dt>
  <dd>A comprehensive, regularly updated guide to JavaScript for all levels of learning from beginner to advanced.</dd>
@@ -236,9 +186,7 @@ tags:
  <dt><strong><a href="http://exploringjs.com/es6/" rel="external">Exploring ES6</a> </strong></dt>
  <dd>Reliable and in-depth information on ECMAScript 2015.</dd>
 </dl>
-</div>
 
-<div class="section">
 <dl>
  <dt><strong><a href="https://shichuan.github.io/javascript-patterns" rel="external">JavaScript Patterns</a></strong></dt>
  <dd>A JavaScript pattern and antipattern collection that covers function patterns, jQuery patterns, jQuery plugin patterns, design patterns, general patterns, literals and constructor patterns, object creation patterns, code reuse patterns, DOM.</dd>
@@ -247,16 +195,10 @@ tags:
  <dt><a href="https://github.com/bolshchikov/js-must-watch">JavaScript Videos</a> </dt>
  <dd>A collection of JavaScript videos to watch.</dd>
 </dl>
-</div>
-</div>
 
 <h3 id="Extension_Development">Extension Development</h3>
 
-<div class="row topicpage-table" style="width: 100%;">
-<div class="section">
 <dl>
  <dt><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions">WebExtensions</a></dt>
  <dd>WebExtensions is a cross-browser system for developing browser add-ons. To a large extent, the system is compatible with the <a class="external-icon external" href="https://developer.chrome.com/extensions">extension API</a> supported by Google Chrome and Opera. Extensions written for these browsers will in most cases run in Firefox or <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/">Microsoft Edge</a> with <a href="https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/">just a few changes</a>. The API is also fully compatible with <a href="/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox">multiprocess Firefox</a>.</dd>
 </dl>
-</div>
-</div>

--- a/files/en-us/webassembly/index.html
+++ b/files/en-us/webassembly/index.html
@@ -18,8 +18,6 @@ tags:
 
 <p>And what's even better is that it is being developed as a web standard via the <a href="https://www.w3.org/wasm/">W3C WebAssembly Working Group</a> and <a href="https://www.w3.org/community/webassembly/">Community Group</a> with active participation from all major browser vendors.</p>
 
-<div class="row topicpage-table">
-<div class="section">
 <h2 id="Guides">Guides</h2>
 
 <dl>
@@ -42,9 +40,7 @@ tags:
  <dt><a href="/en-US/docs/WebAssembly/Text_format_to_wasm">Converting WebAssembly text format to wasm</a></dt>
  <dd>This article provides a guide on how to convert a WebAssembly module written in the text format into a .wasm binary.</dd>
 </dl>
-</div>
 
-<div class="section">
 <h2 id="API_reference">API reference</h2>
 
 <dl>
@@ -69,8 +65,6 @@ tags:
  <dt>{{jsxref("WebAssembly.RuntimeError()")}}</dt>
  <dd>Creates a new WebAssembly <code>RuntimeError</code> object.</dd>
 </dl>
-</div>
-</div>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The `sectioning` flaw is when a `<div>` or something forces a `<h2>` or `<h3>` to be at a deeper level an "root level" which means the page can't be broken down into sections by the `<h2>` and `<h3>`s which is useful for making those heading permalink-clickable and for them to show up in the Table of Contents sidebar. 

> MDN URL of main page changed

Multiple
