### PR TITLE
remove some line breaks in SpecName macros

### DIFF
--- a/files/en-us/web/api/audioworkletnode/audioworkletnode/index.html
+++ b/files/en-us/web/api/audioworkletnode/audioworkletnode/index.html
@@ -71,8 +71,7 @@ var <em>node</em> = new AudioWorkletNode(<em>context</em>, <em>name</em>, <em>op
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audioworkletnode-audioworkletnode','AudioWorkletNode()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-audioworkletnode-audioworkletnode','AudioWorkletNode()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites','authenticatedSignedWrites')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites','authenticatedSignedWrites')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-broadcast','broadcast')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-broadcast','broadcast')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-indicate','indicate')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-indicate','indicate')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-notify','notify')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-notify','notify')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-read','read')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-read','read')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
@@ -39,8 +39,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-reliablewrite','reliableWrite')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-reliablewrite','reliableWrite')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliar/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliar/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-writableauxiliaries','writableAuxiliaries')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-writableauxiliaries','writableAuxiliaries')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-write','write')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-write','write')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutrespponse/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutrespponse/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-writewithoutresponse','authenticatedSignedWrites')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-writewithoutresponse','authenticatedSignedWrites')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/cssrule/parentrule/index.html
+++ b/files/en-us/web/api/cssrule/parentrule/index.html
@@ -58,8 +58,7 @@ console.log(childRules[0].parentRule); // a CSSMediaRule</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule:
-        parentStyleSheet')}}</td>
+      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule: parentStyleSheet')}}</td>
       <td>{{Spec2('CSSOM')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.html
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.html
@@ -43,8 +43,7 @@ console.log(myRules.parentStyleSheet);</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule:
-        parentStyleSheet')}}</td>
+      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule: parentStyleSheet')}}</td>
       <td>{{Spec2('CSSOM')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle','entries')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle','entries')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
@@ -76,8 +76,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#dom-filesystemdirectoryhandle-getdirectoryhandle','getDirectoryHandle')}}
+      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-getdirectoryhandle','getDirectoryHandle')}}
       </td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
@@ -76,8 +76,7 @@ const fileHandle = currentDirHandle.getFileHandle(fileName, {create: true});</pr
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle-getfilehandle','getFileHandle')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-getfilehandle','getFileHandle')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
@@ -42,8 +42,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle-getfilehandle','keys')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-getfilehandle','keys')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
@@ -75,8 +75,7 @@ currentDirHandle.removeEntry(entryName).then( () =&gt; {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle-removeentry','removeEntry')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-removeentry','removeEntry')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
@@ -78,8 +78,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#dom-filesystemdirectoryhandle-resolve','resolve')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-resolve','resolve')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#dom-filesystemdirectoryhandle-resolve','values')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-resolve','values')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
@@ -100,8 +100,7 @@ tags:
 </pre>
 </div>
 
-<p>Leaving out some bits of the CSS that don't matter for the discussion here, let's take
-  a look at the styles for the box that we're animating. First is the box itself, with all
+<p>Leaving out some bits of the CSS that don't matter for the discussion here, let's take a look at the styles for the box that we're animating. First is the box itself, with all
   its properties, including {{cssxref("animation")}}, defined. We go ahead and describe
   the animation in-place here because the animation is intended to begin as soon as the
   page loads, rather than based on an event.</p>
@@ -143,8 +142,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <p>Before we get to the animation code, we define a function which logs information to a
-  box on the user's screen. We'll use this to show information about the events we
-  receive. Note the use of {{domxref("AnimationEvent.animationName")}} and
+  box on the user's screen. We'll use this to show information about the events we receive. Note the use of {{domxref("AnimationEvent.animationName")}} and
   {{domxref("AnimationEvent.elapsedTime")}} to get information about the event which
   occurred.</p>
 
@@ -211,8 +209,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationcancel','onanimationcancel')}}</td>
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationcancel','onanimationcancel')}}</td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -60,8 +60,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationend','onanimationend')}}</td>
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationend','onanimationend')}}</td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
@@ -104,11 +104,9 @@ tags:
 </pre>
 </div>
 
-<p>Leaving out some bits of the CSS that don't matter for the discussion here, let's take
-  a look at the styles for the box that we're animating. First is the box itself. We set
+<p>Leaving out some bits of the CSS that don't matter for the discussion here, let's take a look at the styles for the box that we're animating. First is the box itself. We set
   its size, position, color, and layout. Note that there's nothing there about animation.
-  That's because we don't want the box to start animating right away. We'll add the
-  {{cssxref("animation")}} style later to start animating the box.</p>
+  That's because we don't want the box to start animating right away. We'll add the {{cssxref("animation")}} style later to start animating the box.</p>
 
 <pre class="brush: css">#box {
   width: var(--boxwidth);
@@ -159,8 +157,7 @@ box.onanimationiteration = function(event) {
   which is initially zero, which indicates how many iterations of the animation have
   occurred.</p>
 
-<p>The onanimationiteration event handler is then set up. It sets the box's
-  {{cssxref("animation-play-state")}} to "paused", then updates the text displayed in the
+<p>The onanimationiteration event handler is then set up. It sets the box's {{cssxref("animation-play-state")}} to "paused", then updates the text displayed in the
   button to indicate that clicking the button will start playing the next iteration of
   the animation.</p>
 
@@ -194,8 +191,7 @@ box.onanimationiteration = function(event) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationiteration','onanimationiteration')}}
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationiteration','onanimationiteration')}}
       </td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>

--- a/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
@@ -94,11 +94,9 @@ tags:
  </pre>
 </div>
 
-<p>Leaving out some bits of the CSS that don't matter for the discussion here, let's take
-  a look at the styles for the box that we're animating. First is the box itself. We set
+<p>Leaving out some bits of the CSS that don't matter for the discussion here, let's take a look at the styles for the box that we're animating. First is the box itself. We set
   its size, position, color, and layout. Note that there's nothing there about animation.
-  That's because we don't want the box to start animating right away. We'll add the
-  {{cssxref("animation")}} style later to start animating the box.</p>
+  That's because we don't want the box to start animating right away. We'll add the {{cssxref("animation")}} style later to start animating the box.</p>
 
 <pre class="brush: css">#box {
   width: var(--boxwidth);
@@ -137,14 +135,12 @@ tags:
 }
 </pre>
 
-<p>Since the CSS describes the animation but doesn't connect it to the box, we'll need
-  some JavaScript code to do that.  We'll get to that shortly.</p>
+<p>Since the CSS describes the animation but doesn't connect it to the box, we'll need some JavaScript code to do that.  We'll get to that shortly.</p>
 
 <h3 id="JavaScript_content">JavaScript content</h3>
 
 <p>Before we get to the animation code, we define a function which logs information to a
-  box on the user's screen. We'll use this to show information about the events we
-  receive. Note the use of {{domxref("AnimationEvent.animationName")}} and
+  box on the user's screen. We'll use this to show information about the events we receive. Note the use of {{domxref("AnimationEvent.animationName")}} and
   {{domxref("AnimationEvent.elapsedTime")}} to get information about the event which
   occurred.</p>
 
@@ -207,8 +203,7 @@ box.onanimationend = function(event) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationstart','onanimationstart')}}</td>
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationstart','onanimationstart')}}</td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
@@ -130,8 +130,7 @@ window.onpointerdown = play;</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','webappapis.html#handler-oncontextmenu','oncontextmenu')}}</td>
+      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-oncontextmenu','oncontextmenu')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
@@ -58,8 +58,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Selection
-        API','#dom-globaleventhandlers-onselectstart','GlobalEventHandlers.onselectstart')}}
+      <td>{{SpecName('Selection API','#dom-globaleventhandlers-onselectstart','GlobalEventHandlers.onselectstart')}}
       </td>
       <td>{{Spec2('Selection API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
@@ -43,9 +43,7 @@ tags:
   <code><var>target</var></code>, where the target object is an HTML element
   ({{domxref("HTMLElement")}}), document ({{domxref("Document")}}), or window
   ({{domxref("Window")}}). The function receives as input a single parameter: a
-  {{domxref("TransitionEvent")}} object describing the event which occurred; the event's
-  {{domxref("TransitionEvent.elapsedTime")}} property's value should be the same as the
-  value of {{cssxref("transition-duration")}}.</p>
+  {{domxref("TransitionEvent")}} object describing the event which occurred; the event's {{domxref("TransitionEvent.elapsedTime")}} property's value should be the same as the value of {{cssxref("transition-duration")}}.</p>
 
 <div class="note">
   <p><strong>Note</strong>: <code>elapsedTime</code> does not include time prior to the
@@ -67,16 +65,14 @@ tags:
 
 <h3 id="HTML">HTML</h3>
 
-<p>This creates a {{HTMLElement("div")}} which we'll style with CSS below to make into a
-  box that resizes and changes color and such.</p>
+<p>This creates a {{HTMLElement("div")}} which we'll style with CSS below to make into a box that resizes and changes color and such.</p>
 
 <pre class="brush: html;">&lt;div class="box"&gt;&lt;/div&gt;
 </pre>
 
 <h3 id="CSS">CSS</h3>
 
-<p>The CSS below styles the box and applies a transition effect which makes the box's
-  color and size change, and causes the box to rotate, while the mouse cursor hovers over
+<p>The CSS below styles the box and applies a transition effect which makes the box's color and size change, and causes the box to rotate, while the mouse cursor hovers over
   it.</p>
 
 <pre class="brush: css highlight:[13,14]">.box {
@@ -154,8 +150,7 @@ box.ontransitioncancel = function(event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS3
-        Transitions','#dom-globaleventhandlers-ontransitioncancel','ontransitioncancel')}}
+      <td>{{SpecName('CSS3 Transitions','#dom-globaleventhandlers-ontransitioncancel','ontransitioncancel')}}
       </td>
       <td>{{Spec2('CSS3 Transitions')}}</td>
       <td></td>

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -45,13 +45,11 @@ tags:
   where the target object is an HTML element ({{domxref("HTMLElement")}}), document
   ({{domxref("Document")}}), or window ({{domxref("Window")}}). The function receives as
   input a single parameter: a {{domxref("TransitionEvent")}} object describing the event
-  which occurred; the event's {{domxref("TransitionEvent.elapsedTime")}} property's value
-  should be the same as the value of {{cssxref("transition-duration")}}.</p>
+  which occurred; the event's {{domxref("TransitionEvent.elapsedTime")}} property's value should be the same as the value of {{cssxref("transition-duration")}}.</p>
 
 <div class="note">
   <p><code>elapsedTime</code> does not include time prior to the transition effect
-    beginning; that means that the value of {{cssxref("transition-delay")}} doesn't affect
-    the value of <code>elapsedTime</code>, which is zero until the delay period ends and
+    beginning; that means that the value of {{cssxref("transition-delay")}} doesn't affect the value of <code>elapsedTime</code>, which is zero until the delay period ends and
     the animation begins.</p>
 </div>
 
@@ -64,16 +62,14 @@ tags:
 
 <h3 id="HTML">HTML</h3>
 
-<p>This creates a {{HTMLElement("div")}} which we'll style with CSS below to make into a
-  box that resizes and changes color and such.</p>
+<p>This creates a {{HTMLElement("div")}} which we'll style with CSS below to make into a box that resizes and changes color and such.</p>
 
 <pre class="brush: html;">&lt;div class="box"&gt;&lt;/div&gt;
 </pre>
 
 <h3 id="CSS">CSS</h3>
 
-<p>The CSS below styles the box and applies a transition effect which makes the box's
-  color and size change, and causes the box to rotate, while the mouse cursor hovers over
+<p>The CSS below styles the box and applies a transition effect which makes the box's color and size change, and causes the box to rotate, while the mouse cursor hovers over
   it.</p>
 
 <pre class="brush: css highlight:[13,14]">.box {
@@ -135,8 +131,7 @@ box.ontransitionend = function(event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS3
-        Transitions','#dom-globaleventhandlers-ontransitionend','ontransitionend')}}</td>
+      <td>{{SpecName('CSS3 Transitions','#dom-globaleventhandlers-ontransitionend','ontransitionend')}}</td>
       <td>{{Spec2('CSS3 Transitions')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/mouseevent/buttons/index.html
+++ b/files/en-us/web/api/mouseevent/buttons/index.html
@@ -96,8 +96,7 @@ document.querySelector('#log').appendChild(log)</pre>
 			<td>Current working draft</td>
 		</tr>
 		<tr>
-			<td>{{SpecName('DOM3
-				Events','#widl-MouseEvent-buttons','MouseEvent.buttons')}}</td>
+			<td>{{SpecName('DOM3 Events','#widl-MouseEvent-buttons','MouseEvent.buttons')}}</td>
 			<td>{{Spec2('DOM3 Events')}}</td>
 			<td>Initial definition</td>
 		</tr>

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.html
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.html
@@ -150,8 +150,7 @@ function overListener(event) {
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-MouseEvent-relatedTarget','MouseEvent.relatedTarget')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-relatedTarget','MouseEvent.relatedTarget')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>No change from {{SpecName('DOM2 Events')}}.</td>
     </tr>

--- a/files/en-us/web/api/networkinformation/downlink/index.html
+++ b/files/en-us/web/api/networkinformation/downlink/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Network
-        Information','#dom-networkinformation-downlink','downlink')}}</td>
+      <td>{{SpecName('Network Information','#dom-networkinformation-downlink','downlink')}}</td>
       <td>{{Spec2('Network Information')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/networkinformation/effectivetype/index.html
+++ b/files/en-us/web/api/networkinformation/effectivetype/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Network
-        Information','#dom-networkinformation-effectivetype','effectiveType')}}</td>
+      <td>{{SpecName('Network Information','#dom-networkinformation-effectivetype','effectiveType')}}</td>
       <td>{{Spec2('Network Information')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/networkinformation/onchange/index.html
+++ b/files/en-us/web/api/networkinformation/onchange/index.html
@@ -47,8 +47,7 @@ navigator.connection.onchange = changeHandler;
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Network
-        Information','#dom-networkinformation-onchange','onchange')}}</td>
+      <td>{{SpecName('Network Information','#dom-networkinformation-onchange','onchange')}}</td>
       <td>{{Spec2('Network Information')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/reportingobserver/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/reportingobserver/index.html
@@ -72,8 +72,7 @@ let observer = new ReportingObserver(function(reports, observer) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Reporting
-        API','#dom-reportingobserver-reportingobserver','ReportingObserver()')}}</td>
+      <td>{{SpecName('Reporting API','#dom-reportingobserver-reportingobserver','ReportingObserver()')}}</td>
       <td>{{Spec2('Reporting API')}}</td>
       <td></td>
     </tr>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Lots and lots of uses of `SpecName` has a linebreak in the first argument. 
See https://github.com/mdn/yari/pull/3356 for more info. 

> MDN URL of main page changed
Lots

> Issue number (if there is an associated issue)

> Anything else that could help us review it

@sideshowbarker These changes were a couple I started doing manually as I improved my little Python script. Expect more to come. 