### PR TITLE
Add Credential BCD to parent API doc

### DIFF
--- a/files/en-us/web/api/credential_management_api/index.html
+++ b/files/en-us/web/api/credential_management_api/index.html
@@ -64,3 +64,7 @@ tags:
   </tr>
  </tbody>
 </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.Credential")}}</p>


### PR DESCRIPTION
Fixes #3830

[Credential_Management_API](https://developer.mozilla.org/en-US/docs/Web/API/Credential_Management_API) has broken link to BCD in the experimental macro:
![image](https://user-images.githubusercontent.com/5368500/113538526-c9936f00-961e-11eb-9821-713202950016.png)

This is an API overview page, so there is no "one" BCD to link. I have done what I "think" is the standard thing and added the first/main class in the API BCD table. Hopefully reviewer can confirm I am correct.