### PR TITLE
Adding GravitySensor API documentation.

### DIFF
--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -34,8 +34,8 @@ tags:
         {{domxref('sensor.onreading')}} will be called. A whole number or decimal may be
         used, the latter for frequencies less than a second. The actual reading frequency
         depends on device hardware and consequently may be less than requested. The default
-        frequency is the one defined by the underlying platform</li>
-      <li><code>referenceFrame</code>: The local coordinate system represents 
+        frequency is the one defined by the underlying platform.</li>
+      <li><code>referenceFrame</code>: The local coordinate system representing 
         the reference frame. It can be either  <code>'device'</code> or
         <code>'screen'</code>. The default is <code>'device'</code>.</li>
     </ul>
@@ -46,9 +46,9 @@ tags:
 
 <dl>
   <dt>SecurityError</dt>
-  <dd>If a feature policy blocks use of a feature, it is because your code is inconsistent
-    with the policies set on your server. This is not something that would ever be shown to
-    a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</dd>
+  <dd>Use of this feature was blocked by feature policy. If a feature policy blocks use of a feature,
+    it is because your code is inconsistent with the policies set on your server.
+    This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -18,10 +18,6 @@ tags:
     constructor creates a new {{domxref("GravitySensor")}} object which
     provides on each reading the gravity applied to the device along all three axes.</span></p>
 
-<p>If a feature policy blocks use of a feature, it is because your code is inconsistent
-  with the policies set on your server. This is not something that would ever be shown to
-  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre
@@ -37,11 +33,22 @@ tags:
         be taken, meaning the number of times per second that
         {{domxref('sensor.onreading')}} will be called. A whole number or decimal may be
         used, the latter for frequencies less than a second. The actual reading frequency
-        depends on device hardware and consequently may be less than requested.</li>
-      <li><code>referenceFrame</code>: Either <code>'device'</code> or
+        depends on device hardware and consequently may be less than requested. The default
+        frequency is the one defined by the underlying platform</li>
+      <li><code>referenceFrame</code>: The local coordinate system represents 
+        the reference frame. It can be either  <code>'device'</code> or
         <code>'screen'</code>. The default is <code>'device'</code>.</li>
     </ul>
   </dd>
+</dl>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>SecurityError</dt>
+  <dd>If a feature policy blocks use of a feature, it is because your code is inconsistent
+    with the policies set on your server. This is not something that would ever be shown to
+    a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -46,7 +46,7 @@ tags:
 
 <dl>
   <dt>SecurityError</dt>
-  <dd>Use of this feature was blocked by feature policy. If a feature policy blocks use of a feature,
+  <dd>Use of this feature was blocked by a feature policy. If a feature policy blocks use of a feature,
     it is because your code is inconsistent with the policies set on your server.
     This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</dd>
 </dl>

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -1,0 +1,73 @@
+---
+title: GravitySensor.GravitySensor()
+slug: Web/API/GravitySensor/GravitySensor
+tags:
+- API
+- Accelerometer
+- Constructor
+- Generic Sensor API
+- GravitySensor
+- Reference
+- Sensor
+- Sensor APIs
+- Sensors
+---
+<div>{{APIRef("Generic Sensor API")}}</div>
+
+<p><span class="seoSummary">The <strong><code>GravitySensor</code></strong>
+    constructor creates a new {{domxref("GravitySensor")}} object which
+    provides on each reading the gravity applied to the device along all three axes.</span></p>
+
+<p>If a feature policy blocks use of a feature, it is because your code is inconsistent
+  with the policies set on your server. This is not something that would ever be shown to
+  a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre
+  class="brush: js">let <var>gravitySensor</var> = new GravitySensor([<em>options</em>])</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><em>options</em> {{optional_inline}}</dt>
+  <dd>Options are as follows:
+    <ul>
+      <li><code>frequency</code>: The desired number of times per second a sample should
+        be taken, meaning the number of times per second that
+        {{domxref('sensor.onreading')}} will be called. A whole number or decimal may be
+        used, the latter for frequencies less than a second. The actual reading frequency
+        depends on device hardware and consequently may be less than requested.</li>
+      <li><code>referenceFrame</code>: Either <code>'device'</code> or
+        <code>'screen'</code>. The default is <code>'device'</code>.</li>
+    </ul>
+  </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Specification</th>
+      <th scope="col">Status</th>
+      <th scope="col">Comment</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Generic Sensor')}}</td>
+      <td>{{Spec2('Generic Sensor')}}</td>
+      <td>Defines sensors in general.</td>
+    </tr>
+    <tr>
+      <td>
+        {{SpecName('Accelerometer','#dom-gravitysensor-gravitysensor','GravitySensor')}}
+      </td>
+      <td>{{Spec2('Accelerometer')}}</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.GravitySensor.GravitySensor")}}</p>

--- a/files/en-us/web/api/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/index.html
@@ -19,8 +19,6 @@ tags:
 
 <p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code> device sensor through the {{domxref('Permissions')}} API.</p>
 
-<p>If a feature policy blocks use of a feature it is because your code is inconsistent with the policies set on your server. This is not something that would ever be shown to a user. See {{httpheader('Feature-Policy')}} for implementation instructions.</p>
-
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
@@ -38,12 +36,13 @@ tags:
 
 <pre class="brush: js">let gravitySensor = new GravitySensor({frequency: 60});
 
-gravitySensor.addEventListener('reading', e =&gt; {
-  console.log("Gravity along the X-axis " + gravitySensor.x);
-  console.log("Gravity along the Y-axis " + gravitySensor.y);
-  console.log("Gravity along the Z-axis " + gravitySensor.z);
+gravitySensor.addEventListener("reading", e =&gt; {
+  console.log(`Gravity along the X-axis ${gravitySensor.x}`);
+  console.log(`Gravity along the Y-axis ${gravitySensor.y}`);
+  console.log(`Gravity along the Z-axis ${gravitySensor.z}`);
 });
-laSensor.start();</pre>
+
+gravitySensor.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/index.html
@@ -1,13 +1,13 @@
 ---
-title: LinearAccelerationSensor
-slug: Web/API/LinearAccelerationSensor
+title: GravitySensor
+slug: Web/API/GravitySensor
 tags:
   - API
   - Accelerometer
   - Accelerometer API
   - Generic Sensor API
+  - GravitySensor
   - Interface
-  - LinearAccelerationSensor
   - Reference
   - Sensor
   - Sensor APIs
@@ -15,7 +15,7 @@ tags:
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
-<p><span class="seoSummary">The <strong><code>LinearAccelerationSensor</code></strong> interface of the <a href="/en-US/docs/Web/API/Sensor_APIs">Sensor APIs</a> provides on each reading the acceleration applied to the device along all three axes, but without the contribution of gravity. </span></p>
+<p><span class="seoSummary">The <strong><code>GravitySensor</code></strong> interface of the <a href="/en-US/docs/Web/API/Sensor_APIs">Sensor APIs</a> provides on each reading the gravity applied to the device along all three axes. </span></p>
 
 <p>To use this sensor, the user must grant permission to the <code>'accelerometer'</code> device sensor through the {{domxref('Permissions')}} API.</p>
 
@@ -24,8 +24,8 @@ tags:
 <h2 id="Constructor">Constructor</h2>
 
 <dl>
-	<dt>{{domxref("LinearAccelerationSensor.LinearAccelerationSensor()")}}</dt>
-	<dd>Creates a new <code>LinearAccelerationSensor</code> object.</dd>
+	<dt>{{domxref("GravitySensor.GravitySensor()")}}</dt>
+	<dd>Creates a new <code>GravitySensor</code> object.</dd>
 </dl>
 
 <h2 id="Properties">Properties</h2>
@@ -34,14 +34,14 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>Linear acceleration is typically read in the {{domxref('Sensor.onreading')}} event callback. In the example below this occurs sixty times a second.</p>
+<p>Gravity is typically read in the {{domxref('Sensor.onreading')}} event callback. In the example below this occurs sixty times a second.</p>
 
-<pre class="brush: js">let laSensor = new LinearAccelerationSensor({frequency: 60});
+<pre class="brush: js">let gravitySensor = new GravitySensor({frequency: 60});
 
-laSensor.addEventListener('reading', e =&gt; {
-  console.log("Linear acceleration along the X-axis " + laSensor.x);
-  console.log("Linear acceleration along the Y-axis " + laSensor.y);
-  console.log("Linear acceleration along the Z-axis " + laSensor.z);
+gravitySensor.addEventListener('reading', e =&gt; {
+  console.log("Gravity along the X-axis " + gravitySensor.x);
+  console.log("Gravity along the Y-axis " + gravitySensor.y);
+  console.log("Gravity along the Z-axis " + gravitySensor.z);
 });
 laSensor.start();</pre>
 
@@ -60,7 +60,7 @@ laSensor.start();</pre>
 			<td>Defines sensors in general.</td>
 		</tr>
 		<tr>
-			<td>{{SpecName('Accelerometer','#linearaccelerationsensor-interface','LinearAccelerationSensor')}}</td>
+			<td>{{SpecName('Accelerometer','#gravitysensor-interface','GravitySensor')}}</td>
 			<td>{{Spec2('Accelerometer')}}</td>
 			<td></td>
 		</tr>
@@ -69,4 +69,4 @@ laSensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LinearAccelerationSensor")}}</p>
+<p>{{Compat("api.GravitySensor")}}</p>

--- a/files/en-us/web/api/sensor/index.html
+++ b/files/en-us/web/api/sensor/index.html
@@ -24,6 +24,7 @@ tags:
 <ul>
 	<li>{{domxref('Accelerometer')}}</li>
 	<li>{{domxref('AmbientLightSensor')}}</li>
+	<li>{{domxref('GravitySensor')}}</li>
 	<li>{{domxref('Gyroscope')}}</li>
 	<li>{{domxref('LinearAccelerationSensor')}}</li>
 	<li>{{domxref('Magnetometer')}}</li>

--- a/files/en-us/web/api/sensor_apis/index.html
+++ b/files/en-us/web/api/sensor_apis/index.html
@@ -129,6 +129,10 @@ sensor.onerror = event =&gt; {
    <td><code>'ambient-light-sensor'</code></td>
   </tr>
   <tr>
+   <td><code>GravitySensor</code></td>
+   <td><code>'accelerometer'</code></td>
+  </tr>
+  <tr>
    <td><code>Gyroscope</code></td>
    <td><code>'gyroscope'</code></td>
   </tr>
@@ -175,6 +179,8 @@ magSensor.start();
  <dd>Provides the acceleration applied to the device along all three axes.</dd>
  <dt>{{domxref('AmbientLightSensor')}}{{securecontext_inline}}</dt>
  <dd>Returns the current light level or illuminance of the ambient light around the hosting device.</dd>
+ <dt>{{domxref('GravitySensor')}}{{securecontext_inline}}</dt>
+ <dd>Provides the gravity applied to the device along all three axes, but without the contribution of human artifact.</dd>
  <dt>{{domxref('Gyroscope')}}{{securecontext_inline}}</dt>
  <dd>Provides the angular velocity of the device along all three axes.</dd>
  <dt>{{domxref('LinearAccelerationSensor')}}{{securecontext_inline}}</dt>
@@ -208,7 +214,7 @@ magSensor.start();
   <tr>
    <td>{{SpecName('Accelerometer')}}</td>
    <td>{{Spec2('Accelerometer')}}</td>
-   <td>Defines <code>Accelerometer</code> and <code>LinearAccerationSensor</code>.</td>
+   <td>Defines <code>Accelerometer</code>, <code>GravitySensor</code> and <code>LinearAccelerationSensor</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName('AmbientLight')}}</td>

--- a/files/en-us/web/api/sensor_apis/index.html
+++ b/files/en-us/web/api/sensor_apis/index.html
@@ -180,7 +180,7 @@ magSensor.start();
  <dt>{{domxref('AmbientLightSensor')}}{{securecontext_inline}}</dt>
  <dd>Returns the current light level or illuminance of the ambient light around the hosting device.</dd>
  <dt>{{domxref('GravitySensor')}}{{securecontext_inline}}</dt>
- <dd>Provides the gravity applied to the device along all three axes, but without the contribution of human artifact.</dd>
+ <dd>Provides the gravity applied to the device along all three axes.</dd>
  <dt>{{domxref('Gyroscope')}}{{securecontext_inline}}</dt>
  <dd>Provides the angular velocity of the device along all three axes.</dd>
  <dt>{{domxref('LinearAccelerationSensor')}}{{securecontext_inline}}</dt>
@@ -214,7 +214,7 @@ magSensor.start();
   <tr>
    <td>{{SpecName('Accelerometer')}}</td>
    <td>{{Spec2('Accelerometer')}}</td>
-   <td>Defines <code>Accelerometer</code>, <code>GravitySensor</code> and <code>LinearAccelerationSensor</code>.</td>
+   <td>Defines <code>Accelerometer</code>, <code>GravitySensor</code>, and <code>LinearAccelerationSensor</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName('AmbientLight')}}</td>


### PR DESCRIPTION
Fixes #3524
Implementation of GravitySensor API for Chrome 91 [1]
Dependency with update of compat-data [2]
[1] https://chromestatus.com/features/5384099747332096
[2] https://github.com/mdn/browser-compat-data/pull/9628
