### PR TITLE
Fix up css compat layout

### DIFF
--- a/files/en-us/learn/css/first_steps/what_is_css/index.html
+++ b/files/en-us/learn/css/first_steps/what_is_css/index.html
@@ -105,13 +105,16 @@ p {
 
 <p>As a newcomer to CSS, it is likely that you will find the CSS specs overwhelming — they are intended for engineers to use to implement support for the features in user agents, not for web developers to read to understand CSS. Many experienced developers would much rather refer to MDN documentation or other tutorials. It is however worth knowing that they exist, understanding the relationship between the CSS you are using, browser support (see below), and the specs.</p>
 
-<h2 id="Browser_support">Browser support</h2>
 
-<p>Once CSS has been specified then it is only useful for us in developing web pages if one or more browsers have implemented it. This means that the code has been written to turn the instruction in our CSS file into something that can be output to the screen. We'll look at this process more in the lesson <a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">How CSS works</a>. It is unusual for all browsers to implement a feature at the same time, and so there is usually a gap where you can use some part of CSS in some browsers and not in others. For this reason, being able to check implementation status is useful. On each property page on MDN you can see the status of the property you are interested in, so you can tell if you will be able to use it on a website.</p>
+<h2 id="Browser_support">Browser support information</h2>
 
-<p>What follows is the compat data chart for the CSS <code><a href="/en-US/docs/Web/CSS/font-family">font-family</a></code> property.</p>
+<p>Once CSS has been specified then it is only useful for us in developing web pages if one or more browsers have implemented it. This means that the code has been written to turn the instruction in our CSS file into something that can be output to the screen. We'll look at this process more in the lesson <a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">How CSS works</a>. It is unusual for all browsers to implement a feature at the same time, and so there is usually a gap where you can use some part of CSS in some browsers and not in others. For this reason, being able to check implementation status is useful. </p>
 
-<p>{{Compat("css.properties.font-family")}}</p>
+<p>The browser support status is shown on every MDN property page in a section named "Browser compatibility" (use this to check if the property can be used on your website). For example, the compatibility section for the CSS <code><a href="/en-US/docs/Web/CSS/font-family">font-family</a></code> property is reproduced below.</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div>{{Compat("css.properties.font-family")}}</div>
 
 <h2 id="Whats_next">What's next</h2>
 

--- a/files/en-us/learn/css/first_steps/what_is_css/index.html
+++ b/files/en-us/learn/css/first_steps/what_is_css/index.html
@@ -106,7 +106,7 @@ p {
 <p>As a newcomer to CSS, it is likely that you will find the CSS specs overwhelming — they are intended for engineers to use to implement support for the features in user agents, not for web developers to read to understand CSS. Many experienced developers would much rather refer to MDN documentation or other tutorials. It is however worth knowing that they exist, understanding the relationship between the CSS you are using, browser support (see below), and the specs.</p>
 
 
-<h2 id="Browser_support">Browser support information</h2>
+<h2 id="Browser_support_information">Browser support information</h2>
 
 <p>Once CSS has been specified then it is only useful for us in developing web pages if one or more browsers have implemented it. This means that the code has been written to turn the instruction in our CSS file into something that can be output to the screen. We'll look at this process more in the lesson <a href="/en-US/docs/Learn/CSS/First_steps/How_CSS_works">How CSS works</a>. It is unusual for all browsers to implement a feature at the same time, and so there is usually a gap where you can use some part of CSS in some browsers and not in others. For this reason, being able to check implementation status is useful. </p>
 


### PR DESCRIPTION
The browser support section in https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/What_is_CSS shows the compat table and then has text that refers to it (even though the text is intended to go first). This is caused by the macro, which floats the content up.

I have chosen to fix this by splitting the compat section under its own heading. This is a little unnatural from a flow point of view but about the right effort for the benefit :-)

Fixes #3609

