### PR TITLE
Remove Expérimental from tags.

### DIFF
--- a/files/en-us/web/api/deviceproximityevent/max/index.html
+++ b/files/en-us/web/api/deviceproximityevent/max/index.html
@@ -5,7 +5,6 @@ tags:
   - API
   - DeviceProximityEvent
   - Experimental
-  - Expérimental(2)
   - NeedsBetterSpecLink
   - NeedsExample
   - NeedsMarkupWork

--- a/files/en-us/web/api/deviceproximityevent/min/index.html
+++ b/files/en-us/web/api/deviceproximityevent/min/index.html
@@ -5,7 +5,6 @@ tags:
   - API
   - DeviceProximityEvent
   - Experimental
-  - Expérimental(2)
   - NeedsBetterSpecLink
   - NeedsExample
   - NeedsMarkupWork

--- a/files/en-us/web/api/deviceproximityevent/value/index.html
+++ b/files/en-us/web/api/deviceproximityevent/value/index.html
@@ -5,7 +5,6 @@ tags:
   - API
   - DeviceProximityEvent
   - Experimental
-  - Expérimental(2)
   - NeedsBetterSpecLink
   - NeedsExample
   - NeedsMarkupWork

--- a/files/en-us/web/api/domrectreadonly/bottom/index.html
+++ b/files/en-us/web/api/domrectreadonly/bottom/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/height/index.html
+++ b/files/en-us/web/api/domrectreadonly/height/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/left/index.html
+++ b/files/en-us/web/api/domrectreadonly/left/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/right/index.html
+++ b/files/en-us/web/api/domrectreadonly/right/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/top/index.html
+++ b/files/en-us/web/api/domrectreadonly/top/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/width/index.html
+++ b/files/en-us/web/api/domrectreadonly/width/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/x/index.html
+++ b/files/en-us/web/api/domrectreadonly/x/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/domrectreadonly/y/index.html
+++ b/files/en-us/web/api/domrectreadonly/y/index.html
@@ -7,7 +7,6 @@ tags:
   - DOMRect
   - DOMRectReadOnly
   - Experimental
-  - Expérimental(2)
   - Geometry
   - Property
   - Reference

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.html
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.html
@@ -4,7 +4,6 @@ slug: Web/API/HMDVRDevice/getEyeParameters
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - HMDVRDevice
   - Method
   - Obsolete

--- a/files/en-us/web/api/hmdvrdevice/index.html
+++ b/files/en-us/web/api/hmdvrdevice/index.html
@@ -4,7 +4,6 @@ slug: Web/API/HMDVRDevice
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - HMDVRDevice
   - Interface
   - Obsolete

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.html
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.html
@@ -4,7 +4,6 @@ slug: Web/API/HMDVRDevice/setFieldOfView
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - HMDVRDevice
   - Method
   - Obsolete

--- a/files/en-us/web/api/installevent/installevent/index.html
+++ b/files/en-us/web/api/installevent/installevent/index.html
@@ -5,7 +5,6 @@ tags:
   - API
   - Constructor
   - Experimental
-  - Expérimental(2)
   - InstallEvent
   - Reference
   - Service Workers

--- a/files/en-us/web/api/mediastreamevent/index.html
+++ b/files/en-us/web/api/mediastreamevent/index.html
@@ -4,7 +4,6 @@ slug: Web/API/MediaStreamEvent
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Interface
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/mediastreamevent/mediastreamevent/index.html
+++ b/files/en-us/web/api/mediastreamevent/mediastreamevent/index.html
@@ -4,7 +4,6 @@ slug: Web/API/MediaStreamEvent/MediaStreamEvent
 tags:
   - Constructor
   - Experimental
-  - Expérimental(2)
   - MediaStreamEvent
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/mediastreamevent/stream/index.html
+++ b/files/en-us/web/api/mediastreamevent/stream/index.html
@@ -3,7 +3,6 @@ title: MediaStreamEvent.stream
 slug: Web/API/MediaStreamEvent/stream
 tags:
 - Experimental
-- Expérimental(2)
 - MediaStreamEvent
 - Property
 - Read-only

--- a/files/en-us/web/api/navigatorlanguage/languages/index.html
+++ b/files/en-us/web/api/navigatorlanguage/languages/index.html
@@ -4,7 +4,6 @@ slug: Web/API/NavigatorLanguage/languages
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - NavigatorLanguage
 - Property
 - Read-only

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
@@ -5,7 +5,6 @@ tags:
 - API
 - DOM
 - Experimental
-- Expérimental(2)
 - NodeIterator
 - Property
 ---

--- a/files/en-us/web/api/nodeiterator/referencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/referencenode/index.html
@@ -5,7 +5,6 @@ tags:
 - API
 - DOM
 - Experimental
-- Expérimental(2)
 - NodeIterator
 - Property
 ---

--- a/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice/getImmediateState
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Method
   - Obsolete
   - PositionSensorVRDevice

--- a/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice/getState
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Method
   - Obsolete
   - PositionSensorVRDevice

