### PR TITLE
Remove documentation of display:run-in where possible

### DIFF
--- a/files/en-us/web/css/@supports/index.html
+++ b/files/en-us/web/css/@supports/index.html
@@ -70,8 +70,8 @@ tags:
 
 <p>Multiple conjunctions can be juxtaposed without the need of more parentheses. The following are both equivalent:</p>
 
-<pre class="brush: css">@supports (display: table-cell) and (display: list-item) and (display:run-in) {}
-@supports (display: table-cell) and ((display: list-item) and (display:run-in)) {}</pre>
+<pre class="brush: css">@supports (display: table-cell) and (display: list-item) and (display:contents) {}
+@supports (display: table-cell) and ((display: list-item) and (display:contents)) {}</pre>
 
 <h3 id="The_or_operator">The or operator</h3>
 

--- a/files/en-us/web/css/display-outside/index.html
+++ b/files/en-us/web/css/display-outside/index.html
@@ -22,10 +22,6 @@ tags:
  <dd>The element generates a block element box, generating line breaks both before and after the element when in the normal flow.</dd>
  <dt><code>inline</code></dt>
  <dd>The element generates one or more inline element boxes that do not generate line breaks before or after themselves. In normal flow, the next element will be on the same line if there is space</dd>
- <dt><code>run-in</code> {{Experimental_Inline}}</dt>
- <dd>The element generates a run-in box. If the adjacent sibling of the element defined as <code>display: run-in</code> box is a block box, the <code>run-in</code> box becomes the first inline box of the block box that follows it.<br>
- <br>
- Run-in elements act like inlines or blocks, depending on the surrounding elements. That is: If the run-in box contains a block box, same as block. If a block box follows the run-in box, the run-in box becomes the first inline box of the block box. If an inline box follows, the run-in box becomes a block box.</dd>
 </dl>
 
 <div class="note">


### PR DESCRIPTION
A few cases of it remain which aren't as easy to remove, since they're
referencing what's in the spec, and it is still there:
https://drafts.csswg.org/css-display/#valdef-display-run-in

See https://github.com/mdn/browser-compat-data/pull/9610#issuecomment-811034333