### PR TITLE
FF88 Release note for AbortSignal.abort()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -36,7 +36,7 @@ tags:
 
 <ul>
   <li>The {{cssxref(":-moz-submit-invalid")}} pseudo-class has been hidden behind a preference, therefore removing it from web content ({{bug(1694129)}}).</li>
-  <li>Default styling for the non-standard {{cssxref(":-moz-ui-invalid")}} and {{cssxref(":-moz-ui-valid")}} has been removed ({{bug(1693969)}}).</li>
+  <li>Default styling for the non-standard {{cssxref(":user-invalid")}} and {{cssxref(":-moz-ui-valid")}} has been removed ({{bug(1693969)}}).</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>
@@ -58,6 +58,10 @@ tags:
 <h3 id="APIs">APIs</h3>
 
 <h4 id="DOM">DOM</h4>
+
+<ul>
+  <li>Code can use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted">aborted</a>. This is useful when the signal is requested/created after the associated operation has <em>already</em> been aborted. For more information see {{bug(1698468)}}.</li>
+</ul>
 
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
 

--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -36,7 +36,7 @@ tags:
 
 <ul>
   <li>The {{cssxref(":-moz-submit-invalid")}} pseudo-class has been hidden behind a preference, therefore removing it from web content ({{bug(1694129)}}).</li>
-  <li>Default styling for the non-standard {{cssxref(":user-invalid")}} and {{cssxref(":-moz-ui-valid")}} has been removed ({{bug(1693969)}}).</li>
+  <li>Default styling for the non-standard {{cssxref(":-moz-ui-invalid")}} and {{cssxref(":-moz-ui-valid")}} has been removed ({{bug(1693969)}}).</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>
@@ -60,7 +60,7 @@ tags:
 <h4 id="DOM">DOM</h4>
 
 <ul>
-  <li>Code can use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted">aborted</a>. This is useful when the signal is requested/created after the associated operation has <em>already</em> been aborted. For more information see {{bug(1698468)}}.</li>
+  <li>Code can now use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted">aborted</a>. This is useful when the signal is requested/created after the associated operation has <em>already</em> been aborted. For more information see {{bug(1698468)}}.</li>
 </ul>
 
 <h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>


### PR DESCRIPTION
Add note for new static method `AbortSignal.abort()`. See here for associated: [docs](https://github.com/mdn/content/pull/3616) and [tracking information](https://github.com/mdn/content/issues/3460).