### PR TITLE
Update "Property accessors"

### DIFF
--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.html
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.html
@@ -2,10 +2,10 @@
 title: Property accessors
 slug: Web/JavaScript/Reference/Operators/Property_Accessors
 tags:
-- JavaScript
-- Language feature
-- Operator
-- Reference
+  - JavaScript
+  - Language feature
+  - Operator
+  - Reference
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
@@ -38,7 +38,7 @@ tags:
 <h3 id="Dot_notation">Dot notation</h3>
 
 <p>In the <code><var>object.property</var></code> syntax, the <code>property</code> must
-  be a valid JavaScript <a href="/en-US/docs/Glossary/identifier">identifier</a>. (In the
+  be a valid JavaScript <a href="/en-US/docs/Glossary/Identifier">identifier</a>. (In the
   ECMAScript standard, the names of properties are technically "IdentifierNames", not
   "Identifiers", so reserved words can be used but are not recommended). For example,
   <code><var>object</var>.$1</code> is valid, while <code><var>object</var>.1</code> is
@@ -128,14 +128,14 @@ console.log(object[bar])
   <code>this</code> is not fixed in a method. Put another way, <code>this</code> does not
   necessarily refer to the object containing a method. Instead, <code>this</code> is
   "passed" by the function call. See <a
-    href="/en-US/docs/Web/JavaScript/Reference/Operators/this#Method_binding">method
+    href="/en-US/docs/Web/JavaScript/Reference/Operators/this#method_binding">method
     binding</a>.</p>
 
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Bracket_notation_vs._eval">Bracket notation vs. <code>eval</code></h3>
 
-<p>JavaScript novices often make the mistake of using {{jsxref("eval", "eval()")}} where
+<p>JavaScript novices often make the mistake of using {{jsxref("Global_Objects/eval", "eval()")}} where
   the bracket notation can be used instead.</p>
 
 <p>For example, the following syntax is often seen in many scripts.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are some link flaws.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
