### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/api/worker/index.html
+++ b/files/en-us/web/api/worker/index.html
@@ -82,7 +82,7 @@ first.onchange = function() {
   console.log('Message posted to worker');
 }</pre>
 
-<p>For a full example, see our<a class="external external-icon" href="https://github.com/mdn/simple-web-worker">Basic dedicated worker example</a> (<a class="external external-icon" href="https://mdn.github.io/simple-web-worker/">run dedicated worker</a>).</p>
+<p>For a full example, see our <a class="external external-icon" href="https://github.com/mdn/simple-web-worker">Basic dedicated worker example</a> (<a class="external external-icon" href="https://mdn.github.io/simple-web-worker/">run dedicated worker</a>).</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

A space before "Basic dedicated worker example" link in "Example" section was missing.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Worker

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

https://developer.mozilla.org/en-US/docs/Web/API/Worker#example
