### PR TITLE
Add undefined to JSON.stringify's return type

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.html
@@ -49,7 +49,7 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A JSON string representing the given value.</p>
+<p>A JSON string representing the given value, or undefined.</p>
 
 <h3 id="Exceptions">Exceptions</h3>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

`JSON.stringify` doesn't always return a string. When `undefined` is passed to it as an argument, or there's no arguments, it returns `undefined`.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

> Issue number (if there is an associated issue)

> Anything else that could help us review it

[ECMAScript spec](https://tc39.es/ecma262/#sec-json.stringify):

> The stringify function returns a String in UTF-16 encoded JSON format representing an ECMAScript value, or **undefined**.