### PR TITLE
Note String.p.trim* methods don’t throw if no whitespace trimmed

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/trim/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/trim/index.html
@@ -23,14 +23,9 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A new string representing the <code><var>str</var></code> stripped of whitespace from
-  both ends.</p>
+<p>A new string representing <code><var>str</var></code> stripped of whitespace from both its beginning and end.</p>
 
-<h2 id="Description">Description</h2>
-
-<p>The <code>trim()</code> method returns the string stripped of whitespace from both
-  ends. <code>trim()</code> does not affect the value of the <code><var>str</var></code>
-  itself.</p>
+<p>If neither the beginning or end of <code><var>str</var></code> has any whitespace, a new string is still returned (essentially a copy of <code><var>str</var></code>), with no exception being thrown.</p>
 
 <p>To return a new string with whitespace trimmed from just one end, use {{jsxref("String.prototype.trimStart()", "trimStart()")}} or {{jsxref("String.prototype.trimEnd()", "trimEnd()")}}.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/trimend/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimend/index.html
@@ -23,14 +23,9 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A new string representing the calling string stripped of whitespace from its (right)
-  end.</p>
+<p>A new string representing <code><var>str</var></code> stripped of whitespace from its end (right side).</p>
 
-<h2 id="Description">Description</h2>
-
-<p>The <code>trimEnd()</code> / <code>trimRight()</code> methods return the string
-  stripped of whitespace from its right end. <code>trimEnd()</code> or
-  <code>trimRight()</code> do not affect the value of the string itself.</p>
+<p>If the end of <code><var>str</var></code> has no whitespace, a new string is still returned (essentially a copy of <code><var>str</var></code>), with no exception being thrown.</p>
 
 <h3 id="Aliasing">Aliasing</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.html
@@ -23,14 +23,9 @@ tags:
 
 <h3 id="Return_value">Return value</h3>
 
-<p>A new string representing the calling string stripped of whitespace from its beginning
-  (left end).</p>
+<p>A new string representing <code><var>str</var></code> stripped of whitespace from its beginning (left side).</p>
 
-<h2 id="Description">Description</h2>
-
-<p>The <code>trimStart()</code> / <code>trimLeft()</code> methods return the string
-  stripped of whitespace from its left end. <code>trimLeft()</code> or
-  <code>trimStart()</code> do not affect the value of the string itself.</p>
+<p>If the beginning of <code><var>str</var></code> has no whitespace, a new string is still returned (essentially a copy of <code><var>str</var></code>), with no exception being thrown.</p>
 
 <h3 id="Aliasing">Aliasing</h3>
 


### PR DESCRIPTION
To the Return Values section of each of the articles for the `String.p.trim*` methods, this change adds a statement explaining that if the string contains no whitespace to trim, no exception is thrown (instead the methods essentially just return a copy of the string). Fixes https://github.com/mdn/content/issues/3961#issuecomment-816664813

This change also drops the Description sections from each article — because the contents of those sections just repeats what’s already stated in the Return Values section.