### PR TITLE
Fix Syntax section in JS “if...else” doc

### DIFF
--- a/files/en-us/web/javascript/reference/statements/if...else/index.html
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{jsSidebar("Statements")}}</div>
 
-<p><span class="seoSummary">The <strong><code>if</code> statement</strong> executes a
+<p><span class="seoSummary">The <strong><code>if</code></strong> statement executes a
     statement if a specified condition is {{Glossary("truthy")}}. If the condition is
     {{Glossary("falsy")}}, another statement can be executed.</span></p>
 
@@ -25,10 +25,11 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">if (<var>condition</var>)
+<pre class="brush: js">if (<var>condition</var>) {
    <var>statement1</var>
-[else
-   <var>statement2</var>]
+} else {
+   <var>statement2</var>
+}
 </pre>
 
 <dl>


### PR DESCRIPTION
correct syntax in Syntax section; relocate one tag to correct errant formatting in the first sentence

In correcting the Syntax section, I followed the style of the Example section. 

MDN URL
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else
