### PR TITLE
Minor edits on isNaN()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/isnan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/isnan/index.html
@@ -9,7 +9,7 @@ tags:
 <div>{{jsSidebar("Objects")}}</div>
 
 <p>The <code><strong>isNaN()</strong></code> function determines whether a value is
-  {{jsxref("NaN")}} or not. Note, coercion inside the <code>isNaN</code> function has <a
+  {{jsxref("NaN")}} or not. Heads up, coercion inside the <code>isNaN</code> function has <a
     href="#Description">interesting</a> rules; you may alternatively want to use
   {{jsxref("Number.isNaN()")}}, as defined in ECMAScript 2015.</p>
 
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code>isNaN(v<em>alue</em>)</code></pre>
+<pre class="brush: js"><code>isNaN(<em>value</em>)</code></pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -79,8 +79,8 @@ tags:
 <p>A polyfill for <code>isNaN</code> would be (the polyfill leverages the unique
   never-equal-to-itself characteristic of <code>NaN</code>):</p>
 
-<pre class="brush: js">var isNaN = function(value) {
-    var n = Number(value);
+<pre class="brush: js">const isNaN = function(value) {
+    const n = Number(value);
     return n !== n;
 };</pre>
 

--- a/files/en-us/web/javascript/reference/global_objects/isnan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/isnan/index.html
@@ -9,7 +9,7 @@ tags:
 <div>{{jsSidebar("Objects")}}</div>
 
 <p>The <code><strong>isNaN()</strong></code> function determines whether a value is
-  {{jsxref("NaN")}} or not. Heads up, coercion inside the <code>isNaN</code> function has <a
+  {{jsxref("NaN")}} or not. Heads up: coercion inside the <code>isNaN</code> function has <a
     href="#Description">interesting</a> rules; you may alternatively want to use
   {{jsxref("Number.isNaN()")}}, as defined in ECMAScript 2015.</p>
 


### PR DESCRIPTION
I encountered this page today, and was confused by the line

> The isNaN() function determines whether a value is NaN or not. Note, coercion inside the isNaN function has interesting rules; you may alternatively want to use Number.isNaN(), as defined in ECMAScript 2015.

Due to the typography, the full stop of `not. Note` became almost impossible to spot. Shall we had a `<div class="notecard note">` here? How would that impact the abstract for SEO? I decided to adjust the wording a bit, to not make it read like `not Note`.

While I was at it, I updated the code samples to drop `var` in favour of `const`.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
