### PR TITLE
update createBuffer() page to increase readability

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
@@ -29,8 +29,8 @@ tags:
     data and give back decoded samples, but this ability was removed from the specification,
     because all the decoding was done on the main thread, so
     <code>createBuffer()</code> was blocking other code execution. The asynchronous method
-    <code>decodeAudioData()</code> does the same thing: it takes compressed audio, say, an
-    MP3 file, and it directly gives back an {{ domxref("AudioBuffer") }} that can
+    <code>decodeAudioData()</code> does the same thing — takes compressed audio, such as an
+    MP3 file, and directly gives you back an {{ domxref("AudioBuffer") }} that you can
     then play via an {{ domxref("AudioBufferSourceNode") }}. For simple use cases
     like playing an MP3, <code>decodeAudioData()</code> is what you should be using.</p>
 </div>

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
@@ -26,7 +26,7 @@ tags:
 
 <div class="note">
   <p><strong>Note</strong>: <code>createBuffer()</code> used to be able to take compressed
-    data and give back decoded samples, but this ability is no longer in the specification,
+    data and give back decoded samples, but this ability was removed from the specification,
     because all the decoding was done on the main thread, so
     <code>createBuffer()</code> was blocking other code execution. The asynchronous method
     <code>decodeAudioData()</code> does the same thing: it takes compressed audio, say, an

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
@@ -26,12 +26,12 @@ tags:
 
 <div class="note">
   <p><strong>Note</strong>: <code>createBuffer()</code> used to be able to take compressed
-    data and give back decoded samples, but this ability was removed from the spec,
-    because all the decoding was done on the main thread, therefore
+    data and give back decoded samples, but this ability is no longer in the specification,
+    because all the decoding was done on the main thread, so
     <code>createBuffer()</code> was blocking other code execution. The asynchronous method
-    <code>decodeAudioData()</code> does the same thing — takes compressed audio, say, an
-    MP3 file, and directly gives you back an {{ domxref("AudioBuffer") }} that you can
-    then set to play via in an {{ domxref("AudioBufferSourceNode") }}. For simple uses
+    <code>decodeAudioData()</code> does the same thing: it takes compressed audio, say, an
+    MP3 file, and it directly gives back an {{ domxref("AudioBuffer") }} that can
+    then play via an {{ domxref("AudioBufferSourceNode") }}. For simple use cases
     like playing an MP3, <code>decodeAudioData()</code> is what you should be using.</p>
 </div>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I think there's room for improvement in the readability of the `createBuffer()` page.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createBuffer

> Issue number (if there is an associated issue)

I created issue #3606 to track this issue. This pull request closes #3606 if we merge it.

> Anything else that could help us review it

This is a minor change that just affects one paragraph.