### PR TITLE
removing unused CSS from object-fit example

### DIFF
--- a/files/en-us/web/css/object-fit/index.html
+++ b/files/en-us/web/css/object-fit/index.html
@@ -88,14 +88,6 @@ tags:
   margin: 1em 0 0.3em;
 }
 
-div {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  height: 940px;
-}
-
 img {
   width: 150px;
   height: 100px;


### PR DESCRIPTION
Fixes: #3499 

removed some unused CSS as we've had two people raise an issue about it, and it isn't actually doing anything in the example.