### PR TITLE
[django/deployment] nit: doubled line

### DIFF
--- a/files/en-us/learn/server-side/django/deployment/index.html
+++ b/files/en-us/learn/server-side/django/deployment/index.html
@@ -296,8 +296,6 @@ Changes to be committed:
   <p>In 2020 Github change the default repo branch name to "main" (from "master"). If using an older/existing repository you might call <code>git push origin master</code> instead.</p>
 </div>
 
-<p>When this operation completes, you should be able to go back to the page on Github where</p>
-
 <p>When this operation completes, you should be able to go back to the page on Github where you created your repo, refresh the page, and see that your whole application has now been uploaded. You can continue to update your repository as files change using this add/commit/push cycle.</p>
 
 <div class="notecard note">


### PR DESCRIPTION
- What was wrong/why is this fix needed? (quick summary only)
nit:
> 'When this operation completes, you should be able to go back to the page on Github where' 

is written twice

- MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Deployment

- Issue number (if there is an associated issue)

- Anything else that could help us review it
