### PR TITLE
Adjust parameter role outside the h1 tag

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_link_role/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_link_role/index.html
@@ -48,7 +48,7 @@ tags:
 
 <h3 id="HTML">HTML</h3>
 
-<pre class="brush: html">&lt;h1&gt;role="link" example&lt;/h1&gt;
+<pre class="brush: html">&lt;h1 role="link"&gt;example&lt;/h1&gt;
 
 &lt;span data-href="https://mozilla.org" tabindex="0" id="link1" role="link" class="link"&gt;
   Fake accessible link created using a span


### PR DESCRIPTION
This pull request make a simple adjust in role parameter outside of h1 tag

MDN URL: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_link_role

