### PR TITLE
Fixed typo "OutPut" in canvas tutorial "Basic animations"

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.html
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.html
@@ -448,7 +448,7 @@ function draw() {
 &lt;/html&gt;
 </pre>
 
-<h5 id="OutPut">OutPut</h5>
+<h5 id="Output">Output</h5>
 
 <table class="standard-table">
 	<tbody>


### PR DESCRIPTION
Should be "Output" and not "OutPut":)

**What was wrong/why is this fix needed? (quick summary only)**
There was a typo in "Basic animations" chapter in the canvas tutorial.

**MDN URL of main page changed**
https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations
