### PR TITLE
Fixed a broken link in Web/CSS/text-decoration-thickness

### DIFF
--- a/files/en-us/web/css/text-decoration-thickness/index.html
+++ b/files/en-us/web/css/text-decoration-thickness/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>text-decoration-thickness</code></strong> <a href="/en-US/docs/CSS">CSS</a> property sets the stroke thickness of the decoration line that is used on text in an element, such as a line-through, underline, or overline.</p>
+<p>The <strong><code>text-decoration-thickness</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the stroke thickness of the decoration line that is used on text in an element, such as a line-through, underline, or overline.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Fixed a link

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Fixed a redirected link

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
