### PR TITLE
Added `const` declaration to JS example

### DIFF
--- a/files/en-us/web/api/element/contextmenu_event/index.html
+++ b/files/en-us/web/api/element/contextmenu_event/index.html
@@ -55,7 +55,7 @@ tags:
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js">noContext = document.getElementById('noContextMenu');
+<pre class="brush: js">const noContext = document.getElementById('noContextMenu');
 
 noContext.addEventListener('contextmenu', e =&gt; {
   e.preventDefault();


### PR DESCRIPTION
I've added a `const` declaration to the example showing the usage of the `contextmenu` event on the [page about the `contextmenu` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event).

Although the example would work without that change too (at least in sloppy mode), it used an implicit global, which is a commonly agreed bad practice.

Any kind of declaration would work here (either `var`, `let` or `const`), but I chose `const`, because the cariable isn't supposed to change in the example.