### PR TITLE
Default :focus was not accessible

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.html
+++ b/files/en-us/web/css/_colon_focus-visible/index.html
@@ -63,7 +63,7 @@ tags:
 custom-button:focus {
   /* Provide a fallback style for browsers
      that don't support :focus-visible */
-  outline: none;
+  outline: 2px solid red;
   background: lightgrey;
 }
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

On the default `:focus` example the outline was removed completely, thus making it inaccessible to people using browsers that don't support `:focus-visible`

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible

> Issue number (if there is an associated issue)

(none)

> Anything else that could help us review it
