### PR TITLE
panner image fix

### DIFF
--- a/files/en-us/web/api/pannernode/orientationx/index.html
+++ b/files/en-us/web/api/pannernode/orientationx/index.html
@@ -59,7 +59,7 @@ tags:
 
 <p><img
     alt="This chart visualises how the PannerNode orientation vectors affect the direction of the sound cone."
-    src="pannernode-orientation.png"></p>
+    src="/en-US/docs/Web/API/PannerNode/orientationX/pannernode-orientation.png"></p>
 
 <p>First, let's start by writing a utility function to figure out our <em>orientation
     vector.</em> The X and Z components are always at a 90° to each other, so we can


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Example used throughout panner node properties includes from orientationX example. Updating image url so make sure image shows on other pages

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/orientationX

> Issue number (if there is an associated issue)

Fixes #3299 
