### PR TITLE
Other docs affected by FTP removal

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
@@ -71,7 +71,7 @@ tags:
 	<dt><code>urlMatches</code>{{optional_inline}}</dt>
 	<dd><code>string</code>. Matches if the URL (without fragment identifier) matches a specified <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">regular expression</a>. Port numbers are stripped from the URL if they match the default port number.
 	<ul>
-		<li>For example: <code>urlMatches: "^[^:]*:(?://)?(?:[^/]*\\.)?mozilla\\.org/.*$"</code> matches "https://mozilla.org/", "https://developer.mozilla.org/", "ftp://foo.mozilla.org/", but not "https://developer.fakemozilla.org/".</li>
+		<li>For example: <code>urlMatches: "^[^:]*:(?://)?(?:[^/]*\\.)?mozilla\\.org/.*$"</code> matches "https://mozilla.org/", "https://developer.mozilla.org/", but not "https://developer.fakemozilla.org/".</li>
 	</ul>
 	</dd>
 	<dt><code>originAndPathMatches</code>{{optional_inline}}</dt>
@@ -106,11 +106,11 @@ tags:
 
 <p>{{WebExtExamples}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
-
-<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/events#type-UrlFilter"><code>chrome.events</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json"><code>events.json</code></a> in the Chromium code.</p>
-
-<p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
+<div class="notecard note">
+	<h4>Acknowledgements</h4>
+	<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/events#type-UrlFilter"><code>chrome.events</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json"><code>events.json</code></a> in the Chromium code.</p>
+	
+	<p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.html
@@ -9,11 +9,6 @@ tags:
 ---
 <div>{{AddonSidebar}}</div>
 
-<div class="notecard warning">
-<p><strong>Warning</strong><br>
- You should not use the {{WebExtAPIRef("proxy.register()")}} or {{WebExtAPIRef("proxy.unregister()")}} function to register and remove extended <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register#pac_file_specification">Proxy Auto-Configuration (PAC) file</a>. This API was deprecated in Firefox 68 and will be removed from Firefox 71.</p>
-</div>
-
 <p>Use the proxy API to proxy web requests. You can use the {{WebExtAPIRef("proxy.onRequest")}} event listener to intercept web requests, and return an object that describes whether and how to proxy them.</p>
 
 <p>The advantage of the {{WebExtAPIRef("proxy.onRequest")}} approach is that the code that implements your proxy policy runs in your extension's background script, so it gets full access to the WebExtension APIs available to your extension (including, for example, access to your extension's <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage">storage</a></code> and networking APIs like <code><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/dns">dns</a></code>).</p>
@@ -43,6 +38,11 @@ tags:
 </dl>
 
 <h2 id="Functions">Functions</h2>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>You should not use these methods ({{WebExtAPIRef("proxy.register()")}} or {{WebExtAPIRef("proxy.unregister()")}}) to register and remove an extended <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register#pac_file_specification">Proxy Auto-Configuration (PAC) file</a>. They were deprecated in Firefox 68 and removed in Firefox 71.</p>
