### PR TITLE
Math.clz32 counts leading zero bits not leading (decimal) zeroes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/index.html
@@ -68,7 +68,7 @@ tags:
  <dt>{{jsxref("Global_Objects/Math/ceil", "Math.ceil(<var>x</var>)")}}</dt>
  <dd>Returns the smallest integer greater than or equal to <code><var>x</var></code>.</dd>
  <dt>{{jsxref("Global_Objects/Math/clz32", "Math.clz32(<var>x</var>)")}}</dt>
- <dd>Returns the number of leading zeroes of the 32-bit integer <code><var>x</var></code>.</dd>
+ <dd>Returns the number of leading zero bits of the 32-bit integer <code><var>x</var></code>.</dd>
  <dt>{{jsxref("Global_Objects/Math/cos", "Math.cos(<var>x</var>)")}}</dt>
  <dd>Returns the cosine of <code><var>x</var></code>.</dd>
  <dt>{{jsxref("Global_Objects/Math/cosh", "Math.cosh(<var>x</var>)")}}</dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math

> Issue number (if there is an associated issue)

> Anything else that could help us review it
