### PR TITLE
Trivial grammar fix

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/length/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>length</code> property is an accessor property whose set accessor function is <code>undefined</code>, meaning that you can only read this property. The value is established when a <em>TypedArray</em> is constructed and cannot be changed. If the <em>TypedArray</em> is not specifying an <code>byteOffset</code> or a <code>length</code>, the length of the referenced {{jsxref("ArrayBuffer")}} will be returned. <em>TypedArray</em> is one of the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects">TypedArray objects</a>.</p>
+<p>The <code>length</code> property is an accessor property whose set accessor function is <code>undefined</code>, meaning that you can only read this property. The value is established when a <em>TypedArray</em> is constructed and cannot be changed. If the <em>TypedArray</em> is not specifying a <code>byteOffset</code> or a <code>length</code>, the length of the referenced {{jsxref("ArrayBuffer")}} will be returned. <em>TypedArray</em> is one of the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#TypedArray_objects">TypedArray objects</a>.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Change "an byteOffset" to "a byteOffset" on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length

This problem exists on two pages but I'm using GitHub's web editor and I don't know how to edit two files in one PR, so I figured I'd just post two PRs. This PR is for the "length" function.