### PR TITLE
FF88 ReleaseNote - Intl.DisplayNames/Listformat strict option checking

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -43,7 +43,9 @@ tags:
 
 <ul>
   <li>Added support for <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec">RegExp match indices</a> ({{bug(1519483)}}).</li>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames"><code>Intl.DisplayNames()</code></a> and <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat"><code>Intl.ListFormat()</code></a> now have stricter checking that <code>options</code> passed to the constructor are <a href="/en-US/docs/Learn/JavaScript/Objects">objects</a>, and will throw an exception if a string or other primitive is used instead ({{bug(1696881)}}).</li>
 </ul>
+
 
 <h4 id="removals_js">Removals</h4>
 


### PR DESCRIPTION
This is release note for https://bugzilla.mozilla.org/show_bug.cgi?id=1696881 , which adds stricter checking that options passed to the `Intl.DisplayNames` and `Intl.Listformat` constructor are objects (throwing if they are not). 

This is (the main) part of: https://github.com/mdn/content/issues/3459