### PR TITLE
[Markdown] First draft of Markdown spec

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -1,0 +1,166 @@
+---
+title: Markdown in MDN
+slug: MDN/Contribute/Markdown_in_MDN
+tags:
+  - MDN
+---
+<div>{{MDNSidebar}}</div>
+
+<div class="notecard warning">
+
+<p><strong>This document is a work-in-progress draft at the moment.</strong></p>
+
+<p>It's not actually possible, yet, to write MDN documentation using Markdown, so at the moment this document is used to record the decisions we've made about how we will expect Markdown to be written, when it is supported.</p>
+
+</div>
+
+<p>This page describes how we use Markdown to write documentation on MDN. We have chosen GitHub-Flavored Markdown (GFM) as a baseline, and added some extensions to support some of the things we need to do on MDN that aren't readily supported in GFM.</p>
+
+<h2>Baseline: GitHub-Flavored Markdown</h2>
+
+<p>The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <a href="https://github.github.com/gfm/">https://github.github.com/gfm/</a>. This means that for anything not otherwise specified in this page, you can refer to the GFM specification. GFM in turn is a superset of CommonMark (<a href="http://spec.commonmark.org/">http://spec.commonmark.org/</a>).</p>
+
+<p>GFM and CommonMark describe some extensions to <a href="https://daringfireball.net/projects/markdown/syntax">the original Markdown description</a>). We'll highlight three that are going to be important to us.
+
+<h3>Markdown in HTML blocks</h3>
+
+<p>In GFM and CommonMark, HTML blocks may contain Markdown formatting. So:</p>
+
+<pre>
+&lt;div style="background-color: pink"&gt;
+
+Hello **there**, `Markdown` formatting.
+
+* one
+* two
+* three
+
+&lt;/div&gt;
+</pre>
+
+<p>produces:</p>
+
+<pre>
+&lt;div style="background-color: pink"&gt;
+  &lt;p&gt;Hello &lt;strong&gt;there&lt;/strong&gt;, &lt;code&gt;Markdown&lt;/code&gt; formatting.&lt;/p&gt;
+  &lt;ul&gt;
+    &lt;li&gt;one&lt;/li&gt;
+    &lt;li&gt;two&lt;/li&gt;
+    &lt;li&gt;three&lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/div&gt;
+</pre>
+
+<h3>Code fences and info strings</h3>
+
+<p>In GFM and CommonMark, authors can use "code fences" to demarcate <code>&lt;pre&gt;</code> blocks. The opening code fence may be followed by some text that is called the "info string". From the spec:</p>
+
+<blockquote>
+  <p> The first word of the info string is typically used to specify the language of the code sample, and rendered in the class attribute of the code tag.</p>
+</blockquote>
+
+<p>It's permissible for the info string to contain multiple words, like:</p>
+
+<pre>
+```fee fi fo fum
+// some example code
+```
+</pre>
+
+<h3>Tables</h3>
+
+<p>In GFM (but not CommonMark) there is a syntax for tables: <a href="https://github.github.com/gfm/#tables-extension-">https://github.github.com/gfm/#tables-extension-</a>. We will make use of this but it should be noted that this syntax imposes limitations on the kinds of tables we can write, so in many cases this syntax will not be appropriate and we will need alternative ways of authoring tables.</p>
+
+<p>In particular:</p>
+
+<ul>
+  <li>GFM tables must have a header row.</li>
+  <li>GFM tables may not have a header column.</li>
+  <li>GFM won't parse GFM block elements in table cells.</li>
+</ul>
+
+<p>This last means that if you write:</p>
+
+<pre>
+--------------------------------------
+|  i'm a test    | yes i am          |
+|----------------|-------------------|
+| `inline` is ok | * lists aren't    |
+--------------------------------------
+</pre>
+
+<p>...then the attempt to write a list in the bottom-right cell will just generate <code>&lt;td&gt;* lists aren't&lt;/td&gt;</code> in the output.</p>
+
+
+<h2>Extensions to GFM</h2>
+
+<p>In this section we'll outline ways in which writers will be able to go beyond the syntax defined in the GFM spec.</p>
+
+
+<h3>Example code blocks</h3>
+
+Writers will use code fences for example code blocks. They will be able to specify the language of the code sample using the first word of the info string. The following words will be supported:
+
+<ul>
+  <li><code>js</code></li>
+  <li><code>css</code></li>
+  <li><code>html</code></li>
+  <li><code>svg</code></li>
+  <li><code>json</code></li>
+  <li><code>py</code></li>
+  <li><code>bash</code></li>
+  <li>...?</li>
+</ul>
+
+For example:
+
+<pre>
+```js
+const greeting = "I will get syntax highlighting";
+```
+</pre>
+
+<p>Writers will be able to supply any one of the following additional words, which must come after the language word:</p>
+
+<ul>
+  <li><code>example-good</code>: style this example as a good example (one to follow)</li>
+  <li><code>example-bad</code>: style this example as a bad example (one to avoid)</li>
+  <li><code>hidden</code>: don't render this code block in the page. This is for use in live samples.</li>
+</ul>
+
+For example:
+
+<pre>
+```js example-good
+const greeting = "I'm a good example";
+```
+</pre>
+
+<h3>Notes and warnings</h3>
+
+<h3>Definition lists</h3>
+
+<h3>Tables</h3>
+
+<h3>Heading IDs</h3>
+
+<h3>Live samples</h3>
+
+<h3>Inline styles</h3>
+
+<h3>KumaScript</h3>
+
+<p>Writers will be able to include KumaScript macro calls in prose content:</p>
+
+<pre>
+
+The **`margin-right`** [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)
+property sets the margin area on the right side of an element. A positive value
+places it farther from its neighbors, while a negative value places it closer.
+
+\{{EmbedInteractiveExample("pages/css/margin-right.html")}}
+
+The vertical margins of two adjacent boxes may fuse. This is called
+[*margin collapsing*](https://developer.mozilla.org/en-US/docs/CSS/margin_collapsing).
+
+</pre>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -22,36 +22,7 @@ tags:
 
 <p>The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <a href="https://github.github.com/gfm/">https://github.github.com/gfm/</a>. This means that for anything not otherwise specified in this page, you can refer to the GFM specification. GFM in turn is a superset of CommonMark (<a href="http://spec.commonmark.org/">http://spec.commonmark.org/</a>).</p>
 
-<p>GFM and CommonMark describe some extensions to <a href="https://daringfireball.net/projects/markdown/syntax">the original Markdown description</a>). We'll highlight three that are going to be important to us.
-
-<h3>Markdown in HTML blocks</h3>
-
-<p>In GFM and CommonMark, HTML blocks may contain Markdown formatting. So:</p>
-
-<pre>
-&lt;div style="background-color: pink"&gt;
-
-Hello **there**, `Markdown` formatting.
-
-* one
-* two
-* three
-
-&lt;/div&gt;
-</pre>
-
-<p>produces:</p>
-
-<pre>
-&lt;div style="background-color: pink"&gt;
-  &lt;p&gt;Hello &lt;strong&gt;there&lt;/strong&gt;, &lt;code&gt;Markdown&lt;/code&gt; formatting.&lt;/p&gt;
-  &lt;ul&gt;
-    &lt;li&gt;one&lt;/li&gt;
-    &lt;li&gt;two&lt;/li&gt;
-    &lt;li&gt;three&lt;/li&gt;
-  &lt;/ul&gt;
-&lt;/div&gt;
-</pre>
+<p>GFM and CommonMark describe some extensions to <a href="https://daringfireball.net/projects/markdown/syntax">the original Markdown description</a>). We'll highlight two that are going to be important to us.
 
 <h3>Code fences and info strings</h3>
 

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -75,14 +75,18 @@ tags:
 Writers will use code fences for example code blocks. They will be able to specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block. The following words will be supported:
 
 <ul>
