### PR TITLE
Update Web/API/DOMTokenList

### DIFF
--- a/files/en-us/web/api/domtokenlist/index.html
+++ b/files/en-us/web/api/domtokenlist/index.html
@@ -39,13 +39,13 @@ tags:
  <dt>{{domxref("DOMTokenList.toggle()", "DOMTokenList.toggle(<var>token</var> [, <var>force</var>])")}}</dt>
  <dd>Removes <code><var>token</var></code> from the list if it exists, or adds <code><var>token</var></code> to the list if it doesn't. Returns a boolean indicating whether <code><var>token</var></code> is in the list after the operation.</dd>
  <dt>{{domxref("DOMTokenList.entries()")}}</dt>
- <dd>Returns an {{jsxref("Iteration_protocols","iterator")}}, allowing you to go through all key/value pairs contained in this object.</dd>
+ <dd>Returns an {{jsxref("Iteration_protocols", "iterator", "", 1)}}, allowing you to go through all key/value pairs contained in this object.</dd>
  <dt>{{domxref("DOMTokenList.forEach()", "DOMTokenList.forEach(<var>callback</var> [, <var>thisArg</var>])")}}</dt>
  <dd>Executes a provided <code><var>callback</var></code> function once per <code>DOMTokenList</code> element.</dd>
  <dt>{{domxref("DOMTokenList.keys()")}}</dt>
- <dd>Returns an {{jsxref("Iteration_protocols", "iterator")}}, allowing you to go through all keys of the key/value pairs contained in this object.</dd>
+ <dd>Returns an {{jsxref("Iteration_protocols", "iterator", "", 1)}}, allowing you to go through all keys of the key/value pairs contained in this object.</dd>
  <dt>{{domxref("DOMTokenList.values()")}}</dt>
- <dd>Returns an {{jsxref("Iteration_protocols", "iterator")}}, allowing you to go through all values of the key/value pairs contained in this object.</dd>
+ <dd>Returns an {{jsxref("Iteration_protocols", "iterator", "", 1)}}, allowing you to go through all values of the key/value pairs contained in this object.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

"iterator" isn't a keyword in a code.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
