### PR TITLE
Fixed example output.

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -320,7 +320,7 @@ console.log(myHeaders.get('Content-Length')); // 11
 console.log(myHeaders.get('X-Custom-Header')); // ['ProcessThisImmediately', 'AnotherValue']
 
 myHeaders.delete('X-Custom-Header');
-console.log(myHeaders.get('X-Custom-Header')); // [ ]
+console.log(myHeaders.get('X-Custom-Header')); // null
 </pre>
 
 <p>Some of these operations are only useful in {{domxref("Service_Worker_API","ServiceWorkers")}}, but they provide a much nicer API for manipulating headers.</p>


### PR DESCRIPTION
This fixes log output in the "Headers" section.



URL : https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#headers

Fixes #3265.


