### PR TITLE
Update FinalizationRegistry and WeakRef documents

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.html
@@ -45,7 +45,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('WeakRefs', '#sec-finalization-registry-constructor', 'FinalizationRegistry constructor')}}</td>
+   <td>{{SpecName('ESDraft', '#sec-finalization-registry-constructor', 'FinalizationRegistry constructor')}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/index.html
@@ -129,7 +129,7 @@ registry.unregister(tokenObject);
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('WeakRefs', '#sec-finalization-registry-objects', 'FinalizationRegistry')}}</td>
+   <td>{{SpecName('ESDraft', '#sec-finalization-registry-objects', 'FinalizationRegistry')}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/register/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/register/index.html
@@ -40,9 +40,9 @@ tags:
 <h2 id="Notes">Notes</h2>
 
 <p>See the <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#Avoid_where_possible">Avoid
+    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#avoid_where_possible">Avoid
     where possible</a> and <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#Notes_on_cleanup_callbacks">Notes
+    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry#notes_on_cleanup_callbacks">Notes
     on cleanup callbacks</a> sections of the {{jsxref("FinalizationRegistry")}} page for
   important caveats.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/register/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/register/index.html
@@ -74,7 +74,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('WeakRefs', '#sec-finalization-registry.prototype.register',
+      <td>{{SpecName('ESDraft', '#sec-finalization-registry.prototype.register',
         'FinalizationRegistry.prototype.register')}}</td>
     </tr>
   </tbody>

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/unregister/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/unregister/index.html
@@ -121,7 +121,7 @@ tags:
     </thead>
     <tbody>
         <tr>
-            <td>{{SpecName('WeakRefs', '#sec-finalization-registry.prototype.unregister',
+            <td>{{SpecName('ESDraft', '#sec-finalization-registry.prototype.unregister',
                 'FinalizationRegistry.prototype.unregister')}}</td>
         </tr>
     </tbody>

--- a/files/en-us/web/javascript/reference/global_objects/weakref/deref/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakref/deref/index.html
@@ -61,7 +61,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('WeakRefs', '#sec-weak-ref.prototype.deref',
+      <td>{{SpecName('ESDraft', '#sec-weak-ref.prototype.deref',
         'WeakRef.prototype.deref()')}}</td>
     </tr>
   </tbody>

--- a/files/en-us/web/javascript/reference/global_objects/weakref/deref/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakref/deref/index.html
@@ -26,7 +26,7 @@ tags:
 <h2 id="Notes">Notes</h2>
 
 <p>See the <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#Notes_on_WeakRefs">Notes
+    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#notes_on_weakrefs">Notes
     on WeakRefs</a> section of the {{jsxref("WeakRef")}} page for some important notes.
 </p>
 
@@ -35,7 +35,7 @@ tags:
 <h3 id="Using_deref">Using deref</h3>
 
 <p>See the <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#Examples">Examples</a>
+    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#examples">Examples</a>
   section of the {{jsxref("WeakRef")}} page for the complete example.</p>
 
 <pre class="brush: js">const tick = () =&gt; {

--- a/files/en-us/web/javascript/reference/global_objects/weakref/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakref/index.html
@@ -125,7 +125,7 @@ setTimeout(() =&gt; {
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('WeakRefs', '#sec-weak-ref-objects', 'WeakRef')}}</td>
+   <td>{{SpecName('ESDraft', '#sec-weak-ref-objects', 'WeakRef')}}</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/weakref/weakref/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakref/weakref/index.html
@@ -51,7 +51,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('WeakRefs', '#sec-weak-ref-constructor', 'WeakRef constructor')}}
+      <td>{{SpecName('ESDraft', '#sec-weak-ref-constructor', 'WeakRef constructor')}}
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/javascript/reference/global_objects/weakref/weakref/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakref/weakref/index.html
@@ -30,7 +30,7 @@ tags:
 <h3 id="Creating_a_new_WeakRef_object">Creating a new WeakRef object</h3>
 
 <p>See the main <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#Examples"><code>WeakRef</code></a>
+    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#examples"><code>WeakRef</code></a>
   page for a complete example.</p>
 
 <pre class="brush: js">class Counter {


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

FinalizationRegistry and WeakRef have advanced to Stage 4 of the TC39 process, and they are now included in the official ECMAScript spec draft.

> MDN URL of main page changed

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
