### PR TITLE
Certain HTML elements default to border-box behavior

### DIFF
--- a/files/en-us/web/css/box-sizing/index.html
+++ b/files/en-us/web/css/box-sizing/index.html
@@ -30,7 +30,11 @@ tags:
 
 <ul>
  <li><code>content-box</code> gives you the default CSS box-sizing behavior. If you set an element's width to 100 pixels, then the element's content box will be 100 pixels wide, and the width of any border or padding will be added to the final rendered width, making the element wider than 100px.</li>
- <li><code>border-box</code> tells the browser to account for any border and padding in the values you specify for an element's width and height. If you set an element's width to 100 pixels, that 100 pixels will include any border or padding you added, and the content box will shrink to absorb that extra width. This typically makes it much easier to size elements.</li>
+ <li><code>border-box</code> tells the browser to account for any border and padding in the values you specify for an element's width and height. If you set an element's width to 100 pixels, that 100 pixels will include any border or padding you added, and the content box will shrink to absorb that extra width. This typically makes it much easier to size elements.
+  <div class="notecard note">
+   <p><strong>Note:</strong> Certain HTML elements, such as <code>&lt;button&gt;</code>, default to <code>border-box</code> behavior.</p>
+  </div>
+ </li>
 </ul>
 
 <div class="notecard note">

--- a/files/en-us/web/css/box-sizing/index.html
+++ b/files/en-us/web/css/box-sizing/index.html
@@ -31,11 +31,12 @@ tags:
 <ul>
  <li><code>content-box</code> gives you the default CSS box-sizing behavior. If you set an element's width to 100 pixels, then the element's content box will be 100 pixels wide, and the width of any border or padding will be added to the final rendered width, making the element wider than 100px.</li>
  <li><code>border-box</code> tells the browser to account for any border and padding in the values you specify for an element's width and height. If you set an element's width to 100 pixels, that 100 pixels will include any border or padding you added, and the content box will shrink to absorb that extra width. This typically makes it much easier to size elements.
-  <div class="notecard note">
-   <p><strong>Note:</strong> Certain HTML elements, such as <code>&lt;button&gt;</code>, default to <code>border-box</code> behavior.</p>
-  </div>
  </li>
 </ul>
+
+<div class="notecard note">
+   <p><strong>Note:</strong> Certain HTML elements, <code>&lt;table&gt;</code> and Form controls default to <code>border-box</code> behavior. See <a href="https://html.spec.whatwg.org/multipage/rendering.html#form-controls">WHATWG HTML</a> for details on which is Form controls and have this behavior.</p>
+</div>
 
 <div class="notecard note">
 <p><strong>Note:</strong> It is often useful to set <code>box-sizing</code> to <code>border-box</code> to layout elements. This makes dealing with the sizes of elements much easier, and generally eliminates a number of pitfalls you can stumble on while laying out your content.  On the other hand, when using <code>position: relative</code> or <code>position: absolute</code>, use of <code>box-sizing: content-box</code> allows the positioning values to be relative to the content, and independent of changes to border and padding sizes, which is sometimes desirable.</p>


### PR DESCRIPTION
I had reference below CSS W3C specification:

> Note: Certain HTML elements, such as button, default to border-box behavior. See HTML for details on which elements have this behavior.
> 
> [`border-box`, `box-sizing` property — CSS Box Sizing Module Level 3](https://www.w3.org/TR/css-sizing-3/#valdef-box-sizing-border-box)

You can find a list of "Certain HTML elements" in WHATWG HTML standard:
- [Tables](https://html.spec.whatwg.org/multipage/rendering.html#tables-2)
- [Form controls](https://html.spec.whatwg.org/multipage/rendering.html#form-controls)