### PR TITLE
[django/testing] nit: PEP 8

### DIFF
--- a/files/en-us/learn/server-side/django/testing/index.html
+++ b/files/en-us/learn/server-side/django/testing/index.html
@@ -321,7 +321,7 @@ class AuthorModelTest(TestCase):
         self.assertEqual(field_label, 'first name')
 
     def test_date_of_death_label(self):
-        author=Author.objects.get(id=1)
+        author = Author.objects.get(id=1)
         field_label = author._meta.get_field('date_of_death').verbose_name
         self.assertEqual(field_label, 'died')
 
@@ -436,7 +436,7 @@ from catalog.forms import RenewBookForm
 class RenewBookFormTest(TestCase):
     def test_renew_form_date_field_label(self):
         form = RenewBookForm()
-        self.assertTrue(form.fields['renewal_date'].label == None or form.fields['renewal_date'].label == 'renewal date')
+        self.assertTrue(form.fields['renewal_date'].label is None or form.fields['renewal_date'].label == 'renewal date')
 
     def test_renew_form_date_field_help_text(self):
         form = RenewBookForm()


### PR DESCRIPTION
Hi,

Below a couple of NIT ideas for small improvements in Django Tutorial Part 10 'Testing a Django web application' considering PEP 8 guidelines.

- What was wrong/why is this fix needed? (quick summary only)

1. In section 'LocalLibrary tests'/'Forms' there is:
`self.assertTrue(form.fields['renewal_date'].label == None or form.fields['renewal_date'].label == 'renewal date')`
While I believe there should be:
`self.assertTrue(form.fields['renewal_date'].label is None or form.fields['renewal_date'].label == 'renewal date')`
Comparison with None performed with equality operator. That type of compression should be done with 'is'. PEP 8: comparison to None should be 'if cond is None'.

2. In section 'LocalLibrary tests'/'Models' there is:
```
   def test_date_of_death_label(self):
        author=Author.objects.get(id=1)
```
While I believe there should be:
```
   def test_date_of_death_label(self):
        author = Author.objects.get(id=1)
```
PEP 8: Missing whitespace around an operator (=)


- MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Testing

- Issue number (if there is an associated issue)

- Anything else that could help us review it
