### PR TITLE
Add note that from FF88 browserSettings.ftpProtocolEnabled readonly

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.html
@@ -18,6 +18,11 @@ tags:
 
 <p>The underlying value is a boolean.</p>
 
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>From Firefox version 88 this setting is read-only.</p>
+</div>
+
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>


### PR DESCRIPTION
Adds note that from FF88 the [browserSettings.ftpProtocolEnabled](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/ftpProtocolEnabled) setting is readonly
This comes from https://bugzilla.mozilla.org/show_bug.cgi?id=1626365

There is an associated BCD update https://github.com/mdn/browser-compat-data/pull/9650