### PR TITLE
Small typo on Chromium name, error in version and link

### DIFF
--- a/files/en-us/web/html/using_the_application_cache/index.html
+++ b/files/en-us/web/html/using_the_application_cache/index.html
@@ -15,7 +15,7 @@ tags:
 <p><strong>Do not use this <em>application cache</em> feature!</strong> It is <a href="https://html.spec.whatwg.org/multipage/browsers.html#offline">in the process of being removed from the Web platform</a>.</p>
 
 <ul>
- <li>From Firefox 84 it has been removed ({{bug("1619673")}}). It is also planned for removal in Chomium 90, and is deprecated in Safari.</li>
+ <li>From Firefox 84 it has been removed ({{bug("1619673")}}). It is also planned for removal in <a title="Web.dev article about AppCache removal in Chromium" href="https://web.dev/appcache-removal/">Chromium 93</a>, and is deprecated in Safari.</li>
  <li>From Firefox 60, and in some or all <a href="/en-US/docs/Web/HTML/Using_the_application_cache#Browser_compatibility">supporting browsers</a>, it is only available in <a href="/en-US/docs/Web/Security/Secure_Contexts">secure contexts</a> (HTTPS).</li>
  <li>As of Firefox 44+, when <a href="/en-US/docs/Web/HTML/Using_the_application_cache">AppCache</a> is used to provide offline support for a page, a warning message displays in the console advising developers to use <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Service workers</a> instead ({{bug("1204581")}})</li>
 </ul>


### PR DESCRIPTION
Just those three changes, as mentioned:
- Typo in the word "Chromium"
- Version has been postponed to 93
- Added the source.
