### PR TITLE
[Django/Forms] nit: missing '>' in '<p>'

### DIFF
--- a/files/en-us/learn/server-side/django/forms/index.html
+++ b/files/en-us/learn/server-side/django/forms/index.html
@@ -379,7 +379,7 @@ def renew_book_librarian(request, pk):
 {% block content %}
   &lt;h1&gt;Renew: \{{ book_instance.book.title }}&lt;/h1&gt;
   &lt;p&gt;Borrower: \{{ book_instance.borrower }}&lt;/p&gt;
-  &lt;p{% if book_instance.is_overdue %} class="text-danger"{% endif %}&gt;Due date: \{{ book_instance.due_back }}&lt;/p&gt;
+  &lt;p&gt;{% if book_instance.is_overdue %} class="text-danger"{% endif %}&gt;Due date: \{{ book_instance.due_back }}&lt;/p&gt;
 
 <strong>  &lt;form action="" method="post"&gt;
     {% csrf_token %}


### PR DESCRIPTION
- What was wrong/why is this fix needed? (quick summary only)

In Django Tutorial Part 9 'Working with Forms' in section 'Renew-book form using a Form and function view'/'The template' there is:
`<p{% if book_instance.is_overdue %} class="text-danger"{% endif %}>Due date: {{ book_instance.due_back }}</p>`
While I believe it should be:
`<p>{% if book_instance.is_overdue %} class="text-danger"{% endif %}>Due date: {{ book_instance.due_back }}</p>`

- MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Forms

- Issue number (if there is an associated issue)

- Anything else that could help us review it
