### PR TITLE
Update HTMLSelectElement.autofocus

### DIFF
--- a/files/en-us/web/api/htmlselectelement/autofocus/index.html
+++ b/files/en-us/web/api/htmlselectelement/autofocus/index.html
@@ -10,8 +10,7 @@ tags:
 ---
 <p>{{ APIRef("HTML DOM") }}</p>
 
-<p>The <code><strong>HTMLSelectElement.autofocus</strong></code> property is
-  a {{jsxref("Boolean")}} that reflects the {{htmlattrxref("autofocus", "select")}} HTML
+<p>The <code><strong>HTMLSelectElement.autofocus</strong></code> property has a value of either <code>true</code> or <code>false</code> that reflects the {{htmlattrxref("autofocus", "select")}} HTML
   attribute, which indicates whether the associated {{HTMLElement("select")}} element 
   will get input focus when the page loads, unless the user overrides it.</p>
 
@@ -73,10 +72,5 @@ var hasAutofocus = document.getElementById('mySelect').autofocus;
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("api.HTMLSelectElement.autofocus")}}</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

{{jsxref("Boolean")}} is incorrect because it doesn't have Boolean JavaScript object.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/autofocus

> Issue number (if there is an associated issue)

related to https://github.com/mdn/content/issues/3898

> Anything else that could help us review it