--- a/files/en-us/web/api/positionsensorvrdevice/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/index.html
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Interface
   - Obsolete
   - PositionSensorVRDevice

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice/resetSensor
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Method
   - Obsolete
   - PositionSensorVRDevice

--- a/files/en-us/web/api/rtcidentityerrorevent/idp/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/idp/index.html
@@ -3,7 +3,6 @@ title: RTCIdentityErrorEvent.idp
 slug: Web/API/RTCIdentityErrorEvent/idp
 tags:
 - Experimental
-- Expérimental(2)
 - Property
 - RTCIdentityErrorEvent
 - Read-only

--- a/files/en-us/web/api/rtcidentityerrorevent/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/index.html
@@ -4,7 +4,6 @@ slug: Web/API/RTCIdentityErrorEvent
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Interface
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/rtcidentityerrorevent/loginurl/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/loginurl/index.html
@@ -3,7 +3,6 @@ title: RTCIdentityErrorEvent.loginUrl
 slug: Web/API/RTCIdentityErrorEvent/loginUrl
 tags:
 - Experimental
-- Expérimental(2)
 - Property
 - RTCIdentityErrorEvent
 - Read-only

--- a/files/en-us/web/api/rtcidentityerrorevent/protocol/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/protocol/index.html
@@ -3,7 +3,6 @@ title: RTCIdentityErrorEvent.protocol
 slug: Web/API/RTCIdentityErrorEvent/protocol
 tags:
 - Experimental
-- Expérimental(2)
 - Property
 - RTCIdentityErrorEvent
 - Read-only

--- a/files/en-us/web/api/rtcidentityevent/assertion/index.html
+++ b/files/en-us/web/api/rtcidentityevent/assertion/index.html
@@ -3,7 +3,6 @@ title: RTCIdentityEvent.assertion
 slug: Web/API/RTCIdentityEvent/assertion
 tags:
 - Experimental
-- Expérimental(2)
 - Property
 - RTCIdentyEvent
 - Read-only

--- a/files/en-us/web/api/rtcpeerconnection/localdescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/localdescription/index.html
@@ -3,7 +3,6 @@ title: RTCPeerConnection.localDescription
 slug: Web/API/RTCPeerConnection/localDescription
 tags:
 - Experimental
-- Expérimental(2)
 - Property
 - RTCPeerConnection
 - Read-only

--- a/files/en-us/web/api/rtcsessiondescription/tojson/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/tojson/index.html
@@ -3,7 +3,6 @@ title: RTCSessionDescription.toJSON()
 slug: Web/API/RTCSessionDescription/toJSON
 tags:
 - Experimental
-- Expérimental(2)
 - Method
 - RTCSessionDescription
 - Reference

--- a/files/en-us/web/api/urlutilsreadonly/hash/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/hash/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/hash
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - Reference

--- a/files/en-us/web/api/urlutilsreadonly/host/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/host/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/host
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - Reference

--- a/files/en-us/web/api/urlutilsreadonly/hostname/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/hostname/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/hostname
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/href/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/href/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/href
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/origin/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/origin/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/origin
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/pathname/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/pathname/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/pathname
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/port/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/port/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/port
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/protocol/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/protocol/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/protocol
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/search/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/search/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/search
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Property
 - Read-only
 - URL API

--- a/files/en-us/web/api/urlutilsreadonly/tostring/index.html
+++ b/files/en-us/web/api/urlutilsreadonly/tostring/index.html
@@ -4,7 +4,6 @@ slug: Web/API/URLUtilsReadOnly/toString
 tags:
 - API
 - Experimental
-- Expérimental(2)
 - Method
 - Stringifier
 - URL API

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VREyeParameters/maximumFieldOfView
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VREyeParameters/minimumFieldOfView
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference

--- a/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VREyeParameters/recommendedFieldOfView
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference

--- a/files/en-us/web/api/vreyeparameters/renderrect/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderrect/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VREyeParameters/renderRect
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/angularAcceleration
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Property
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/angularVelocity
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Property
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/vrpose/hasorientation/index.html
+++ b/files/en-us/web/api/vrpose/hasorientation/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/hasOrientation
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference

--- a/files/en-us/web/api/vrpose/hasposition/index.html
+++ b/files/en-us/web/api/vrpose/hasposition/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/hasPosition
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/linearAcceleration
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Property
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/linearVelocity
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Property
   - Reference
   - Référence(2)

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/orientation
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Orientation
   - Property
   - Reference

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/position
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Position
   - Property
   - Reference

--- a/files/en-us/web/api/vrpose/timestamp/index.html
+++ b/files/en-us/web/api/vrpose/timestamp/index.html
@@ -4,7 +4,6 @@ slug: Web/API/VRPose/timeStamp
 tags:
   - API
   - Experimental
-  - Expérimental(2)
   - Obsolete
   - Property
   - Reference


### PR DESCRIPTION
We decided to remove this tag from MDN pages several years ago. 