### PR TITLE
Fix document.domain Permissions Policy description

### DIFF
--- a/files/en-us/web/api/document/domain/index.html
+++ b/files/en-us/web/api/document/domain/index.html
@@ -95,14 +95,14 @@ tags:
 
 <ul>
   <li>The {{httpheader('Feature-Policy/document-domain','document-domain')}}
-    {{HTTPHeader("Feature-Policy")}} is enabled</li>
-  <li>The document is inside a sandboxed {{htmlelement("iframe")}}</li>
-  <li>The document has no {{glossary("browsing context")}}</li>
+    {{HTTPHeader("Feature-Policy")}} is disabled.</li>
+  <li>The document is inside a sandboxed {{htmlelement("iframe")}}.</li>
+  <li>The document has no {{glossary("browsing context")}}.</li>
   <li>The document's <a
       href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-effective-domain">effective
-      domain</a> is <code>null</code></li>
+      domain</a> is <code>null</code>.</li>
   <li>The given value is neither the same as the page's current hostname, nor a parent
-    domain of it</li>
+    domain of it.</li>
 </ul>
 
 <p>As an example of this last failure case, trying to set <code>document.domain</code> to

--- a/files/en-us/web/http/headers/feature-policy/document-domain/index.html
+++ b/files/en-us/web/http/headers/feature-policy/document-domain/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header
     <code>document-domain</code> directive controls whether the current document is
-    allowed to set {{domxref("document.domain")}}. When this policy is enabled, attempting
+    allowed to set {{domxref("document.domain")}}. When this policy is disabled, attempting
     to set {{domxref("document.domain")}} will fail and cause a <code>SecurityError</code>
     {{domxref("DOMException")}} to be thrown.</span></p>
 


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction:document-domain-feature for confirmation that a SecurityError is thrown for `document.domain` calls when the `document.domain` Permissions Policy feature is *disabled* — not when it’s enabled. Fixes https://github.com/mdn/content/issues/3326.