### PR TITLE
small fix to text-align

### DIFF
--- a/files/en-us/web/css/text-align/index.html
+++ b/files/en-us/web/css/text-align/index.html
@@ -6,11 +6,11 @@ tags:
   - CSS Property
   - CSS Text
   - Reference
-  - 'recipe:css-property'
+  - recipe:css-property
 ---
 <div>{{CSSRef}}</div>
 
-<p>The <strong><code>text-align</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the horizontal alignment of a block element or table-cell box. This means it works like {{cssxref("vertical-align")}} but in the horizontal direction.</p>
+<p>The <strong><code>text-align</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property sets the horizontal alignment of the content inside a block element or table-cell box. This means it works like {{cssxref("vertical-align")}} but in the horizontal direction.</p>
 
 <div>{{EmbedInteractiveExample("pages/css/text-align.html")}}</div>
 
@@ -76,7 +76,7 @@ text-align: unset;
 <p>The inconsistent spacing between words created by justified text can be problematic for people with cognitive concerns such as Dyslexia.</p>
 
 <ul>
- <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.4_Make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background">MDN Understanding WCAG, Guideline 1.4 explanations</a></li>
+ <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background">MDN Understanding WCAG, Guideline 1.4 explanations</a></li>
  <li><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-visual-presentation.html">Understanding Success Criterion 1.4.8 | Understanding WCAG 2.0</a></li>
 </ul>
 
@@ -155,26 +155,6 @@ text-align: unset;
 <h4 id="Result_3">Result</h4>
 
 <p>{{EmbedLiveSample("Justify","100%","100%")}}</p>
-
-<h3 id="Notes">Notes</h3>
-
-<p>The standard-compatible way to center a block itself without centering its inline content is setting the left and right {{cssxref("margin")}} to <code>auto</code>, e.g.:</p>
-
-<pre class="brush: css">.something {
-  margin: auto;
-}
-</pre>
-
-<pre class="brush: css">.something {
-  margin: 0 auto;
-}
-</pre>
-
-<pre class="brush: css">.something {
-  margin-left: auto;
-  margin-right: auto;
-}
-</pre>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes #3839 

Small text change, also fixed flaws and removed a weird section at the end which was described alignment with auto margins. I think this may be a throwback (in some version of IE you had to specify text-align to do the centering with margins trick, but this was long long ago).