### PR TITLE
Fix broken document fragment link

### DIFF
--- a/files/en-us/learn/css/styling_text/web_fonts/index.html
+++ b/files/en-us/learn/css/styling_text/web_fonts/index.html
@@ -43,7 +43,7 @@ tags:
   font-family: Helvetica, "Trebuchet MS", Verdana, sans-serif;
 }</pre>
 
-<p>This system works well, but traditionally web developers' font choices were limited. There are only a handful of fonts that you can guarantee to be available across all common systems — the so-called <a href="/en-US/docs/Learn/CSS/Styling_text/Fundamentals#web_safe_fonts">Web-safe fonts</a>. You can use the font stack to specify preferable fonts, followed by web-safe alternatives, followed by the default system font, but this adds overhead in terms of testing to make sure that your designs look ok with each font.</p>
+<p>This system works well, but traditionally web developers' font choices were limited. There are only a handful of fonts that you can guarantee to be available across all common systems — the so-called <a href="/en-US/docs/Learn/CSS/Styling_text/Fundamentals#Web_safe_fonts">Web-safe fonts</a>. You can use the font stack to specify preferable fonts, followed by web-safe alternatives, followed by the default system font, but this adds overhead in terms of testing to make sure that your designs look ok with each font.</p>
 
 <h2 id="Web_fonts">Web fonts</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Fixed link to `#Web_safe_fonts`. The incorrect casing caused it to not work in Chrome (and likely other browsers, too).

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Web_fonts
