### PR TITLE
Delete FF88 note about Presentation API

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -73,10 +73,6 @@ tags:
 
 <h4 id="removals_media">Removals</h4>
 
-<ul>
-  <li>The <a href="/en-US/docs/Web/API/Presentation">Presentation API</a> is no longer supported. For more information see {{bug(1697680)}}.</li>
-</ul>
-
 <h3 id="WebAssembly">WebAssembly</h3>
 
 <h4 id="removals_wasm">Removals</h4>


### PR DESCRIPTION
Reverts the note added in https://github.com/mdn/content/pull/3865 about about FF88 removal of the presentation API. Done because AnneK just added [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1697680#c18)

> I rather we don't say anything unless we actually had support for it. I would classify this as code cleanup, if anything.

@chrisdavidmills I don't know our "policy" regarding release notes. Personally if I'd been using this in the past (even if behind a preference) I'd want to be notified of the removal, and release notes is where I'd expect to find out. On the other hand, this is/will be in the BCD, so perhaps I'm just being precious. So up to you - if you think it should be kept, just close this PR.

Tracking for whole change in #3461