### PR TITLE
Fix caret*FromPoint examples and explanation

### DIFF
--- a/files/en-us/web/api/document/caretpositionfrompoint/index.html
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.html
@@ -59,9 +59,9 @@ tags:
     textNode = range.offsetNode;
     offset = range.offset;
   } else {
-    document.body.innerHTML = "[This browser supports neither"
-      + " &lt;code&gt;document.caretRangeFromPoint&lt;/code&gt;"
-      + " nor &lt;code&gt;document.caretPositionFromPoint&lt;/code&gt;.]";
+    document.body.textContent = "[This browser supports neither"
+      + " document.caretRangeFromPoint"
+      + " nor document.caretPositionFromPoint.]";
     return;
   }
   // Only split TEXT_NODEs

--- a/files/en-us/web/api/document/caretpositionfrompoint/index.html
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.html
@@ -34,52 +34,56 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>This example inserts line breaks wherever you click. The code for it is below the demo.
-</p>
+<p>Click anywhere in the <strong>Demo</strong> paragraph below to insert a line break at the point where you click. The code for it is below the demo.</p>
+
 
 <h3 id="Demo">Demo</h3>
 
-<p>{{EmbedLiveSample('Example', '100%', '300px')}}</p>
+<p>{{EmbedLiveSample('Example', '100%', '100px')}}</p>
 
-<h3 id="HTML_Content">HTML Content</h3>
+<p>The code below first checks for {{domxref("Document.caretRangeFromPoint", "document.caretRangeFromPoint")}} support, but if the browser doesn’t support that, the code then checks for <code>document.caretPositionFromPoint</code>, and uses that instead.</p>
+
+<h3 id="JavaScript">JavaScript</h3>
+
+<pre class="brush: js">function insertBreakAtPoint(e) {
+  let range;
+  let textNode;
+  let offset;
+
+  if (document.caretRangeFromPoint) {
+    range = document.caretRangeFromPoint(e.clientX, e.clientY);
+    textNode = range.startContainer;
+    offset = range.startOffset;
+  } else if (document.caretPositionFromPoint) {
+    range = document.caretPositionFromPoint(e.clientX, e.clientY);
+    textNode = range.offsetNode;
+    offset = range.offset;
+  } else {
+    document.body.innerHTML = "[This browser supports neither"
+      + " &lt;code&gt;document.caretRangeFromPoint&lt;/code&gt;"
+      + " nor &lt;code&gt;document.caretPositionFromPoint&lt;/code&gt;.]";
+    return;
+  }
+  // Only split TEXT_NODEs
+  if (textNode &amp;&amp; textNode.nodeType == 3) {
+    let replacement = textNode.splitText(offset);
+    let br = document.createElement('br');
+    textNode.parentNode.insertBefore(br, replacement);
+  }
+}
+
+let paragraphs = document.getElementsByTagName("p");
+for (let i = 0; i &lt; paragraphs.length; i++) {
+  paragraphs[i].addEventListener('click', insertBreakAtPoint, false);
+}</pre>
+
+<h3 id="HTML">HTML</h3>
 
 <pre
   class="brush: html">&lt;p&gt;Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
 sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
 sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
 Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.&lt;/p&gt;</pre>
-
-<h3 id="JavaScript_Content">JavaScript Content</h3>
-
-<pre class="brush: js">function insertBreakAtPoint(e) {
-  var range;
-  var textNode;
-  var offset;
-
-  if (document.caretPositionFromPoint) {
-    range = document.caretPositionFromPoint(e.clientX, e.clientY);
-    textNode = range.offsetNode;
-    offset = range.offset;
-  } else if (document.caretRangeFromPoint) {
-    range = document.caretRangeFromPoint(e.clientX, e.clientY);
-    textNode = range.startContainer;
-    offset = range.startOffset;
-  }
-
-  // only split TEXT_NODEs
-  if (textNode.nodeType == 3) {
-    var replacement = textNode.splitText(offset);
-    var br = document.createElement('br');
-    textNode.parentNode.insertBefore(br, replacement);
-  }
-}
-
-window.onload = function (){
-  var paragraphs = document.getElementsByTagName("p");
-  for (i=0 ; i &lt; paragraphs.length; i++) {
-    paragraphs[i].addEventListener("click", insertBreakAtPoint, false);
-  }
-};</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/document/caretrangefrompoint/index.html
+++ b/files/en-us/web/api/document/caretrangefrompoint/index.html
@@ -43,15 +43,13 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>Basic demo: When clicking in a paragraph insert a line break at the caret position:</p>
+<p>Click anywhere in the <strong>Demo</strong> paragraph below to insert a line break at the point where you click. The code for it is below the demo.</p>
 
-<h3 id="HTML">HTML</h3>
+<h3 id="Demo">Demo</h3>
 
-<pre
-  class="brush: html">&lt;p&gt;Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
-sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
-sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
-Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.&lt;/p&gt;</pre>
+<p>{{EmbedLiveSample('Example', '100%', '100px')}}</p>
+
+<p>The code below first checks for <code>document.caretRangeFromPoint</code> support, but if the browser doesn’t support that, the code then checks for {{domxref("Document.caretPositionFromPoint", "document.caretPositionFromPoint")}}, and uses that instead.</p>
 
 <h3 id="JavaScript">JavaScript</h3>
 
@@ -60,21 +58,26 @@ Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit ame
   let textNode;
   let offset;
 
-  if (document.caretPositionFromPoint) {
-    range = document.caretPositionFromPoint(e.clientX, e.clientY);
-    textNode = range.offsetNode;
-    offset = range.offset;
-  } else if (document.caretRangeFromPoint) {
-    range = document.caretRangeFromPoint(e.clientX, e.clientY);
-    textNode = range.startContainer;
-    offset = range.startOffset;
-  }
-  // Only split TEXT_NODEs
-  if (textNode &amp;&amp; textNode.nodeType == 3) {
-    let replacement = textNode.splitText(offset);
-    let br = document.createElement('br');
-    textNode.parentNode.insertBefore(br, replacement);
-  }
+  if (document.caretRangeFromPoint) {
+    range = document.caretRangeFromPoint(e.clientX, e.clientY);
+    textNode = range.startContainer;
+    offset = range.startOffset;
+  } else if (document.caretPositionFromPoint) {
+    range = document.caretPositionFromPoint(e.clientX, e.clientY);
+    textNode = range.offsetNode;
+    offset = range.offset;
+  } else {
+    document.body.innerHTML = "[This browser supports neither"
+      + " &lt;code&gt;document.caretRangeFromPoint&lt;/code&gt;"
+      + " nor &lt;code&gt;document.caretPositionFromPoint&lt;/code&gt;.]";
+    return;
+  }
+  // Only split TEXT_NODEs
+  if (textNode &amp;&amp; textNode.nodeType == 3) {
+    let replacement = textNode.splitText(offset);
+    let br = document.createElement('br');
+    textNode.parentNode.insertBefore(br, replacement);
+  }
 }
 
 let paragraphs = document.getElementsByTagName("p");
@@ -82,10 +85,13 @@ for (let i = 0; i &lt; paragraphs.length; i++) {
   paragraphs[i].addEventListener('click', insertBreakAtPoint, false);
 }</pre>
 
-<h3 id="Result">Result</h3>
+<h3 id="HTML">HTML</h3>
 
-<p>{{ EmbedLiveSample('Example', '', '', '', 'Web/API/Document/caretRangeFromPoint') }}
-</p>
+<pre
+  class="brush: html">&lt;p&gt;Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.&lt;/p&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/caretrangefrompoint/index.html
+++ b/files/en-us/web/api/document/caretrangefrompoint/index.html
@@ -67,9 +67,9 @@ tags:
     textNode = range.offsetNode;
     offset = range.offset;
   } else {
-    document.body.innerHTML = "[This browser supports neither"
-      + " &lt;code&gt;document.caretRangeFromPoint&lt;/code&gt;"
-      + " nor &lt;code&gt;document.caretPositionFromPoint&lt;/code&gt;.]";
+    document.body.textContent = "[This browser supports neither"
+      + " document.caretRangeFromPoint"
+      + " nor document.caretPositionFromPoint.]";
     return;
   }
   // Only split TEXT_NODEs


### PR DESCRIPTION
This change fixes the examples in the document.caretPositionFromPoint() and document.caretRangeFromPoint() articles to first try `caretRangeFromPoint()` (which is non-standard, but more widely supported) but then, if that’s not supported, fall back to `caretPositionFromPoint()`.

The change also adds a prose explanation of what the code is doing, as well we reordering the parts of the example for a better user experience.

Fixes https://github.com/mdn/content/issues/4044