### PR TITLE
Use === instead of == in example

### DIFF
--- a/files/en-us/web/javascript/a_re-introduction_to_javascript/index.html
+++ b/files/en-us/web/javascript/a_re-introduction_to_javascript/index.html
@@ -288,14 +288,14 @@ x = x + 5;
 <p>JavaScript has a similar set of control structures to other languages in the C family. Conditional statements are supported by <code>if</code> and <code>else</code>; you can chain them together if you like:</p>
 
 <pre class="brush: js">var name = 'kittens';
-if (name == 'puppies') {
+if (name === 'puppies') {
   name += ' woof';
-} else if (name == 'kittens') {
+} else if (name === 'kittens') {
   name += ' meow';
 } else {
   name += '!';
 }
-name == 'kittens meow';
+name === 'kittens meow';
 </pre>
 
 <p>JavaScript has <code>while</code> loops and <code>do-while</code> loops. The first is good for basic looping; the second for loops where you wish to ensure that the body of the loop is executed at least once:</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

This follows right after a section about the quirks of == so seeing == was a bit jarring. Also seems better to promote === in an introduction. 

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript

> Issue number (if there is an associated issue)

> Anything else that could help us review it
