### PR TITLE
Remove hidden divs from JavaScript docs

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/assertions/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/assertions/index.html
@@ -17,7 +17,6 @@ tags:
 
 <h2 id="Types">Types</h2>
 
-<div class="hidden">The following section is also duplicated on <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet">this cheatsheet</a>. Do not forget to edit it as well, thanks!</div>
 
 <h3 id="Boundary-type_assertions">Boundary-type assertions</h3>
 

--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
@@ -17,7 +17,6 @@ tags:
 
 <h2 id="Types">Types</h2>
 
-<div class="hidden">The following table is also duplicated on <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet">this cheatsheet</a>. Do not forget to edit it as well, thanks!</div>
 
 <table class="standard-table">
  <thead>
@@ -186,9 +185,6 @@ console.table(nonEnglishText.match(regexpBMPWord));
 [ 'Приключения', 'Алисы', 'в', 'Стране', 'чудес' ]
 </pre>
 
-<div class="hidden">
-<p>Note for MDN editors: please do not try to add funny examples with emoji as those characters are not handled by the platform (Kuma).</p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.html
@@ -13,7 +13,6 @@ tags:
 
 <h2 id="Character_classes"><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes">Character classes</a></h2>
 
-<div class="hidden">If you are looking to contribute to this document, please also edit <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes">the original article</a></div>
 
 <table class="standard-table">
  <thead>
@@ -144,7 +143,6 @@ tags:
 
 <h2 id="Assertions"><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions">Assertions</a></h2>
 
-<div class="hidden">If you are looking to contribute to this document, please also edit <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions">the original article</a></div>
 
 <h3 id="Boundary-type_assertions">Boundary-type assertions</h3>
 
@@ -242,7 +240,6 @@ tags:
 
 <h2 id="Groups_and_ranges"><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges">Groups and ranges</a></h2>
 
-<div class="hidden">If you are looking to contribute to this document, please also edit <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges">the original article</a></div>
 
 <table class="standard-table">
  <thead>
@@ -331,7 +328,6 @@ tags:
 
 <h2 id="Quantifiers"><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers">Quantifiers</a></h2>
 
-<div class="hidden">If you are looking to contribute to this document, please also edit <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers">the original article</a></div>
 
 <div class="notecard note">
 <p><strong>Note:</strong> In the following, <em>item</em> refers not only to singular characters, but also includes <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes">character classes</a>, <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes">Unicode property escapes</a>, <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges">groups and ranges</a>.</p>
@@ -406,7 +402,6 @@ tags:
 
 <h2 id="Unicode_property_escapes"><a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes">Unicode property escapes</a></h2>
 
-<div class="hidden">If you are looking to contribute to this document, please also edit <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes">the original article</a></div>
 
 <pre class="brush: js">// Non-binary values
 \p{<em>UnicodePropertyValue</em>}

--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
@@ -18,7 +18,6 @@ tags:
 
 <h2 id="Types">Types</h2>
 
-<div class="hidden">The following section is also duplicated on <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet">this cheatsheet</a>. Do not forget to edit it as well, thanks!</div>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.html
@@ -17,7 +17,6 @@ tags:
 
 <h2 id="Types">Types</h2>
 
-<div class="hidden">The following table is also duplicated on <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet">this cheatsheet</a>. Do not forget to edit it as well, thanks!</div>
 
 <div class="notecard note">
 <p><strong>Note:</strong> In the following, <em>item</em> refers not only to singular characters, but also includes <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes">character classes</a>, <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes">Unicode property escapes</a>, <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges">groups and ranges</a>.</p>

--- a/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.html
@@ -25,7 +25,6 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<div class="hidden">The following section is also duplicated on <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Cheatsheet">this cheatsheet</a>. Do not forget to edit it as well, thanks!</div>
 
 <pre class="brush: js">// Non-binary values
 \p{<em>UnicodePropertyValue</em>}

--- a/files/en-us/web/javascript/guide/text_formatting/index.html
+++ b/files/en-us/web/javascript/guide/text_formatting/index.html
@@ -14,7 +14,6 @@ tags:
 
 <p>JavaScript's <a href="/en-US/docs/Glossary/String">String</a> type is used to represent textual data. It is a set of "elements" of 16-bit unsigned integer values  (UTF-16 code units). Each element in the String occupies a position in the String. The first element is at index 0, the next at index 1, and so on. The length of a String is the number of elements in it. You can create strings using string literals or string objects.</p>
 
-<div class="hidden">CAUTION: if you edit this page, do not include any characters above U+FFFF, until MDN bug 857438 is fixed ( <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=857438">https://bugzilla.mozilla.org/show_bug.cgi?id=857438</a> ).</div>
 
 <h3 id="String_literals">String literals</h3>
 

--- a/files/en-us/web/javascript/reference/classes/extends/index.html
+++ b/files/en-us/web/javascript/reference/classes/extends/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/classes-extends.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/classes/static/index.html
+++ b/files/en-us/web/javascript/reference/classes/static/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/classes-static.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/functions/arguments/index.html
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/functions-arguments.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -97,7 +97,6 @@ console.log(atWay); // Logs: 'green'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Array.at")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
@@ -16,7 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-filter.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-findindex.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <p>See also the {{jsxref("Array.find", "find()")}} method, which returns the
   <strong>value</strong> of an array element, instead of its index.</p>

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-includes.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -125,12 +120,6 @@ arr.includes('a', -2)   // false
   console.log(Array.prototype.includes.call(arguments, 'd'))  // false
 })('a','b','c') </pre>
 
-<div class="hidden">
-  <p>Please do not add polyfills on reference articles. For more details and discussion,
-    see <a
-      href="https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500">https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500</a>
-  </p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-indexof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/keys/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-keys.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-length.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 
@@ -109,7 +108,6 @@ console.log(numbers); // [undefined, undefined, undefined]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Array.length")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-map.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-pop.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-push.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-reduce.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a Pull Request.</div>
 
 <p>The <strong>reducer</strong> function takes four arguments:</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-reverse.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-shift.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.html
@@ -17,10 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-slice.html")}}</div>
 
-<div class="hidden">The source for this interactive demo is stored in a GitHub repository.
-  If you'd like to contribute to the interactive demo project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-some.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/array-splice.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/arraybuffer/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/arraybuffer-constructor.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/bytelength/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/bytelength/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/arraybuffer-bytelength.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/isview/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/isview/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/arraybuffer-isview.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/slice/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/arraybuffer-slice.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/add/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/add/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/atomics-add.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/and/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/and/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/atomics-and.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/compareexchange/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/atomics-compareexchange.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/exchange/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/exchange/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/atomics-exchange.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/or/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/or/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/atomics-or.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/atomics/store/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/store/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/atomics-store.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/bigint-asintn.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/bigint-asuintn.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.html
@@ -283,7 +283,6 @@ nthPrime(20n)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.BigInt")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/buffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/buffer/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-buffer.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/bytelength/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/bytelength/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-bytelength.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/byteoffset/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/byteoffset/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-byteoffset.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/dataview/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/dataview/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-constructor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getfloat32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getfloat32/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getfloat32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getfloat64/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getfloat64/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getfloat64.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getint16/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getint16/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getint16.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getint32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getint32/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getint32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getint8/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getint8/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getint8.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getuint16/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getuint16/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getuint16.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getuint32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getuint32/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getuint32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getuint8/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getuint8/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-getuint8.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setfloat32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setfloat32/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setfloat32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setfloat64/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setfloat64/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setfloat64.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setint16/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setint16/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setint16.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setint32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setint32/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setint32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setint8/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setint8/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setint8.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setuint16/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setuint16/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setuint16.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/dataview/setuint32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/setuint32/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/dataview-setuint32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-constructor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getdate/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getdate/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getdate.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getday/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getday/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getday.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getfullyear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getfullyear/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getfullyear.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getmilliseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getmilliseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getmilliseconds.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getminutes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getminutes/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getminutes.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getmonth/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getmonth/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getmonth.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getseconds.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcdate.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcday.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcfullyear.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutchours.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcmilliseconds.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcminutes.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcmonth.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-getutcseconds.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/parse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/parse/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-parse.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setdate/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setdate/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setdate.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setfullyear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setfullyear/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setfullyear.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/sethours/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/sethours/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-sethours.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setmilliseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setmilliseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setmilliseconds.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setminutes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setminutes/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setminutes.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setseconds.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/settime/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/settime/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-settime.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcdate/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcdate/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutcdate.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcfullyear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcfullyear/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutcmonth.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutchours/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutchours/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutchours.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcmilliseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcmilliseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutcmilliseconds.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcminutes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcminutes/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutcminutes.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcmonth/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcmonth/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutcmonth.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/setutcseconds/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/setutcseconds/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-setutcseconds.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/toisostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/toisostring/index.html
@@ -23,11 +23,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-toisostring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tojson/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/tojson/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-tojson.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.html
@@ -22,11 +22,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-tolocaledatestring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-tolocaletimestring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/totimestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/totimestring/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-totimestring.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/toutcstring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/toutcstring/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-toutcstring.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/utc/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/utc/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/date-utc.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/encodeuri/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuri/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-encodeuri.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.html
@@ -18,11 +18,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/globalprops-encodeuricomponent.html","shorter")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.html
@@ -87,10 +87,6 @@ escape('@*_+-./');    // "@*_+-./"</pre>
   </tbody>
 </table>
 
