### PR TITLE
Adds PerformanceObserver.supportedEntryTypes

### DIFF
--- a/files/en-us/web/api/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/index.html
@@ -23,6 +23,13 @@ tags:
  <dd>Creates and returns a new <code>PerformanceObserver</code> object.</dd>
 </dl>
 
+<h2 id="Properties">Properties</h2>
+
+<dl>
+  <dt>{{domxref("PerformanceObserver.supportedEntryTypes")}}{{readonlyInline}}</dt>
+  <dd>Returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.</dd>
+</dl>
+
 <h2 id="Methods">Methods</h2>
 
 <dl>

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
@@ -27,12 +27,28 @@ tags:
 
 <h2 id="Example">Example</h2>
 
+<h3>Using the console to check supported types</h3>
+
 <p>To find out which {{domxref("PerformanceEntry.entryType","entryType")}} values a browser supports enter <kbd>PerformanceObserver.supportedEntryTypes</kbd> into the console. This will return an array of <code>EntryType</code> values.</p>
 
 <pre class="brush: js">PerformanceObserver.supportedEntryTypes
 
 // returns ["element", "event", "first-input", "largest-contentful-paint", "layout-shift", "longtask", "mark", "measure", "navigation", "paint", "resource"] in Chrome 89
 </pre>
+
+<h3>Checking for unsupported types</h3>
+
+<p>The following function checks for support of an array of possible entry types. The unsupported types are logged to the console, however this information could be logged to client-side analytics to indicate that the particular type could not be observed.</p>
+
+<pre class="brush:js">function detectSupport(entryTypes) {
+  for (const entryType of entryTypes) {
+    if (!PerformanceObserver.supportedEntryTypes.includes(entryType)) {
+      console.log(entryType);
+    }
+  }
+}
+
+detectSupport(["resource", "mark", "frame"]);</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
@@ -1,0 +1,56 @@
+---
+title: PerformanceObserver.supportedEntryTypes
+slug: Web/API/PerformanceObserver/supportedEntryTypes
+tags:
+- API
+- Property
+- Reference
+- Web Performance
+- PerformanceObserver
+- supportedEntryTypes
+---
+<div>{{APIRef("Performance Timeline API")}}</div>
+
+<p class="summary">The <strong><code>supportedEntryTypes</code></strong> read-only property of the
+    {{domxref("PerformanceObserver")}} interface returns an array of the {{domxref("PerformanceEntry.entryType","entryType")}} values supported by the user agent.</p>
+
+<p>As the list of supported entries varies per browser and is evolving, this property allows web developers to check which are available.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">var supportedEntryTypes = PerformanceObserver.supportedEntryTypes;
+</pre>
+
+<h3 id="Return_Value">Return value</h3>
+
+<p>An array of {{domxref("PerformanceEntry.entryType")}} values.</p>
+
+<h2 id="Example">Example</h2>
+
+<p>To find out which {{domxref("PerformanceEntry.entryType","entryType")}} values a browser supports enter <kbd>PerformanceObserver.supportedEntryTypes</kbd> into the console. This will return an array of <code>EntryType</code> values.</p>
+
+<pre class="brush: js">PerformanceObserver.supportedEntryTypes
+
+// returns ["element", "event", "first-input", "largest-contentful-paint", "layout-shift", "longtask", "mark", "measure", "navigation", "paint", "resource"] in Chrome 89
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Performance Timeline Level 2', '#supportedentrytypes-attribute', 'PerformanceObserver.supportedEntryTypes')}}</td>
+    <td>{{Spec2('Performance Timeline Level 2')}}</td>
+    <td>Initial definition of <code>PerformanceObserver</code> interface.</td>
+   </tr>
+  </tbody>
+ </table>
+
+ <h2 id="Browser_compatibility">Browser compatibility</h2>
+
+ <p>{{Compat("api.PerformanceObserver.supportedEntryTypes")}}</p>


### PR DESCRIPTION
Fixes: #2667 

Adds a page for the `supportedEntryTypes` property and the link to it from the main `PerformanceObserver` page.

Reviewer @jpmedley 