-  <li><code>js</code></li>
+  <li><code>bash</code></li>
+  <li><code>cpp</code> (for C/C++)</li>
   <li><code>css</code></li>
   <li><code>html</code></li>
-  <li><code>svg</code></li>
+  <li><code>java</code></li>
+  <li><code>js</code> (for JavaScript)</li>
   <li><code>json</code></li>
-  <li><code>py</code></li>
-  <li><code>bash</code></li>
-  <li>...?</li>
+  <li><code>php</code></li>
+  <li><code>python</code></li>
+  <li><code>sql</code></li>
+  <li><code>xml</code></li>
+  <li><code>wasm</code> (for WebAssembly text format)</li>
 </ul>
 
 For example:

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -8,7 +8,9 @@ tags:
 
 <div class="notecard warning">
 
-<p><strong>This document is a work-in-progress draft at the moment.</strong></p>
+<h4>Warning</h4>
+
+<p>This document is a work-in-progress draft at the moment.</p>
 
 <p>It's not actually possible, yet, to write MDN documentation using Markdown, so at the moment this document is used to record the decisions we've made about how we will expect Markdown to be written, when it is supported.</p>
 
@@ -154,13 +156,10 @@ const greeting = "I'm a good example";
 
 <pre>
 
-The **`margin-right`** [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS)
-property sets the margin area on the right side of an element. A positive value
-places it farther from its neighbors, while a negative value places it closer.
+The **`margin`** [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) property sets the [margin area](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model) on all four sides of an element. It is a shorthand for {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}.
 
