### PR TITLE
syntax corrections to JS string .concat() doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
@@ -24,12 +24,12 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre
-  class="brush: js"><var>str</var>.concat(<var>str2</var> [, ...<var>strN</var>])</pre>
+  class="brush: js"><var>str</var>.concat(<var>str2</var>, <var>strN</var>)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>str2</var> [, ...<var>strN</var>]</code></dt>
+  <dt><code><var>str2</var>, <var>strN</var></code></dt>
   <dd>Strings to concatenate to <code><var>str</var></code>.</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
@@ -23,8 +23,9 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>str</var>.concat(<var>str2</var>, <var>strN</var>)</pre>
+<pre class="brush: js">str.concat(str2);
+str.concat(str2, str3);
+str.concat(str2, str3, ... , strN);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/concat/index.html
@@ -30,8 +30,8 @@ str.concat(str2, str3, ... , strN);</pre>
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>str2</var>, <var>strN</var></code></dt>
-  <dd>Strings to concatenate to <code><var>str</var></code>.</dd>
+  <dt><code>strN</code></dt>
+  <dd>One or more strings to concatenate to <code>str</code>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>


### PR DESCRIPTION
syntax corrections to the **Syntax** section; similar revisions to the **Parameters** section for consistency

MDN URL
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat