### PR TITLE
remove references to the intermediary canvas

### DIFF
--- a/files/en-us/web/guide/audio_and_video_manipulation/index.html
+++ b/files/en-us/web/guide/audio_and_video_manipulation/index.html
@@ -28,9 +28,9 @@ tags:
 <p>The general technique is to:</p>
 
 <ol>
- <li>Write a frame from the {{htmlelement("video")}} element to an intermediary {{htmlelement("canvas")}} element.</li>
- <li>Read the data from the intermediary <code>&lt;canvas&gt;</code> element and manipulate it.</li>
- <li>Write the manipulated data to your "display" <code>&lt;canvas&gt;</code>.</li>
+ <li>Write a frame from the {{htmlelement("video")}} element to the {{htmlelement("canvas")}} element.</li>
+ <li>Read the data from the <code>&lt;canvas&gt;</code> element and manipulate it.</li>
+ <li>Write the manipulated data to your "display" <code>&lt;canvas&gt;</code> (which effectively can be the same element).</li>
  <li>Pause and repeat.</li>
 </ol>
 
@@ -103,6 +103,8 @@ tags:
 <p>{{EmbedLiveSample("Video_and_canvas", '100%', 580)}}</p>
 
 <p>This is a pretty simple example showing how to manipulate video frames using a canvas. For efficiency, you should consider using {{domxref("Window.requestAnimationFrame", "requestAnimationFrame()")}} instead of <code>setTimeout()</code> when running on browsers that support it.</p>
+
+<p>You can achieve the same result by applying the {{cssxref("filter-function/grayscale()", "grayscale()")}} CSS function to the source <code>&lt;video&gt;</code> element.</p>
 
 <div class="note">
 <p><strong>Note</strong>: Due to potential security issues if your video is on a different domain than your code, you'll need to enable <a href="/en-US/docs/Web/HTTP/CORS">CORS (Cross Origin Resource Sharing)</a> on your video server.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

As it was pointed in #3333 the intermediate canvas element which is mentioned at the beginning of the article is not used in the code which might lead to misunderstanding. This PR simply removes references to the intermediate canvas.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_manipulation

> Issue number (if there is an associated issue)

#3333 

> Anything else that could help us review it

Even though the original issue is fixed some further changes might be applied to the article. For example, the performant video processing (on CPU, meaning without GPU/shaders) might require some intermediate `(offscreen)canvas` element and/or WebWorkers/WASM.
