### PR TITLE
Drop unnecessary terminology from postMessage docs

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
@@ -26,8 +26,8 @@ tags:
  <dt><em>aMessage</em></dt>
  <dd>The object to deliver to the main thread; this will be in the data field in the event delivered to the {{domxref("Worker.onmessage")}} handler. This may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</dd>
  <dt><em>transferList</em> {{optional_inline}}</dt>
- <dd>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable (<em>neutered</em>) in the context it was sent from and it becomes available only to the main thread it was sent to.</dd>
- <dd>Only {{domxref("MessagePort")}} and {{domxref("ArrayBuffer")}} objects can be transferred.</dd>
+ <dd>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.</dd>
+ <dd>Only {{domxref("MessagePort")}} and {{jsxref("ArrayBuffer")}} objects can be transferred.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>

--- a/files/en-us/web/api/worker/postmessage/index.html
+++ b/files/en-us/web/api/worker/postmessage/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <code><strong>postMessage()</strong></code> method of the {{domxref("Worker")}} interface sends a message to the worker's inner scope. This accepts a single parameter, which is the data to send to the worker. The data may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/Guide/DOM/The_structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</p>
+<p>The <code><strong>postMessage()</strong></code> method of the {{domxref("Worker")}} interface sends a message to the worker's inner scope. This accepts a single parameter, which is the data to send to the worker. The data may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</p>
 
 <p>Note this method blocks the thread which receives the message.</p>
 
@@ -26,11 +26,11 @@ tags:
 
 <dl>
  <dt><em>message</em></dt>
- <dd>The object to deliver to the worker; this will be in the <code>data</code> field in the event delivered to the {{domxref("DedicatedWorkerGlobalScope.onmessage")}} handler. This may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/Guide/DOM/The_structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</dd>
+ <dd>The object to deliver to the worker; this will be in the <code>data</code> field in the event delivered to the {{domxref("DedicatedWorkerGlobalScope.onmessage")}} handler. This may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</dd>
  <dd>If the <code>message</code> parameter is <em>not</em> provided, a <code>TypeError</code> will be thrown. If the data to be passed to the worker is unimportant, <code>null</code> or <code>undefined</code> can be passed explicitly.</dd>
  <dt><em>transfer</em> {{optional_inline}}</dt>
- <dd>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable (<em>neutered</em>) in the context it was sent from and becomes available only to the worker it was sent to.</dd>
- <dd>Transferable objects are instances of classes like {{domxref("ArrayBuffer")}}, {{domxref("MessagePort")}} or {{domxref("ImageBitmap")}} objects that can be transferred. <code>null</code> is not an acceptable value for <code>transfer</code>.</dd>
+ <dd>An optional <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">array</a> of {{domxref("Transferable")}} objects to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.</dd>
+ <dd>Transferable objects are instances of classes like {{jsxref("ArrayBuffer")}}, {{domxref("MessagePort")}} or {{domxref("ImageBitmap")}} objects that can be transferred. <code>null</code> is not an acceptable value for <code>transfer</code>.</dd>
 </dl>
 
 <h3 id="Returns">Returns</h3>


### PR DESCRIPTION
https://html.spec.whatwg.org/#dom-messageport-postmessage-options-dev describes transferable objects as being *“no longer usable”* on the side they’re sent from. So we have *“becomes unusable”* in the docs, and there’s no reason to introduce any additional term that’s not in the spec.

This is a follow-up to https://github.com/mdn/content/pull/3690, which made a change to the Channel Messaging API article, for the same reason.

This change also fixes a couple of link/macro flaws.