### PR TITLE
Fixing Parameter in WebXR Code Example

### DIFF
--- a/files/en-us/web/api/webxr_device_api/rendering/index.html
+++ b/files/en-us/web/api/webxr_device_api/rendering/index.html
@@ -38,7 +38,7 @@ tags:
 <pre class="brush: js">let worldRefSpace;
 
 async function runXR(xrSession) {
-  worldRefSpace = await xrSession.requestReferenceSpace("immersive-vr");
+  worldRefSpace = await xrSession.requestReferenceSpace("local");
 
   if (worldRefSpace) {
     viewerRefSpace = worldRefSpace.getOffsetReferenceSpace(


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There is a code snippet in the "Rendering and the WebXR frame animation callback" of the WebXR Device API docs that attempts to request a reference space using a session mode value. I have updated it to use `local` as that is the most general but if that is not correct, I am happy to update that to the intended type based on any feedback.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Rendering

> Issue number (if there is an associated issue)

> Anything else that could help us review it
