### PR TITLE
Drop tabindex from HTMLObjectElement doc

### DIFF
--- a/files/en-us/web/api/htmlobjectelement/index.html
+++ b/files/en-us/web/api/htmlobjectelement/index.html
@@ -50,8 +50,6 @@ tags:
  <dd>Returns a {{domxref("DOMString")}} that reflects the {{htmlattrxref("name", "object")}} HTML attribute, specifying the name of the browsing context.</dd>
  <dt>{{domxref("HTMLObjectElement.standby")}} {{obsolete_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("standby", "object")}} HTML attribute, specifying a message to display while the object loads.</dd>
- <dt>{{domxref("HTMLObjectElement.tabindex")}}</dt>
- <dd>Is a <code>long</code> representing the position of the element in the tabbing navigation order for the current document.</dd>
  <dt>{{domxref("HTMLObjectElement.type")}}</dt>
  <dd>Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("type", "object")}} HTML attribute, specifying the MIME type of the resource.</dd>
  <dt>{{domxref("HTMLObjectElement.useMap")}}</dt>


### PR DESCRIPTION
The `tabindex` IDL attribute is documented in the `HTMLElement` article at http://localhost:3000/en-US/docs/Web/API/HTMLElement — and the `HTMLObjectElement` article says “Inherits properties from its parent, \_HTMLElement\_ (hyperlinked). So we don’t need to re-document `tabindex` n the `HTMLObjectElement` article, and can instead drop it. Fixes https://github.com/mdn/content/issues/3637