### PR TITLE
Fixed hueRotate snippet

### DIFF
--- a/files/en-us/web/css/filter/index.html
+++ b/files/en-us/web/css/filter/index.html
@@ -664,9 +664,9 @@ table.standard-table td {
 </div>
 
 <pre class="brush: html">&lt;svg style="position: absolute; top: -999999px" xmlns="http://www.w3.org/2000/svg"&gt;
-  &lt;filter id="svgHueRotate" &gt;
-    &lt;feColorMatrix type="hueRotate" values="[angle]" /&gt;
-  &lt;filter /&gt;
+  &lt;filter id="svgHueRotate"&gt;
+    &lt;feColorMatrix type="hueRotate" values="[angle]"/&gt;
+  &lt;/filter&gt;
 &lt;/svg&gt;</pre>
 
 <p>{{EmbedLiveSample('huerotate_example','100%','221px','','', 'no-codepen')}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The hue-rotation() snippet was incorrect.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/filter

> Issue number (if there is an associated issue)

> Anything else that could help us review it