-\{{EmbedInteractiveExample("pages/css/margin-right.html")}}
+\{{EmbedInteractiveExample("pages/css/margin.html")}}
 
-The vertical margins of two adjacent boxes may fuse. This is called
-[*margin collapsing*](https://developer.mozilla.org/en-US/docs/CSS/margin_collapsing).
+The top and bottom margins have no effect on replaced inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.
 
 </pre>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -52,7 +52,7 @@ tags:
   <li>GFM won't parse GFM block elements in table cells.</li>
 </ul>
 
-<p>This last means that if you write:</p>
+<p>This last point means that if you write:</p>
 
 <pre>
 --------------------------------------

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -99,7 +99,7 @@ Hello **there**, `Markdown` formatting.
 
 <h3>Example code blocks</h3>
 
-Writers will use code fences for example code blocks. They will be able to specify the language of the code sample using the first word of the info string. The following words will be supported:
+Writers will use code fences for example code blocks. They will be able to specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block. The following words will be supported:
 
 <ul>
   <li><code>js</code></li>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -99,7 +99,7 @@ Hello **there**, `Markdown` formatting.
 
 <h3>Example code blocks</h3>
 
-Writers will use code fences for example code blocks. They will be able to specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block. The following words will be supported:
+Writers will use code fences for example code blocks. They must specify the language of the code sample using the first word of the info string, and this will be used to provide syntax highlighting for the block. The following words will be supported:
 
 <ul>
   <li><code>js</code></li>


### PR DESCRIPTION
Here's a first draft of a spec for writing Markdown in MDN.

The idea is that this specifies a baseline (GFM) and we then add extra bits for anything else we need to support. Adding these extra bits would be separate PRs which would close separate issues, like https://github.com/mdn/content/issues/3483. 

However, I included a resolution for https://github.com/mdn/content/issues/3512 to show what it would look like, and because this seemed like it could be resolved in the way I've written it up here.

So anyway, I'm interested in things like:

* whether we think this is going to be adequate in terms of the guidance it gives to writers and implementors.
* whether this general approach of landing a draft spec full of holes and then filling the holes in subsequent PRs sounds like a good one (I think it is, since it gives us a place to work these things out).
* is the extra stuff highlighting aspects of GFM useful? We could omit it and just ask people to read the spec but it feels like helpful background for some of the later sections.
* anything else?

There is also a need for some other spec about how we manage the conversion - how we get from the HTML we have to this Markdown. But since that's more of a project doc that has a limited shelf-life, it seems better to keep is separate. Then this doc can just talk about how things will be in the end state.
