### PR TITLE
FF88 ftp experimental table version changed

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -1580,7 +1580,7 @@ tags:
  <thead>
   <tr>
    <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Version changed</th>
    <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
   </tr>
  </thead>
@@ -1592,17 +1592,17 @@ tags:
   </tr>
   <tr>
    <th scope="row">Developer Edition</th>
-   <td>77</td>
+   <td>88</td>
    <td>No</td>
   </tr>
   <tr>
    <th scope="row">Beta</th>
-   <td>77</td>
+   <td>88</td>
    <td>No</td>
   </tr>
   <tr>
    <th scope="row">Release</th>
-   <td>77</td>
+   <td>88</td>
    <td>No</td>
   </tr>
   <tr>


### PR DESCRIPTION
FF88 uses a preference to turn of FTP on beta and release. The table column header said "version added" which is incorrect - the feature was added a long time ago, as was the preference. Changed this to "Version changed", which is the release in which the version last changed. Makes more sense than "added" and would also work for both "added" or "removed".

Follows on from https://github.com/mdn/content/pull/3617#pullrequestreview-622931012

