### PR TITLE
Fix the datatype info in HTMLOptionElement doc

### DIFF
--- a/files/en-us/web/api/htmloptionelement/index.html
+++ b/files/en-us/web/api/htmloptionelement/index.html
@@ -20,10 +20,10 @@ tags:
 
 <dl>
  <dt>{{domxref("HTMLOptionElement.defaultSelected")}}</dt>
- <dd>Is a {{domxref("Boolean")}} that contains the initial value of the {{htmlattrxref("selected", "option")}} HTML attribute, indicating whether the option is selected by default or not.</dd>
+ <dd>Has a value of either <code>true</code> or <code>false</code> that shows the initial value of the {{htmlattrxref("selected", "option")}} HTML attribute, indicating whether the option is selected by default or not.</dd>
 
  <dt>{{domxref("HTMLOptionElement.disabled")}}</dt>
- <dd>Is a {{domxref("Boolean")}} representing the value of the {{htmlattrxref("disabled", "option")}} HTML attribute, which indicates that the option is unavailable to be selected. An option can also be disabled if it is a child of an {{HTMLElement("optgroup")}} element that is disabled.</dd>
+ <dd>Has a value of either <code>true</code> or <code>false</code> representing the value of the {{htmlattrxref("disabled", "option")}} HTML attribute, which indicates that the option is unavailable to be selected. An option can also be disabled if it is a child of an {{HTMLElement("optgroup")}} element that is disabled.</dd>
 
  <dt>{{domxref("HTMLOptionElement.form")}} {{readonlyInline}}</dt>
  <dd>Is a {{domxref("HTMLFormElement")}} representing the same value as the <code>form</code> of the corresponding {{HTMLElement("select")}} element, if the option is a descendant of a {{HTMLElement("select")}} element, or null if none is found. </dd>
@@ -35,7 +35,7 @@ tags:
  <dd>Is a {{domxref("DOMString")}} that reflects the value of the {{htmlattrxref("label", "option")}} HTML attribute, which provides a label for the option. If this attribute isn't specifically set, reading it returns the element's text content.</dd>
 
  <dt>{{domxref("HTMLOptionElement.selected")}}</dt>
- <dd>Is a {{domxref("Boolean")}} that indicates whether the option is currently selected.</dd>
+ <dd>Has a value of either <code>true</code> or <code>false</code> that indicates whether the option is currently selected.</dd>
  <dt>{{domxref("HTMLOptionElement.text")}}</dt>
  <dd>Is a {{domxref("DOMString")}} that contains the text content of the element.</dd>
  <dt>{{domxref("HTMLOptionElement.value")}}</dt>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The properties don't have a Boolean (wrapper) object.
So it should avoid to use {{domxref("Boolean")}}.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement

> Issue number (if there is an associated issue)

related to https://github.com/mdn/content/issues/3898

> Anything else that could help us review it
