### PR TITLE
remove linebreaks in SpecName macro arguments

### DIFF
--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.html
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.html
@@ -104,8 +104,7 @@ function outputTimestamps() {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audiocontext-getoutputtimestamp','getOutputTimestamp()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-audiocontext-getoutputtimestamp','getOutputTimestamp()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/audiocontextoptions/latencyhint/index.html
+++ b/files/en-us/web/api/audiocontextoptions/latencyhint/index.html
@@ -59,8 +59,7 @@ var <em>latencyHint</em> = <em>audioContextOptions</em>.latencyHint;</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audiocontextoptions-latencyhint','AudioContextOptions.latencyHint')}}
+      <td>{{SpecName('Web Audio API','#dom-audiocontextoptions-latencyhint','AudioContextOptions.latencyHint')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/audiocontextoptions/samplerate/index.html
+++ b/files/en-us/web/api/audiocontextoptions/samplerate/index.html
@@ -52,8 +52,7 @@ var <em>sampleRate</em> = <em>audioContextOptions</em>.sampleRate;</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audiocontextoptions-samplerate','AudioContextOptions.sampleRate')}}
+      <td>{{SpecName('Web Audio API','#dom-audiocontextoptions-samplerate','AudioContextOptions.sampleRate')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/audionode/connect/index.html
+++ b/files/en-us/web/api/audionode/connect/index.html
@@ -183,8 +183,7 @@ lfo.start();</pre>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio API', '#dom-audionode-connect-destinationparam-output',
-        'connect() to an AudioParam')}}</td>
+      <td>{{SpecName('Web Audio API', '#dom-audionode-connect-destinationparam-output', 'connect() to an AudioParam')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/audioparam/cancelandholdattime/index.html
+++ b/files/en-us/web/api/audioparam/cancelandholdattime/index.html
@@ -48,8 +48,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audioparam-cancelandholdattime','cancelAndHoldAtTime()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-audioparam-cancelandholdattime','cancelAndHoldAtTime()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/audiotrack/kind/index.html
+++ b/files/en-us/web/api/audiotrack/kind/index.html
@@ -70,14 +70,12 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', 'media.html#dom-audiotrack-kind', 'AudioTrack:
-        kind')}}</td>
+      <td>{{SpecName('HTML WHATWG', 'media.html#dom-audiotrack-kind', 'AudioTrack: kind')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML5 W3C', 'embedded-content-0.html#dom-audiotrack-kind',
-        'AudioTrack.kind')}}</td>
+      <td>{{SpecName('HTML5 W3C', 'embedded-content-0.html#dom-audiotrack-kind', 'AudioTrack.kind')}}</td>
       <td>{{Spec2('HTML5 W3C')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/audioworkletnode/audioworkletnode/index.html
+++ b/files/en-us/web/api/audioworkletnode/audioworkletnode/index.html
@@ -71,8 +71,7 @@ var <em>node</em> = new AudioWorkletNode(<em>context</em>, <em>name</em>, <em>op
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audioworkletnode-audioworkletnode','AudioWorkletNode()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-audioworkletnode-audioworkletnode','AudioWorkletNode()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.html
@@ -108,8 +108,7 @@ const testNode = new AudioWorkletNode(audioContext, 'test-processor', {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-audioworkletprocessor-audioworkletprocessor','AudioWorkletProcessor()')}}
+      <td>{{SpecName('Web Audio API','#dom-audioworkletprocessor-audioworkletprocessor','AudioWorkletProcessor()')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/barcodedetector/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/barcodedetector/index.html
@@ -60,8 +60,7 @@ if (barcodeDetector) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Shape Detection
-        API','#dom-barcodedetector-barcodedetector','BarcodeDetector.BarcodeDetector()')}}
+      <td>{{SpecName('Shape Detection API','#dom-barcodedetector-barcodedetector','BarcodeDetector.BarcodeDetector()')}}
       </td>
       <td>{{Spec2('Shape Detection API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/barcodedetector/detect/index.html
+++ b/files/en-us/web/api/barcodedetector/detect/index.html
@@ -78,8 +78,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Shape Detection
-        API','#dom-barcodedetector-detect','BarcodeDetector.detect()')}}</td>
+      <td>{{SpecName('Shape Detection API','#dom-barcodedetector-detect','BarcodeDetector.detect()')}}</td>
       <td>{{Spec2('Shape Detection API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
@@ -54,8 +54,7 @@ BarcodeDetector.getSupportedFormats()
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Shape Detection
-        API','#dom-barcodedetector-getsupportedformats','BarcodeDetector.getSupportedFormats()')}}
+      <td>{{SpecName('Shape Detection API','#dom-barcodedetector-getsupportedformats','BarcodeDetector.getSupportedFormats()')}}
       </td>
       <td>{{Spec2('Shape Detection API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -42,8 +42,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-baseaudiocontext-createconstantsource','createConstantSource()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-baseaudiocontext-createconstantsource','createConstantSource()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/blobevent/blobevent/index.html
+++ b/files/en-us/web/api/blobevent/blobevent/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream Recording', '#dom-blobevent-blobevent', 'BlobEvent:
-        BlobEvent')}}</td>
+      <td>{{SpecName('MediaStream Recording', '#dom-blobevent-blobevent', 'BlobEvent: BlobEvent')}}</td>
       <td>{{Spec2('MediaStream Recording')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites','authenticatedSignedWrites')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites','authenticatedSignedWrites')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-broadcast','broadcast')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-broadcast','broadcast')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-indicate','indicate')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-indicate','indicate')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-notify','notify')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-notify','notify')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-read','read')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-read','read')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
@@ -39,8 +39,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-reliablewrite','reliableWrite')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-reliablewrite','reliableWrite')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliar/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliar/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-writableauxiliaries','writableAuxiliaries')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-writableauxiliaries','writableAuxiliaries')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-write','write')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-write','write')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutrespponse/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutrespponse/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothcharacteristicproperties-writewithoutresponse','authenticatedSignedWrites')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothcharacteristicproperties-writewithoutresponse','authenticatedSignedWrites')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
@@ -37,8 +37,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothremotegattdescriptor-characteristic','characteristic')}}
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-characteristic','characteristic')}}
       </td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
@@ -39,8 +39,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothremotegattdescriptor-readvalue','readValue()')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-readvalue','readValue()')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Bluetooth','#dom-bluetoothremotegattdescriptor-writevalue','writeValue()')}}</td>
+      <td>{{SpecName('Web Bluetooth','#dom-bluetoothremotegattdescriptor-writevalue','writeValue()')}}</td>
       <td>{{Spec2('Web Bluetooth')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/compositionevent/compositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/compositionevent/index.html
@@ -54,8 +54,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#dom-compositionevent-compositionevent','CompositionEvent()')}}</td>
+      <td>{{SpecName('DOM3 Events','#dom-compositionevent-compositionevent','CompositionEvent()')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -57,8 +57,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#idl-interface-CompositionEvent-initializers','initCompositionEvent()')}}
+      <td>{{SpecName('DOM3 Events','#idl-interface-CompositionEvent-initializers','initCompositionEvent()')}}
       </td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/constantsourcenode/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/constantsourcenode/index.html
@@ -65,9 +65,7 @@ let myConstantSource = new ConstantSourceNode(audioContext, { offset: 0.5 });</p
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-constantsourcenode-constantsourcenode','ConstantSourceNode:
-        ConstantSourceNode')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-constantsourcenode-constantsourcenode','ConstantSourceNode: ConstantSourceNode')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/contactsmanager/getproperties/index.html
+++ b/files/en-us/web/api/contactsmanager/getproperties/index.html
@@ -79,8 +79,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Contact Picker
-        API','#dom-contactsmanager-getproperties','getProperties')}}</td>
+      <td>{{SpecName('Contact Picker API','#dom-contactsmanager-getproperties','getProperties')}}</td>
       <td>{{Spec2('Contact Picker API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -74,8 +74,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-convolvernode-convolvernode','ConvolverNode()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-convolvernode-convolvernode','ConvolverNode()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
@@ -53,8 +53,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Credential
-        Management','#dom-credentialscontainer-preventsilentaccess','preventSilentAccess()')}}
+      <td>{{SpecName('Credential Management','#dom-credentialscontainer-preventsilentaccess','preventSilentAccess()')}}
       </td>
       <td>{{Spec2('Credential Management')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
@@ -71,8 +71,7 @@ console.dir( keyword );
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-csskeywordvalue-csskeywordvalue','CSSKeywordValue')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-csskeywordvalue-csskeywordvalue','CSSKeywordValue')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
@@ -40,8 +40,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssmathproduct-cssmathproduct','CSSMathProduct()')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-cssmathproduct-cssmathproduct','CSSMathProduct()')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/cssmathvalue/operator/index.html
+++ b/files/en-us/web/api/cssmathvalue/operator/index.html
@@ -107,8 +107,7 @@ console.log( styleMap.get('width').values[1].operator ) // 'negate'
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssmathvalue-operator','CSSMathValue.operator')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-cssmathvalue-operator','CSSMathValue.operator')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssmatrixcomponent-cssmatrixcomponent','CSSMatrixComponent')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-cssmatrixcomponent-cssmatrixcomponent','CSSMatrixComponent')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssmatrixcomponent-cssmatrixcomponent-matrix-options-matrix','matrix')}}
+      <td>{{SpecName('CSS Typed OM','#dom-cssmatrixcomponent-cssmatrixcomponent-matrix-options-matrix','matrix')}}
       </td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/csspropertyrule/inherits/index.html
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.html
@@ -46,8 +46,7 @@ console.log(myRules[0].inherits); //returns false</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Properties and Values
-        API','#dom-csspropertyrule-inherits','Inherits')}}</td>
+      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-inherits','Inherits')}}</td>
       <td>{{Spec2('CSS Properties and Values API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.html
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.html
@@ -48,8 +48,7 @@ console.log(myRules[0].initialValue); //the string "#c0ffee"</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Properties and Values
-        API','#dom-csspropertyrule-initialvalue','InitialValue')}}</td>
+      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-initialvalue','InitialValue')}}</td>
       <td>{{Spec2('CSS Properties and Values API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/csspropertyrule/syntax/index.html
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.html
@@ -46,8 +46,7 @@ console.log(myRules[0].syntax); //the string "&lt;color&gt;"</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Properties and Values
-        API','#dom-csspropertyrule-syntax','Syntax')}}</td>
+      <td>{{SpecName('CSS Properties and Values API','#dom-csspropertyrule-syntax','Syntax')}}</td>
       <td>{{Spec2('CSS Properties and Values API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/cssrule/parentrule/index.html
+++ b/files/en-us/web/api/cssrule/parentrule/index.html
@@ -58,8 +58,7 @@ console.log(childRules[0].parentRule); // a CSSMediaRule</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule:
-        parentStyleSheet')}}</td>
+      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule: parentStyleSheet')}}</td>
       <td>{{Spec2('CSSOM')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.html
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.html
@@ -43,8 +43,7 @@ console.log(myRules.parentStyleSheet);</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule:
-        parentStyleSheet')}}</td>
+      <td>{{SpecName('CSSOM', '#dom-cssrule-parentstylesheet', 'CSSRule: parentStyleSheet')}}</td>
       <td>{{Spec2('CSSOM')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#CSSTransformComponent-stringification-behavior','toString()')}}</td>
+      <td>{{SpecName('CSS Typed OM','#CSSTransformComponent-stringification-behavior','toString()')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/cssunitvalue/value/index.html
+++ b/files/en-us/web/api/cssunitvalue/value/index.html
@@ -50,8 +50,7 @@ console.log( pos.y.value ); // 10
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('CSS Typed
-				OM','#dom-cssunitvalue-value','CSSUnitValue.value')}}</td>
+			<td>{{SpecName('CSS Typed OM','#dom-cssunitvalue-value','CSSUnitValue.value')}}</td>
 			<td>{{Spec2('CSS Typed OM')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
@@ -46,8 +46,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssvariablereferencevalue-cssvariablereferencevalue','CSSVariableReferenceValue()')}}
+      <td>{{SpecName('CSS Typed OM','#dom-cssvariablereferencevalue-cssvariablereferencevalue','CSSVariableReferenceValue()')}}
       </td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
@@ -39,8 +39,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssvariablereferencevalue-fallback','fallback')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-cssvariablereferencevalue-fallback','fallback')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
@@ -40,8 +40,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-cssvariablereferencevalue-variable','variable')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-cssvariablereferencevalue-variable','variable')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/document/createattribute/index.html
+++ b/files/en-us/web/api/document/createattribute/index.html
@@ -59,8 +59,7 @@ console.log(node.getAttribute("my_attrib")); // "newVal"
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('DOM
-        WHATWG','#dom-document-createattribute','Document.createAttribute()')}}</td>
+      <td>{{SpecName('DOM WHATWG','#dom-document-createattribute','Document.createAttribute()')}}</td>
       <td>{{Spec2("DOM WHATWG")}}</td>
       <td>Precised behavior with uppercase characters</td>
     </tr>

--- a/files/en-us/web/api/document/createtextnode/index.html
+++ b/files/en-us/web/api/document/createtextnode/index.html
@@ -69,8 +69,7 @@ function addTextNode(text) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-document-createtextnode', 'Document:
-        createTextNode')}}</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-document-createtextnode', 'Document: createTextNode')}}</td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/document/documentelement/index.html
+++ b/files/en-us/web/api/document/documentelement/index.html
@@ -50,8 +50,7 @@ for (const child of firstTier) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM
-        WHATWG','#dom-document-documentelement','Document.documentElement')}}</td>
+      <td>{{SpecName('DOM WHATWG','#dom-document-documentelement','Document.documentElement')}}</td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/document/domain/index.html
+++ b/files/en-us/web/api/document/domain/index.html
@@ -159,8 +159,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','origin.html#relaxing-the-same-origin-restriction','document.domain')}}
+      <td>{{SpecName('HTML WHATWG','origin.html#relaxing-the-same-origin-restriction','document.domain')}}
       </td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>

--- a/files/en-us/web/api/document/getelementsbytagname/index.html
+++ b/files/en-us/web/api/document/getelementsbytagname/index.html
@@ -129,8 +129,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM
-        WHATWG','#dom-document-getelementsbytagname','document.getElementsByTagName')}}
+      <td>{{SpecName('DOM WHATWG','#dom-document-getelementsbytagname','document.getElementsByTagName')}}
       </td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>

--- a/files/en-us/web/api/document/visibilitystate/index.html
+++ b/files/en-us/web/api/document/visibilitystate/index.html
@@ -73,9 +73,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Page Visibility
-        API','#visibility-states-and-the-visibilitystate-enum',
-        'Document.visibilityState')}}</td>
+      <td>{{SpecName('Page Visibility API','#visibility-states-and-the-visibilitystate-enum', 'Document.visibilityState')}}</td>
       <td>{{Spec2('Page Visibility API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/dommatrix/dommatrix/index.html
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.html
@@ -61,8 +61,7 @@ var transformedPoint = point.matrixTransform(matrix);
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Geometry
-        Interfaces','#dom-dommatrixreadonly-dommatrixreadonly','DOMMatrix')}}</td>
+      <td>{{SpecName('Geometry Interfaces','#dom-dommatrixreadonly-dommatrixreadonly','DOMMatrix')}}</td>
       <td>{{Spec2('Geometry Interfaces')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.html
@@ -39,8 +39,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Geometry
-				Interfaces','#dom-dommatrixreadonly-dommatrixreadonly','DOMMatrixReadOnly')}}
+			<td>{{SpecName('Geometry Interfaces','#dom-dommatrixreadonly-dommatrixreadonly','DOMMatrixReadOnly')}}
 			</td>
 			<td>{{Spec2('Geometry Interfaces')}}</td>
 			<td>Initial definition.</td>

--- a/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
@@ -58,8 +58,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dynamicscompressornode','DynamicsCompressorNode()')}}</td>
+      <td>{{SpecName('Web Audio API','#dynamicscompressornode','DynamicsCompressorNode()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/element/computedstylemap/index.html
+++ b/files/en-us/web/api/element/computedstylemap/index.html
@@ -95,8 +95,7 @@ for (const [prop, val] of allComputedStyles) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Typed
-        OM','#dom-element-computedstylemap','computedStyleMap()')}}</td>
+      <td>{{SpecName('CSS Typed OM','#dom-element-computedstylemap','computedStyleMap()')}}</td>
       <td>{{Spec2('CSS Typed OM')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/element/removeattribute/index.html
+++ b/files/en-us/web/api/element/removeattribute/index.html
@@ -62,7 +62,7 @@ document.getElementById("div1").removeAttribute("align");
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattribute', 'Element" removeAttribute')}}</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattribute', 'Element: removeAttribute')}}</td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/element/removeattribute/index.html
+++ b/files/en-us/web/api/element/removeattribute/index.html
@@ -62,8 +62,7 @@ document.getElementById("div1").removeAttribute("align");
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattribute', 'Element"
-        removeAttribute')}}</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattribute', 'Element" removeAttribute')}}</td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/element/removeattributenode/index.html
+++ b/files/en-us/web/api/element/removeattributenode/index.html
@@ -59,8 +59,7 @@ d.removeAttributeNode(d_align);
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattributenode', 'Element:
-        removeAttributeNode')}}</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattributenode', 'Element: removeAttributeNode')}}</td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/element/removeattributens/index.html
+++ b/files/en-us/web/api/element/removeattributens/index.html
@@ -54,8 +54,7 @@ d.removeAttributeNS("http://www.mozilla.org/ns/specialspace", "specialAlign");
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattributens', 'Element:
-        removeAttributeNS')}}</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-element-removeattributens', 'Element: removeAttributeNS')}}</td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/element/requestpointerlock/index.html
+++ b/files/en-us/web/api/element/requestpointerlock/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Pointer
-        Lock','#dom-element-requestpointerlock','requestPointerLock()')}}</td>
+      <td>{{SpecName('Pointer Lock','#dom-element-requestpointerlock','requestPointerLock()')}}</td>
       <td>{{Spec2('Pointer Lock')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/federatedcredential/protocol/index.html
+++ b/files/en-us/web/api/federatedcredential/protocol/index.html
@@ -45,8 +45,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Credential
-        Management','#dom-federatedcredential-protocol','protocol')}}</td>
+      <td>{{SpecName('Credential Management','#dom-federatedcredential-protocol','protocol')}}</td>
       <td>{{Spec2('Credential Management')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/fetchevent/navigationpreload/index.html
+++ b/files/en-us/web/api/fetchevent/navigationpreload/index.html
@@ -58,8 +58,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Service
-        Workers','#service-worker-registration-navigationpreload','navigationPreload')}}
+      <td>{{SpecName('Service Workers','#service-worker-registration-navigationpreload','navigationPreload')}}
       </td>
       <td>{{Spec2('Service Workers')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle','entries')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle','entries')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
@@ -76,8 +76,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#dom-filesystemdirectoryhandle-getdirectoryhandle','getDirectoryHandle')}}
+      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-getdirectoryhandle','getDirectoryHandle')}}
       </td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
@@ -76,8 +76,7 @@ const fileHandle = currentDirHandle.getFileHandle(fileName, {create: true});</pr
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle-getfilehandle','getFileHandle')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-getfilehandle','getFileHandle')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
@@ -42,8 +42,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle-getfilehandle','keys')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-getfilehandle','keys')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
@@ -75,8 +75,7 @@ currentDirHandle.removeEntry(entryName).then( () =&gt; {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemdirectoryhandle-removeentry','removeEntry')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemdirectoryhandle-removeentry','removeEntry')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
@@ -78,8 +78,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#dom-filesystemdirectoryhandle-resolve','resolve')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-resolve','resolve')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#dom-filesystemdirectoryhandle-resolve','values')}}</td>
+      <td>{{SpecName('File System Access API','#dom-filesystemdirectoryhandle-resolve','values')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
@@ -56,8 +56,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemwritablefilestream-seek','seek')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream-seek','seek')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
@@ -66,8 +66,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemwritablefilestream-truncate','truncate')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream-truncate','truncate')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.html
@@ -119,8 +119,7 @@ writableStream.write({ type: "truncate", size: size })
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System Access
-        API','#api-filesystemwritablefilestream-write','write')}}</td>
+      <td>{{SpecName('File System Access API','#api-filesystemwritablefilestream-write','write')}}</td>
       <td>{{Spec2('File System Access API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/fontface/featuresettings/index.html
+++ b/files/en-us/web/api/fontface/featuresettings/index.html
@@ -37,8 +37,7 @@ FontFace.featureSettings = <em>featureSettingDescriptor</em>;</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3 Font
-        Loading','#dom-fontface-featuresettings','featureSettings')}}</td>
+      <td>{{SpecName('CSS3 Font Loading','#dom-fontface-featuresettings','featureSettings')}}</td>
       <td>{{Spec2('CSS3 Font Loading')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/fontface/fontface/index.html
+++ b/files/en-us/web/api/fontface/fontface/index.html
@@ -71,8 +71,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3 Font Loading','#font-face-constructor','FontFace
-        Constructor')}}</td>
+      <td>{{SpecName('CSS3 Font Loading','#font-face-constructor','FontFace Constructor')}}</td>
       <td>{{Spec2('CSS3 Font Loading')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
@@ -36,8 +36,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3 Font
-        Loading','#dom-fontfacesetloadevent-fontfaces','fontfaces')}}</td>
+      <td>{{SpecName('CSS3 Font Loading','#dom-fontfacesetloadevent-fontfaces','fontfaces')}}</td>
       <td>{{Spec2('CSS3 Font Loading')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3 Font
-        Loading','#dom-fontfacesetloadevent-fontfacesetloadevent','FontFaceSetLoadEvent()')}}
+      <td>{{SpecName('CSS3 Font Loading','#dom-fontfacesetloadevent-fontfacesetloadevent','FontFaceSetLoadEvent()')}}
       </td>
       <td>{{Spec2('CSS3 Font Loading')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/formdataevent/formdataevent/index.html
+++ b/files/en-us/web/api/formdataevent/formdataevent/index.html
@@ -65,9 +65,7 @@ for (let value of fdEv.formData.values()) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','form-control-infrastructure.html#the-formdataevent-interface',
-        'FormDataEvent')}}</td>
+      <td>{{SpecName('HTML WHATWG','form-control-infrastructure.html#the-formdataevent-interface', 'FormDataEvent')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
@@ -211,8 +211,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationcancel','onanimationcancel')}}</td>
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationcancel','onanimationcancel')}}</td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -60,8 +60,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationend','onanimationend')}}</td>
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationend','onanimationend')}}</td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
@@ -194,8 +194,7 @@ box.onanimationiteration = function(event) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationiteration','onanimationiteration')}}
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationiteration','onanimationiteration')}}
       </td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>

--- a/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
@@ -207,8 +207,7 @@ box.onanimationend = function(event) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS3
-        Animations','#eventdef-animationevent-animationstart','onanimationstart')}}</td>
+      <td>{{SpecName('CSS3 Animations','#eventdef-animationevent-animationstart','onanimationstart')}}</td>
       <td>{{Spec2('CSS3 Animations')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
@@ -130,8 +130,7 @@ window.onpointerdown = play;</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','webappapis.html#handler-oncontextmenu','oncontextmenu')}}</td>
+      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-oncontextmenu','oncontextmenu')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
@@ -58,8 +58,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Selection
-        API','#dom-globaleventhandlers-onselectstart','GlobalEventHandlers.onselectstart')}}
+      <td>{{SpecName('Selection API','#dom-globaleventhandlers-onselectstart','GlobalEventHandlers.onselectstart')}}
       </td>
       <td>{{Spec2('Selection API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
@@ -154,8 +154,7 @@ box.ontransitioncancel = function(event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS3
-        Transitions','#dom-globaleventhandlers-ontransitioncancel','ontransitioncancel')}}
+      <td>{{SpecName('CSS3 Transitions','#dom-globaleventhandlers-ontransitioncancel','ontransitioncancel')}}
       </td>
       <td>{{Spec2('CSS3 Transitions')}}</td>
       <td></td>

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -135,8 +135,7 @@ box.ontransitionend = function(event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('CSS3
-        Transitions','#dom-globaleventhandlers-ontransitionend','ontransitionend')}}</td>
+      <td>{{SpecName('CSS3 Transitions','#dom-globaleventhandlers-ontransitionend','ontransitionend')}}</td>
       <td>{{Spec2('CSS3 Transitions')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/hashchangeevent/newurl/index.html
+++ b/files/en-us/web/api/hashchangeevent/newurl/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hashchangeevent-newurl', 'HashChangeEvent:
-        newURL')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-hashchangeevent-newurl', 'HashChangeEvent: newURL')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/hashchangeevent/oldurl/index.html
+++ b/files/en-us/web/api/hashchangeevent/oldurl/index.html
@@ -38,8 +38,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-hashchangeevent-oldurl', 'HashChangeEvent:
-        oldURL')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-hashchangeevent-oldurl', 'HashChangeEvent: oldURL')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmlelement/iscontenteditable/index.html
+++ b/files/en-us/web/api/htmlelement/iscontenteditable/index.html
@@ -53,21 +53,17 @@ document.getElementById('infoText2').innerHTML += document.getElementById('myTex
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', "editing.html#dom-iscontenteditable",
-        "HTMLElement.contenteditable")}}</td>
+      <td>{{SpecName('HTML WHATWG', "editing.html#dom-iscontenteditable", "HTMLElement.contenteditable")}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>No change from latest snapshot, {{SpecName('HTML5.1')}}</td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML5.1', "editing.html#dom-iscontenteditable",
-        "HTMLElement.contenteditable")}}</td>
+      <td>{{SpecName('HTML5.1', "editing.html#dom-iscontenteditable", "HTMLElement.contenteditable")}}</td>
       <td>{{Spec2('HTML5.1')}}</td>
-      <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5
-        W3C')}}</td>
+      <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML5 W3C', "editing.html#dom-iscontenteditable",
-        "HTMLElement.contenteditable")}}</td>
+      <td>{{SpecName('HTML5 W3C', "editing.html#dom-iscontenteditable", "HTMLElement.contenteditable")}}</td>
       <td>{{Spec2('HTML5 W3C')}}</td>
       <td>Snapshot of {{SpecName('HTML WHATWG')}}, initial definition.</td>
     </tr>

--- a/files/en-us/web/api/htmlformelement/acceptcharset/index.html
+++ b/files/en-us/web/api/htmlformelement/acceptcharset/index.html
@@ -40,8 +40,7 @@ form.acceptCharset = string;
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-form-acceptcharset', 'HTMLFormElement:
-        acceptCharset')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-form-acceptcharset', 'HTMLFormElement: acceptCharset')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.html
@@ -78,14 +78,12 @@ body.appendChild(iframe); // Fetch the image using the complete URL as the refer
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute',
-        'referrerpolicy attribute')}}</td>
+      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute', 'referrerpolicy attribute')}}</td>
       <td>{{Spec2('Referrer Policy')}}</td>
       <td>Added the <code>referrerPolicy</code> attribute.</td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-iframe-referrerpolicy', 'HTMLIFrameElement:
-        referrerPolicy')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-iframe-referrerpolicy', 'HTMLIFrameElement: referrerPolicy')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.html
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.html
@@ -67,8 +67,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media Capture DOM
-        Elements','#dom-htmlmediaelement-capturestream','captureStream()')}}</td>
+      <td>{{SpecName('Media Capture DOM Elements','#dom-htmlmediaelement-capturestream','captureStream()')}}</td>
       <td>{{Spec2('Media Capture DOM Elements')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/htmlmediaelement/seekable/index.html
+++ b/files/en-us/web/api/htmlmediaelement/seekable/index.html
@@ -49,20 +49,17 @@ for (let count = 0; count &lt; timeRangesObject.length; count ++) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML WHATWG', "the-video-element.html#dom-media-seekable",
-        "HTMLMediaElement")}}</td>
+      <td>{{SpecName('HTML WHATWG', "the-video-element.html#dom-media-seekable", "HTMLMediaElement")}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>No change from {{SpecName('HTML5 W3C')}}</td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#dom-media-seekable",
-        "HTMLMediaElement")}}</td>
+      <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#dom-media-seekable", "HTMLMediaElement")}}</td>
       <td>{{Spec2('HTML5 W3C')}}</td>
       <td>Initial definition.</td>
     </tr>
     <tr>
-      <td>{{SpecName('Media Source Extensions','#htmlmediaelement-extensions','HTMLMediaElement extensions, like for
-        seekable')}}</td>
+      <td>{{SpecName('Media Source Extensions','#htmlmediaelement-extensions','HTMLMediaElement extensions, like for seekable')}}</td>
       <td>{{Spec2('Media Source Extensions')}}</td>
       <td>Specifies a new algorithm for returning the seekable time range of a media
         element whose source is a {{domxref("MediaSource")}} object.</td>

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.html
@@ -84,8 +84,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('HTML
-				WHATWG','#dom-cva-setcustomvalidity','setCustomValidity')}}</td>
+			<td>{{SpecName('HTML WHATWG','#dom-cva-setcustomvalidity','setCustomValidity')}}</td>
 			<td>{{Spec2('HTML WHATWG')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/htmlobjectelement/typemustmatch/index.html
+++ b/files/en-us/web/api/htmlobjectelement/typemustmatch/index.html
@@ -49,8 +49,7 @@ console.log(obj.typeMustMatch);
       <td>{{SpecName('HTML5 W3C', "embedded-content-0.html#dom-object-typemustmatch",
         "HTMLObjectElement")}}</td>
       <td>{{Spec2('HTML5 W3C')}}</td>
-      <td>The W3C specification is a latest of a previous version of {{SpecName("HTML
-        WHATWG")}}<br>
+      <td>The W3C specification is a latest of a previous version of {{SpecName("HTML WHATWG")}}<br>
         First snapshot with this property.</td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/htmlorforeignelement/dataset/index.html
+++ b/files/en-us/web/api/htmlorforeignelement/dataset/index.html
@@ -164,8 +164,7 @@ if ('someDataAttr' in el.dataset === false) {
     <tr>
       <td>{{SpecName('HTML5.1', "dom.html#dom-dataset", "HTMLElement.dataset")}}</td>
       <td>{{Spec2('HTML5.1')}}</td>
-      <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5
-        W3C')}}</td>
+      <td>Snapshot of {{SpecName('HTML WHATWG')}}, no change from {{SpecName('HTML5 W3C')}}</td>
     </tr>
     <tr>
       <td>{{SpecName('HTML5 W3C', "dom.html#dom-dataset", "HTMLElement.dataset")}}</td>

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.html
@@ -88,14 +88,12 @@ document.body.appendChild(scriptElem);
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute',
-        'referrerpolicy attribute')}}</td>
+      <td>{{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute', 'referrerpolicy attribute')}}</td>
       <td>{{Spec2('Referrer Policy')}}</td>
       <td>Added the <code>referrerPolicy</code> attribute.</td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-script-referrerpolicy', 'HTMLScriptElement:
-        referrerPolicy')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-script-referrerpolicy', 'HTMLScriptElement: referrerPolicy')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.html
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.html
@@ -72,8 +72,7 @@ slots[1].addEventListener('slotchange', function(e) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','scripting.html#dom-slot-assignednodes','assignedNodes')}}</td>
+      <td>{{SpecName('HTML WHATWG','scripting.html#dom-slot-assignednodes','assignedNodes')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/createcaption/index.html
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.html
@@ -65,8 +65,7 @@ caption.textContent = 'This caption was created by JavaScript!';</pre>
 	</thead>
 	<tbody>
 		<tr>
-			<td>{{SpecName('HTML WHATWG', '#dom-table-createcaption', 'HTMLTableElement:
-				createCaption')}}</td>
+			<td>{{SpecName('HTML WHATWG', '#dom-table-createcaption', 'HTMLTableElement: createCaption')}}</td>
 			<td>{{Spec2('HTML WHATWG')}}</td>
 			<td></td>
 		</tr>

--- a/files/en-us/web/api/htmltableelement/createtbody/index.html
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.html
@@ -49,8 +49,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-createtbody', 'HTMLTableElement:
-        createTBody')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-createtbody', 'HTMLTableElement: createTBody')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.html
@@ -48,8 +48,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-createtfoot', 'HTMLTableElement:
-        createTFoot')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-createtfoot', 'HTMLTableElement: createTFoot')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/createthead/index.html
+++ b/files/en-us/web/api/htmltableelement/createthead/index.html
@@ -48,8 +48,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-createthead', 'HTMLTableElement:
-        createTHead')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-createthead', 'HTMLTableElement: createTHead')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.html
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.html
@@ -53,8 +53,7 @@ table.deleteCaption();</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deletecaption', 'HTMLTableElement:
-        deleteCaption')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-deletecaption', 'HTMLTableElement: deleteCaption')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/deleterow/index.html
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.html
@@ -74,8 +74,7 @@ table.deleteRow(1);</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deleterow', 'HTMLTableElement:
-        deleteRow')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-deleterow', 'HTMLTableElement: deleteRow')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.html
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.html
@@ -52,8 +52,7 @@ table.deleteTFoot();</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deletetfoot', 'HTMLTableElement:
-        deleteTFoot')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-deletetfoot', 'HTMLTableElement: deleteTFoot')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltableelement/deletethead/index.html
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.html
@@ -51,8 +51,7 @@ table.deleteTHead();</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-table-deletethead', 'HTMLTableElement:
-        deleteTHead')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-table-deletethead', 'HTMLTableElement: deleteTHead')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/htmltemplateelement/content/index.html
+++ b/files/en-us/web/api/htmltemplateelement/content/index.html
@@ -35,15 +35,13 @@ var documentFragment = templateElement.content.cloneNode(true);</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','scripting.html#dom-template-content','HTMLTemplateElement interface')}}
+      <td>{{SpecName('HTML WHATWG','scripting.html#dom-template-content','HTMLTemplateElement interface')}}
       </td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('HTML5
-        W3C','scripting-1.html#dom-template-content','HTMLTemplateElement interface')}}
+      <td>{{SpecName('HTML5 W3C','scripting-1.html#dom-template-content','HTMLTemplateElement interface')}}
       </td>
       <td>{{Spec2('HTML5 W3C')}}</td>
       <td>Initial definition</td>

--- a/files/en-us/web/api/iirfilternode/iirfilternode/index.html
+++ b/files/en-us/web/api/iirfilternode/iirfilternode/index.html
@@ -67,8 +67,7 @@ const iirFilter = new IIRFilterNode(audioCtx, { feedforward: feedForward, feedba
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Web Audio
-				API','#dom-iirfilternode-iirfilternode','IIRFilterNode()')}}</td>
+			<td>{{SpecName('Web Audio API','#dom-iirfilternode-iirfilternode','IIRFilterNode()')}}</td>
 			<td>{{Spec2('Web Audio API')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.html
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.html
@@ -79,8 +79,7 @@ navigator.mediaDevices.getUserMedia({video: true})
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Image','#dom-imagecapture-getphotocapabilities','getPhotoCapabilities()')}}</td>
+      <td>{{SpecName('MediaStream Image','#dom-imagecapture-getphotocapabilities','getPhotoCapabilities()')}}</td>
       <td>{{Spec2('MediaStream Image')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.html
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.html
@@ -92,8 +92,7 @@ navigator.mediaDevices.getUserMedia({video: true})
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Image','#dom-imagecapture-getphotosettings','getPhotoSettings()')}}</td>
+      <td>{{SpecName('MediaStream Image','#dom-imagecapture-getphotosettings','getPhotoSettings()')}}</td>
       <td>{{Spec2('MediaStream Image')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/imagecapture/imagecapture/index.html
+++ b/files/en-us/web/api/imagecapture/imagecapture/index.html
@@ -61,8 +61,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Image','#dom-imagecapture-imagecapture','ImageCapture')}}</td>
+      <td>{{SpecName('MediaStream Image','#dom-imagecapture-imagecapture','ImageCapture')}}</td>
       <td>{{Spec2('MediaStream Image')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/inputevent/iscomposing/index.html
+++ b/files/en-us/web/api/inputevent/iscomposing/index.html
@@ -37,8 +37,7 @@ console.log(inputEvent.isComposing); // return false
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-InputEvent-isComposing','InputEvent.isComposing')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-InputEvent-isComposing','InputEvent.isComposing')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
@@ -109,8 +109,7 @@ tags:
     </tr>
     <tr>
       <td>
-        {{SpecName('IntersectionObserver','#dom-intersectionobserver-intersectionobserver','IntersectionObserver
-        constructor')}}</td>
+        {{SpecName('IntersectionObserver','#dom-intersectionobserver-intersectionobserver','IntersectionObserver constructor')}}</td>
       <td>{{Spec2('IntersectionObserver')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/keyboard/lock/index.html
+++ b/files/en-us/web/api/keyboard/lock/index.html
@@ -66,8 +66,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{experimental_inline}} {{SpecName('Keyboard
-        Lock','#h-keyboard-lock','lock()')}}</td>
+      <td>{{experimental_inline}} {{SpecName('Keyboard Lock','#h-keyboard-lock','lock()')}}</td>
       <td>{{Spec2('Keyboard Lock')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/keyboardevent/charcode/index.html
+++ b/files/en-us/web/api/keyboardevent/charcode/index.html
@@ -92,8 +92,7 @@ input.addEventListener('keypress', function(e) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-KeyboardEvent-charCode','KeyboardEvent.charCode')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-charCode','KeyboardEvent.charCode')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition; specified as deprecated</td>
     </tr>

--- a/files/en-us/web/api/keyboardevent/ctrlkey/index.html
+++ b/files/en-us/web/api/keyboardevent/ctrlkey/index.html
@@ -59,8 +59,7 @@ You can also use the SHIFT key together with the CTRL key.&lt;/p&gt;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-KeyboardEvent-ctrlKey','KeyboardEvent.ctrlKey')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-ctrlKey','KeyboardEvent.ctrlKey')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/keyboardevent/iscomposing/index.html
+++ b/files/en-us/web/api/keyboardevent/iscomposing/index.html
@@ -39,14 +39,12 @@ console.log(kbdEvent.isComposing); // return false
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('UI Events', '#dom-keyboardevent-iscomposing',
-        'KeyboardEvent.prototype.isComposing')}}</td>
+      <td>{{SpecName('UI Events', '#dom-keyboardevent-iscomposing', 'KeyboardEvent.prototype.isComposing')}}</td>
       <td>{{Spec2('UI Events')}}</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-KeyboardEvent-isComposing','KeyboardEvent.prototype.isComposing')}}
+      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-isComposing','KeyboardEvent.prototype.isComposing')}}
       </td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.html
@@ -85,8 +85,7 @@ tags:
 	</thead>
 	<tbody>
 		<tr>
-			<td>{{SpecName('UI
-				Events','#dom-keyboardevent-keyboardevent','KeyboardEvent()')}}</td>
+			<td>{{SpecName('UI Events','#dom-keyboardevent-keyboardevent','KeyboardEvent()')}}</td>
 			<td>{{Spec2('UI Events')}}</td>
 			<td>Current definition.</td>
 		</tr>

--- a/files/en-us/web/api/keyboardevent/metakey/index.html
+++ b/files/en-us/web/api/keyboardevent/metakey/index.html
@@ -58,8 +58,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-KeyboardEvent-metaKey','KeyboardEvent.metaKey')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-metaKey','KeyboardEvent.metaKey')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/keyboardevent/shiftkey/index.html
+++ b/files/en-us/web/api/keyboardevent/shiftkey/index.html
@@ -62,8 +62,7 @@ You can also use the SHIFT key together with the ALT key.&lt;/p&gt;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-KeyboardEvent-shiftKey','KeyboardEvent.shiftKey')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-KeyboardEvent-shiftKey','KeyboardEvent.shiftKey')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/keyboardevent/which/index.html
+++ b/files/en-us/web/api/keyboardevent/which/index.html
@@ -82,8 +82,7 @@ alert("onkeydown handler: \n"
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#legacy-interface-KeyboardEvent','KeyboardEvent.which')}}</td>
+      <td>{{SpecName('DOM3 Events','#legacy-interface-KeyboardEvent','KeyboardEvent.which')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>Initial definition; specified as deprecated</td>
     </tr>

--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.html
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.html
@@ -80,8 +80,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media Capture', '#dom-mediadevices-enumeratedevices', 'mediaDevices:
-        enumerateDevices')}}</td>
+      <td>{{SpecName('Media Capture', '#dom-mediadevices-enumeratedevices', 'mediaDevices: enumerateDevices')}}</td>
       <td>{{Spec2('Media Capture')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.html
@@ -51,8 +51,7 @@ console.log(source.mediaElement);</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-mediaelementaudiosourcenode-mediaelement','MediaElementAudioSourceNode.mediaElement')}}
+      <td>{{SpecName('Web Audio API','#dom-mediaelementaudiosourcenode-mediaelement','MediaElementAudioSourceNode.mediaElement')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/mediametadata/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.html
@@ -68,8 +68,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediametadata-mediametadata','MediaMetadata()')}}</td>
+      <td>{{SpecName('Media Session','#dom-mediametadata-mediametadata','MediaMetadata()')}}</td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediapositionstate/duration/index.html
+++ b/files/en-us/web/api/mediapositionstate/duration/index.html
@@ -77,8 +77,7 @@ navigator.mediaSession.setPositionState(positionState);
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediapositionstate-duration','MediaPositionState.duration')}}</td>
+      <td>{{SpecName('Media Session','#dom-mediapositionstate-duration','MediaPositionState.duration')}}</td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediapositionstate/playbackrate/index.html
+++ b/files/en-us/web/api/mediapositionstate/playbackrate/index.html
@@ -86,8 +86,7 @@ navigator.mediaSession.setPositionState(positionState);
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediapositionstate-playbackrate','MediaPositionState.playbackRate')}}
+      <td>{{SpecName('Media Session','#dom-mediapositionstate-playbackrate','MediaPositionState.playbackRate')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediapositionstate/position/index.html
+++ b/files/en-us/web/api/mediapositionstate/position/index.html
@@ -81,8 +81,7 @@ let <em>duration</em> = <em>positionState</em>.duration;
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediapositionstate-position','MediaPositionState.position')}}</td>
+      <td>{{SpecName('Media Session','#dom-mediapositionstate-position','MediaPositionState.position')}}</td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Recording','#dom-mediarecorder-audiobitspersecond','audioBitsPerSecond')}}</td>
+      <td>{{SpecName('MediaStream Recording','#dom-mediarecorder-audiobitspersecond','audioBitsPerSecond')}}</td>
       <td>{{Spec2('MediaStream Recording')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediarecorder/videobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/videobitspersecond/index.html
@@ -32,8 +32,7 @@ slug: Web/API/MediaRecorder/videoBitsPerSecond
             <th scope="col">Comment</th>
         </tr>
         <tr>
-            <td>{{SpecName('MediaStream
-                Recording','#dom-mediarecorder-videobitspersecond','videoBitsPerSecond')}}
+            <td>{{SpecName('MediaStream Recording','#dom-mediarecorder-videobitspersecond','videoBitsPerSecond')}}
             </td>
             <td>{{Spec2('MediaStream Recording')}}</td>
             <td>Initial definition.</td>

--- a/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
@@ -66,8 +66,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Recording','#dom-mediarecordererrorevent-mediarecordererrorevent','MediaRecorderErrorEvent()')}}
+      <td>{{SpecName('MediaStream Recording','#dom-mediarecordererrorevent-mediarecordererrorevent','MediaRecorderErrorEvent()')}}
       </td>
       <td>{{Spec2('MediaStream Recording')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasession/metadata/index.html
+++ b/files/en-us/web/api/mediasession/metadata/index.html
@@ -61,8 +61,7 @@ navigator.mediaSession.metadata = <em>mediaMetadata</em>;</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasession-metadata','MediaSession.metadata')}}</td>
+      <td>{{SpecName('Media Session','#dom-mediasession-metadata','MediaSession.metadata')}}</td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediasession/setpositionstate/index.html
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.html
@@ -107,8 +107,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasession-setpositionstate','MediaSession.setPositionState()')}}
+      <td>{{SpecName('Media Session','#dom-mediasession-setpositionstate','MediaSession.setPositionState()')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasessionactiondetails/action/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/action/index.html
@@ -44,8 +44,7 @@ let <em>actionType</em> = <em>mediaSessionActionDetails</em>.action;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasessionactiondetails-action','MediaSessionActionDetails.action')}}
+      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-action','MediaSessionActionDetails.action')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasessionactiondetails/fastseek/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/fastseek/index.html
@@ -52,8 +52,7 @@ let <em>shouldFastSeek</em> = <em>mediaSessionActionDetails</em>.fastSeek;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasessionactiondetails-fastseek','MediaSessionActionDetails.fastSeek')}}
+      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-fastseek','MediaSessionActionDetails.fastSeek')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasessionactiondetails/seekoffset/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/seekoffset/index.html
@@ -53,8 +53,7 @@ let <em>deltaTime</em> = <em>mediaSessionActionDetails</em>.seekOffset;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasessionactiondetails-seekoffset','MediaSessionActionDetails.seekOffset')}}
+      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-seekoffset','MediaSessionActionDetails.seekOffset')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasessionactiondetails/seektime/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/seektime/index.html
@@ -67,8 +67,7 @@ let <em>absTime</em> = <em>mediaSessionActionDetails</em>.seekTime;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-mediasessionactiondetails-seektime','MediaSessionActionDetails.seekTime')}}
+      <td>{{SpecName('Media Session','#dom-mediasessionactiondetails-seektime','MediaSessionActionDetails.seekTime')}}
       </td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasource/clearliveseekablerange/index.html
+++ b/files/en-us/web/api/mediasource/clearliveseekablerange/index.html
@@ -42,8 +42,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media Source
-        Extensions','#dom-mediasource-clearliveseekablerange','clearLiveSeekableRange()')}}
+      <td>{{SpecName('Media Source Extensions','#dom-mediasource-clearliveseekablerange','clearLiveSeekableRange()')}}
       </td>
       <td>{{Spec2('Media Source Extensions')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediasource/setliveseekablerange/index.html
+++ b/files/en-us/web/api/mediasource/setliveseekablerange/index.html
@@ -59,8 +59,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media Source
-        Extensions','#dom-mediasource-setliveseekablerange','setLiveSeekableRange()')}}
+      <td>{{SpecName('Media Source Extensions','#dom-mediasource-setliveseekablerange','setLiveSeekableRange()')}}
       </td>
       <td>{{Spec2('Media Source Extensions')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.html
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.html
@@ -79,8 +79,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Media
-        Capture','#dom-mediastream-getaudiotracks','getAudioTracks()')}}</td>
+      <td>{{SpecName('Media Capture','#dom-mediastream-getaudiotracks','getAudioTracks()')}}</td>
       <td>{{Spec2('Media Capture')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediastream/getvideotracks/index.html
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.html
@@ -78,8 +78,7 @@ navigator.mediaDevices.getUserMedia({video: true})
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Capture','#dom-mediastream-getvideotracks','getVideoTracks()')}}</td>
+      <td>{{SpecName('Media Capture','#dom-mediastream-getvideotracks','getVideoTracks()')}}</td>
       <td>{{Spec2('Media Capture')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.html
@@ -59,8 +59,7 @@ console.log(source.mediaStream);</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-mediastreamaudiosourcenode-mediastream','MediaStreamAudioSourceNode.mediaStream')}}
+      <td>{{SpecName('Web Audio API','#dom-mediastreamaudiosourcenode-mediastream','MediaStreamAudioSourceNode.mediaStream')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.html
@@ -96,8 +96,7 @@ if (navigator.mediaDevices.getUserMedia) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode','MediaStreamAudioSourceNode()')}}
+      <td>{{SpecName('Web Audio API','#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode','MediaStreamAudioSourceNode()')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/mediastreamaudiosourceoptions/mediastream/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourceoptions/mediastream/index.html
@@ -52,8 +52,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-mediastreamaudiosourceoptions-mediastream','MediaStreamAudioSourceOptions.mediaStream')}}
+      <td>{{SpecName('Web Audio API','#dom-mediastreamaudiosourceoptions-mediastream','MediaStreamAudioSourceOptions.mediaStream')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.html
@@ -103,8 +103,7 @@ if (navigator.mediaDevices.getUserMedia) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode','MediaStreamTrackAudioSourceNode()')}}
+      <td>{{SpecName('Web Audio API','#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode','MediaStreamTrackAudioSourceNode()')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/mediastreamtrackaudiosourceoptions/mediastreamtrack/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourceoptions/mediastreamtrack/index.html
@@ -56,8 +56,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack','MediaStreamTrackAudioSourceOptions.mediaStream')}}
+      <td>{{SpecName('Web Audio API','#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack','MediaStreamTrackAudioSourceOptions.mediaStream')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/mouseevent/buttons/index.html
+++ b/files/en-us/web/api/mouseevent/buttons/index.html
@@ -96,8 +96,7 @@ document.querySelector('#log').appendChild(log)</pre>
 			<td>Current working draft</td>
 		</tr>
 		<tr>
-			<td>{{SpecName('DOM3
-				Events','#widl-MouseEvent-buttons','MouseEvent.buttons')}}</td>
+			<td>{{SpecName('DOM3 Events','#widl-MouseEvent-buttons','MouseEvent.buttons')}}</td>
 			<td>{{Spec2('DOM3 Events')}}</td>
 			<td>Initial definition</td>
 		</tr>

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.html
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.html
@@ -144,14 +144,12 @@ function overListener(event) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('UI Events', '#dom-mouseevent-relatedtarget',
-        'MouseEvent.relatedTarget')}}</td>
+      <td>{{SpecName('UI Events', '#dom-mouseevent-relatedtarget', 'MouseEvent.relatedTarget')}}</td>
       <td>{{Spec2('UI Events')}}</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Events','#widl-MouseEvent-relatedTarget','MouseEvent.relatedTarget')}}</td>
+      <td>{{SpecName('DOM3 Events','#widl-MouseEvent-relatedTarget','MouseEvent.relatedTarget')}}</td>
       <td>{{Spec2('DOM3 Events')}}</td>
       <td>No change from {{SpecName('DOM2 Events')}}.</td>
     </tr>

--- a/files/en-us/web/api/navigator/contacts/index.html
+++ b/files/en-us/web/api/navigator/contacts/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Contact Picker
-        API','#extensions-to-navigator','Navigator.contacts')}}</td>
+      <td>{{SpecName('Contact Picker API','#extensions-to-navigator','Navigator.contacts')}}</td>
       <td>{{Spec2('Contact Picker API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/navigator/mediasession/index.html
+++ b/files/en-us/web/api/navigator/mediasession/index.html
@@ -74,8 +74,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Media
-        Session','#dom-navigator-mediasession','navigator.mediaSession')}}</td>
+      <td>{{SpecName('Media Session','#dom-navigator-mediasession','navigator.mediaSession')}}</td>
       <td>{{Spec2('Media Session')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/navigator/productsub/index.html
+++ b/files/en-us/web/api/navigator/productsub/index.html
@@ -53,8 +53,7 @@ function prodsub() {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-productsub', 'NavigatorID:
-        productSub')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-navigator-productsub', 'NavigatorID: productSub')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/navigator/vendorsub/index.html
+++ b/files/en-us/web/api/navigator/vendorsub/index.html
@@ -36,8 +36,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-vendorsub', 'NavigatorID:
-        vendorSub')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-navigator-vendorsub', 'NavigatorID: vendorSub')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/navigatorlanguage/language/index.html
+++ b/files/en-us/web/api/navigatorlanguage/language/index.html
@@ -49,8 +49,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-language', 'NavigatorLanguage:
-        language')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-navigator-language', 'NavigatorLanguage: language')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/navigatorlanguage/languages/index.html
+++ b/files/en-us/web/api/navigatorlanguage/languages/index.html
@@ -54,8 +54,7 @@ navigator.languages  //["en-US", "zh-CN", "ja-JP"]
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-navigator-languages', 'NavigatorLanguage:
-        languages')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-navigator-languages', 'NavigatorLanguage: languages')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/networkinformation/downlink/index.html
+++ b/files/en-us/web/api/networkinformation/downlink/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Network
-        Information','#dom-networkinformation-downlink','downlink')}}</td>
+      <td>{{SpecName('Network Information','#dom-networkinformation-downlink','downlink')}}</td>
       <td>{{Spec2('Network Information')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/networkinformation/effectivetype/index.html
+++ b/files/en-us/web/api/networkinformation/effectivetype/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Network
-        Information','#dom-networkinformation-effectivetype','effectiveType')}}</td>
+      <td>{{SpecName('Network Information','#dom-networkinformation-effectivetype','effectiveType')}}</td>
       <td>{{Spec2('Network Information')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/networkinformation/onchange/index.html
+++ b/files/en-us/web/api/networkinformation/onchange/index.html
@@ -47,8 +47,7 @@ navigator.connection.onchange = changeHandler;
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Network
-        Information','#dom-networkinformation-onchange','onchange')}}</td>
+      <td>{{SpecName('Network Information','#dom-networkinformation-onchange','onchange')}}</td>
       <td>{{Spec2('Network Information')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/node/comparedocumentposition/index.html
+++ b/files/en-us/web/api/node/comparedocumentposition/index.html
@@ -111,15 +111,13 @@ if (head.compareDocumentPosition(body) &amp; Node.DOCUMENT_POSITION_FOLLOWING) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('DOM
-        WHATWG','#dom-node-comparedocumentposition','Node.compareDocumentPosition()')}}
+      <td>{{SpecName('DOM WHATWG','#dom-node-comparedocumentposition','Node.compareDocumentPosition()')}}
       </td>
       <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>
     <tr>
-      <td>{{SpecName('DOM3
-        Core','core.html#Node3-compareDocumentPosition','Node.compareDocumentPosition()')}}
+      <td>{{SpecName('DOM3 Core','core.html#Node3-compareDocumentPosition','Node.compareDocumentPosition()')}}
       </td>
       <td>{{Spec2('DOM3 Core')}}</td>
       <td>Initial definition</td>

--- a/files/en-us/web/api/notificationevent/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.html
@@ -50,8 +50,7 @@ var myNotificationEvent = new NotificationEvent(type, init);
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Web
-        Notifications','#dom-notificationevent-notificationevent','NotificationEvent()
+      <td>{{SpecName('Web Notifications','#dom-notificationevent-notificationevent','NotificationEvent()
         constructor')}}</td>
       <td>{{Spec2('Web Notifications')}}</td>
       <td>Living standard.</td>

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
@@ -54,8 +54,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Web Audio
-				API','#dom-offlineaudiocompletionevent-offlineaudiocompletionevent','OfflineAudioCompletionEvent()')}}
+			<td>{{SpecName('Web Audio API','#dom-offlineaudiocompletionevent-offlineaudiocompletionevent','OfflineAudioCompletionEvent()')}}
 			</td>
 			<td>{{Spec2('Web Audio API')}}</td>
 			<td>Initial definition.</td>

--- a/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
@@ -34,8 +34,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-offlineaudiocompletionevent-renderedbuffer','renderedBuffer')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-offlineaudiocompletionevent-renderedbuffer','renderedBuffer')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
@@ -96,8 +96,7 @@ const source = offlineCtx.createBufferSource();
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-offlineaudiocontext-offlineaudiocontext','OfflineAudioContext()')}}
+      <td>{{SpecName('Web Audio API','#dom-offlineaudiocontext-offlineaudiocontext','OfflineAudioContext()')}}
       </td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td></td>

--- a/files/en-us/web/api/orientationsensor/populatematrix/index.html
+++ b/files/en-us/web/api/orientationsensor/populatematrix/index.html
@@ -69,8 +69,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Orientation
-        Sensor','#orientationsensor-populatematrix','populateMatrix')}}</td>
+      <td>{{SpecName('Orientation Sensor','#orientationsensor-populatematrix','populateMatrix')}}</td>
       <td>{{Spec2('Orientation Sensor')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.html
@@ -70,8 +70,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Web Audio
-				API','#dom-oscillatornode-oscillatornode','OscillatorNode()')}}</td>
+			<td>{{SpecName('Web Audio API','#dom-oscillatornode-oscillatornode','OscillatorNode()')}}</td>
 			<td>{{Spec2('Web Audio API')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/overconstrainederror/constraint/index.html
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.html
@@ -39,8 +39,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Capture','#dom-overconstrainederror-constraint','constraint')}}</td>
+      <td>{{SpecName('Media Capture','#dom-overconstrainederror-constraint','constraint')}}</td>
       <td>{{Spec2('Media Capture')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
@@ -46,8 +46,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Media
-        Capture','#dom-overconstrainederror-constructor','OverconstrainedError()')}}</td>
+      <td>{{SpecName('Media Capture','#dom-overconstrainederror-constructor','OverconstrainedError()')}}</td>
       <td>{{Spec2('Media Capture')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/paintworklet/registerpaint/index.html
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.html
@@ -101,8 +101,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSS Painting
-        API','#dom-paintworkletglobalscope-registerpaint','PaintWorkletGlobalScope.registerPaint')}}
+      <td>{{SpecName('CSS Painting API','#dom-paintworkletglobalscope-registerpaint','PaintWorkletGlobalScope.registerPaint')}}
       </td>
       <td>{{Spec2('CSS Painting API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/passwordcredential/iconurl/index.html
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.html
@@ -36,8 +36,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Credential
-        Management','#dom-credentialuserdata-iconurl','iconURL')}}</td>
+      <td>{{SpecName('Credential Management','#dom-credentialuserdata-iconurl','iconURL')}}</td>
       <td>{{Spec2('Credential Management')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/passwordcredential/password/index.html
+++ b/files/en-us/web/api/passwordcredential/password/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Credential
-        Management','#dom-passwordcredential-password','password')}}</td>
+      <td>{{SpecName('Credential Management','#dom-passwordcredential-password','password')}}</td>
       <td>{{Spec2('Credential Management')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.html
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Payment
-        Handler','#paymentrequestorigin-attribute','paymentRequestOrigin')}}</td>
+      <td>{{SpecName('Payment Handler','#paymentrequestorigin-attribute','paymentRequestOrigin')}}</td>
       <td>{{Spec2('Payment Handler')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/paymentresponse/complete/index.html
+++ b/files/en-us/web/api/paymentresponse/complete/index.html
@@ -116,8 +116,7 @@ payment.show().then(function(paymentResponse) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Payment','#dom-paymentresponse-complete','PaymentResponse:
-        complete')}}</td>
+      <td>{{SpecName('Payment','#dom-paymentresponse-complete','PaymentResponse: complete')}}</td>
       <td>{{Spec2('Payment')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/performance/timeorigin/index.html
+++ b/files/en-us/web/api/performance/timeorigin/index.html
@@ -36,8 +36,7 @@ tags:
 			<th scope="col">Status</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Highres Time Level
-				2','#dom-performance-timeorigin','timeOrigin')}}</td>
+			<td>{{SpecName('Highres Time Level 2','#dom-performance-timeorigin','timeOrigin')}}</td>
 			<td>{{Spec2('Highres Time Level 2')}}</td>
 		</tr>
 	</tbody>

--- a/files/en-us/web/api/performancelongtasktiming/attribution/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/attribution/index.html
@@ -27,8 +27,7 @@ slug: Web/API/PerformanceLongTaskTiming/attribution
             <th scope="col">Comment</th>
         </tr>
         <tr>
-            <td>{{SpecName('Long
-                Tasks','#dom-performancelongtasktiming-attribution','attribution')}}</td>
+            <td>{{SpecName('Long Tasks','#dom-performancelongtasktiming-attribution','attribution')}}</td>
             <td>{{Spec2('Long Tasks')}}</td>
             <td>Initial definition.</td>
         </tr>

--- a/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
@@ -65,8 +65,7 @@ psEvent.tag; // should return 'unique-tag'
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Periodic Background
-        Sync','#periodicsync-event','PeriodicSyncEvent')}}</td>
+      <td>{{SpecName('Periodic Background Sync','#periodicsync-event','PeriodicSyncEvent')}}</td>
       <td>{{Spec2('Periodic Background Sync')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/periodicsyncmanager/gettags/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/gettags/index.html
@@ -61,8 +61,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Periodic Background
-        Sync','#dom-periodicsyncmanager-gettags','getTags')}}</td>
+      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncmanager-gettags','getTags')}}</td>
       <td>{{Spec2('Periodic Background Sync')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/periodicsyncmanager/register/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.html
@@ -79,8 +79,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Periodic Background
-        Sync','#dom-periodicsyncmanager-register','register')}}</td>
+      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncmanager-register','register')}}</td>
       <td>{{Spec2('Periodic Background Sync')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/periodicsyncmanager/unregister/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/unregister/index.html
@@ -57,8 +57,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Periodic Background
-        Sync','#dom-periodicsyncmanager-unregister','unregister')}}</td>
+      <td>{{SpecName('Periodic Background Sync','#dom-periodicsyncmanager-unregister','unregister')}}</td>
       <td>{{Spec2('Periodic Background Sync')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/photocapabilities/filllightmode/index.html
+++ b/files/en-us/web/api/photocapabilities/filllightmode/index.html
@@ -48,8 +48,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('MediaStream
-				Image','#dom-photocapabilities-filllightmode','fillLightMode')}}</td>
+			<td>{{SpecName('MediaStream Image','#dom-photocapabilities-filllightmode','fillLightMode')}}</td>
 			<td>{{Spec2('MediaStream Image')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/photocapabilities/imageheight/index.html
+++ b/files/en-us/web/api/photocapabilities/imageheight/index.html
@@ -37,8 +37,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Image','#dom-photocapabilities-imageheight','imageHeight')}}</td>
+      <td>{{SpecName('MediaStream Image','#dom-photocapabilities-imageheight','imageHeight')}}</td>
       <td>{{Spec2('MediaStream Image')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/photocapabilities/imagewidth/index.html
+++ b/files/en-us/web/api/photocapabilities/imagewidth/index.html
@@ -37,8 +37,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Image','#dom-photocapabilities-imagewidth','imageWidth')}}</td>
+      <td>{{SpecName('MediaStream Image','#dom-photocapabilities-imagewidth','imageWidth')}}</td>
       <td>{{Spec2('MediaStream Image')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/photocapabilities/redeyereduction/index.html
+++ b/files/en-us/web/api/photocapabilities/redeyereduction/index.html
@@ -48,8 +48,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('MediaStream
-        Image','#dom-photocapabilities-redeyereduction','redEyeReduction')}}</td>
+      <td>{{SpecName('MediaStream Image','#dom-photocapabilities-redeyereduction','redEyeReduction')}}</td>
       <td>{{Spec2('MediaStream Image')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
@@ -39,8 +39,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Pointer Events
-        3','#dom-pointerevent-getcoalescedevents','getCoalescedEvents()')}}</td>
+      <td>{{SpecName('Pointer Events 3','#dom-pointerevent-getcoalescedevents','getCoalescedEvents()')}}</td>
       <td>{{Spec2('Pointer Events 3')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.html
+++ b/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.html
@@ -86,8 +86,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#the-promiserejectionevent-interface', 'the
-        PromiseRejectionEvent interface')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#the-promiserejectionevent-interface', 'the PromiseRejectionEvent interface')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Push
-        API','#dom-pushmanager-supportedcontentencodings','supportedContentEncodings')}}
+      <td>{{SpecName('Push API','#dom-pushmanager-supportedcontentencodings','supportedContentEncodings')}}
       </td>
       <td>{{Spec2('Push API')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/pushsubscription/tojson/index.html
+++ b/files/en-us/web/api/pushsubscription/tojson/index.html
@@ -51,8 +51,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Push API','#dom-pushsubscription-tojson','PushSubscription:
-        toJSON')}}</td>
+      <td>{{SpecName('Push API','#dom-pushsubscription-tojson','PushSubscription: toJSON')}}</td>
       <td>{{Spec2('Push API')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
@@ -55,8 +55,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Orientation
-				Sensor','#dom-relativeorientationsensor-relativeorientationsensor','RelativeOrientationSensor()')}}
+			<td>{{SpecName('Orientation Sensor','#dom-relativeorientationsensor-relativeorientationsensor','RelativeOrientationSensor()')}}
 			</td>
 			<td>{{Spec2('Orientation Sensor')}}</td>
 			<td>Initial definition.</td>

--- a/files/en-us/web/api/reportingobserver/disconnect/index.html
+++ b/files/en-us/web/api/reportingobserver/disconnect/index.html
@@ -54,8 +54,7 @@ observer.disconnect()
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Reporting
-        API','#dom-reportingobserver-disconnect','ReportingObserver.disconnect()')}}</td>
+      <td>{{SpecName('Reporting API','#dom-reportingobserver-disconnect','ReportingObserver.disconnect()')}}</td>
       <td>{{Spec2('Reporting API')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/reportingobserver/observe/index.html
+++ b/files/en-us/web/api/reportingobserver/observe/index.html
@@ -45,8 +45,7 @@ observer.observe()
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Reporting
-        API','#dom-reportingobserver-observe','ReportingObserver.observe()')}}</td>
+      <td>{{SpecName('Reporting API','#dom-reportingobserver-observe','ReportingObserver.observe()')}}</td>
       <td>{{Spec2('Reporting API')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/reportingobserver/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/reportingobserver/index.html
@@ -72,8 +72,7 @@ let observer = new ReportingObserver(function(reports, observer) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Reporting
-        API','#dom-reportingobserver-reportingobserver','ReportingObserver()')}}</td>
+      <td>{{SpecName('Reporting API','#dom-reportingobserver-reportingobserver','ReportingObserver()')}}</td>
       <td>{{Spec2('Reporting API')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/reportingobserver/takerecords/index.html
+++ b/files/en-us/web/api/reportingobserver/takerecords/index.html
@@ -54,8 +54,7 @@ console.log(records);
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Reporting
-        API','#dom-reportingobserver-takerecords','ReportingObserver.takeRecords()')}}
+      <td>{{SpecName('Reporting API','#dom-reportingobserver-takerecords','ReportingObserver.takeRecords()')}}
       </td>
       <td>{{Spec2('Reporting API')}}</td>
       <td></td>

--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.html
@@ -90,8 +90,7 @@ resizeObserver.observe(divElem);</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Resize
-        Observer','#dom-resizeobserver-resizeobserver','ResizeObserver')}}</td>
+      <td>{{SpecName('Resize Observer','#dom-resizeobserver-resizeobserver','ResizeObserver')}}</td>
       <td>{{Spec2('Resize Observer')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/resizeobserverentry/contentrect/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentrect/index.html
@@ -74,8 +74,7 @@ resizeObserver.observe(divElem);</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('Resize
-        Observer','#dom-resizeobserverentry-contentrect','contentRect')}}</td>
+      <td>{{SpecName('Resize Observer','#dom-resizeobserverentry-contentrect','contentRect')}}</td>
       <td>{{Spec2('Resize Observer')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
@@ -124,8 +124,7 @@ let pc = new RTCPeerConnection(config);</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcconfiguration-bundlepolicy','RTCConfiguration.bundlePolicy')}}</td>
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-bundlepolicy','RTCConfiguration.bundlePolicy')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcconfiguration/certificates/index.html
+++ b/files/en-us/web/api/rtcconfiguration/certificates/index.html
@@ -108,8 +108,7 @@ let <em>certificates</em> = <em>rtcConfiguration</em>.certificates;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcconfiguration-certificates','RTCConfiguration.certificates')}}</td>
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-certificates','RTCConfiguration.certificates')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcconfiguration/iceservers/index.html
+++ b/files/en-us/web/api/rtcconfiguration/iceservers/index.html
@@ -95,8 +95,7 @@ var pc = new RTCPeerConnection(configuration);</pre>
         <th scope="col">Comment</th>
       </tr>
       <tr>
-        <td>{{SpecName('WebRTC
-          1.0','#dom-rtcconfiguration-iceservers','RTCConfiguration.iceServers')}}</td>
+        <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-iceservers','RTCConfiguration.iceServers')}}</td>
         <td>{{Spec2('WebRTC 1.0')}}</td>
         <td>Initial definition.</td>
       </tr>

--- a/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
@@ -88,8 +88,7 @@ let pc = new RTCPeerConnection(config);</pre>
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcconfiguration-icetransportpolicy','RTCCandidate.iceTransportPolicy')}}
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcconfiguration-icetransportpolicy','RTCCandidate.iceTransportPolicy')}}
       </td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/rtcicecandidate/address/index.html
+++ b/files/en-us/web/api/rtcicecandidate/address/index.html
@@ -113,8 +113,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-address', 'RTCIceCandidate:
-        address')}}</td>
+      <td>{{SpecName('WebRTC 1.0', '#dom-rtcicecandidate-address', 'RTCIceCandidate: address')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
@@ -59,8 +59,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpcontributingsource-audiolevel','audioLevel')}}</td>
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpcontributingsource-audiolevel','audioLevel')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpsynchronizationsource-rtptimestamp','rtpTimestamp')}}</td>
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsynchronizationsource-rtptimestamp','rtpTimestamp')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.html
@@ -60,8 +60,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpencodingparameters-maxbitrate','RTCRtpEncodingParameters.maxBitrate')}}
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpencodingparameters-maxbitrate','RTCRtpEncodingParameters.maxBitrate')}}
       </td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.html
@@ -62,8 +62,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpencodingparameters-scaleresolutiondownby','RTCRtpEncodingParameters.scaleResolutionDownBy')}}
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpencodingparameters-scaleresolutiondownby','RTCRtpEncodingParameters.scaleResolutionDownBy')}}
       </td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.html
@@ -45,8 +45,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpreceiver-getcontributingsources','getContributingSources()')}}
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiver-getcontributingsources','getContributingSources()')}}
       </td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/rtcrtpreceiver/getparameters/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getparameters/index.html
@@ -60,8 +60,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpreceiver-getparameters','RTCRtpReceiver.getParameters()')}}</td>
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiver-getparameters','RTCRtpReceiver.getParameters()')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcrtpreceiver/getsynchronizationsources/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getsynchronizationsources/index.html
@@ -54,8 +54,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpreceiver-getsynchronizationsources','getSynchronizationSources()')}}
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpreceiver-getsynchronizationsources','getSynchronizationSources()')}}
       </td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.html
@@ -203,8 +203,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpsender-setparameters','RTCRtpSender.setParameters()')}}</td>
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsender-setparameters','RTCRtpSender.setParameters()')}}</td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/rtcrtpsendparameters/encodings/index.html
+++ b/files/en-us/web/api/rtcrtpsendparameters/encodings/index.html
@@ -59,8 +59,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebRTC
-        1.0','#dom-rtcrtpsendparameters-encodings','RTCRtpSendParameters.encodings')}}
+      <td>{{SpecName('WebRTC 1.0','#dom-rtcrtpsendparameters-encodings','RTCRtpSendParameters.encodings')}}
       </td>
       <td>{{Spec2('WebRTC 1.0')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.html
@@ -42,8 +42,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-blockeduri','blockedURI')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-blockeduri','blockedURI')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-columnnumber','columnNumber')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-columnnumber','columnNumber')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.html
@@ -46,8 +46,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-disposition','disposition')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-disposition','disposition')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-documenturi','documentURI')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-documenturi','documentURI')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-effectivedirective','effectiveDirective')}}
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-effectivedirective','effectiveDirective')}}
       </td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-linenumber','lineNumber')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-linenumber','lineNumber')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-originalpolicy','originalPolicy')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-originalpolicy','originalPolicy')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.html
@@ -100,8 +100,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-securitypolicyviolationevent','SecurityPolicyViolationEvent')}}
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-securitypolicyviolationevent','SecurityPolicyViolationEvent')}}
       </td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-sourcefile','sourceFile')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-sourcefile','sourceFile')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-statuscode','statusCode')}}</td>
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-statuscode','statusCode')}}</td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.html
+++ b/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.html
@@ -44,8 +44,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('CSP
-        3.0','#dom-securitypolicyviolationevent-violateddirective','violatedDirective')}}
+      <td>{{SpecName('CSP 3.0','#dom-securitypolicyviolationevent-violateddirective','violatedDirective')}}
       </td>
       <td>{{Spec2('CSP 3.0')}}</td>
       <td>Initial definition</td>

--- a/files/en-us/web/api/selection/getrangeat/index.html
+++ b/files/en-us/web/api/selection/getrangeat/index.html
@@ -55,8 +55,7 @@ for(let i = 0; i &lt; sel.rangeCount; i++) {
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Selection API', '#dom-selection-getrangeat', 'Selection:
-				getRangeAt()')}}</td>
+			<td>{{SpecName('Selection API', '#dom-selection-getrangeat', 'Selection: getRangeAt()')}}</td>
 			<td>{{Spec2('Selection API')}}</td>
 			<td>Current</td>
 		</tr>

--- a/files/en-us/web/api/sensorerrorevent/sensorerrorevent/index.html
+++ b/files/en-us/web/api/sensorerrorevent/sensorerrorevent/index.html
@@ -46,8 +46,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Generic
-        Sensor','#dom-sensorerrorevent-sensorerrorevent','SensorErrorEvent')}}</td>
+      <td>{{SpecName('Generic Sensor','#dom-sensorerrorevent-sensorerrorevent','SensorErrorEvent')}}</td>
       <td>{{Spec2('Generic Sensor')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/serviceworkerglobalscope/onnotificationclose/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onnotificationclose/index.html
@@ -54,8 +54,7 @@ self.onnotificationclose = function(event) {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Notifications','#dom-serviceworkerglobalscope-onnotificationclose','onnotificationclick')}}
+      <td>{{SpecName('Web Notifications','#dom-serviceworkerglobalscope-onnotificationclose','onnotificationclick')}}
       </td>
       <td>{{Spec2('Web Notifications')}}</td>
       <td>Initial definition. This property is specified on the

--- a/files/en-us/web/api/serviceworkerregistration/index/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/index/index.html
@@ -63,8 +63,7 @@ const contentIndex = self.registration.index;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Content Index
-        API','#extensions-to-service-worker-registration','index')}}</td>
+      <td>{{SpecName('Content Index API','#extensions-to-service-worker-registration','index')}}</td>
       <td>{{Spec2('Content Index API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/serviceworkerregistration/navigationpreload/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/navigationpreload/index.html
@@ -36,8 +36,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Service
-        Workers','#service-worker-registration-navigationpreload','navigationPreload')}}
+      <td>{{SpecName('Service Workers','#service-worker-registration-navigationpreload','navigationPreload')}}
       </td>
       <td>{{Spec2('Service Workers')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/serviceworkerregistration/periodicsync/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/periodicsync/index.html
@@ -63,8 +63,7 @@ const periodicSync = self.registration.periodicSync;
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Periodic Background
-        Sync','#extensions-to-serviceworkerregistration','periodicSync')}}</td>
+      <td>{{SpecName('Periodic Background Sync','#extensions-to-serviceworkerregistration','periodicSync')}}</td>
       <td>{{Spec2('Periodic Background Sync')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.html
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.html
@@ -140,8 +140,7 @@ function showNotification() {
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        Notifications','#dom-serviceworkerregistration-shownotification','showNotification()')}}
+      <td>{{SpecName('Web Notifications','#dom-serviceworkerregistration-shownotification','showNotification()')}}
       </td>
       <td>{{Spec2('Web Notifications')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/stereopannernode/stereopannernode/index.html
+++ b/files/en-us/web/api/stereopannernode/stereopannernode/index.html
@@ -55,8 +55,7 @@ tags:
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Web Audio
-				API','#dom-stereopannernode-stereopannernode','StereoPannerNode()')}}</td>
+			<td>{{SpecName('Web Audio API','#dom-stereopannernode-stereopannernode','StereoPannerNode()')}}</td>
 			<td>{{Spec2('Web Audio API')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/taskattributiontiming/containerid/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Long
-        Tasks','#dom-taskattributiontiming-containerid','containerId')}}</td>
+      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containerid','containerId')}}</td>
       <td>{{Spec2('Long Tasks')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/taskattributiontiming/containername/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Long
-        Tasks','#dom-taskattributiontiming-containername','containerName')}}</td>
+      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containername','containerName')}}</td>
       <td>{{Spec2('Long Tasks')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Long
-        Tasks','#dom-taskattributiontiming-containersrc','containerSrc')}}</td>
+      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containersrc','containerSrc')}}</td>
       <td>{{Spec2('Long Tasks')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.html
@@ -35,8 +35,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Long
-        Tasks','#dom-taskattributiontiming-containertype','containerType')}}</td>
+      <td>{{SpecName('Long Tasks','#dom-taskattributiontiming-containertype','containerType')}}</td>
       <td>{{Spec2('Long Tasks')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/texttracklist/length/index.html
+++ b/files/en-us/web/api/texttracklist/length/index.html
@@ -60,8 +60,7 @@ if (mediaElem.textTracks) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-texttracklist-length', 'TextTrackList:
-        length')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-texttracklist-length', 'TextTrackList: length')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/texttracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/texttracklist/onaddtrack/index.html
@@ -74,8 +74,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onaddtrack', 'TextTrackList:
-        onaddtrack')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onaddtrack', 'TextTrackList: onaddtrack')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/texttracklist/onchange/index.html
+++ b/files/en-us/web/api/texttracklist/onchange/index.html
@@ -59,8 +59,7 @@ trackList.onchange = function(event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onchange', 'TextTrackList:
-        onchange')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onchange', 'TextTrackList: onchange')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/texttracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/texttracklist/onremovetrack/index.html
@@ -70,8 +70,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onremovetrack', 'TextTrackList:
-        onremovetrack')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onremovetrack', 'TextTrackList: onremovetrack')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/usbdevice/controltransferout/index.html
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.html
@@ -62,8 +62,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        USB','#dom-usbdevice-controltransferout','controlTransferOut()')}}</td>
+      <td>{{SpecName('Web USB','#dom-usbdevice-controltransferout','controlTransferOut()')}}</td>
       <td>{{Spec2('Web USB')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/usbdevice/deviceversionsubminor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionsubminor/index.html
@@ -36,8 +36,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        USB','#dom-usbdevice-deviceversionsubminor','deviceVersionSubminor')}}</td>
+      <td>{{SpecName('Web USB','#dom-usbdevice-deviceversionsubminor','deviceVersionSubminor')}}</td>
       <td>{{Spec2('Web USB')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/usbdevice/isochronoustransferin/index.html
+++ b/files/en-us/web/api/usbdevice/isochronoustransferin/index.html
@@ -47,8 +47,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        USB','#dom-usbdevice-isochronoustransferin','isochronousTransferIn()')}}</td>
+      <td>{{SpecName('Web USB','#dom-usbdevice-isochronoustransferin','isochronousTransferIn()')}}</td>
       <td>{{Spec2('Web USB')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.html
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.html
@@ -49,8 +49,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        USB','#dom-usbdevice-isochronoustransferout','isochronousTransferOut()')}}</td>
+      <td>{{SpecName('Web USB','#dom-usbdevice-isochronoustransferout','isochronousTransferOut()')}}</td>
       <td>{{Spec2('Web USB')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.html
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.html
@@ -46,8 +46,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        USB','#dom-usbdevice-selectalternateinterface','selectAlternateInterface()')}}
+      <td>{{SpecName('Web USB','#dom-usbdevice-selectalternateinterface','selectAlternateInterface()')}}
       </td>
       <td>{{Spec2('Web USB')}}</td>
       <td>Initial definition.</td>

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.html
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.html
@@ -43,8 +43,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web
-        USB','#dom-usbdevice-selectconfiguration','selectConfiguration')}}</td>
+      <td>{{SpecName('Web USB','#dom-usbdevice-selectconfiguration','selectConfiguration')}}</td>
       <td>{{Spec2('Web USB')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/videotracklist/length/index.html
+++ b/files/en-us/web/api/videotracklist/length/index.html
@@ -63,8 +63,7 @@ if (videoElem.videoTracks) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-length', 'VideoTrackList:
-        length')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-length', 'VideoTrackList: length')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/videotracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/videotracklist/onaddtrack/index.html
@@ -76,8 +76,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onaddtrack', 'VideoTrackList:
-        onaddtrack')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onaddtrack', 'VideoTrackList: onaddtrack')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/videotracklist/onchange/index.html
+++ b/files/en-us/web/api/videotracklist/onchange/index.html
@@ -76,8 +76,7 @@ trackList.onchange = function(event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onchange', 'VideoTrackList:
-        onchange')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onchange', 'VideoTrackList: onchange')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/videotracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/videotracklist/onremovetrack/index.html
@@ -70,8 +70,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onremovetrack', 'VideoTrackList:
-        onremovetrack')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-tracklist-onremovetrack', 'VideoTrackList: onremovetrack')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/videotracklist/selectedindex/index.html
+++ b/files/en-us/web/api/videotracklist/selectedindex/index.html
@@ -40,8 +40,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-selectedindex', 'VideoTrackList:
-        selectedIndex')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-videotracklist-selectedindex', 'VideoTrackList: selectedIndex')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/wakelocksentinel/released/index.html
+++ b/files/en-us/web/api/wakelocksentinel/released/index.html
@@ -51,8 +51,7 @@ await sentinel.release();
 			<th scope="col">Comment</th>
 		</tr>
 		<tr>
-			<td>{{SpecName('Screen Wake
-				Lock','#dom-wakelocksentinel-released','released')}}</td>
+			<td>{{SpecName('Screen Wake Lock','#dom-wakelocksentinel-released','released')}}</td>
 			<td>{{Spec2('Screen Wake Lock')}}</td>
 			<td>Initial definition.</td>
 		</tr>

--- a/files/en-us/web/api/waveshapernode/waveshapernode/index.html
+++ b/files/en-us/web/api/waveshapernode/waveshapernode/index.html
@@ -55,8 +55,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Web Audio
-        API','#dom-waveshapernode-waveshapernode','WaveShaperNode()')}}</td>
+      <td>{{SpecName('Web Audio API','#dom-waveshapernode-waveshapernode','WaveShaperNode()')}}</td>
       <td>{{Spec2('Web Audio API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/websocket/binarytype/index.html
+++ b/files/en-us/web/api/websocket/binarytype/index.html
@@ -61,8 +61,7 @@ socket.addEventListener("message", function (event) {
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-websocket-binarytype', 'WebSocket:
-        binaryType')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-websocket-binarytype', 'WebSocket: binaryType')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/websocket/bufferedamount/index.html
+++ b/files/en-us/web/api/websocket/bufferedamount/index.html
@@ -37,8 +37,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-websocket-bufferedamount', 'WebSocket:
-        bufferedAmount')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-websocket-bufferedamount', 'WebSocket: bufferedAmount')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/websocket/extensions/index.html
+++ b/files/en-us/web/api/websocket/extensions/index.html
@@ -35,8 +35,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-websocket-extensions', 'WebSocket:
-        extensions')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-websocket-extensions', 'WebSocket: extensions')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/websocket/onmessage/index.html
+++ b/files/en-us/web/api/websocket/onmessage/index.html
@@ -36,8 +36,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#handler-websocket-onmessage', 'WebSocket:
-        onmessage')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#handler-websocket-onmessage', 'WebSocket: onmessage')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/websocket/readystate/index.html
+++ b/files/en-us/web/api/websocket/readystate/index.html
@@ -64,8 +64,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG', '#dom-websocket-readystate', 'WebSocket:
-        readyState')}}</td>
+      <td>{{SpecName('HTML WHATWG', '#dom-websocket-readystate', 'WebSocket: readyState')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/window/cancelanimationframe/index.html
+++ b/files/en-us/web/api/window/cancelanimationframe/index.html
@@ -63,8 +63,7 @@ cancelAnimationFrame(myReq);
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','#animationframeprovider-cancelanimationframe','cancelAnimationFrame()')}}
+      <td>{{SpecName('HTML WHATWG','#animationframeprovider-cancelanimationframe','cancelAnimationFrame()')}}
       </td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>

--- a/files/en-us/web/api/window/ongamepaddisconnected/index.html
+++ b/files/en-us/web/api/window/ongamepaddisconnected/index.html
@@ -41,8 +41,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Gamepad', '#event-gamepaddisconnected', 'gamepaddisconnected
-        event')}}</td>
+      <td>{{SpecName('Gamepad', '#event-gamepaddisconnected', 'gamepaddisconnected event')}}</td>
       <td>{{Spec2('Gamepad')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/window/showdirectorypicker/index.html
+++ b/files/en-us/web/api/window/showdirectorypicker/index.html
@@ -59,8 +59,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System
-        Access','#api-showdirectorypicker','showDirectoryPicker')}}</td>
+      <td>{{SpecName('File System Access','#api-showdirectorypicker','showDirectoryPicker')}}</td>
       <td>{{Spec2('File System Access')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/window/showsavefilepicker/index.html
+++ b/files/en-us/web/api/window/showsavefilepicker/index.html
@@ -83,8 +83,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('File System
-        Access','#api-showsavefilepicker','showSaveFilePicker')}}</td>
+      <td>{{SpecName('File System Access','#api-showsavefilepicker','showSaveFilePicker')}}</td>
       <td>{{Spec2('File System Access')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/windowclient/focused/index.html
+++ b/files/en-us/web/api/windowclient/focused/index.html
@@ -60,8 +60,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('Service Workers', '#dom-windowclient-focused', 'WindowClient:
-        focused')}}</td>
+      <td>{{SpecName('Service Workers', '#dom-windowclient-focused', 'WindowClient: focused')}}</td>
       <td>{{Spec2('Service Workers')}}</td>
       <td>Initial definition</td>
     </tr>

--- a/files/en-us/web/api/windoweventhandlers/onstorage/index.html
+++ b/files/en-us/web/api/windoweventhandlers/onstorage/index.html
@@ -52,8 +52,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('HTML
-        WHATWG','webappapis.html#handler-window-onstorage','onstorage')}}</td>
+      <td>{{SpecName('HTML WHATWG','webappapis.html#handler-window-onstorage','onstorage')}}</td>
       <td>{{Spec2('HTML WHATWG')}}</td>
       <td></td>
     </tr>

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.html
@@ -40,8 +40,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebXR Device
-        API','#dom-xrrenderstate-depthfar','XRRenderState.depthFar')}}</td>
+      <td>{{SpecName('WebXR Device API','#dom-xrrenderstate-depthfar','XRRenderState.depthFar')}}</td>
       <td>{{Spec2('WebXR Device API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.html
@@ -40,8 +40,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebXR Device
-        API','#dom-xrrenderstate-depthnear','XRRenderState.depthNear')}}</td>
+      <td>{{SpecName('WebXR Device API','#dom-xrrenderstate-depthnear','XRRenderState.depthNear')}}</td>
       <td>{{Spec2('WebXR Device API')}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/xrsession/environmentblendmode/index.html
+++ b/files/en-us/web/api/xrsession/environmentblendmode/index.html
@@ -62,8 +62,7 @@ tags:
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName("WebXR AR
-        Module","#xrenvironmentblendmode-enum","XRSession.environmentBlendMode")}}</td>
+      <td>{{SpecName("WebXR AR Module","#xrenvironmentblendmode-enum","XRSession.environmentBlendMode")}}</td>
       <td>{{Spec2("WebXR")}}</td>
       <td>Initial definition.</td>
     </tr>

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
@@ -167,8 +167,7 @@ tags:
       <th scope="col">Comment</th>
     </tr>
     <tr>
-      <td>{{SpecName('WebXR','#dom-xrwebgllayer-getnativeframebufferscalefactor','static
-        XRWebGLLayer.getNativeFramebufferScaleFactor()')}}</td>
+      <td>{{SpecName('WebXR','#dom-xrwebgllayer-getnativeframebufferscalefactor','static XRWebGLLayer.getNativeFramebufferScaleFactor()')}}</td>
       <td>{{Spec2('WebXR')}}</td>
       <td>Initial definition.</td>
     </tr>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There are lots of cases of calling the `SpecName()` KS macro with a string that contains a line break. 
This is, the beginning, of a solution to automate cleaning this up.

