### PR TITLE
Document that duplicating a tab copies the tab’s sessionStorage

### DIFF
--- a/files/en-us/web/api/window/sessionstorage/index.html
+++ b/files/en-us/web/api/window/sessionstorage/index.html
@@ -30,8 +30,8 @@ tags:
       work.</strong></li>
   <li>Opening multiple tabs/windows with the same URL creates <code>sessionStorage</code>
     for each tab/window.</li>
-  <li>Duplicating a tab copies the current tab's <code>sessionStorage</code> into the new
-    tab</li>
+  <li>Duplicating a tab copies the tab's <code>sessionStorage</code> into the new
+    tab.</li>
   <li>Closing a tab/window ends the session and clears objects in
     <code>sessionStorage</code>.</li>
 </ul>

--- a/files/en-us/web/api/window/sessionstorage/index.html
+++ b/files/en-us/web/api/window/sessionstorage/index.html
@@ -30,6 +30,8 @@ tags:
       work.</strong></li>
   <li>Opening multiple tabs/windows with the same URL creates <code>sessionStorage</code>
     for each tab/window.</li>
+  <li>Duplicating a tab copies the current tab's <code>sessionStorage</code> into the new
+    tab</li>
   <li>Closing a tab/window ends the session and clears objects in
     <code>sessionStorage</code>.</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The fact that duplicating a tab creates a copy of the tab's session storage wasn't covered in the docs. This is somewhat surprising, because the rest of the docs suggest that each tab gets its own, entirely fresh `sessionStorage`.

Someone even decided to write a whole blog post about their surprise: https://medium.com/swlh/a-less-known-thing-about-session-storage-api-4e59f6218af9

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/3688

> Anything else that could help us review it
