### PR TITLE
Fix nginx syntax in “CORS error” doc

### DIFF
--- a/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.html
+++ b/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.html
@@ -69,7 +69,7 @@ tags:
 
 <p>For Nginx, the command to set up this header is:</p>
 
-<pre>add_header 'Access-Control-Allow-Origin' '<em>origin-list</em>'</pre>
+<pre>add_header 'Access-Control-Allow-Origin' '<em>origin-list</em>';</pre>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Nginx directive should be terminated by `;`

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
