### PR TITLE
Add AbortSignal.abort() static method (FF88)

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -69,7 +69,7 @@ tags:
 <h4 id="DOM">DOM</h4>
 
 <ul>
-  <li>Code can now use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted">aborted</a>. This is useful when the signal is requested/created after the associated operation has <em>already</em> been aborted. For more information see {{bug(1698468)}}.</li>
+  <li>Code can now use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted">aborted</a>. For more information see {{bug(1698468)}}.</li>
 </ul>
 
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -1,0 +1,50 @@
+---
+title: AbortSignal.abort()
+slug: Web/API/AbortSignal/abort
+tags:
+  - API
+  - AbortSignal
+  - Method
+  - Reference
+  - abort
+---
+<div>{{APIRef("DOM")}}</div>
+
+<p class="summary">The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does trigger an abort event).</p>
+
+<p>This is useful because the {{domxref("AbortSignal")}} is lazily created when first requested, and might not be called for until after the associated operation, for example an HTTP request, has <em>already</em> been aborted. This method allows code to return an aborted signal instance rather than an undefined object, or raising an exception.</p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The method is similar in purpose to {{JSxRef("Promise.reject")}}</p>
+</div>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">AbortSignal.abort();</pre>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>An <code>AbortSignal</code> instance with the {{domxref("AbortSignal.aborted")}} property set to <code>true</code>.</p>.
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('DOM WHATWG', '#interface-AbortSignal', 'AbortSignal')}}</td>
+   <td>{{Spec2('DOM WHATWG')}}</td>
+   <td>Initial definition</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.AbortSignal.abort")}}</p>

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -18,7 +18,7 @@ tags:
 controller.abort();
 return controller.signal;</pre>
 
-<p>This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organised such that this code should be run even if the intended fetch operation has not been started).</p>
+<p>This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organised such that the abort logic should be run even if the intended fetch operation has not been started).</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p class="summary">The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an abort event).</p>
 
-<p>This is useful because the {{domxref("AbortSignal")}} is lazily created when first requested, and might not be called for until after the associated operation, for example an HTTP request, has <em>already</em> been aborted. This method allows code to return an aborted signal instance rather than an undefined object, or raising an exception.</p>
+<p>This is useful because the {{domxref("AbortSignal")}} is lazily created when first requested, and might not be accessed until after the associated operation has <em>already</em> been aborted (for example an HTTP request). This method allows code to return an aborted signal instance rather than an undefined object, or raising an exception.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -12,7 +12,13 @@ tags:
 
 <p class="summary">The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an abort event).</p>
 
-<p>This is useful because the {{domxref("AbortSignal")}} is lazily created when first requested, and might not be accessed until after the associated operation has <em>already</em> been aborted (for example an HTTP request). This method allows code to return an aborted signal instance rather than an undefined object, or raising an exception.</p>
+<p>This is shorthand for the following code:</p>
+
+<pre class="brush: js">const controller = new AbortController();
+  controller.abort();
+  return controller.signal;</pre>
+
+<p>This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organised such that this code should be run even if the intended fetch operation has not been started).</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -15,8 +15,8 @@ tags:
 <p>This is shorthand for the following code:</p>
 
 <pre class="brush: js">const controller = new AbortController();
-  controller.abort();
-  return controller.signal;</pre>
+controller.abort();
+return controller.signal;</pre>
 
 <p>This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organised such that this code should be run even if the intended fetch operation has not been started).</p>
 

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p class="summary">The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does trigger an abort event).</p>
+<p class="summary">The static <strong><code>AbortSignal.abort()</code></strong> method returns an {{domxref("AbortSignal")}} that is already set as aborted (and which does not trigger an abort event).</p>
 
 <p>This is useful because the {{domxref("AbortSignal")}} is lazily created when first requested, and might not be called for until after the associated operation, for example an HTTP request, has <em>already</em> been aborted. This method allows code to return an aborted signal instance rather than an undefined object, or raising an exception.</p>
 

