### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.html
@@ -647,8 +647,8 @@ var Schema = mongoose.Schema;
 
 var AuthorSchema = new Schema(
   {
-    first_name: {type: String, required: true, maxlength: 100},
-    family_name: {type: String, required: true, maxlength: 100},
+    first_name: {type: String, required: true, maxLength: 100},
+    family_name: {type: String, required: true, maxLength: 100},
     date_of_birth: {type: Date},
     date_of_death: {type: Date},
   }


### PR DESCRIPTION
Simple typo here
maxlength -> maxLength

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Mongoose schema type validator for String length must be maxLength or minLength 

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
