### PR TITLE
fixed link flaws of {{jsxref("this")}}

### DIFF
--- a/files/en-us/web/api/domtokenlist/foreach/index.html
+++ b/files/en-us/web/api/domtokenlist/foreach/index.html
@@ -36,7 +36,7 @@ tags:
     </dl>
   </dd>
   <dt><code><var>thisArg</var></code> {{Optional_inline}}</dt>
-  <dd>Value to use as {{jsxref("this")}} when executing <code><var>callback</var></code>.
+  <dd>Value to use as {{jsxref("Operators/this", "this")}} when executing <code><var>callback</var></code>.
   </dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/globalthis/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/globalthis/index.html
@@ -80,5 +80,5 @@ if (typeof globals.setTimeout !== 'function') {
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{jsxref("this")}}</li>
+ <li>{{jsxref("Operators/this", "this")}}</li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are link flaws where {{jsxref("this")}} is used.

> MDN URL of main page changed

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
- https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/forEach

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it

I have replaced it with {{jsxref("Operators/this", "this")}}