### PR TITLE
Add info about redirects not handled by moving

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,11 +532,11 @@ push your branch to your fork:
 
 1. Now you're ready to create your [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 
-
 ### Redirecting a document
 
-If you are [moving a document](#moving-one-or-more-documents) as shown above you don't need to create a redirect.
-However, you may need to when [deleting a document](#deleting-a-document) or otherwise fixing up a broken link.
+If you are [moving a document](#moving-one-or-more-documents) as shown
+above you don't need to create a redirect. However, you may need to when
+[deleting a document](#deleting-a-document) or otherwise fixing up a broken link.
 
 The best way to do this is to use the `yarn content add-redirect` command:
 
@@ -557,6 +557,7 @@ The best way to do this is to use the `yarn content add-redirect` command:
     ```sh
     yarn content add-redirect /en-US/path/of/deleted/page /en-US/path/of/target/page
     ```
+    
     Note that the target page can be an external URL or another page.
 
 1. Add and commit all of the deleted files, as well as

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ hosted within the [MDN Organization](https://github.com/mdn) on GitHub.
   - [Adding a new document](#adding-a-new-document)
   - [Moving one or more documents](#moving-one-or-more-documents)
   - [Deleting a document](#deleting-a-document)
+  - [Redirecting a document](#redirecting-a-document)
   - [Adding images](#adding-images)
   - [Updating a browser compatibility table](#updating-a-browser-compatibility-table)
   - [Adding code examples](#adding-code-examples)
@@ -520,6 +521,7 @@ entire `/en-US/Learn/Accessibility` tree:
     yarn content delete Learn/Accessibility --recursive
     ```
 
+1. [Add a redirect](#redirecting-a-document) (if needed).
 1. Add and commit all of the deleted files, as well as
 push your branch to your fork:
 
@@ -529,6 +531,41 @@ push your branch to your fork:
     ```
 
 1. Now you're ready to create your [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+
+
+### Redirecting a document
+
+If you [moving a document](#moving-one-or-more-documents) as shown above you don't need to create a redirect.
+However you may need to when [deleting a document](#deleting-a-document) or otherwise fixing up a broken link.
+
+The best way to do this is to use the `yarn content add-redirect` command:
+
+1. Start a fresh branch to work within:
+
+    ```sh
+    cd ~/repos/mdn/content
+    git checkout main
+    git pull mdn main
+    # Run "yarn" again just to ensure you've
+    # installed the latest Yari dependency.
+    yarn
+    git checkout -b my-delete
+    ```
+
+1. Perform the redirect:
+
+    ```sh
+    yarn content add-redirect /en-US/path/of/deleted/page /en-US/path/of/target/page
+    ```
+    Note that the target page can be an external URL or another page.
+
+1. Add and commit all of the deleted files, as well as
+push your branch to your fork:
+
+    ```sh
+    git commit -a
+    git push -u origin my-delete
+    ```
 
 ### Adding images
 

--- a/README.md
+++ b/README.md
@@ -535,12 +535,12 @@ push your branch to your fork:
 
 ### Redirecting a document
 
-If you [moving a document](#moving-one-or-more-documents) as shown above you don't need to create a redirect.
-However you may need to when [deleting a document](#deleting-a-document) or otherwise fixing up a broken link.
+If you are [moving a document](#moving-one-or-more-documents) as shown above you don't need to create a redirect.
+However, you may need to when [deleting a document](#deleting-a-document) or otherwise fixing up a broken link.
 
 The best way to do this is to use the `yarn content add-redirect` command:
 
-1. Start a fresh branch to work within:
+1. Start a fresh branch to work in:
 
     ```sh
     cd ~/repos/mdn/content
@@ -560,7 +560,7 @@ The best way to do this is to use the `yarn content add-redirect` command:
     Note that the target page can be an external URL or another page.
 
 1. Add and commit all of the deleted files, as well as
-push your branch to your fork:
+pushing your branch to your fork:
 
     ```sh
     git commit -a

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The best way to do this is to use the `yarn content add-redirect` command:
     ```sh
     yarn content add-redirect /en-US/path/of/deleted/page /en-US/path/of/target/page
     ```
-    
+
     Note that the target page can be an external URL or another page.
 
 1. Add and commit all of the deleted files, as well as


### PR DESCRIPTION
After you delete a file, and sometimes at other points you need to create a redirect. This is best done using `yari content add-redirect`. This fix explains how.