### PR TITLE
fix anchor links in audio_codecs

### DIFF
--- a/files/en-us/web/media/formats/audio_codecs/index.html
+++ b/files/en-us/web/media/formats/audio_codecs/index.html
@@ -45,37 +45,37 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row">{{anch("AAC_advanced_audio_coding")}}</th>
+   <th scope="row">{{anch("AAC Advanced Audio Coding")}}</th>
    <td>Advanced Audio Coding</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("ALAC_apple_lossless_audio_codec")}}</th>
+   <th scope="row">{{anch("ALAC Apple Lossless Audio Codec")}}</th>
    <td>Apple Lossless Audio Codec</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a> (MOV)</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("AMR_adaptive_multi-rate")}}</th>
+   <th scope="row">{{anch("AMR Adaptive Multi-Rate")}}</th>
    <td>Adaptive Multi-Rate</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("FLAC_free_lossless_audio_codec")}}</th>
+   <th scope="row">{{anch("FLAC Free Lossless Audio Codec")}}</th>
    <td>Free Lossless Audio Codec</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#flac">FLAC</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("G.711_pulse_code_modulation_of_voice_frequencies")}}</th>
+   <th scope="row">{{anch("G.711 Pulse Code Modulation of Voice Frequencies")}}</th>
    <td>Pulse Code Modulation (PCM) of Voice Frequencies</td>
    <td>{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("G.722_64_kbps_7_khz_audio_coding")}}</th>
+   <th scope="row">{{anch("G.722 64 kbps 7 khz Audio Coding")}}</th>
    <td>7 kHz Audio Coding Within 64 kbps (for telephony/{{Glossary("VoIP")}})</td>
    <td>{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("MP3_mpeg-1_audio_layer_iii")}}</th>
+   <th scope="row">{{anch("MP3 MPEG-1 Audio Layer III")}}</th>
    <td>MPEG-1 Audio Layer III</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg">MPEG</a><sup><a href="#in-brief-footnote1">1</a></sup>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>

--- a/files/en-us/web/media/formats/audio_codecs/index.html
+++ b/files/en-us/web/media/formats/audio_codecs/index.html
@@ -45,37 +45,37 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row">{{anch("AAC")}}</th>
+   <th scope="row">{{anch("AAC_advanced_audio_coding")}}</th>
    <td>Advanced Audio Coding</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("ALAC")}}</th>
+   <th scope="row">{{anch("ALAC_apple_lossless_audio_codec")}}</th>
    <td>Apple Lossless Audio Codec</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a> (MOV)</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("AMR")}}</th>
+   <th scope="row">{{anch("AMR_adaptive_multi-rate")}}</th>
    <td>Adaptive Multi-Rate</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("FLAC")}}</th>
+   <th scope="row">{{anch("FLAC_free_lossless_audio_codec")}}</th>
    <td>Free Lossless Audio Codec</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#flac">FLAC</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("G.711")}}</th>
+   <th scope="row">{{anch("G.711_pulse_code_modulation_of_voice_frequencies")}}</th>
    <td>Pulse Code Modulation (PCM) of Voice Frequencies</td>
    <td>{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("G.722")}}</th>
+   <th scope="row">{{anch("G.722_64_kbps_7_khz_audio_coding")}}</th>
    <td>7 kHz Audio Coding Within 64 kbps (for telephony/{{Glossary("VoIP")}})</td>
    <td>{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("MP3")}}</th>
+   <th scope="row">{{anch("MP3_mpeg-1_audio_layer_iii")}}</th>
    <td>MPEG-1 Audio Layer III</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg">MPEG</a><sup><a href="#in-brief-footnote1">1</a></sup>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
@@ -385,7 +385,7 @@ tags:
    <td>8 (up to 7.1 surround)</td>
   </tr>
   <tr>
-   <th scope="row">Audio frequency  bandwidth</th>
+   <th scope="row">Audio frequency bandwidth</th>
    <td>?</td>
   </tr>
   <tr>

--- a/files/en-us/web/media/formats/video_codecs/index.html
+++ b/files/en-us/web/media/formats/video_codecs/index.html
@@ -1549,7 +1549,7 @@ tags:
 </pre>
  </li>
  <li>
-  <p>An <strong><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a></strong> container and the <strong>{{anch("AVC")}}</strong> (<strong>H.264</strong>) video codec, ideally with <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#aac">AAC</a></strong> as your audio codec. This is because the MP4 container with AVC and AAC codecs within is a broadly-supported combination—by every major browser, in fact—and the quality is typically good for most use cases. Make sure you verify your compliance with the license requirements, however.</p>
+  <p>An <strong><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a></strong> container and the <strong>{{anch("AVC")}}</strong> (<strong>H.264</strong>) video codec, ideally with <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#AAC_advanced_audio_coding">AAC</a></strong> as your audio codec. This is because the MP4 container with AVC and AAC codecs within is a broadly-supported combination—by every major browser, in fact—and the quality is typically good for most use cases. Make sure you verify your compliance with the license requirements, however.</p>
 
   <pre class="brush: html">&lt;video controls&gt;
   &lt;source type="video/webm"

--- a/files/en-us/web/media/formats/webrtc_codecs/index.html
+++ b/files/en-us/web/media/formats/webrtc_codecs/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Containerless_media">Containerless media</h2>
 
-<p>WebRTC uses bare {{domxref("MediaStreamTrack")}} objects for each track being shared from one peer to another, without a container or even a {{domxref("MediaStream")}} associated with the tracks. Which codecs can be within those tracks is not mandated by the WebRTC specification. However, {{RFC(7742)}} specifies that all WebRTC-compatible browsers must support <a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a> and <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">H.264</a>'s Constrained Baseline profile for video, and {{RFC(7874)}} specifies that browsers must support at least the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a> codec as well as <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711</a>'s PCMA and PCMU formats.</p>
+<p>WebRTC uses bare {{domxref("MediaStreamTrack")}} objects for each track being shared from one peer to another, without a container or even a {{domxref("MediaStream")}} associated with the tracks. Which codecs can be within those tracks is not mandated by the WebRTC specification. However, {{RFC(7742)}} specifies that all WebRTC-compatible browsers must support <a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a> and <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">H.264</a>'s Constrained Baseline profile for video, and {{RFC(7874)}} specifies that browsers must support at least the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a> codec as well as <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#G.711_pulse_code_modulation_of_voice_frequencies">G.711</a>'s PCMA and PCMU formats.</p>
 
 <p>These two RFCs also lay out options that must be supported for each codec, as well as specific user comfort features such as echo cancelation. This guide reviews the codecs that browsers are required to implement as well as other codecs that some or all browsers support for WebRTC.</p>
 
@@ -177,11 +177,11 @@ tags:
    <td>Chrome, Edge, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711 PCM (A-law)</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#G.711_pulse_code_modulation_of_voice_frequencies">G.711 PCM (A-law)</a></th>
    <td>Chrome, Firefox, Safari</td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#g.711">G.711 PCM (µ-law)</a></th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#G.711_pulse_code_modulation_of_voice_frequencies">G.711 PCM (µ-law)</a></th>
    <td>Chrome, Firefox, Safari</td>
   </tr>
  </tbody>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

It seems sections' `id` have changed and now include sub-titles too.
This broke various links across the docs.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Audio_codecs

> Issue number (if there is an associated issue)

`N/A`

> Anything else that could help us review it

Not sure this fix is the best way to handle it though, since while it quick-fixes internal links, it may leave links from outside broken. But I have no way to get any number of such links, and there may very well be links to the new format too...
