### PR TITLE
Fix placement of compat table in “Debugging CSS” doc

### DIFF
--- a/files/en-us/learn/css/building_blocks/debugging_css/index.html
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.html
@@ -153,6 +153,7 @@ tags:
 
 <p>You can also take a look at the Browser compatibility tables at the bottom of each property page on MDN. These show you browser support for that property, often broken down if there is support for some usage of the property and not others. The below table shows the compat data for the {{cssxref("shape-outside")}} property.</p>
 
+<h3><!-- intentionally blank; hack to force placement of table --></h3>
 <p>{{Compat("css.properties.shape-outside")}}</p>
 
 <h3 id="Is_something_else_overriding_your_CSS">Is something else overriding your CSS?</h3>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/4000

---

@mdn/core-dev

The problem here is that when a Compat macro is used within a document, Yari seems to move it to being the first following sibling of the nearest previous h3 in the document — even if there’s other content which follows that same h3 before the point in the source where the Compat macro is placed.

So the initial commit in this PR branch attempts to work around that by adding an empty `<h3></h3>` element just before the Compat macro — like this:

```diff
 <p> … The below table shows the compat data for the {{cssxref("shape-outside")}} property.</p>
+ <h3><!-- intentionally blank; hack to force placement of table --></h3>
 <p>{{Compat("css.properties.shape-outside")}}</p>
```
Otherwise, without that  `<h3></h3>` heading added, Yari takes the `<p>{{Compat("css.properties.shape-outside")}}</p>` output and moves it so it renders above that *`<p> … The below table shows the compat data`* paragraph rather than below it.

But if adding an empty heading like that is too ugly of a hack, then an alternative would be to replace this:

> The below table shows the compat data for the {{cssxref("shape-outside")}} property.

…with:

> For an example, see `<a href="/en-US/docs/Web/CSS/shape-outside#browser_compatibility">the compat data table for the shape-outside property</a>`.

…which seems suboptimal, since it means that users would need to navigate away just to see an example of what a compat table looks like. So I guess another alternative would be to replace it with a screenshot.