### PR TITLE
Drop survey link from JS Date doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.html
@@ -15,8 +15,7 @@ tags:
 <p><span class="seoSummary">JavaScript <strong><code>Date</code></strong> objects represent a single moment in time in a platform-independent format.</span> <code>Date</code> objects contain a <code>Number</code> that represents milliseconds since 1 January 1970 UTC.</p>
 
 <div class="notecard note">
-<p>TC39 is working on <a href="https://tc39.es/proposal-temporal/docs/index.html">Temporal</a>, a new Date/Time API.<br>
- Read more about it on the <a href="https://blogs.igalia.com/compilers/2020/06/23/dates-and-times-in-javascript/">Igalia blog</a> and fill out the <a href="https://forms.gle/iL9iZg7Y9LvH41Nv8">survey</a>. It needs real-world feedback from web developers, but is not yet ready for production use!</p>
+<p>TC39 is working on <a href="https://tc39.es/proposal-temporal/docs/index.html">Temporal</a>, a new Date/Time API. Read more about it on the <a href="https://blogs.igalia.com/compilers/2020/06/23/dates-and-times-in-javascript/">Igalia blog</a>. It is not yet ready for production use!</p>
 </div>
 
 <h2 id="Description">Description</h2>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There was a link to a closed survey

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/3701

> Anything else that could help us review it
