### PR TITLE
Link to Unicode Property Escapes from Character Classes doc

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
@@ -127,6 +127,10 @@ tags:
    <td>(Only when the <code>u</code> flag is set.) Matches the character with the Unicode value <code>U+<em>hhhh</em></code> or <code>U+<em>hhhhh</em></code> (hexadecimal digits).</td>
   </tr>
   <tr>
+   <td><code>\p{<em>UnicodeProperty</em>}</code>, <code>\P{<em>UnicodeProperty</em>}</code></td>
+   <td>Matches a character based on its <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes">Unicode character properties</a> (to match just, for example, emoji characters, or Japanese <em>katakana</em> characters, or Chinese/Japanese Han/Kanji characters, etc.).</td>
+  </tr>
+  <tr>
    <td><code>\</code></td>
    <td>
     <p>Indicates that the following character should be treated specially, or "escaped". It behaves one of two ways.</p>


### PR DESCRIPTION
In the Types table of the “Character classes” article (documenting character classes that can be used in JavaScript regular expressions), this change adds a row for Unicode property escapes (which use the syntax `\p{…}` to specify Unicode character properties to match against). Fixes https://github.com/mdn/content/issues/3722