### PR TITLE
Unhide code blocks in live sample for Promise

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.html
@@ -333,6 +333,8 @@ function promiseGetWord(parityInfo) {
 
 <p>The fulfillment of the promise is logged, via a fulfill callback set using {{JSxRef("Promise.prototype.then()","p1.then()")}}. A few logs show how the synchronous part of the method is decoupled from the asynchronous completion of the promise.</p>
 
+<p>By clicking the button several times in a short amount of time, you'll even see the different promises being fulfilled one after another.</p>
+
 <h4>HTML</h4>
 
 <pre class="brush: html">&lt;button id="make-promise"&gt;Make a promise!&lt;/button&gt;
@@ -382,9 +384,7 @@ if ("Promise" in window) {
 }
 </pre>
 
-<p>This example is started by clicking the button. (You need a browser that supports <code>Promise</code>. )</p>
-
-<p>By clicking the button several times in a short amount of time, you'll even see the different promises being fulfilled one after another.</p>
+<h4>Result</h4>
 
 <p>{{EmbedLiveSample("Advanced_Example", "500", "200")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.html
@@ -294,7 +294,7 @@ function troubleWithGetNumber(reason) {
 
 function promiseGetWord(parityInfo) {
   // The "tetheredGetWord()" function gets "parityInfo" as closure variable.
-  var tetheredGetWord = function(resolve,reject) {
+  const tetheredGetWord = function(resolve,reject) {
     const theNumber = parityInfo.theNumber;
     const threshold_B = THRESHOLD_A - 1;
     if(theNumber &gt;= threshold_B) {
@@ -329,18 +329,20 @@ function promiseGetWord(parityInfo) {
 
 <h3 id="Advanced_Example">Advanced Example</h3>
 
-<div class="hidden">
-<pre class="brush: html">&lt;button id="btn"&gt;Make a promise!&lt;/button&gt;
-&lt;div id="log"&gt;&lt;/div&gt;
-</pre>
-</div>
-
 <p>This small example shows the mechanism of a <code>Promise</code>. The <code>testPromise()</code> method is called each time the {{HTMLElement("button")}} is clicked. It creates a promise that will be fulfilled, using {{domxref("WindowOrWorkerGlobalScope.setTimeout")}}, to the promise count (number starting from 1) every 1-3 seconds, at random. The <code>Promise()</code> constructor is used to create the promise.</p>
 
 <p>The fulfillment of the promise is logged, via a fulfill callback set using {{JSxRef("Promise.prototype.then()","p1.then()")}}. A few logs show how the synchronous part of the method is decoupled from the asynchronous completion of the promise.</p>
 
+<h4>HTML</h4>
+
+<pre class="brush: html">&lt;button id="make-promise"&gt;Make a promise!&lt;/button&gt;
+&lt;div id="log"&gt;&lt;/div&gt;
+</pre>
+
+<h4>JavaScript</h4>
+
 <pre class="brush: js">"use strict";
-var promiseCount = 0;
+let promiseCount = 0;
 
 function testPromise() {
   let thisPromiseCount = ++promiseCount;
@@ -371,18 +373,14 @@ function testPromise() {
   log.insertAdjacentHTML('beforeend', thisPromiseCount + ') Promise made&lt;br&gt;');
 }
 
-</pre>
-
-<div class="hidden">
-<pre class="brush: js">if ("Promise" in window) {
-  let btn = document.getElementById("btn");
+if ("Promise" in window) {
+  let btn = document.getElementById("make-promise");
   btn.addEventListener("click",testPromise);
 } else {
   log = document.getElementById('log');
   log.textContent = "Live example not available as your browser doesn't support the &lt;code&gt;Promise&lt;code&gt; interface.";
 }
 </pre>
-</div>
 
 <p>This example is started by clicking the button. (You need a browser that supports <code>Promise</code>. )</p>
 


### PR DESCRIPTION
This PR is related to https://github.com/mdn/content/issues/3694 and https://github.com/mdn/content/issues/3512, and it removes the only place in the JS docs where we use `class="hidden"` to hide part of a live sample.

I could have chosen to move `hidden` to the code blocks themselves, but in this case (and I expect in many other cases) think it's better not to hide them, so someone can see the whole example.

I also changed a couple of `var`s to `let` and `const`, and renamed the `id` on the `<button>` in the example, because `<button id="btn">` was upsetting.