--- a/files/en-us/web/api/abortsignal/aborted/index.html
+++ b/files/en-us/web/api/abortsignal/aborted/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p>The <strong><code>aborted</code></strong> read-only property returns a {{domxref("Boolean")}} that indicates whether the DOM request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</p>
+<p>The <strong><code>aborted</code></strong> read-only property returns a {{Glossary("Boolean")}} that indicates whether the DOM request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -19,7 +19,7 @@ tags:
 
 <h3 id="Value">Value</h3>
 
-<p>A {{domxref("Boolean")}}</p>
+<p>A {{Glossary("Boolean")}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/abortsignal/aborted/index.html
+++ b/files/en-us/web/api/abortsignal/aborted/index.html
@@ -11,19 +11,19 @@ tags:
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p>The <strong><code>aborted</code></strong> read-only property returns a {{Glossary("Boolean")}} that indicates whether the DOM request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</p>
+<p>The <strong><code>aborted</code></strong> read-only property returns a value that indicates whether the DOM request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var isAborted = abortSignal.aborted;</pre>
+<pre class="brush: js">abortSignal.aborted;</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>A {{Glossary("Boolean")}}</p>
+<p><code>true</code> (aborted) or <code>false</code></p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following snippet, we create a new <code>AbortController</code> object, and get its {{domxref("AbortSignal")}} (available in the <code>signal</code> property). Later on we check whether or not it the signal has been aborted using the <code>aborted</code> property, and send an appropriate log to the console.</p>
+<p>In the following snippet, we create a new <code>AbortController</code> object, and get its {{domxref("AbortSignal")}} (available in the <code>signal</code> property). Later on we check whether or not the signal has been aborted using the <code>aborted</code> property, and send an appropriate log to the console.</p>
 
 <pre class="brush: js">var controller = new AbortController();
 var signal = controller.signal;

--- a/files/en-us/web/api/abortsignal/index.html
+++ b/files/en-us/web/api/abortsignal/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt>{{domxref("AbortSignal.aborted")}} {{readonlyInline}}</dt>
- <dd>A {{domxref("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</dd>
+ <dd>A {{jsxref("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</dd>
 </dl>
 
 <h2 id="Events">Events</h2>
@@ -34,7 +34,16 @@ tags:
 
 <h2 id="Methods">Methods</h2>
 
-<p><em>The AbortSignal interface inherits methods from its parent interface, {{domxref("EventTarget")}}.</em></p>
+<p><em>The <code><strong>AbortSignal</strong></code> interface inherits methods from its parent interface, {{domxref("EventTarget")}}.</em></p>
+
+
+<h2 id="Static_methods">Static methods</h2>
+
+<dl>
+	<dt>{{domxref("AbortSignal.abort()")}}</dt>
+	<dd>Returns an <strong><code>AbortSignal</code></strong> instance that is already set as aborted.</dd>
+</dl>
+
 
 <h2 id="Examples">Examples</h2>
 
@@ -66,12 +75,14 @@ function fetchVideo() {
   })
 }</pre>
 
-<div class="note">
-<p><strong>Note</strong>: When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with an <code>AbortError</code>.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with an <code>AbortError</code>.</p>
 </div>
 
-<div class="warning">
-<p>Current version of Firefox rejects the promise with a <code>DOMException</code></p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>Current versions of Firefox rejects the promise with a <code>DOMException</code></p>
 </div>
 
 <p>You can find a full working example on GitHub — see <a href="https://github.com/mdn/dom-examples/tree/master/abort-api">abort-api</a> (<a href="https://mdn.github.io/dom-examples/abort-api/">see it running live also</a>).</p>

--- a/files/en-us/web/api/abortsignal/index.html
+++ b/files/en-us/web/api/abortsignal/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt>{{domxref("AbortSignal.aborted")}} {{readonlyInline}}</dt>
- <dd>A {{jsxref("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</dd>
+ <dd>A {{Glossary("Boolean")}} that indicates whether the request(s) the signal is communicating with is/are aborted (<code>true</code>) or not (<code>false</code>).</dd>
 </dl>
 
 <h2 id="Events">Events</h2>


### PR DESCRIPTION
Firefox 88 adds a new static method `AbortSignal.abort()`. 
- Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1698468
- Useful background: https://github.com/whatwg/dom/issues/959#issuecomment-794307026

BCD and Release notes in separate PR. 

FYI @sideshowbarker 

 MDN tracking bug: #3460