### PR TITLE
formatting fix JS return doc

### DIFF
--- a/files/en-us/web/javascript/reference/statements/return/index.html
+++ b/files/en-us/web/javascript/reference/statements/return/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <div>{{jsSidebar("Statements")}}</div>
 
-<p>The <strong><code>return</code> statement</strong> ends function execution and
+<p>The <strong><code>return</code></strong> statement ends function execution and
   specifies a value to be returned to the function caller.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/statement-return.html")}}</div>


### PR DESCRIPTION
fixed errant formatting in the introduction by moving a </strong> tag

MDN URL
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return