### PR TITLE
FF88 Add ftp to the list of protocol handlers

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -49,7 +49,7 @@ tags:
  <p>A string defining the protocol. This must be either:</p>
 
  <ul>
-  <li>one of the following: "bitcoin", "dat", "dweb", "geo", "gopher", "im", "ipfs", "ipns", "irc", "ircs", "magnet", "mailto", "mms", "news", "nntp", "sip", "sms", "smsto", "ssb", "ssh", "tel", "urn", "webcal", "wtai", "xmpp".</li>
+  <li>one of the following: "bitcoin", "dat", "dweb", "ftp", "geo", "gopher", "im", "ipfs", "ipns", "irc", "ircs", "magnet", "mailto", "mms", "news", "nntp", "sip", "sms", "smsto", "ssb", "ssh", "tel", "urn", "webcal", "wtai", "xmpp".</li>
   <li>a string consisting of a custom name prefixed with "web+" or "ext+". For example: "web+foo" or "ext+foo". The custom name must consist only of lower-case ASCII characters. It's recommended that extensions use the "ext+" form.</li>
  </ul>
  </dd>
@@ -61,7 +61,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: json  no-line-numbers">"protocol_handlers": [
+<pre class="brush: json">"protocol_handlers": [
   {
     "protocol": "magnet",
     "name": "Magnet Extension",
@@ -71,7 +71,7 @@ tags:
 
 <p>If the protocol is not in the allowed list then it has to start with 'ext+'</p>
 
-<pre class="brush: json  no-line-numbers">"protocol_handlers": [
+<pre class="brush: json">"protocol_handlers": [
   {
     "protocol": "ext+foo",
     "name": "Foo Extension",
@@ -81,7 +81,7 @@ tags:
 
 <p>Handlers can also be <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages">extension pages</a>.</p>
 
-<pre class="brush: json  no-line-numbers">"protocol_handlers": [
+<pre class="brush: json">"protocol_handlers": [
   {
     "protocol": "magnet",
     "name": "Magnet Extension",

--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -50,7 +50,7 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
-  <li>FTP has been disabled on all releases (preference <code>network.ftp.enabled</code> now defaults to <code>false</code>), with the intent of removing it altogether in Firefox 90 ({{bug(1691890)}}). As part of this change the extension setting <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/ftpProtocolEnabled">browserSettings.ftpProtocolEnabled</a> is now read-only ({{bug(1626365)}}).</li>
+  <li>FTP has been disabled on all releases (preference <code>network.ftp.enabled</code> now defaults to <code>false</code>), with the intent of removing it altogether in Firefox 90 ({{bug(1691890)}}). Complementing this change, the extension setting <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/ftpProtocolEnabled">browserSettings.ftpProtocolEnabled</a> has been made read-only, and web extensions can now register themselves as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers">protocol handlers</a> for FTP ({{bug(1626365)}}).</li>
 </ul>
 
 <h4 id="removals_http">Removals</h4>


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1626365#c10 FF88 adds ftp to the list of protocol_handlers as part of removing FTP. 

This updates the associated page and the release notes. There is a separate issue for fixing up the BCD: https://github.com/mdn/browser-compat-data/pull/9775

Docs tracking issue is #3462