### PR TITLE
Remove id attributes from JS documentation

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -42,7 +42,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
-  <li>Added support for <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#indices">RegExp match indices</a> ({{bug(1519483)}}).</li>
+  <li>Added support for <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec">RegExp match indices</a> ({{bug(1519483)}}).</li>
 </ul>
 
 <h4 id="removals_js">Removals</h4>

--- a/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
+++ b/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
@@ -322,7 +322,7 @@ mark.projects = ['navigator'];</pre>
 
 <p>The constructor functions shown so far do not let you specify property values when you create an instance. As with Java, you can provide arguments to constructors to initialize property values for instances. The following figure shows one way to do this.</p>
 
-<p><img alt="" class="internal" id="figure8.5" src="figure8.5.png"><br>
+<p><img alt="" class="internal" src="figure8.5.png"><br>
  <small><strong>Specifying properties in a constructor, take 1</strong></small></p>
 
 <p>The following pairs of examples show the Java and JavaScript definitions for these objects.</p>

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.html
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.html
@@ -340,7 +340,7 @@ y = 42 + ' is the answer' // "42 is the answer"
 <p>In the case that a value representing a number is in memory as a string, there are methods for conversion.</p>
 
 <ul>
- <li id="parseInt()_and_parseFloat()">{{jsxref("parseInt", "parseInt()")}}</li>
+ <li>{{jsxref("parseInt", "parseInt()")}}</li>
  <li>{{jsxref("parseFloat", "parseFloat()")}}</li>
 </ul>
 

--- a/files/en-us/web/javascript/guide/regular_expressions/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.html
@@ -203,7 +203,7 @@ var myArray = myRe.exec('cdbbdbsbz');
     // /d(b+)d/g.exec('cdbbdbsbz') outputs Array [ 'dbbd', 'bb', index: 1, input: 'cdbbdbsbz' ].
 </pre>
 
-<p>(See <a href="#g-different-behaviors">different behaviors</a> for further info about the different behaviors.)</p>
+<p>(See <a href="#using_the_global_search_flag_with_exec">Using the global search flag with <code>exec()</code></a> for further info about the different behaviors.)</p>
 
 <p>If you want to construct the regular expression from a string, yet another alternative is this script:</p>
 
@@ -364,15 +364,17 @@ console.log(myArray);
 
 <p>and get the same result.</p>
 
-<p id="g-different-behaviors">The behavior associated with the <code>g</code> flag is different when the <code>.exec()</code> method is used.  The roles of "class" and "argument" get reversed: In the case of <code>.match()</code>, the string class (or data type) owns the method and the regular expression is just an argument, while in the case of <code>.exec()</code>, it is the regular expression that owns the method, with the string being the argument.  Contrast this <em><code>str.match(re)</code></em> versus <em><code>re.exec(str)</code></em>.  The <code>g</code> flag is used with the <strong><code>.exec()</code></strong> method to get iterative progression.</p>
+<p>The <code>m</code> flag is used to specify that a multiline input string should be treated as multiple lines. If the <code>m</code> flag is used, <code>^</code> and <code>$</code> match at the start or end of any line within the input string instead of the start or end of the entire string.</p>
+
+<h4 id="using_the_global_search_flag_with_exec">Using the global search flag with exec()</h4>
+
+<p>The behavior associated with the <code>g</code> flag is different when the <code>.exec()</code> method is used.  The roles of "class" and "argument" get reversed: In the case of <code>.match()</code>, the string class (or data type) owns the method and the regular expression is just an argument, while in the case of <code>.exec()</code>, it is the regular expression that owns the method, with the string being the argument.  Contrast this <em><code>str.match(re)</code></em> versus <em><code>re.exec(str)</code></em>.  The <code>g</code> flag is used with the <strong><code>.exec()</code></strong> method to get iterative progression.</p>
 
 <pre class="brush: js">var xArray; while(xArray = re.exec(str)) console.log(xArray);
 // produces:
 // ["fee ", index: 0, input: "fee fi fo fum"]
 // ["fi ", index: 4, input: "fee fi fo fum"]
 // ["fo ", index: 7, input: "fee fi fo fum"]</pre>
-
-<p>The <code>m</code> flag is used to specify that a multiline input string should be treated as multiple lines. If the <code>m</code> flag is used, <code>^</code> and <code>$</code> match at the start or end of any line within the input string instead of the start or end of the entire string.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.html
@@ -377,7 +377,7 @@ console.log(Object.getPrototypeOf(g).hasOwnProperty('addVertex'));
 <p>Here are all 4 ways and their pros/cons. All of the examples listed below create exactly the same resulting <code>inst</code> object (thus logging the same results to the console), except in different ways.</p>
 
 <h4 class="name">#1: New initialization</h4>
-<div class="notecard warning" id="Bad_practice_Extension_of_native_prototypes">
+<div class="notecard warning">
 <p>One misfeature that is often used is to extend <code>Object.prototype</code> or one of the other built-in prototypes.</p>
 
 <p>This technique is called monkey patching and breaks <em>encapsulation</em>. While used by popular frameworks such as Prototype.js, there is still no good reason for cluttering built-in types with additional <em>non-standard</em> functionality.</p>
@@ -512,8 +512,8 @@ console.log(inst.bar_prop)</pre>
     </tr>
   </tbody>
 </table>
-<h4 class="example">#4: Setting the {{jsxref("Object/proto","__proto__")}} property</h4>
-<pre id="example-4" class="brush: js">
+<h4 class="example" id="4_setting_the___proto___property">#4: Setting the {{jsxref("Object/proto","__proto__")}} property</h4>
+<pre class="brush: js">
 // Technique 1
 function A(){}
 A.prototype = {
@@ -561,7 +561,7 @@ console.log(inst.bar_prop)</pre>
 
 <p>JavaScript is a bit confusing for developers coming from Java or C++, as it's all dynamic, all runtime, and it has no classes at all. It's all just instances (objects). Even the "classes" we simulate are just a function object.</p>
 
-<p>You probably already noticed that our <a href="#example-4">function A</a> has a special property called <code>prototype</code>. This special property works with the JavaScript <code>new </code>operator. The reference to the prototype object is copied to the internal <code>[[Prototype]]</code> property of the new instance. For example, when you do <code>var a1 = new A()</code>, JavaScript (after creating the object in memory and before running function <code>A()</code> with <code>this</code> defined to it) sets <code>a1.[[Prototype]] = A.prototype</code>. When you then access properties of the instance, JavaScript first checks whether they exist on that object directly, and if not, it looks in <code>[[Prototype]]</code>. This means that all the stuff you define in <code>prototype</code> is effectively shared by all instances, and you can even later change parts of <code>prototype</code> and have the changes appear in all existing instances, if you wanted to.</p>
+<p>You probably already noticed that our <a href="#4_setting_the___proto___property">function A</a> has a special property called <code>prototype</code>. This special property works with the JavaScript <code>new </code>operator. The reference to the prototype object is copied to the internal <code>[[Prototype]]</code> property of the new instance. For example, when you do <code>var a1 = new A()</code>, JavaScript (after creating the object in memory and before running function <code>A()</code> with <code>this</code> defined to it) sets <code>a1.[[Prototype]] = A.prototype</code>. When you then access properties of the instance, JavaScript first checks whether they exist on that object directly, and if not, it looks in <code>[[Prototype]]</code>. This means that all the stuff you define in <code>prototype</code> is effectively shared by all instances, and you can even later change parts of <code>prototype</code> and have the changes appear in all existing instances, if you wanted to.</p>
 
 <p>If, in the example above, you do <code>var a1 = new A(); var a2 = new A();</code> then <code>a1.doSomething</code> would actually refer to <code>Object.getPrototypeOf(a1).doSomething</code>, which is the same as the <code>A.prototype.doSomething</code> you defined, i.e. <code>Object.getPrototypeOf(a1).doSomething == Object.getPrototypeOf(a2).doSomething == A.prototype.doSomething</code>.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/index.html
@@ -139,7 +139,3 @@ Atomics.notify(int32, 0, 1);</pre>
  <li><a href="https://github.com/tc39/ecmascript_sharedmem/blob/master/TUTORIAL.md">Shared Memory – a brief tutorial</a></li>
  <li><a href="https://hacks.mozilla.org/2016/05/a-taste-of-javascripts-new-parallel-primitives/">A Taste of JavaScript’s New Parallel Primitives – Mozilla Hacks</a></li>
 </ul>
-
-<div id="gtx-trans" style="position: absolute; left: 25px; top: 2197px;">
-<div class="gtx-trans-icon"></div>
-</div>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -104,7 +104,7 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
       <td><code>4</code></td>
     </tr>
     <tr>
-      <td><code id="indices">indices</code></td>
+      <td><code>indices</code></td>
       <td>An array where each entry represents a substring match.
         Each substring match itself is an array where the first entry
         represents its start index and the second entry its end index.<br/>

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.html
@@ -107,19 +107,17 @@ tags:
 
 <h3 id="Using_split">Using <code>split()</code></h3>
 
-<div id="split_empty_string">
-  <p>When the string is empty, <code>split()</code> returns an array containing one empty
-    string, rather than an empty array. If the string and separator are both empty
-    strings, an empty array is returned.</p>
+<p>When the string is empty, <code>split()</code> returns an array containing one empty
+  string, rather than an empty array. If the string and separator are both empty
+  strings, an empty array is returned.</p>
 
-  <pre class="brush: js">const myString = ''
+<pre class="brush: js">const myString = ''
 const splits = myString.split()
 
 console.log(splits)
 
 // ↪ [""]
 </pre>
-</div>
 
 <p>The following example defines a function that splits a string into an array of strings
   using <code><var>separator</var></code>. After splitting the string, the function logs

--- a/files/en-us/web/javascript/reference/operators/in/index.html
+++ b/files/en-us/web/javascript/reference/operators/in/index.html
@@ -27,7 +27,7 @@ tags:
     coerced to strings).</dd>
   <dt><code><var>object</var></code></dt>
   <dd>Object to check if it (or its prototype chain) <span class="short_text"
