### PR TITLE
move track constraints and video tag code from "Create the signalling and peer connection"

### DIFF
--- a/files/en-us/web/api/webrtc_api/perfect_negotiation/index.html
+++ b/files/en-us/web/api/webrtc_api/perfect_negotiation/index.html
@@ -50,13 +50,10 @@ tags:
 
 <p>First, the signaling channel needs to be opened and the {{domxref("RTCPeerConnection")}} needs to be created. The {{Glossary("STUN")}} server listed here is obviously not a real one; you'll need to replace <code>stun.myserver.tld</code> with the address of a real STUN server.</p>
 
-<pre class="brush: js">const constraints = { audio: true, video: true };
+<pre class="brush: js">
 const config = {
   iceServers: [{ urls: "stun:stun.mystunserver.tld" }]
 };
-
-const selfVideo = document.querySelector("video.selfview");
-const remoteVideo = document.querySelector("video.remoteview");
 
 const signaler = new SignalingChannel();
 const pc = new RTCPeerConnection(config);
@@ -66,9 +63,15 @@ const pc = new RTCPeerConnection(config);
 
 <h3 id="Connecting_to_a_remote_peer">Connecting to a remote peer</h3>
 
-<p>The <code>start()</code> function shown here can be called by either of the two end-points that want to talk to one another. It doesn't matter who does it first; the negotiation will just work.</p>
 
-<pre class="brush: js">async function start() {
+
+<pre class="brush: js">
+const constraints = { audio: true, video: true };
+const selfVideo = document.querySelector("video.selfview");
+const remoteVideo = document.querySelector("video.remoteview");
+
+
+async function start() {
   try {
     const stream = await navigator.mediaDevices.getUserMedia(constraints);
 
@@ -82,6 +85,7 @@ const pc = new RTCPeerConnection(config);
 }
 </pre>
 
+<p>The <code>start()</code> function shown above can be called by either of the two end-points that want to talk to one another. It doesn't matter who does it first; the negotiation will just work.</p>
 <p>This isn't appreciably different from older WebRTC connection establishment code. The user's camera and microphone are obtained by calling {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}}. The resulting media tracks are then added to the {{domxref("RTCPeerConnection")}} by passing them into {{domxref("RTCPeerConnection.addTrack", "addTrack()")}}. Then, finally, the media source for the self-view {{HTMLElement("video")}} element indicated by the <code>selfVideo</code> constant is set to the camera and microphone stream, allowing the local user to see what the other peer sees.</p>
 
 <h3 id="Handling_incoming_tracks">Handling incoming tracks</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Previosuly track constraints and video tag selector code was written in ``Create the signaling and peer connections``, whereas for the given Title the constraints and video tag selection code seems to be dead code (in the sense that creation of signaling and peer connection object have not connection with them) and hence making entire Section a bit Vague, Coupling this code with next section i.e ``Connecting to a remote peer`` makes code more readable.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation
