### PR TITLE
Update Web/API/HTMLInputElement

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -129,7 +129,7 @@ tags:
   </tr>
   <tr>
    <td><code>width</code></td>
-   <td><code><em>string</em></code><em>:</em> <strong>Returns / Sets</strong> the document's {{ htmlattrxref("width", "input") }} attribute, which defines the width of the image displayed for the button, if the value of {{htmlattrxref("type","input")}} is <code>image</code>.</td>
+   <td><code><em>string</em></code><em>:</em> <strong>Returns / Sets</strong> the element's {{ htmlattrxref("width", "input") }} attribute, which defines the width of the image displayed for the button, if the value of {{htmlattrxref("type","input")}} is <code>image</code>.</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
The "width" attribute is element's rather than document's.

> What was wrong/why is this fix needed? (quick summary only)
The "width" attribute is element's, not a document's.

> MDN URL of main page changed
Web/API/HTMLInputElement

> Issue number (if there is an associated issue)
none

> Anything else that could help us review it
