### PR TITLE
Drop “check compat table” note from clipboard.writeText() doc

### DIFF
--- a/files/en-us/web/api/clipboard/writetext/index.html
+++ b/files/en-us/web/api/clipboard/writetext/index.html
@@ -26,14 +26,6 @@ tags:
     href="/en-US/docs/Web/API/Permissions_API">Permissions API</a>, is granted
   automatically to pages when they are in the active tab.</p>
 
-<div class="note">
-  <p><strong>Note:</strong> Browser support for the asynchronous clipboard APIs is still
-    in the process of being implemented. Be sure to check the {{anch("Browser
-    compatibility", "compatibility table")}} as well as
-    {{SectionOnPage("/en-US/docs/Web/API/Clipboard", "Clipboard availability")}} for more
-    information.</p>
-</div>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/3593