### PR TITLE
Typo in glossary HTTP safe entry

### DIFF
--- a/files/en-us/glossary/safe/index.html
+++ b/files/en-us/glossary/safe/index.html
@@ -13,7 +13,7 @@ tags:
 
 <p>It is the responsibility of the application on the server to implement the safe semantic correctly, the webserver itself, being Apache, Nginx or IIS, can't enforce it by itself. In particular, an application should not allow {{HTTPMethod("GET")}} requests to alter its state.</p>
 
-<p>A call to a safe method, not changing the state for the server:</p>
+<p>A call to a safe method, not changing the state of the server:</p>
 
 <pre>GET /pageX.html HTTP/1.1
 </pre>


### PR DESCRIPTION
Fixed typo

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Typo fix only.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Glossary/safe

> Issue number (if there is an associated issue)
NA

> Anything else that could help us review it
NA