### PR TITLE
In example, don't compare directly to undefined

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
@@ -70,7 +70,7 @@ console.log('Removed this element:', shifted);
 
 <pre class="brush: js">var names = ["Andrew", "Edward", "Paul", "Chris" ,"John"];
 
-while( (i = names.shift()) !== undefined ) {
+while( typeof (i = names.shift()) !== 'undefined' ) {
     console.log(i);
 }
 // Andrew, Edward, Paul, Chris, John


### PR DESCRIPTION
_What was wrong/why is this fix needed? (quick summary only):_
Comparison to `undefined` can sometimes lead to unexpected results.
See https://eslint.org/docs/rules/no-undefined for details.

_MDN URL of main page changed:_
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift

_Issue number (if there is an associated issue):_
None yet, but might be worth adding one to do a more thorough check through the documentation
