### PR TITLE
Add deprecation headers to deprecated pages

### DIFF
--- a/files/en-us/web/api/audiolistener/setposition/index.html
+++ b/files/en-us/web/api/audiolistener/setposition/index.html
@@ -10,7 +10,9 @@ tags:
   - Web Audio API
   - setPosition
 ---
-<p>{{ APIRef("Web Audio API") }}</p>
+<p>{{ APIRef("Web Audio API") }} {{deprecated_header}}</p>
+
+
 
 <p>The <code>setPosition()</code> method of the {{ domxref("AudioListener") }} Interface defines the position of the listener.</p>
 

--- a/files/en-us/web/api/blobbuilder/index.html
+++ b/files/en-us/web/api/blobbuilder/index.html
@@ -11,14 +11,18 @@ tags:
 ---
 <p>{{APIRef("File API")}}{{ deprecated_header}}</p>
 
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The <code>BlobBuilder</code> interface has been
+  deprecated in favor of the newly introduced {{domxref('Blob')}} constructor.</p>
+</div>
+
 <p>The <strong><code>BlobBuilder</code></strong> interface provides an easy way to
   construct {{domxref("Blob")}} objects. Just create a <code>BlobBuilder</code> and append
   chunks of data to it by calling the {{manch("append")}} method. When you're done
   building your blob, call {{manch("getBlob")}} to retrieve a {{domxref("Blob")}}
   containing the data you sent into the blob builder.</p>
 
-<div class="note"><strong>Note:</strong> The <code>BlobBuilder</code> interface has been
-  deprecated in favor of the newly introduced {{domxref('Blob')}} constructor.</div>
 
 <h2 id="Method_overview">Method overview</h2>
 

--- a/files/en-us/web/api/bluetoothdevice/addata/index.html
+++ b/files/en-us/web/api/bluetoothdevice/addata/index.html
@@ -1,5 +1,5 @@
 ---
-title: adData
+title: BluetoothDevice.adData
 slug: Web/API/BluetoothDevice/adData
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/connectgatt/index.html
+++ b/files/en-us/web/api/bluetoothdevice/connectgatt/index.html
@@ -1,5 +1,5 @@
 ---
-title: connectGATT()
+title: BluetoothDevice.connectGATT()
 slug: Web/API/BluetoothDevice/connectGATT
 tags:
   - API

--- a/files/en-us/web/api/bluetoothdevice/deviceclass/index.html
+++ b/files/en-us/web/api/bluetoothdevice/deviceclass/index.html
@@ -1,5 +1,5 @@
 ---
-title: deviceClass
+title: BluetoothDevice.deviceClass
 slug: Web/API/BluetoothDevice/deviceClass
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/gattserver/index.html
+++ b/files/en-us/web/api/bluetoothdevice/gattserver/index.html
@@ -1,5 +1,5 @@
 ---
-title: gattServer
+title: BluetoothDevice.gattServer
 slug: Web/API/BluetoothDevice/gattServer
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/id/index.html
+++ b/files/en-us/web/api/bluetoothdevice/id/index.html
@@ -1,5 +1,5 @@
 ---
