### PR TITLE
remove some obsolete project links

### DIFF
--- a/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
+++ b/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
@@ -192,7 +192,7 @@ input[type="button"] {
 
 <p>As you can see, considering browser and operating system default form control appearance is important. There are many techniques to handle these issue; however mastering all of them is beyond the scope of this article. The basic premise is to consider whether altering the default implementation is worth the work before embarking on the challenge.</p>
 
-<p>If you read all the articles of this <a href="/en-US/docs/Learn/Forms">HTML Forms guide</a>, you should now be at ease with using forms. If you discover new techniques or hints, please help <a href="/en-US/docs/Project:How_to_help">improve the guide</a>.</p>
+<p>If you read all the articles of this <a href="/en-US/docs/Learn/Forms">HTML Forms guide</a>, you should now be at ease with using forms. If you discover new techniques or hints, please help improve the guide.</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/contribute/howto/tag/index.html
+++ b/files/en-us/mdn/contribute/howto/tag/index.html
@@ -177,9 +177,9 @@ tags:
  <dt><code>NeedsContent</code></dt>
  <dd>The article is a stub, or is otherwise lacking information. This tag means that someone should review the content and add more details and/or finish writing the article.</dd>
  <dt><code>NeedsExample</code></dt>
- <dd>The article needs one or more examples created to help illustrate the article's point. These examples should use the <a href="/en-US/docs/Project:MDN/Contributing/How_to_help/Code_samples">live sample system</a>.</dd>
+ <dd>The article needs one or more examples created to help illustrate the article's point. These examples should use one of the <a href="/en-US/docs/MDN/Structures/Code_examples">code example styles</a>.</dd>
  <dt><code>NeedsLiveSamples</code></dt>
- <dd>The article has one or more examples that need to be updated to use the <a href="/en-US/docs/Project:MDN/Contributing/How_to_help/Code_samples">live sample system</a>.</dd>
+ <dd>The article has one or more examples that need to be updated to use the <a href="/en-US/docs/MDN/Structures/Live_samples">live sample system</a>.</dd>
  <dt><code>NeedsMarkupWork</code></dt>
  <dd>The article needs improvement to the page markup (usually because the page content consists mostly or entirely of {{HTMLElement("p")}} tags).</dd>
  <dt><code>NeedsSpecTable</code></dt>
@@ -222,5 +222,3 @@ tags:
  <dt>Tag spam</dt>
  <dd>This insidious beast is the most revolting tag problem of all: some Web vermin has deposited its droppings in the page tags (like "Free warez!" or "Hey I was browsing your site and wanted to ask you if you could help me solve this problem I'm having with Flash crashing all the time"). We've got to delete these right away! They're ugly, they're hard to manage if they're allowed to linger too long, and they're terrible for {{Glossary("SEO")}}.</dd>
 </dl>
-
-<p>If you see one (or more) of these problems, please <a href="/en-US/docs/Project:MDN/Contributing/Getting_started#Logging_into_MDN">log into MDN</a> and click EDIT at the top right of the MDN window. Once the editor loads up, scroll down to the bottom of the page, where you'll see the tag box. For more details on the tagging interface, see "<a href="/en-US/docs/MDN/Contribute/Editor/Basics/Tags">The tags box</a>" in the <a href="/en-US/docs/MDN/Contribute/Editor">MDN editor guide</a>.</p>

--- a/files/en-us/mdn/structures/macros/other/index.html
+++ b/files/en-us/mdn/structures/macros/other/index.html
@@ -49,7 +49,7 @@ tags:
 <p><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/page.ejs">page</a></code> lets you embed some or all of a specific page into a document. It accepts five parameters:</p>
 
 <ol>
- <li>The URI of the page to transclude. For example, "/en-US/docs/Project:MDN/About".</li>
+ <li>The URI of the page to transclude. For example, "/en-US/docs/MDN/About".</li>
  <li>The name of the section within the page to transclude. This can be specified either as the title string or as the ID of a block to copy over. If not specified, the entire article is transcluded. {{optional_inline}}</li>
  <li>The revision number of the page version to transclude. This feature is not currently implemented, but would allow including text from specific versions of an article. {{unimplemented_inline}}</li>
  <li>A Boolean value indicating whether or not to show the heading of the top-level section being transcluded. This is useful if you wish to specify your own heading. The default value is false, meaning the heading is not included by default. {{optional_inline}}</li>


### PR DESCRIPTION
Chipping away at some more of these obsolete Mindtouch namespace URL's like `User:`, `Project:`, `Talk:` and others (thanks for the reviews @sideshowbarker!).