### PR TITLE
Correct aria-labelledby reference in landmark labelling example

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/region_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/region_role/index.html
@@ -67,7 +67,7 @@ tags:
 
 <p>If there is more than one <code>region</code> landmark role in a document, provide a label for each one. This label will allow an assistive technology user to be able to quickly understand the purpose of each landmark.</p>
 
-<pre class="brush: html">&lt;div role="region" aria-labelledby="heading"&gt;
+<pre class="brush: html">&lt;div role="region" aria-labelledby="use-discretion"&gt;
   &lt;h3 id="use-discretion"&gt;Please use the &lt;code&gt;region&lt;/code&gt; role with discretion&lt;/h3&gt;
   &lt;!-- content --&gt;
 &lt;/div&gt;


### PR DESCRIPTION
Corrects the `aria-labelledby` reference in the landmark labelling example on the [ARIA: Region role ](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Region_role#labeling_landmark) page. There's no element tagged with an id of `"heading"`, this simply changes it to `"use-discretion"`.

### Before

```html
<div role="region" aria-labelledby="heading">
  <h3 id="use-discretion">Please use the <code>region</code> role with discretion</h3>
  <!-- content -->
</div>
```

### After
```html
<div role="region" aria-labelledby="use-discretion">
  <h3 id="use-discretion">Please use the <code>region</code> role with discretion</h3>
  <!-- content -->
</div>
```
