### PR TITLE
Remove Noah from switch statement example

### DIFF
--- a/files/en-us/web/javascript/reference/statements/switch/index.html
+++ b/files/en-us/web/javascript/reference/statements/switch/index.html
@@ -192,11 +192,11 @@ switch (Animal) {
   case 'Giraffe':
   case 'Dog':
   case 'Pig':
-    console.log('This animal will go on Noah\'s Ark.');
+    console.log('This animal is not extinct.');
     break;
   case 'Dinosaur':
   default:
-    console.log('This animal will not.');
+    console.log('This animal is extinct.');
 }</pre>
 
 <h4 id="Multi-case_chained_operations">Multi-<code>case</code> : chained operations</h4>


### PR DESCRIPTION
Fixes #3824

Removes mention of "Noah's ark" from example here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#methods_for_multi-criteria_case

While I don't see this as any kind of problem, faster to change it than explain why. Noah is not mentioned elsewhere in this document, so if the text shown in the change is OK, then this fix is OK (no need to look at whole doc to see if there is more context - there isn't)