### PR TITLE
Fix the Option() parameter info

### DIFF
--- a/files/en-us/web/api/htmloptionelement/option/index.html
+++ b/files/en-us/web/api/htmloptionelement/option/index.html
@@ -35,13 +35,13 @@ tags:
     value, e.g. for the associated {{htmlelement("select")}} element's value when the form
     is submitted to the server.</dd>
   <dt><code>defaultSelected</code> {{optional_inline}}</dt>
-  <dd>A {{domxref("Boolean")}} that sets the {{htmlattrxref("selected", "option")}}
+  <dd>A value of either <code>true</code> or <code>false</code> that sets the {{htmlattrxref("selected", "option")}}
     attribute value, i.e. so that this {{htmlelement("option")}} will be the default value
     selected in the {{htmlelement("select")}} element when the page is first loaded. If
     this is not specified, a default value of false is used. Note that a value of true
     does not set the option to selected if it is not already selected.</dd>
   <dt><code>selected</code> {{optional_inline}}</dt>
-  <dd>A {{domxref("Boolean")}} that sets the option's selected state; the default is false
+  <dd>A value of either <code>true</code> or <code>false</code> that sets the option's selected state; the default is false
     (not selected). If omitted, even if the defaultSelected argument is true, the option
     is not selected.</dd>
 </dl>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This constructor doesn't take {{domxref("Boolean")}} objects as parameters.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement/Option

> Issue number (if there is an associated issue)

related to https://github.com/mdn/content/issues/3898

> Anything else that could help us review it
