### PR TITLE
fix a description of HTMLOptionElement

### DIFF
--- a/files/en-us/web/api/htmloptionelement/index.html
+++ b/files/en-us/web/api/htmloptionelement/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
-<p>The <strong><code>HTMLOptionElement</code></strong> interface represents {{HTMLElement("option")}} elements and inherits all classes and methods of the {{domxref("HTMLElement")}} interface.</p>
+<p>The <strong><code>HTMLOptionElement</code></strong> interface represents {{HTMLElement("option")}} elements and inherits all properties and methods of the {{domxref("HTMLElement")}} interface.</p>
 
 <p>{{InheritanceDiagram(600, 120)}}</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

HTMLOptionElement inherits properties rather than classes.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement

> Issue number (if there is an associated issue)

fix #4017 

> Anything else that could help us review it
