### PR TITLE
Correct link to return type

### DIFF
--- a/files/en-us/web/api/domimplementation/index.html
+++ b/files/en-us/web/api/domimplementation/index.html
@@ -25,7 +25,7 @@ tags:
  <dt>{{domxref("DOMImplementation.createDocumentType()")}}</dt>
  <dd>Creates and returns a {{domxref("DocumentType")}}.</dd>
  <dt>{{domxref("DOMImplementation.createHTMLDocument()")}}</dt>
- <dd>Creates and returns an HTML {{domxref("Document")}}.</dd>
+ <dd>Creates and returns an {{domxref("HTMLDocument")}}.</dd>
  <dt>{{domxref("DOMImplementation.hasFeature()")}}</dt>
  <dd>Returns a {{domxref("Boolean")}} indicating if a given feature is supported or not. This function is unreliable and kept for compatibility purpose alone: except for SVG-related queries, it always returns <code>true</code>. Old browsers are very inconsistent in their behavior.</dd>
 </dl>


### PR DESCRIPTION
`createHTMLDocument` always returns an `HTMLDocument` according to the spec.
So I changed the link to point to that documentation.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The link I changed pointed to a more generic type.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation

> Issue number (if there is an associated issue)

Didn't search for it.

> Anything else that could help us review it