-title: id
+title: BluetoothDevice.id
 slug: Web/API/BluetoothDevice/id
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/index.html
+++ b/files/en-us/web/api/bluetoothdevice/index.html
@@ -45,7 +45,7 @@ BluetoothDevice implements ServiceEventHandlers;
   <dd>A {{DOMxRef("DOMString")}} that provices a human-readable name for the device.</dd>
   <dt>{{DOMxRef("BluetoothDevice.gatt")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
   <dd>A reference to the device's {{DOMxRef("BluetoothRemoteGATTServer")}}.</dd>
-  <dt>{{DOMxRef("BluetoothDevice.uuids")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
+  <dt>{{DOMxRef("BluetoothDevice.uuids")}} {{Experimental_Inline}}{{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>Lists the UUID's of GATT services provided by the device, that the current origin is
     allowed to access.</dd>
   <dt>
@@ -64,34 +64,34 @@ BluetoothDevice implements ServiceEventHandlers;
 
 <dl>
   <dt>{{DOMxRef("BluetoothDevice.adData")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>An instance of {{DOMxRef("BluetoothAdvertisingData")}} containing the most recent
     advertising data received for the device.</dd>
   <dt>{{DOMxRef("BluetoothDevice.deviceClass")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>A number representing the Bluetooth devices "Class of Device".</dd>
   <dt>{{DOMxRef("BluetoothDevice.vendorIDSource")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>The Vendor ID Source field in the <code>pnp_id</code> characteristic in
     the <code>device_information</code> service.</dd>
   <dt>{{DOMxRef("BluetoothDevice.vendorID")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>The 16-bit Vendor ID field in the <code>pnp_id</code> characteristic in
     the <code>device_information</code> service.</dd>
   <dt>{{DOMxRef("BluetoothDevice.productID")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>The 16-bit Product ID field in the <code>pnp_id</code> characteristic in
     the <code>device_information</code> service.</dd>
   <dt>{{DOMxRef("BluetoothDevice.productVersion")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>The 16-bit Product Version field in the <code>pnp_id</code> characteristic in the
     <code>device_information</code> service.</dd>
   <dt>{{DOMxRef("BluetoothDevice.paired")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>A {{jsxref("Boolean")}} value indicating whether the device is paired with the
     system.</dd>
   <dt>{{DOMxRef("BluetoothDevice.gattServer")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
+    {{deprecated_inline}}{{ReadOnlyInline}}</dt>
   <dd>A reference to the device's GATT server or null if the device is disconnected.</dd>
 </dl>
 
@@ -103,8 +103,7 @@ BluetoothDevice implements ServiceEventHandlers;
     an error if advetisments can’t shown for any reason.</dd>
   <dt>{{DOMxRef("BluetoothDevice.unwatchAdvertisments()")}} {{Experimental_Inline}}</dt>
   <dd>Stops watching for advertisments.</dd>
-  <dt>{{DOMxRef("BluetoothDevice.connectGATT()")}} {{Non-standard_Inline}}
-    {{Obsolete_Inline}}</dt>
+  <dt>{{DOMxRef("BluetoothDevice.connectGATT()")}} {{Non-standard_Inline}} {{deprecated_inline}}</dt>
   <dd>A {{jsxref("Promise")}} that resolves to an instance
     of {{DOMxRef("BluetoothRemoteGATTServer")}}.</dd>
 </dl>

--- a/files/en-us/web/api/bluetoothdevice/paired/index.html
+++ b/files/en-us/web/api/bluetoothdevice/paired/index.html
@@ -16,16 +16,16 @@ tags:
 <p>The <strong><code>BluetoothDevice.paired</code></strong> read-only property returns a
   {{JSxRef("Boolean")}} value indicating whether the device is paired with the system.</p>
 
-<div class="note">
-  <p>This page describes the W3C Community Group BluetoothDevice.paired property. For the
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This page describes the W3C Community Group <code>BluetoothDevice.paired</code> property. For the
     Firefox OS property of the same name, see
     {{DOMxRef("BluetoothDevice_%28Firefox_OS%29/paired", "BluetoothDevice.paired")}}.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">var <em>paired</em> = <em>instanceOfBluetoothDevice</em>.paired</pre>
+<pre class="brush: js">var <em>paired</em> = <em>instanceOfBluetoothDevice</em>.paired</pre>
 
 <h2 id="Returns">Returns</h2>
 

--- a/files/en-us/web/api/bluetoothdevice/productid/index.html
+++ b/files/en-us/web/api/bluetoothdevice/productid/index.html
@@ -1,5 +1,5 @@
 ---
-title: productID
+title: BluetoothDevice.productID
 slug: Web/API/BluetoothDevice/productID
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/productversion/index.html
+++ b/files/en-us/web/api/bluetoothdevice/productversion/index.html
@@ -1,5 +1,5 @@
 ---
-title: productVersion
+title: BluetoothDevice.productVersion
 slug: Web/API/BluetoothDevice/productVersion
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/vendorid/index.html
+++ b/files/en-us/web/api/bluetoothdevice/vendorid/index.html
@@ -1,5 +1,5 @@
 ---
-title: vendorID
+title: BluetoothDevice.vendorID
 slug: Web/API/BluetoothDevice/vendorID
 tags:
 - API

--- a/files/en-us/web/api/bluetoothdevice/vendoridsource/index.html
+++ b/files/en-us/web/api/bluetoothdevice/vendoridsource/index.html
@@ -1,5 +1,5 @@
 ---
-title: vendorIDSource
+title: BluetoothDevice.vendorIDSource
 slug: Web/API/BluetoothDevice/vendorIDSource
 tags:
 - API

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
@@ -8,7 +8,7 @@ tags:
 - NeedsExample
 - getCounterValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getCounterValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get the <a

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -7,7 +7,7 @@ tags:
 - Method
 - getFloatValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getFloatValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get a float value in a specified

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
@@ -7,7 +7,7 @@ tags:
 - Method
 - getRectValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getRectValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get a rect value. If this CSS

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
@@ -7,7 +7,7 @@ tags:
 - Method
 - getRGBColorValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getRGBColorValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get an RGB color value. If this

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
@@ -7,7 +7,7 @@ tags:
 - Method
 - getStringValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>getStringValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to get a string value. If this CSS

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -9,7 +9,7 @@ tags:
   - Obsolete
   - Reference
 ---
-<div>{{APIRef("CSSOM")}}</div>
+<div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>CSSPrimitiveValue</strong></code> interface derives from the {{DOMxRef("CSSValue")}} interface and represents the current computed value of a CSS property.</p>
 

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -8,7 +8,7 @@ tags:
 - NeedsExample
 - setFloatValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>setFloatValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to set a float value. If the property

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -8,7 +8,7 @@ tags:
   - NeedsExample
   - setStringValue
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
 <p>The <code><strong>setStringValue()</strong></code> method of the
   {{domxref("CSSPrimitiveValue")}} interface is used to set a string value. If the

--- a/files/en-us/web/api/cssrule/type/index.html
+++ b/files/en-us/web/api/cssrule/type/index.html
@@ -9,7 +9,7 @@ tags:
 - Read-only
 - Deprecated
 ---
-<div>{{APIRef("CSSOM")}}{{Deprecated_header}} </div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p class="summary">The read-only <strong><code>type</code></strong> property of the
   {{domxref("CSSRule")}} interface is a deprecated property that returns an integer

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -8,7 +8,7 @@ tags:
 - Reference
 - cssText
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>cssText</strong></code> property of the {{domxref("CSSValue")}}
   interface represents the current computed CSS property value.</p>

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -9,7 +9,7 @@ tags:
 - Reference
 - cssValueType
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>cssValueType</strong></code> read-only property of the
   {{domxref("CSSValue")}} interface represents the type of the current computed CSS

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -10,7 +10,7 @@ tags:
   - Obsolete
   - Reference
 ---
-<div>{{APIRef("CSSOM")}}</div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>CSSValue</strong></code> interface represents the current computed value of a CSS property.</p>
 

--- a/files/en-us/web/api/cssvaluelist/index.html
+++ b/files/en-us/web/api/cssvaluelist/index.html
@@ -9,7 +9,7 @@ tags:
   - Obsolete
   - Reference
 ---
-<div>{{APIRef("CSSOM")}}</div>
+<div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>CSSValueList</strong></code> interface derives from the {{DOMxRef("CSSValue")}} interface and provides the abstraction of an ordered collection of CSS values.</p>
 

--- a/files/en-us/web/api/cssvaluelist/item/index.html
+++ b/files/en-us/web/api/cssvaluelist/item/index.html
@@ -8,7 +8,7 @@ tags:
 - Reference
 - item
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>item()</strong></code> method of the {{domxref("CSSValueList")}}
   interface is used to retrieve a {{domxref("CSSValue")}} by ordinal index.</p>

--- a/files/en-us/web/api/cssvaluelist/length/index.html
+++ b/files/en-us/web/api/cssvaluelist/length/index.html
@@ -10,7 +10,7 @@ tags:
 - Reference
 - length
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>length</strong></code> read-only property of the
   {{domxref("CSSValueList")}} interface represents the number of {{domxref("CSSValue")}}s

--- a/files/en-us/web/api/customevent/initcustomevent/index.html
+++ b/files/en-us/web/api/customevent/initcustomevent/index.html
@@ -9,7 +9,7 @@ tags:
 - Method
 - Reference
 ---
-<p>{{APIRef("DOM")}}</p>
+<p>{{APIRef("DOM")}}{{Deprecated_header}}</p>
 
 <p>The <code><strong>CustomEvent.initCustomEvent()</strong></code> method initializes a
   <code>CustomEvent</code> object. If the event has already been dispatched, this method


### PR DESCRIPTION
As per https://github.com/mdn/content/issues/2086#issuecomment-813850288 I did a check of which topics BCD mark as deprecated vs what MDN topics have the deprecated_inline header. This fixes a small bunch of MDN side docs to have the header to match BCD. It also fixes a few cases where my scripts didn't find the match because the titles of attributes were missing their parent (e.g. BluetoothDevice).

I am aware that BCD is the "reference" and more important. But I still this this is useful, because this header is what you see when you first get to the page.