### PR TITLE
Fix wrong parameter type in DOMTokenList.item()

### DIFF
--- a/files/en-us/web/api/domtokenlist/item/index.html
+++ b/files/en-us/web/api/domtokenlist/item/index.html
@@ -23,7 +23,7 @@ tags:
 
 <dl>
   <dt><code><var>index</var></code></dt>
-  <dd>A {{domxref("DOMString")}} representing the index of the item you want to return.
+  <dd>A 32-bit unsigned integer ({{jsxref("Number")}}) representing the index of the item you want to return.
   </dd>
 </dl>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The type of this parameter should be unsigned long, accrding to the DOM Specification.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/item

> Issue number (if there is an associated issue)

fix #3869 

> Anything else that could help us review it
