### PR TITLE
Add info about autoplay blocked by default on Android

### DIFF
--- a/files/en-us/web/media/autoplay_guide/index.html
+++ b/files/en-us/web/media/autoplay_guide/index.html
@@ -21,7 +21,7 @@ tags:
 ---
 <p>Automatically starting the playback of audio (or videos with audio tracks) immediately upon page load can be an unwelcome surprise to users. While autoplay of media serves a useful purpose, it should be used carefully and only when needed. In order to give users control over this, browsers often provide various forms of autoplay blocking. <span class="seoSummary">In this guide, we'll cover autoplay functionality in the various media and Web Audio APIs, including a brief overview of how to use autoplay and how to work with browsers to handle autoplay blocking gracefully.</span></p>
 
-<p>Autoplay blocking is <em>not</em> applied to {{HTMLElement("video")}} elements when the source media does not have an audio track, or if the audio track is muted. Media with an active audio track are considered to be <strong>audible</strong>, and autoplay blocking applies to them. <strong>Inaudible</strong> media are not affected by autoplay blocking.</p>
+<p>On desktop autoplay blocking is <em>not</em> applied to {{HTMLElement("video")}} elements when the source media does not have an audio track, or if the audio track is muted. Media with an active audio track are considered to be <strong>audible</strong>, and autoplay blocking applies to them. On desktop <strong>inaudible</strong> media are not affected by autoplay blocking.</p>
 
 <h2 id="Autoplay_and_autoplay_blocking">Autoplay and autoplay blocking</h2>
 
@@ -57,6 +57,8 @@ tags:
 
 <p>Otherwise, the playback will likely be blocked. The exact situations that result in blocking, and the specifics of how sites become whitelisted vary from browser to browser, but the above are good guidelines to go by.</p>
 
+<p>Firefox on Android blocks all autoplay by default. This behavior can be changed by the user in the browser settings under site permissions.</p> 
+  
 <p>For details, see the auto-play policies for <a href="https://developers.google.com/web/updates/2017/09/autoplay-policy-changes">Google Chrome</a> and <a href="https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/">WebKit</a>.</p>
 
 <div class="notecard note">


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was no information included about Firefox on Android blocking autoplay by default and not information in general readily available online. 
> MDN URL of main page changed

[https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide)
> Issue number (if there is an associated issue)

none
> Anything else that could help us review it

This was discussed in the Firefox Android Community and the team member 'kbrosnan' confirmed this to be true. I also added a call for contributions to the MDN channel and will link this issue in both channels.

An additional issue that should be addressed, is that even the devtools console output via remote debugging is somewhat misleading as it states:
>Autoplay is only allowed when approved by the user, the site is activated by the user, or media is muted.

 In combination with the information provided in the autoplay guide, this leads to long debug sessions.
I would be thankful, if anybody could point me in a direction on how to contribute regarding the devtools output.

Edits to the wording, restructuring, or additional information are very welcome!

Have a wonderful day! :sunny: 