-      id="result_box" lang="en">contains</span> the property with specified name
+      lang="en">contains</span> the property with specified name
     (<code><var>prop</var></code>).</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/operators/inequality/index.html
+++ b/files/en-us/web/javascript/reference/operators/inequality/index.html
@@ -107,7 +107,3 @@ object2 != object2 // false</pre>
   <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality">Strict
       inequality operator</a></li>
 </ul>
-
-<div id="gtx-trans" style="position: absolute; left: 16px; top: 1743.2px;">
-  <div class="gtx-trans-icon"></div>
-</div>

--- a/files/en-us/web/javascript/reference/statements/let/index.html
+++ b/files/en-us/web/javascript/reference/statements/let/index.html
@@ -71,7 +71,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Scoping_rules_2">Scoping rules</h3>
+<h3 id="Scoping_rules">Scoping rules</h3>
 
 <p>Variables declared by <strong><code>let</code></strong> have their scope in the block
   for which they are declared, as well as in any contained sub-blocks. In this way,
@@ -98,7 +98,7 @@ function letTest() {
 }
 </pre>
 
-<p id="Scoping_rules">At the top level of programs and functions,
+<p>At the top level of programs and functions,
   <strong><code>let</code></strong>, unlike <strong><code>var</code></strong>, does not
   create a property on the global object. For example:</p>
 

--- a/files/en-us/web/javascript/reference/strict_mode/index.html
+++ b/files/en-us/web/javascript/reference/strict_mode/index.html
@@ -14,8 +14,8 @@ tags:
 <div class="notecard note">
   <h3>Note</h3>
   <p>Sometimes you'll see the default, non-strict mode referred to as <strong>"<a
-      href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode"
-      id="sloppyModeId333">sloppy mode</a>"</strong>. This isn't an official term, but be
+      href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">
+      sloppy mode</a>"</strong>. This isn't an official term, but be
   aware of it, just in case.</p>
 </div>
 


### PR DESCRIPTION
This is based on https://github.com/mdn/content/issues/3607, "[Markdown] id attributes in the JavaScript documentation", and removes all `id` attributes from our JS documentation, except those attached to `<h1>...<h6>` elements.

Or at least I think it does.

What I did:

* grepped files/en-us/web/javascript for `id="`
* excluded those attached to `<h1>...<h6>`, and those that just appeared in sample code

This gave me:

```
./files/en-us/web/javascript//guide/grammar_and_types/index.html: <li id="parseInt()_and_parseFloat()">{{jsxref("parseInt", "parseInt()")}}</li>
./files/en-us/web/javascript//guide/regular_expressions/index.html:<p id="g-different-behaviors">The behavior associated with the <code>g</code> flag is different when the <code>.exec()</code> method is used.  The roles of "class" and "argument" get reversed: In the case of <code>.match()</code>, the string class (or data type) owns the method and the regular expression is just an argument, while in the case of <code>.exec()</code>, it is the regular expression that owns the method, with the string being the argument.  Contrast this <em><code>str.match(re)</code></em> versus <em><code>re.exec(str)</code></em>.  The <code>g</code> flag is used with the <strong><code>.exec()</code></strong> method to get iterative progression.</p>
./files/en-us/web/javascript//guide/details_of_the_object_model/index.html:<p><img alt="" class="internal" id="figure8.5" src="figure8.5.png"><br>
./files/en-us/web/javascript//inheritance_and_the_prototype_chain/index.html:<div class="notecard warning" id="Bad_practice_Extension_of_native_prototypes">
./files/en-us/web/javascript//inheritance_and_the_prototype_chain/index.html:<pre id="example-4" class="brush: js">
./files/en-us/web/javascript//reference/operators/in/index.html:      id="result_box" lang="en">contains</span> the property with specified name
./files/en-us/web/javascript//reference/operators/inequality/index.html:<div id="gtx-trans" style="position: absolute; left: 16px; top: 1743.2px;">
./files/en-us/web/javascript//reference/statements/let/index.html:<p id="Scoping_rules">At the top level of programs and functions,
./files/en-us/web/javascript//reference/global_objects/regexp/exec/index.html:      <td><code id="indices">indices</code></td>
./files/en-us/web/javascript//reference/global_objects/atomics/index.html:<div id="gtx-trans" style="position: absolute; left: 25px; top: 2197px;">
./files/en-us/web/javascript//reference/global_objects/string/split/index.html:<div id="split_empty_string">
./files/en-us/web/javascript//reference/strict_mode/index.html:      id="sloppyModeId333">sloppy mode</a>"</strong>. This isn't an official term, but be
```

(this omits some items from the list in https://github.com/mdn/content/issues/3607 - on closer inspection, several of those are actually attached to headings, and one has since been [removed by another PR](https://github.com/mdn/content/pull/3574/files#diff-7ac7b1540d8648d54c5742b58038cedb01ac75a5279dba7aa26a1adc63df0245L23-R23).)

I grepped the entire files/en-us tree for references to each `id` attribute:
* Where there were no references I just removed the `id` attribute.
* Where there was a reference I replaced it with a reference to a heading ID. The only place I wasn't able to do that was in [the Firefox 88 release notes](https://github.com/mdn/content/blob/main/files/en-us/mozilla/firefox/releases/88/index.html#L45), which wants to refer to `#indices`, and it would be hard to reorganize that page so `indices` gets a heading. But I think it's OK to just link to the page here.