+</div>
 
 <dl>
  <dt>{{WebExtAPIRef("proxy.register()")}} {{Deprecated_Inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -22,7 +22,7 @@ tags:
 </div>
 
 
-<p>Registers a <a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file">Proxy Auto-Configuration (PAC) file</a>. The file is executed immediately, and its <code>FindProxyForURL()</code> function will be called for any HTTP, or HTTPS requests.</p>
+<p>Registers a <a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file">Proxy Auto-Configuration (PAC) file</a>. The file is executed immediately, and its <code>FindProxyForURL()</code> function will be called for any HTTP or HTTPS requests.</p>
 
 <p>If PAC files are registered by more than one extension, then requests will be passed initially to the one that was registered first.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -14,11 +14,15 @@ tags:
 ---
 <p>{{AddonSidebar()}} {{deprecated_header}}</p>
 
-<p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
 
-<p><img alt="" src="proxy_register_warning.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
+  <p><img alt="" src="proxy_register_warning.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
+</div>
 
-<p>Registers a <a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file">Proxy Auto-Configuration (PAC) file</a>. The file is executed immediately, and its <code>FindProxyForURL()</code> function will be called for any HTTP, HTTPS, or FTP requests.</p>
+
+<p>Registers a <a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file">Proxy Auto-Configuration (PAC) file</a>. The file is executed immediately, and its <code>FindProxyForURL()</code> function will be called for any HTTP, or HTTPS requests.</p>
 
 <p>If PAC files are registered by more than one extension, then requests will be passed initially to the one that was registered first.</p>
 
@@ -154,7 +158,7 @@ browser.proxy.register(proxyScriptURL);</pre>
 
 <p>{{Compat("webextensions.api.proxy.register")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
-
-<p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
+<div class="notecard note">
+  <h4>Acknowledgements</h4>
+  <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.html
@@ -16,7 +16,8 @@ tags:
 <p>A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that can be used to change the browser's proxy settings.</p>
 
 <div class="notecard note">
-<p><strong>Note</strong>: The ability to change proxy settings requires private window access because proxy settings affect both private and non-private windows. Therefore, if an extension has not been granted private window permission, calls to <code>proxy.settings.set()</code> will throw an exception.</p>
+  <h4>Note</h4>
+  <p>The ability to change proxy settings requires private window access because proxy settings affect both private and non-private windows. Therefore, if an extension has not been granted private window permission, calls to <code>proxy.settings.set()</code> will throw an exception.</p>
 </div>
 
 <p>The underlying value is an object with the properties listed below.</p>
@@ -28,8 +29,9 @@ tags:
  <dd><code>string</code>. A URL to use to configure the proxy.</dd>
  <dt><code>autoLogin</code>{{optional_inline}}</dt>
  <dd><code>boolean</code>. Do not prompt for authentication if the password is saved. Defaults to <code>false</code>.</dd>
- <dt><code>ftp</code>{{optional_inline}}</dt>
- <dd><code>string</code>. The address of the FTP proxy. Can include a port.</dd>
+ <dt><code>ftp</code>{{optional_inline}} {{Deprecated_Inline}}</dt>
+ <dd><code>string</code>. The address of the FTP proxy. Can include a port.
+</dd>
  <dt><code>http</code>{{optional_inline}}</dt>
  <dd><code>string</code>. The address of the HTTP proxy. Can include a port.</dd>
  <dt><code>httpProxyAll</code>{{optional_inline}}</dt>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
@@ -15,9 +15,13 @@ tags:
 
 <div>{{deprecated_header}}</div>
 
-<p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This method was deprecated in Firefox 68 and removed in Firefox 71. In Firefox 68–70, calling this method logs an error message to the console:</p>
 
-<p><img alt="" src="proxy_unregister_warning.png" style="border: 1px solid black; display: block; margin: 0 auto;"></p>
+  <p><img alt="" src="proxy_unregister_warning.png" style="border: 1px solid black; display: block; margin: 0 auto;"></p>
+</div>
+
 
 <p>Unregisters a <a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file">Proxy Auto-Configuration (PAC) file</a>. that was registered by an earlier call to {{WebExtAPIRef("proxy.register()")}}.</p>
 
@@ -48,7 +52,7 @@ tags:
 
 <p>{{Compat("webextensions.api.proxy.unregister")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
-
-<p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
+<div class="notecard note">
+  <h4>Acknowledgements</h4>
+  <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
@@ -16,7 +16,7 @@ tags:
 
 <p><span class="seoSummary">Injects JavaScript code into a page.</span></p>
 
-<p>You can inject code into pages whose URL can be expressed using a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match pattern</a>. To do so, its scheme must be one of: <code>http</code>, <code>https</code>, <code>file</code>, or <code>ftp</code>.</p>
+<p>You can inject code into pages whose URL can be expressed using a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match pattern</a>. To do so, its scheme must be one of: <code>http</code>, <code>https</code>, or <code>file</code>.</p>
 
 <p>You must have the permission for the page's URL—either explicitly, as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permission</a>—or, via the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission">activeTab permission</a>.</p>
 
@@ -32,7 +32,7 @@ tags:
 
 <p>You <em>cannot</em> inject code into any of the browser's built-in pages, such as: <code>about:debugging</code>, <code>about:addons</code>, or the page that opens when you open a new empty tab.</p>
 
-<p>The scripts you inject are called <em>content scripts</em>. <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts">Learn more about content scripts</a>.</p>
+<p>The scripts you inject are called <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts">content scripts</a>.</p>
 
 <p>This is an asynchronous function that returns a <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>.</p>
 
@@ -185,9 +185,9 @@ executing.then(onExecuted, onError);</pre>
 
 <p>{{Compat("webextensions.api.tabs.executeScript")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
-
-<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-executeScript"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
+<div class="notecard note">
+	<h4>Acknowledgements</h4>
+	<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-executeScript"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
 </div>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p>To use this API you must have the permission for the page's URL, either explicitly as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permission</a>, or using the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission">activeTab permission</a>.</p>
 
-<p>You can only inject CSS into pages whose URL can be expressed using a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match pattern</a>: meaning, its scheme must be one of "http", "https", "file". This means that you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.</p>
+<p>You can only inject CSS into pages whose URL can be expressed using a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match pattern</a>: meaning, its scheme must be one of "http", "https", or "file". This means that you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.</p>
 
 <div class="notecard note">
   <h4>Note</h4>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
@@ -18,10 +18,11 @@ tags:
 
 <p>To use this API you must have the permission for the page's URL, either explicitly as a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions">host permission</a>, or using the <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission">activeTab permission</a>.</p>
 
-<p>You can only inject CSS into pages whose URL can be expressed using a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match pattern</a>: meaning, its scheme must be one of "http", "https", "file", "ftp". This means that you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.</p>
+<p>You can only inject CSS into pages whose URL can be expressed using a <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match pattern</a>: meaning, its scheme must be one of "http", "https", "file". This means that you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.</p>
 
 <div class="notecard note">
-<p>Firefox resolves URLs in injected CSS files relative to the CSS file itself, rather than to the page it's injected into.</p>
+  <h4>Note</h4>
+  <p>Firefox resolves URLs in injected CSS files relative to the CSS file itself, rather than to the page it's injected into.</p>
 </div>
 
 <p>The inserted CSS may be removed again by calling {{WebExtAPIRef("tabs.removeCSS()")}}.</p>
@@ -106,15 +107,15 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <p>{{Compat("webextensions.api.tabs.insertCSS")}}</p>
 
-<div class="note"><strong>Acknowledgements</strong>
-
-<p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-insertCSS"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
-
-<p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
+<div class="notecard note">
+  <h4>Acknowledgements</h4>
+  <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/tabs#method-insertCSS"><code>chrome.tabs</code></a> API. This documentation is derived from <a href="https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json"><code>tabs.json</code></a> in the Chromium code.</p>
+  
+  <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>
 </div>
 
 <div class="hidden">
-<pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+<pre>// Copyright 2015 The Chromium Authors. All rights reserved. 
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.html
@@ -124,10 +124,10 @@ tags:
       currentTab = tabs[0];
       if (isSupportedProtocol(currentTab.url)) {</pre>
 
-<p><code>isSupportedProtocol()</code> determines if the URL displayed in the active tab is one that can be bookmarked. To extract the protocol from the tab’s URL, the extension takes advantage of the <a href="/en-US/docs/Web/API/HTMLHyperlinkElementUtils">HTMLHyperlinkElementUtils</a> by adding the tab’s URL to an <code>&lt;a&gt;</code> element and then getting the protocol using the <code>protocol</code> property.</p>
+<p><code>isSupportedProtocol()</code> determines if the URL displayed in the active tab is one that can be bookmarked. To extract the protocol from the tab’s URL, the extension takes advantage of the <a href="/en-US/docs/Web/API/HTMLAnchorElement">HTMLAnchorElement</a> by adding the tab’s URL to an <code>&lt;a&gt;</code> element and then getting the protocol using the <code>protocol</code> property.</p>
 
 <pre class="brush: js">  function isSupportedProtocol(urlString) {
-    var supportedProtocols = ["https:", "http:", "ftp:", "file:"];
+    var supportedProtocols = ["https:", "http:", "file:"];
     var url = document.createElement('a');
     url.href = urlString;
     return supportedProtocols.indexOf(url.protocol) != -1;


### PR DESCRIPTION
There are some docs that are kind of "indirectly" affected by removal of FTP - ie nothing changes in code but someone trying to use the documented feature might find it doesn't work. For example, you can still bookmark an FTP page, but it won't open in Firefox. In addition, we use FTP in some general examples - e.g. for pattern matching - and that is no longer a good way to show things.

List of these kind of things was found in https://bugzilla.mozilla.org/show_bug.cgi?id=1626365#c10. 

This is a catch all PR for this kind of thing.