### PR TITLE
Fix missing word in “Manipulating documents” article

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.html
@@ -119,7 +119,7 @@ tags:
  <li>{{domxref("Document.getElementsByTagName()")}}, which returns an array-like object containing all the elements on the page of a given type, for example <code>&lt;p&gt;</code>s, <code>&lt;a&gt;</code>s, etc. The element type is passed to the function as a parameter, i.e. <code>const elementRefArray = document.getElementsByTagName('p')</code>.</li>
 </ul>
 
-<p>These two work in older browsers than the modern methods like <code>querySelector()</code>, but are not as convenient. Have a look and see what others you can find!</p>
+<p>These two work better in older browsers than the modern methods like <code>querySelector()</code>, but are not as convenient. Have a look and see what others you can find!</p>
 
 <h3 id="Creating_and_placing_new_nodes">Creating and placing new nodes</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Seems like a word was missing.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Manipulating_documents#active_learning_basic_dom_manipulation

> Issue number (if there is an associated issue)

> Anything else that could help us review it

I assume this is what the author meant. See also: https://stackoverflow.com/questions/26848289/javascript-queryselector-vs-getelementbyid

