### PR TITLE
Minor fix: h2 id did not match content

### DIFF
--- a/files/en-us/web/index.html
+++ b/files/en-us/web/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>The open Web presents incredible opportunities for developers. To take full advantage of these technologies, you need to know how to use them. Below you'll find links to our Web technology documentation.</p>
 
-<h2 class="Documentation" id="Docs_for_web_developers">Documentation for Web developers</h2>
+<h2 id="documentation_for_web_developers">Documentation for Web developers</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Reference">Web Developer Reference</a></dt>
@@ -20,7 +20,7 @@ tags:
  <dd>Progressive Web Apps are web apps that use emerging web browser APIs and features along with traditional progressive enhancement strategy to bring a native app-like user experience to cross-platform web applications.</dd>
 </dl>
 
-<h2 class="Documentation" id="Web_technology_references">Web technology references</h2>
+<h2 class="Documentation" id="web_technology_references">Web technology references</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Reference/API">Web APIs</a></dt>
@@ -37,7 +37,7 @@ tags:
  <dd>The Mathematical Markup Language makes it possible to display complex mathematical equations and syntax.</dd>
 </dl>
 
-<h3 id="Temporary">Temporary</h3>
+<h3 id="temporary">Temporary</h3>
 
 <p>The stuff below here is temporary to help keep track of things while organization work is ongoing. Pay it no mind.</p>
 

--- a/files/en-us/web/index.html
+++ b/files/en-us/web/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>The open Web presents incredible opportunities for developers. To take full advantage of these technologies, you need to know how to use them. Below you'll find links to our Web technology documentation.</p>
 
-<h2 class="Documentation" id="Docs_for_add-on_developers">Documentation for Web developers</h2>
+<h2 class="Documentation" id="Docs_for_web_developers">Documentation for Web developers</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/Reference">Web Developer Reference</a></dt>


### PR DESCRIPTION
In https://developer.mozilla.org/en-US/docs/Web
  <h2 …. id="Docs_for_add-on_developers">Documentation for Web developers</h2>
probably should have id="Docs_for_web_developers", I think.
