### PR TITLE
Correct grid track definition

### DIFF
--- a/files/en-us/glossary/grid_tracks/index.html
+++ b/files/en-us/glossary/grid_tracks/index.html
@@ -4,7 +4,7 @@ slug: Glossary/Grid_Tracks
 tags:
   - CSS Grids
 ---
-<p>A <strong>grid track</strong> is the space between two {{glossary("grid lines")}}. They are defined in the <em>explicit grid</em> by using the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} properties or the shorthand {{cssxref("grid")}} or {{cssxref("grid-template")}} properties. Tracks are also created in the <em>implicit grid</em> by positioning a grid item outside of the tracks created in the explicit grid.</p>
+<p>A <strong>grid track</strong> is the space between two adjacent {{glossary("grid lines")}}. They are defined in the <em>explicit grid</em> by using the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} properties or the shorthand {{cssxref("grid")}} or {{cssxref("grid-template")}} properties. Tracks are also created in the <em>implicit grid</em> by positioning a grid item outside of the tracks created in the explicit grid.</p>
 
 <p>The image below shows the first row track on a grid.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Grid tracks are the space between two adjacent lines, not just any lines in grid layout!

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Glossary/Grid_Tracks