### PR TITLE
Update HTMLSelectElement

### DIFF
--- a/files/en-us/web/api/htmlselectelement/index.html
+++ b/files/en-us/web/api/htmlselectelement/index.html
@@ -20,7 +20,7 @@ tags:
 
 <dl>
  <dt>{{domxref("HTMLSelectElement.autofocus")}}</dt>
- <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("autofocus", "select")}} HTML attribute, which indicates whether the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified. {{gecko_minversion_inline("2.0")}}</dd>
+ <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("autofocus", "select")}} HTML attribute, which indicates whether the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified. </dd>
  <dt>{{domxref("HTMLSelectElement.disabled")}}</dt>
  <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("disabled", "select")}} HTML attribute, which indicates whether the control is disabled. If it is disabled, it does not accept clicks.</dd>
  <dt>{{domxref("HTMLSelectElement.form")}}{{ReadOnlyInline}}</dt>
@@ -36,7 +36,7 @@ tags:
  <dt>{{domxref("HTMLSelectElement.options")}}{{ReadOnlyInline}}</dt>
  <dd>An {{domxref("HTMLOptionsCollection")}} representing the set of {{HTMLElement("option")}} ({{domxref("HTMLOptionElement")}}) elements contained by this element.</dd>
  <dt>{{domxref("HTMLSelectElement.required")}}</dt>
- <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("required", "select")}} HTML attribute, which indicates whether the user is required to select a value before submitting the form. {{gecko_minversion_inline("2.0")}}</dd>
+ <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("required", "select")}} HTML attribute, which indicates whether the user is required to select a value before submitting the form. </dd>
  <dt>{{domxref("HTMLSelectElement.selectedIndex")}}</dt>
  <dd>A <code>long</code> reflecting the index of the first selected {{HTMLElement("option")}} element. The value <code>-1</code> indicates no element is selected.</dd>
  <dt>{{domxref("HTMLSelectElement.selectedOptions")}}{{ReadOnlyInline}}</dt>
@@ -151,8 +151,6 @@ console.log(select.options[select.selectedIndex].value) // Second
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("api.HTMLSelectElement")}}</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

- There are flaws, removing {{gecko_minversion_inline}} macros
- There is an instruction for BCD

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
