### PR TITLE
Fix “Clearing the cache” example in offline-PWAs doc

### DIFF
--- a/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
+++ b/files/en-us/web/progressive_web_apps/offline_service_workers/index.html
@@ -177,11 +177,10 @@ self.addEventListener('install', (e) =&gt; {
 <p>Remember the <code>activate</code> event we skipped? It can be used to clear out the old cache we don't need anymore:</p>
 
 <pre class="brush: js">self.addEventListener('activate', (e) =&gt; {
-  e.waitUntil((async () =&gt; {
-    const keyList = await caches.keys();
-    await Promise.all(keyList.map((key) =&gt; {
+  e.waitUntil(caches.keys().then((keyList) =&gt; {
+    Promise.all(keyList.map((key) =&gt; {
       if (key === cacheName) { return; }
-      await caches.delete(key);
+      caches.delete(key);
     }))
   })());
 });</pre>


### PR DESCRIPTION
This change fixes and simplifies the “Clearing the cache” code example in the “Making PWAs work offline with Service workers” article. Fixes https://github.com/mdn/content/issues/3684.

The change replaces this code:

```js
self.addEventListener('activate', (e) => {
  e.waitUntil((async () => {
    const keyList = await caches.keys();
    await Promise.all(keyList.map((key) => {
      if (key === cacheName) { return; }
      await caches.delete(key);
    }))
  })());
});
```
…with this code:
```js
self.addEventListener('activate', (e) => {
  e.waitUntil(caches.keys().then((keyList) => {
    Promise.all(keyList.map((key) => {
      if (key === cacheName) { return; }
      caches.delete(key);
    }))
  })());
});
```