-<div class="hidden">Please do not add polyfills to reference pages. For more information,
-  see <a
-    href="https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500">https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500</a>
-</div>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/function-apply.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/function-bind.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/function/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/function/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/function-constructor.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.html
@@ -12,7 +12,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/function-length.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/name/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/name/index.html
@@ -100,9 +100,6 @@ try { object_someMethod } catch(e) { console.log(e); }
 
 <p>The name property is read-only and cannot be changed by the assigment operator:</p>
 
-<div class="hidden">
-<p>Example below contradicts with what is said at the beginning of this section and doesn't work as described.</p>
-</div>
 
 <pre class="brush: js"> let object = {
   // anonymous

--- a/files/en-us/web/javascript/reference/global_objects/function/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/tostring/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/function-tostring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-    repository. If you'd like to contribute to the interactive examples project, please
-    clone <a
-        href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-    and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/infinity/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/infinity/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-infinity.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/int16array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/index.html
@@ -153,7 +153,6 @@ var int16 = new Int16Array(iterable);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden"><strong>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</strong></div>
 
 <p><strong>{{Compat("javascript.builtins.Int16Array")}}</strong></p>
 

--- a/files/en-us/web/javascript/reference/global_objects/isfinite/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/isfinite/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-isfinite.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/json/parse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/json/parse/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/json-parse.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-@@iterator.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/@@tostringtag/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@tostringtag/index.html
@@ -17,11 +17,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-@@tostringtag.html","shorter")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/clear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/clear/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-clear.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/delete/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/delete/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-delete.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/entries/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-entries.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/foreach/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-foreach.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/get/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/get/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-get.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/has/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/has/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-has.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/keys/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-keys.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/set/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-set.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/size/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/size/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-size.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/map/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/values/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/map-prototype-values.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/abs/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/abs/index.html
@@ -81,11 +81,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-abs.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/acos/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/acos/index.html
@@ -69,11 +69,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-acos.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/acosh/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/acosh/index.html
@@ -57,11 +57,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-acosh.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/asin/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/asin/index.html
@@ -81,11 +81,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-asin.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/asinh/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/asinh/index.html
@@ -50,11 +50,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-asinh.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-    repository. If you'd like to contribute to the interactive examples project, please
-    clone <a
-        href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-    and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/atan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/atan/index.html
@@ -67,11 +67,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-atan.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/atan2/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/atan2/index.html
@@ -16,12 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-atan2.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to
-  contribute to the interactive examples project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a
-  pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/atanh/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/atanh/index.html
@@ -64,11 +64,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-atanh.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.html
@@ -57,11 +57,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-cbrt.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -158,10 +153,6 @@ Math.cbrt(2);  // 1.2599210498948732
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-</div><a href="https://github.com/mdn/browser-compat-data"> and send us a pull request.
 
   <p>{{Compat("javascript.builtins.Math.cbrt")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-ceil.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/clz32/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/clz32/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-clz32.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/cos/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/cos/index.html
@@ -45,11 +45,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-cos.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/cosh/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/cosh/index.html
@@ -44,11 +44,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-cosh.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/e/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/e/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-e.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/exp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/exp/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-exp.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/expm1/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/expm1/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-expm1.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/floor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/floor/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-floor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/fround/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/fround/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-fround.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/hypot/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/hypot/index.html
@@ -89,11 +89,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-hypot.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/imul/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/imul/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-imul.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ln10/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/ln10/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-ln10.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ln2/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/ln2/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-ln2.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log/index.html
@@ -57,11 +57,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-log.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log10/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10/index.html
@@ -58,11 +58,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-log10.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log10e/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10e/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-log10e.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log2/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2/index.html
@@ -58,11 +58,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-log2.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log2e/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2e/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-log2e.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.html
@@ -22,11 +22,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-max.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/min/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/min/index.html
@@ -22,11 +22,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-min.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pi/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/pi/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-pi.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/pow/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/pow/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-pow.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sign/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sign/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-sign.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -84,9 +79,6 @@ Math.sign();      // NaN
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Math.sign")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sin/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sin/index.html
@@ -13,11 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-sin.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sinh/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sinh/index.html
@@ -45,11 +45,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-sinh.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt/index.html
@@ -63,11 +63,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-sqrt.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt1_2/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt1_2/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-sqrt1_2.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt2/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt2/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-sqrt2.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/tan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/tan/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-tan.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/trunc/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/trunc/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/math-trunc.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-nan.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-epsilon.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-isfinite.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/isinteger/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-isinteger.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-isnan.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-issafeinteger.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <p>A safe integer is an integer that</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-maxsafeinteger.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/max_value/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_value/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-maxvalue.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_safe_integer/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-min-safe-integer.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/min_value/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/min_value/index.html
@@ -12,7 +12,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-min-value.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/nan/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/nan/index.html
@@ -12,7 +12,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-nan.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>You do not have to create a {{jsxref("Number")}} object to access this static property (use <code>Number.NaN</code>).</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/negative_infinity/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/negative_infinity/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-negative-infinity.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/parsefloat/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-parsefloat.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/positive_infinity/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/positive_infinity/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-positive-infinity.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/toexponential/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/toexponential/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-toexponential.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/tofixed/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/tofixed/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-tofixed.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/tostring/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-tostring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/valueof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/valueof/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/number-valueof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-assign.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.html
@@ -211,9 +211,6 @@ Child.prototype = Object.create(ParentWithStatic.prototype)
 
 <h2 id="See_also">See also</h2>
 
-<div class="hidden">
-<p>The curly braces here invoke standard macroses defined by the MDN wiki. Checkout here for more info: <a href="/en-US/docs/MDN/Contribute/Structures/Macros/Commonly-used_macros">https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Macros/Commonly-used_macros</a></p>
-</div>
 
 <ul>
  <li>{{jsxref("statements/class","Class declaration","",1)}}</li>

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-create.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-defineproperties.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-defineproperty.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.html
@@ -26,11 +26,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-freeze.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/fromentries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/fromentries/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-fromentries.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -90,11 +85,6 @@ const object2 = Object.fromEntries(
 console.log(object2);
 // { a: 2, b: 4, c: 6 }</pre>
 
-<div class="hidden">
-  <p>Please do not add polyfills on MDN pages. For more details, refer to: <a
-      href="https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500">https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500</a>
-  </p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertysymbols/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-getownpropertysymbols.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-getprototypeof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasownproperty/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-prototype-hasownproperty.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.html
@@ -257,7 +257,6 @@ mime.greet();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Object")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-isextensible.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-isfrozen.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/isprototypeof/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-prototype-isprototypeof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <div class="note">
   <p><code>isPrototypeOf()</code> differs from the {{jsxref("Operators/instanceof",

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-issealed.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/keys/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-keys.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -160,9 +155,6 @@ if (!Object.keys) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Object.keys")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/object/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/object/index.html
@@ -75,9 +75,6 @@ console.log(o)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.Object.Object")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-preventextensions.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/seal/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/seal/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-seal.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/tolocalestring/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-prototype-tolocalestring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/object-prototype-tostring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-parsefloat.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-	repository. If you'd like to contribute to the interactive examples project, please
-	clone <a
-		href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-	and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.html
@@ -92,10 +92,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</div>
 
 <p>{{Compat("javascript.builtins.Promise.allSettled")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/promise-catch.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -202,10 +197,6 @@ p2.then(function (value) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</div>
 
 <p>{{Compat("javascript.builtins.Promise.catch")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.html
@@ -94,11 +94,6 @@ fetch(myRequest).then(function(response) {
 
 </pre>
 
-<div class="hidden">
-  <p>Please do not add polyfills on MDN pages. For more details, refer to: <a
-      href="https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500">https://discourse.mozilla.org/t/mdn-rfc-001-mdn-wiki-pages-shouldnt-be-a-distributor-of-polyfills/24500</a>
-  </p>
-</div>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -118,10 +113,6 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</div>
 
 <p>{{Compat("javascript.builtins.Promise.finally")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.html
@@ -407,7 +407,6 @@ if ("Promise" in window) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request against this repository: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</div>
 
 <p>{{Compat("javascript.builtins.Promise")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/promise/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/promise/index.html
@@ -14,10 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/promise-constructor.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive demo is stored in a GitHub repository.
-  If you'd like to contribute to the interactive demo project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -135,10 +131,6 @@ rejectionFunc(reason) // call on <em>rejected</em></pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</div>
 
 <p>{{Compat("javascript.builtins.Promise.Promise")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
@@ -16,10 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/promise-race.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive demo is stored in a GitHub repository.
-  If you'd like to contribute to the interactive demo project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/reject/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/reject/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/promise-reject.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -70,10 +65,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</div>
 
 <p>{{Compat("javascript.builtins.Promise.reject")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.html
@@ -334,10 +334,6 @@ p3.then(function(v) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</div>
 
 <p>{{Compat("javascript.builtins.Promise.then")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-apply.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-construct.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.html
@@ -15,11 +15,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-defineproperty.html", "taller")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.html
@@ -15,11 +15,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-deleteproperty.html", "taller")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-get.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-getownpropertydescriptor.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.html
@@ -15,11 +15,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-getprototypeof.html", "taller")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-    repository. If you'd like to contribute to the interactive examples project, please
-    clone <a
-        href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-    and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-has.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.html
@@ -15,11 +15,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-isextensible.html", "taller")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-preventextensions.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-set.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.html
@@ -16,11 +16,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/proxyhandler-setprototypeof.html", "taller",
   "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-apply.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-defineproperty.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-getownpropertydescriptor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-getprototypeof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/isextensible/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-isextensible.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/ownkeys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/ownkeys/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-ownkeys.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/preventextensions/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-preventextensions.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/set/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-set.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-setprototypeof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.html
@@ -17,11 +17,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-@@matchall.html", "taller")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-@@replace.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-@@search.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@species/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-getregexp-@@species.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/dotall/index.html
@@ -69,7 +69,6 @@ console.log(str2.replace(regex2,'')); // Output: bar
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.RegExp.dotAll")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.html
@@ -16,7 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-flags.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <p>{{JS_Property_Attributes(0, 0, 1)}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/global/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/global/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-global.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/hasindices/index.html
@@ -61,7 +61,6 @@ console.log(regex2.exec(str2).indices); // Output: undefined
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.RegExp.hasIndices")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/ignorecase/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-ignorecase.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/multiline/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-multiline.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-constructor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/source/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/source/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-source.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/test/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/test/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-test.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/tostring/index.html
@@ -17,11 +17,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-tostring.html", "taller")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/unicode/index.html
@@ -16,7 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-unicode.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0, 0, 1)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-@@iterator.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/add/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/add/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-add.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/clear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/clear/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-clear.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/delete/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/delete/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-delete.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/entries/index.html
@@ -22,11 +22,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-entries.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/foreach/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-foreach.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/has/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/has/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-has.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/size/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/size/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-size.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/set/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/values/index.html
@@ -24,11 +24,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/set-prototype-values.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/sharedarraybuffer-bytelength.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.html
@@ -25,11 +25,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/sharedarraybuffer-constructor.html","shorter")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/sharedarraybuffer-slice.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/@@iterator/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-iterator.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/at/index.html
@@ -93,7 +93,6 @@ console.log(atWay); // Logs: 't'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.String.at")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/charat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/charat/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-charat.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/charcodeat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/charcodeat/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-charcodeat.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <p>The UTF-16 code unit matches the Unicode code point for code points which can be
   represented in a single UTF-16 code unit. If the Unicode code point cannot be

--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-codepointat.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-concat.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/endswith/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/endswith/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-endswith.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-fromcharcode.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-indexof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <div class="note"><strong>Note:</strong> For the Array method, see
   {{jsxref("Array.prototype.indexOf()")}}.</div>

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-lastindexof.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/match/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/match/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-match.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-matchall.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-padend.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-padstart.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -90,9 +85,6 @@ console.log(leftFillNum(num, 5));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.String.padStart")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/repeat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/repeat/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-repeat.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/search/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/search/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-search.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-split.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/substr/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/substr/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-substr.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/substring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/substring/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-substring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tolocalelowercase/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocalelowercase/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-tolocalelowercase.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolocaleuppercase/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-tolocaleuppercase.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/trimend/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimend/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-trimend.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/string-trimstart.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/for/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/for/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-for.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/hasinstance/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-hasinstance.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-replace.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-search.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/species/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/species/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-species.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.html
@@ -15,7 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-split.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/symbol/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/symbol/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-constructor.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-toprimitive.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tostring/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-prototype-tostring.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tostringtag/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-tostringtag.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/unscopables/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/symbol-unscopables.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/at/index.html
@@ -92,7 +92,6 @@ console.log(atWay); // Logs: 11
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("javascript.builtins.TypedArray.at")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/buffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/buffer/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-buffer.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/bytelength/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/bytelength/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-bytelength.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-bytes-per-element.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/copywithin/index.html
@@ -22,11 +22,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-copywithin.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/every/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-every.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/fill/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-fill.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-filter.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/find/index.html
@@ -24,11 +24,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-find.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-findindex.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/from/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-from.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-    repository. If you'd like to contribute to the interactive examples project, please
-    clone <a
-        href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-    and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/includes/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-includes.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-constructor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/indexof/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-indexof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-join.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-keys.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/lastindexof/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-lastindexof.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-map.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/name/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/name/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-name.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <div>{{js_property_attributes(0,0,0)}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/of/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-of.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-reduce.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reverse/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-reverse.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-set.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-slice.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/sort/index.html
@@ -20,11 +20,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-sort.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/subarray/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/subarray/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-subarray.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/tostring/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-tostring.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-undefined.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/delete/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/delete/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/weakmap-prototype-delete.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/get/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/get/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/weakmap-prototype-get.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/has/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/has/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/weakmap-prototype-has.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/set/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/set/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/weakmap-prototype-set.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakset/delete/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/delete/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/weakset-prototype-delete.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/weakset/has/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakset/has/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/weakset-prototype-has.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_and/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-bitwise-and.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-bitwise-or.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-bitwise-or-assignment.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-bitwise-xor.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -115,9 +110,6 @@ After:              10100000000000000110000000000001</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
 
 <p>{{Compat("javascript.operators.bitwise_xor")}}</p>
 

--- a/files/en-us/web/javascript/reference/operators/class/index.html
+++ b/files/en-us/web/javascript/reference/operators/class/index.html
@@ -21,11 +21,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-classexpression.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/conditional_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/conditional_operator/index.html
@@ -26,11 +26,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-conditionaloperators.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-    repository. If you'd like to contribute to the interactive examples project, please
-    clone <a
-        href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-    and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -122,9 +117,6 @@ function example(…) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-    data. If you'd like to contribute to the data, please check out <a         href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</div>
 
 <p>{{Compat("javascript.operators.conditional")}}</p>
 

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -17,7 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-destructuringassignment.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-division-assignment.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/equality/index.html
+++ b/files/en-us/web/javascript/reference/operators/equality/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-equality.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/function/index.html
+++ b/files/en-us/web/javascript/reference/operators/function/index.html
@@ -19,11 +19,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/expressions-functionexpression.html",
   "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/function_star_/index.html
+++ b/files/en-us/web/javascript/reference/operators/function_star_/index.html
@@ -18,11 +18,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/expressions-functionasteriskexpression.html",
    "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-   repository. If you'd like to contribute to the interactive examples project, please
-   clone <a
-      href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-   and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/left_shift/index.html
+++ b/files/en-us/web/javascript/reference/operators/left_shift/index.html
@@ -14,7 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-left-shift.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.html
+++ b/files/en-us/web/javascript/reference/operators/less_than_or_equal/index.html
@@ -13,7 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-less-than-or-equal.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-logical-and.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_and_assignment/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-logical-and-assignment.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_not/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_not/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-logical-not.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_nullish_assignment/index.html
@@ -18,11 +18,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/expressions-logical-nullish-assignment.html")}}
 </div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-logical-or.html", "shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-logical-or-assignment.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.html
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-operatorprecedence.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-    repository. If you'd like to contribute to the interactive examples project, please
-    clone <a
-        href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-    and send us a pull request.</div>
 
 <h2 id="Precedence_And_Associativity">Precedence And Associativity</h2>
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.html
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.html
@@ -31,11 +31,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/expressions-optionalchainingoperator.html",
   "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/right_shift/index.html
+++ b/files/en-us/web/javascript/reference/operators/right_shift/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-right-shift.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.html
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-spreadsyntax.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-   repository. If you'd like to contribute to the interactive examples project, please
-   clone <a
-      href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-   and send us a pull request.</div>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/operators/strict_equality/index.html
+++ b/files/en-us/web/javascript/reference/operators/strict_equality/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-strict-equality.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/strict_inequality/index.html
+++ b/files/en-us/web/javascript/reference/operators/strict_inequality/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-strict-inequality.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/this/index.html
+++ b/files/en-us/web/javascript/reference/operators/this/index.html
@@ -28,11 +28,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-this.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/unary_negation/index.html
+++ b/files/en-us/web/javascript/reference/operators/unary_negation/index.html
@@ -13,11 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-unary-negation.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.html
+++ b/files/en-us/web/javascript/reference/operators/unsigned_right_shift/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-unsigned-right-shift.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/operators/yield/index.html
+++ b/files/en-us/web/javascript/reference/operators/yield/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-yield.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.html
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.html
@@ -18,10 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-async.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive demo is stored in a GitHub repository.
-  If you'd like to contribute to the interactive demo project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/block/index.html
+++ b/files/en-us/web/javascript/reference/statements/block/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-block.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/break/index.html
+++ b/files/en-us/web/javascript/reference/statements/break/index.html
@@ -16,11 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-break.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/class/index.html
+++ b/files/en-us/web/javascript/reference/statements/class/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-class.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <div class="noinclude">
   <p>You can also define a class using a {{jsxref("Operators/class", "class expression",

--- a/files/en-us/web/javascript/reference/statements/const/index.html
+++ b/files/en-us/web/javascript/reference/statements/const/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-const.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/continue/index.html
+++ b/files/en-us/web/javascript/reference/statements/continue/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-continue.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/do...while/index.html
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.html
@@ -15,11 +15,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-dowhile.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/empty/index.html
+++ b/files/en-us/web/javascript/reference/statements/empty/index.html
@@ -13,11 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-empty.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/for...of/index.html
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.html
@@ -354,9 +354,6 @@ iterable.foo = 'hello';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
 
 <p>{{Compat("javascript.statements.for_of")}}</p>
 

--- a/files/en-us/web/javascript/reference/statements/for/index.html
+++ b/files/en-us/web/javascript/reference/statements/for/index.html
@@ -19,11 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-for.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/function/index.html
+++ b/files/en-us/web/javascript/reference/statements/function/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-function.html","shorter")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/if...else/index.html
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-ifelse.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/label/index.html
+++ b/files/en-us/web/javascript/reference/statements/label/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-label.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/let/index.html
+++ b/files/en-us/web/javascript/reference/statements/let/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-let.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/return/index.html
+++ b/files/en-us/web/javascript/reference/statements/return/index.html
@@ -13,11 +13,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-return.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/throw/index.html
+++ b/files/en-us/web/javascript/reference/statements/throw/index.html
@@ -18,11 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-throw.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.html
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-trycatch.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/javascript/reference/statements/var/index.html
+++ b/files/en-us/web/javascript/reference/statements/var/index.html
@@ -14,11 +14,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/statement-var.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</div>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
This PR removes all `<div=class="hidden">` elements from the JS documentation, except for the ones that are really part of a live sample, that are dealt with in https://github.com/mdn/content/pull/3718.

These are almost all boilerplate notes attached to BCD or interactive examples, although there are a few more targeted comments, that we might want to convert into HTML comments?

Assuming we do want to do this, but not in one huge PR, I can easily enough split it up into bits.
