### PR TITLE
fix typo "memozied"

### DIFF
--- a/files/en-us/web/javascript/reference/functions/get/index.html
+++ b/files/en-us/web/javascript/reference/functions/get/index.html
@@ -133,7 +133,7 @@ console.log(obj.foo); // "bar"</pre>
     expect to change, because if the getter is lazy then it will not recalculate the
     value.</p>
 
-  <p>Note that getters are not “lazy” or “memozied” by nature; you must implement this
+  <p>Note that getters are not “lazy” or “memoized” by nature; you must implement this
     technique if you desire this behavior.</p>
 </div>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The getter page has a typo ("memozied" where "memoized" is expected).

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get
