### PR TITLE
Drop extraneous bold formatting in JS “switch” doc

### DIFF
--- a/files/en-us/web/javascript/reference/statements/switch/index.html
+++ b/files/en-us/web/javascript/reference/statements/switch/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{jsSidebar("Statements")}}</div>
 
-<p><span class="seoSummary">The <strong><code>switch</code> statement</strong> evaluates
+<p><span class="seoSummary">The <strong><code>switch</code></strong> statement evaluates
     an <a
       href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators">expression</a>,
     matching the expression's value to a <code>case</code> clause, and executes <a


### PR DESCRIPTION
relocated a </strong> tag to remove extraneous bold formatting

MDN URL
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch
