### PR TITLE
Updated the correct link to fix page not found error

### DIFF
--- a/files/en-us/web/html/global_attributes/lang/index.html
+++ b/files/en-us/web/html/global_attributes/lang/index.html
@@ -39,7 +39,7 @@ tags:
 <p>To find the correct subtag codes for a language, try <a href="https://r12a.github.io/app-subtags/" rel="external">the Language Subtag Lookup</a>.</p>
 </div>
 
-<p>Even if the <strong>lang</strong> attribute is set, it may not be taken into account, as the <a href="/en-US/docs/Web/HTML/Global_attributes/xml:lang"><strong>xml:lang</strong></a> attribute has priority.</p>
+<p>Even if the <strong>lang</strong> attribute is set, it may not be taken into account, as the <a href="/en-US/docs/Web/HTML/Global_attributes/#attr-xml:lang"><strong>xml:lang</strong></a> attribute has priority.</p>
 
 <p>For the CSS pseudo-class {{cssxref(":lang")}}, two invalid language names are different if their names are different. So while <code>:lang(es)</code> matches both <code>lang="es-ES"</code> and <code>lang="es-419"</code>, <code>:lang(xyzzy)</code> would <em>not</em> match <code>lang="xyzzy-Zorp!"</code>.</p>
 


### PR DESCRIPTION
Fixed the link which resulted in 404

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The link in the href was wrong which resulted in Page Not Found.

> MDN URL of main page changed
https://github.com/mdn/content/tree/main/files/en-us/web/html/global_attributes/lang/index.html

> Issue number (if there is an associated issue)
3919

