### PR TITLE
referrer-policy preference for setting default incorrect

### DIFF
--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -222,8 +222,7 @@ Referrer-Policy: unsafe-url
 
 <p>Firefox preferences can be used to configure the <em>default</em> referrer policy. The preference names are version specific:</p>
 <ul>
-  <li>Firefox version 87: <code>network.http.referer.userControlPolicy</code></li>
-  <li>Firefox versions 59 to 86: <code>network.http.referer.defaultPolicy</code> (and <code>network.http.referer.defaultPolicy.pbmode</code> for private networks)</li>
+  <li>Firefox version 59 and later: <code>network.http.referer.defaultPolicy</code> (and <code>network.http.referer.defaultPolicy.pbmode</code> for private networks)</li>
   <li>Firefox versions 53 to 58: <code>network.http.referer.userControlPolicy</code></li>
 </ul>
 <p>All of these settings take the same set of values: <code>0 = no-referrer</code>, <code>1 = same-origin</code>, <code>2 = strict-origin-when-cross-origin</code>, <code>3 = no-referrer-when-downgrade</code>.</p>


### PR DESCRIPTION
Fixes #3640

The preference name for setting default is indicated as changed in FF87. I made that change, and I would have thought I had a reason, but on checking this is incorrect. The default "default value" changed from 3 to 2, but the actual preference is the same. 

This fixes it.