### PR TITLE
Fixed 'Improves' -> 'improves' in the middle of a statement

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.html
@@ -181,7 +181,7 @@ tags:
 
 <h3 id="Tooling">Tooling</h3>
 
-<p>Because each of the frameworks in this module have a large, active community, each framework's ecosystem provides tooling that Improves the developer experience. These tools make it easy to add things like testing (to ensure that your application behaves as it should) or linting (to ensure that your code is error-free and stylistically consistent).</p>
+<p>Because each of the frameworks in this module have a large, active community, each framework's ecosystem provides tooling that improves the developer experience. These tools make it easy to add things like testing (to ensure that your application behaves as it should) or linting (to ensure that your code is error-free and stylistically consistent).</p>
 
 <div class="notecard note">
 <p><strong>Note</strong>: If you want to find out more details about web tooling concepts, have a read of our <a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">Client-side tooling overview</a>.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> 'Improves' in the middle of the statement should begin with a lowercase.

> MDN URL of main page changed: https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction#tooling