### PR TITLE
add[webAPI]: links to docs on mentioned methods

### DIFF
--- a/files/en-us/web/api/history/state/index.html
+++ b/files/en-us/web/api/history/state/index.html
@@ -73,6 +73,6 @@ console.log(`History.state after pushState: ${history.state}`);</pre>
 
 <ul>
   <li><a href="/en-US/docs/Web/API/History_API/Working_with_the_History_API">Working with the History API</a></li>
-  <li><a href="/en-US/docs/Web/API/History/pushState">History.pushState</a></li>
-  <li><a href="/en-US/docs/Web/API/History/replaceState">History.replaceState</a></li>
+  <li><a href="/en-US/docs/Web/API/History/pushState"><code>History.pushState()</code></a></li>
+  <li><a href="/en-US/docs/Web/API/History/replaceState"><code>History.replaceState()</code></a></li>
 </ul>

--- a/files/en-us/web/api/history/state/index.html
+++ b/files/en-us/web/api/history/state/index.html
@@ -72,6 +72,7 @@ console.log(`History.state after pushState: ${history.state}`);</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/History_API/Working_with_the_History_API">Working with
-      the History API</a></li>
+  <li><a href="/en-US/docs/Web/API/History_API/Working_with_the_History_API">Working with the History API</a></li>
+  <li><a href="/en-US/docs/Web/API/History/pushState">History.pushState</a></li>
+  <li><a href="/en-US/docs/Web/API/History/replaceState">History.replaceState</a></li>
 </ul>


### PR DESCRIPTION
Add links to replaceState and pushState to the *See also* section

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Nothing, just a minor enhancement.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/History/state
