### PR TITLE
Fix grammar in code example in canvas “Compositing example” doc

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/compositing/example/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/example/index.html
@@ -39,7 +39,7 @@ var gcoText = [
 'Where both shapes overlap the color is determined by adding color values.',
 'Only the new shape is shown.',
 'Shapes are made transparent where both overlap and drawn normal everywhere else.',
-'The pixels are of the top layer are multiplied with the corresponding pixel of the bottom layer. A darker picture is the result.',
+'The pixels of the top layer are multiplied with the corresponding pixel of the bottom layer. A darker picture is the result.',
 'The pixels are inverted, multiplied, and inverted again. A lighter picture is the result (opposite of multiply)',
 'A combination of multiply and screen. Dark parts on the base layer become darker, and light parts become lighter.',
 'Retains the darkest pixels of both layers.',


### PR DESCRIPTION
Grammar improvement.

<!-- Please provide the following information to help us review this PR: -->

**What was wrong/why is this fix needed? (quick summary only)**
Redundant "are" in description for 'multiply'

**MDN URL of main page changed**
https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing/Example
This will also be changed:
https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing

