### PR TITLE
remove obsolete links

### DIFF
--- a/files/en-us/web/progressive_web_apps/responsive/media_types/index.html
+++ b/files/en-us/web/progressive_web_apps/responsive/media_types/index.html
@@ -74,7 +74,6 @@ tags:
 
 <p>For full details of media types, see <a href="https://www.w3.org/TR/CSS21/media.html">Media</a> in the CSS Specification.</p>
 
-<p>There are more examples of the {{CSSxRef("display")}} property in a later page in this tutorial: <a href="/en-US/docs/Web/Guide/CSS/Getting_Started/XML_data">XML data</a>.</p>
 </div>
 
 <h3 id="Printing">Printing</h3>
@@ -394,7 +393,5 @@ h1:first-child {
 <p><a href="/en-US/docs/Web/Guide/CSS/Getting_started/Challenge_solutions#media">See solutions to these challenges.</a></p>
 
 <h2 id="What_next">What next?</h2>
-
-<p>If you had difficulty understanding this page, or if you have other comments about it, please contribute to its <a href="/Talk:en-US/docs/Web/Guide/CSS/Getting_Started/Media">Discussion</a> page.</p>
 
 <p>So far, all the style rules in this tutorial have been specified in files. The rules and their values are fixed. The next page describes how you can change rules dynamically by using a programming language: <strong><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Manipulating_documents">JavaScript</a></strong>.</p>


### PR DESCRIPTION
Remove broken/obsolete links on https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Responsive/Media_types
