### PR TITLE
fix typo

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -48,7 +48,7 @@ tags:
 
 <div>{{draft}}{{SeeCompatTable}}{{securecontext_header}}{{deprecated_header}}{{APIRef("GroupDataName")}}</div>
 
-<p class="summary">The summary paragraph — start by naming the constructor, and saying what it does. This should ideally be 1 or 2 short sentences. You could copy most of this from the consrtructor's summary on the corresponding API reference page.</p>
+<p class="summary">The summary paragraph — start by naming the constructor, and saying what it does. This should ideally be 1 or 2 short sentences. You could copy most of this from the constructor's summary on the corresponding API reference page.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There was a typo that should be fixed

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_constructor_subpage_template

> Issue number (if there is an associated issue)

> Anything else that could help us review it
