### PR TITLE
CORP: Rm ref to bug that cannot be reproduced

### DIFF
--- a/files/en-us/web/http/cross-origin_resource_policy_(corp)/index.html
+++ b/files/en-us/web/http/cross-origin_resource_policy_(corp)/index.html
@@ -82,5 +82,4 @@ tags:
 
 <ul>
  <li>{{HTTPHeader("Cross-Origin-Resource-Policy")}} HTTP Header</li>
- <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1459573">Bugzilla bug 1459573</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Following discussion on https://bugzilla.mozilla.org/show_bug.cgi?id=1638323 it would appear this bug is no longer relevant.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
