### PR TITLE
Add a polyfill for Headers.getAll()

### DIFF
--- a/files/en-us/web/api/headers/getall/index.html
+++ b/files/en-us/web/api/headers/getall/index.html
@@ -53,8 +53,17 @@ myHeaders.append('Accept-Encoding', 'gzip');
 myHeaders.getAll('Accept-Encoding'); // Returns [ "deflate", "gzip" ]</pre>
 
 <div class="note">
-<p><strong>Note</strong>: Use {{domxref("Headers.get")}} to return only the first value added to the <code>Headers</code> object.</p>
+<p><strong>Note</strong>: Use {{domxref("Headers.get")}} to get the values as a single string with comma separators.</p>
 </div>
+
+<h2 id="JavaScript_polyfill">JavaScript polyfill</h2>
+
+You can use the following JavaScript polyfill to reimplement the feature in a modern browser.
+
+<pre class="brush: js">
+Headers.prototype.getAll = function(name) {
+  return this.get(name).split(',').map(v => v.trimStart());
+}</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The `Headers.getAll( )` method was deprecated. However, the page did not provide code for reimplementing the feature using other available methods.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Headers/getAll

> Anything else that could help us review it

I posted a related question on StackOverflow https://stackoverflow.com/questions/66967858/deprecated-headers-getall-api-reimplementation