### PR TITLE
Fix aria basic button example triggering for all keys

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/button_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.html
@@ -113,7 +113,7 @@ tags:
     &lt;ul id="nameList"&gt;&lt;/ul&gt;
     &lt;label for="newName"&gt;Enter your Name: &lt;/label&gt;
     &lt;input type="text" id="newName"&gt;
-    &lt;span role="button" tabindex="0" onclick="handleCommand()" onKeyDown="handleCommand()"&gt;Add Name&lt;/span&gt;</pre>
+    &lt;span role="button" tabindex="0" onclick="handleCommand(event)" onKeyDown="handleCommand(event)"&gt;Add Name&lt;/span&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
 
@@ -138,6 +138,11 @@ ul {
 <pre class="brush: js">function handleCommand(event) {
     // Handles both mouse clicks and keyboard
     // activate with Enter or Space
+    
+    // Keypresses other then Enter and Space should not trigger a command
+    if (event instanceof KeyboardEvent &amp;&amp; event.key !== 'Enter' &amp;&amp; event.key !== ' ') {
+        return;
+    }
 
     // Get the new name value from the input element
     let newNameInput = document.getElementById('newName');


### PR DESCRIPTION
The Basic button example triggers the command on every keypress, not just Space and Enter as the guideline suggests.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

In the example for basic buttons with the Aria role of `button` pressing any key (e.g. <kbd>F</kbd>, <kbd>Shift</kbd>, or <kbd>Tab</kbd>) would trigger the action. This is incorrect. Only <kbd>Space</kbd> or <kbd>Enter</kbd> should trigger the action.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role

> Issue number (if there is an associated issue)

> Anything else that could help us review it
