### PR TITLE
Drop <code> from non-code terms in "Arrow function expressions"

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.html
@@ -34,9 +34,9 @@ tags:
     and <a
       href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind"><code>bind</code></a>
     methods, which generally rely on establishing a <a
-      href="/en-US/docs/Glossary/Scope"><code>scope</code>.</a></li>
+      href="/en-US/docs/Glossary/Scope">scope</a>.</li>
   <li>Can not be used as
-    <code><a href="/en-US/docs/Glossary/constructor">constructors</a></code>.</li>
+    <a href="/en-US/docs/Glossary/constructor">constructors</a>.</li>
   <li>Can not use
     <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/yield">yield</a></code>,
     within its body.</li>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

"scope" and "constructors" are not keywords in a code.
So they shouldn't be marked as <code>.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

> Issue number (if there is an associated issue)

none
