### PR TITLE
Add hyperlinks in “HTTP response status codes” ToC

### DIFF
--- a/files/en-us/web/http/status/index.html
+++ b/files/en-us/web/http/status/index.html
@@ -14,7 +14,7 @@ tags:
 <p class="summary"><span class="seoSummary">HTTP response status codes indicate whether a specific <a href="/en-US/docs/Web/HTTP">HTTP</a> request has been successfully completed. Responses are grouped in five classes: </span></p>
 
 <ol>
- <li><span class="seoSummary"><a href="#information-responses">Informational responses</a> (<code>100</code>–<code>199</code>)</span></li>
+ <li><span class="seoSummary"><a href="#information_responses">Informational responses</a> (<code>100</code>–<code>199</code>)</span></li>
  <li><span class="seoSummary"><a href="#successful_responses">Successful responses</a> (<code>200</code>–<code>299</code>)</span></li>
  <li><span class="seoSummary"><a href="#redirection_messages">Redirects</a> (<code>300</code>–<code>399</code>)</span></li>
  <li><span class="seoSummary"><a href="#client_error_responses">Client errors</a> (<code>400</code>–<code>499</code>)</span></li>

--- a/files/en-us/web/http/status/index.html
+++ b/files/en-us/web/http/status/index.html
@@ -14,11 +14,11 @@ tags:
 <p class="summary"><span class="seoSummary">HTTP response status codes indicate whether a specific <a href="/en-US/docs/Web/HTTP">HTTP</a> request has been successfully completed. Responses are grouped in five classes: </span></p>
 
 <ol>
- <li><span class="seoSummary">Informational responses (<code>100</code>–<code>199</code>)</span></li>
- <li><span class="seoSummary">Successful responses (<code>200</code>–<code>299</code>)</span></li>
- <li><span class="seoSummary">Redirects (<code>300</code>–<code>399</code>)</span></li>
- <li><span class="seoSummary">Client errors (<code>400</code>–<code>499</code>)</span></li>
- <li><span class="seoSummary">Server errors (<code>500</code>–<code>599</code>)</span></li>
+ <li><span class="seoSummary"><a href="#information-responses">Informational responses</a> (<code>100</code>–<code>199</code>)</span></li>
+ <li><span class="seoSummary"><a href="#successful_responses">Successful responses</a> (<code>200</code>–<code>299</code>)</span></li>
+ <li><span class="seoSummary"><a href="#redirection_messages">Redirects</a> (<code>300</code>–<code>399</code>)</span></li>
+ <li><span class="seoSummary"><a href="#client_error_responses">Client errors</a> (<code>400</code>–<code>499</code>)</span></li>
+ <li><span class="seoSummary"><a href="#server_error_responses">Server errors</a> (<code>500</code>–<code>599</code>)</span></li>
 </ol>
 
 <p>The below status codes are defined by <a href="https://datatracker.ietf.org/doc/html/rfc2616#section-10">section 10 of RFC 2616</a>. You can find an updated specification in <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1">RFC 7231</a>.</p>


### PR DESCRIPTION
There was already a table of contents-like system in place at the top of the page, and I frequent this page a lot. It's annoying to have to scroll all the way down to the 400 or 500 sections, so I am proposing adding hyperlinks to each section.

Here's a preview of what it will look like:

![Changes made locally](https://i.imgur.com/nwMUb5e.png)

I thought it looked a bit off if it included the `(<code>###</code>-<code>###</code>)` in the hyperlink, but feel free to include that if it's preferred.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
