### PR TITLE
Remove duplicated gap properties

### DIFF
--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.html
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.html
@@ -66,9 +66,6 @@ tags:
  <li>{{cssxref("row-gap")}}</li>
  <li>{{cssxref("column-gap")}}</li>
  <li>{{cssxref("gap")}}</li>
- <li>{{cssxref("row-gap")}}</li>
- <li>{{cssxref("column-gap")}}</li>
- <li>{{cssxref("gap")}}</li>
 </ul>
 
 <p>The Grid specification originally contained the definition for the properties {{cssxref("row-gap")}}, {{cssxref("column-gap")}} and {{cssxref("gap")}}. These have since been moved into the Box Alignment specification and renamed to {{cssxref("row-gap")}}, {{cssxref("column-gap")}}, and {{cssxref("gap")}}. This allows them to be used for other layout methods where a gap between items makes sense.</p>


### PR DESCRIPTION
> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Grid_Layout#gap_and_legacy_grid-gap_properties