### PR TITLE
Basic fixes for Mouse gesture events for Firefox extensions

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1486,7 +1486,7 @@
 /en-US/docs/DOM/MouseEvent	/en-US/docs/Web/API/MouseEvent
 /en-US/docs/DOM/MouseScrollEvent	/en-US/docs/Web/API/MouseScrollEvent
 /en-US/docs/DOM/MouseWheelEvent	/en-US/docs/Web/API/MouseWheelEvent
-/en-US/docs/DOM/Mouse_gesture_events	/en-US/docs/Web/Guide/Events/Mouse_gesture_events
+/en-US/docs/DOM/Mouse_gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/DOM/Mozilla_event_reference	/en-US/docs/Web/Events
 /en-US/docs/DOM/Mozilla_event_reference/DOMContentLoaded	/en-US/docs/Web/API/Window/DOMContentLoaded_event
 /en-US/docs/DOM/Mozilla_event_reference/DOMContentLoaded_(event)	/en-US/docs/Web/API/Window/DOMContentLoaded_event
@@ -3064,7 +3064,7 @@
 /en-US/docs/Document_Object_Model_(DOM)/Locating_DOM_elements_using_selectors	/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors
 /en-US/docs/Document_Object_Model_(DOM)/MediaQueryList	/en-US/docs/Web/API/MediaQueryList
 /en-US/docs/Document_Object_Model_(DOM)/MediaQueryListListener	/en-US/docs/Web/API/MediaQueryList
-/en-US/docs/Document_Object_Model_(DOM)/Mouse_gesture_events	/en-US/docs/Web/Guide/Events/Mouse_gesture_events
+/en-US/docs/Document_Object_Model_(DOM)/Mouse_gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/Document_Object_Model_(DOM)/NamedNodeMap	/en-US/docs/Web/API/NamedNodeMap
 /en-US/docs/Document_Object_Model_(DOM)/Node.appendChild	/en-US/docs/Web/API/Node/appendChild
 /en-US/docs/Document_Object_Model_(DOM)/Node.attributes	/en-US/docs/Web/API/Element/attributes
@@ -5843,7 +5843,7 @@
 /en-US/docs/Merging_client.mk_changes_from_CVS_to_mozilla-central	/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Updating_NSPR_or_NSS_in_mozilla-central
 /en-US/docs/Mobile/Mobile_Web_Development	/en-US/docs/Web/Guide/Mobile
 /en-US/docs/MouseEvent.initMouseEvent	/en-US/docs/Web/API/MouseEvent/initMouseEvent
-/en-US/docs/Mouse_gesture_events	/en-US/docs/Web/Guide/Events/Mouse_gesture_events
+/en-US/docs/Mouse_gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/Mozilla's_Quirks_Mode	/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll()	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
 /en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/update	/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/update
@@ -10677,7 +10677,7 @@
 /en-US/docs/Web/Guide/API/DOM/Events/Creating_and_triggering_events	/en-US/docs/Web/Events/Creating_and_triggering_events
 /en-US/docs/Web/Guide/API/DOM/Events/Event_dispatching_example	/en-US/docs/Web/Events/Creating_and_triggering_events
 /en-US/docs/Web/Guide/API/DOM/Events/Event_handlers	/en-US/docs/Web/Guide/Events/Event_handlers
-/en-US/docs/Web/Guide/API/DOM/Events/Mouse_gesture_events	/en-US/docs/Web/Guide/Events/Mouse_gesture_events
+/en-US/docs/Web/Guide/API/DOM/Events/Mouse_gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/Web/Guide/API/DOM/Events/Orientation_and_motion_data_explained	/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained
 /en-US/docs/Web/Guide/API/DOM/Events/Overview_of_Events_and_Handlers	/en-US/docs/Web/Guide/Events/Overview_of_Events_and_Handlers
 /en-US/docs/Web/Guide/API/DOM/Events/Touch_events	/en-US/docs/Web/API/Touch_events
@@ -10750,12 +10750,12 @@
 /en-US/docs/Web/Guide/DOM/Events/Creating_and_triggering_events	/en-US/docs/Web/Events/Creating_and_triggering_events
 /en-US/docs/Web/Guide/DOM/Events/Event_dispatching_example	/en-US/docs/Web/Events/Creating_and_triggering_events
 /en-US/docs/Web/Guide/DOM/Events/Event_handlers	/en-US/docs/Web/Guide/Events/Event_handlers
-/en-US/docs/Web/Guide/DOM/Events/Mouse_gesture_events	/en-US/docs/Web/Guide/Events/Mouse_gesture_events
+/en-US/docs/Web/Guide/DOM/Events/Mouse_gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/Web/Guide/DOM/Events/Orientation_and_motion_data_explained	/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained
 /en-US/docs/Web/Guide/DOM/Events/Touch_events	/en-US/docs/Web/API/Touch_events
 /en-US/docs/Web/Guide/DOM/Events/Touch_events_(Mozilla_experimental)	/en-US/docs/Web/API/Touch_events/Mozilla_experimental_events
 /en-US/docs/Web/Guide/DOM/Events/Using_device_orientation_with_3D_transforms	/en-US/docs/Web/Guide/Events/Using_device_orientation_with_3D_transforms
-/en-US/docs/Web/Guide/DOM/Gesture_events	/en-US/docs/Web/Guide/Events/Mouse_gesture_events
+/en-US/docs/Web/Guide/DOM/Gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/Web/Guide/DOM/Locating_DOM_elements_using_selectors	/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors
 /en-US/docs/Web/Guide/DOM/Manipulating_the_browser_history	/en-US/docs/Web/API/History_API
 /en-US/docs/Web/Guide/DOM/Manipulating_the_browser_history/Example	/en-US/docs/Web/API/History_API/Example
@@ -10767,6 +10767,7 @@
 /en-US/docs/Web/Guide/Events/Creating_and_triggering_events	/en-US/docs/Web/Events/Creating_and_triggering_events
 /en-US/docs/Web/Guide/Events/Event_dispatching_example	/en-US/docs/Web/Events/Creating_and_triggering_events
 /en-US/docs/Web/Guide/Events/Media_events	/en-US/docs/Web/Events#media
+/en-US/docs/Web/Guide/Events/Mouse_gesture_events	/en-US/docs/Web/Events/Mouse_gesture_events
 /en-US/docs/Web/Guide/Events/Mutation_events	/en-US/docs/Web/API/MutationEvent
 /en-US/docs/Web/Guide/Events/Touch_events	/en-US/docs/Web/API/Touch_events
 /en-US/docs/Web/Guide/Events/Touch_events_(Mozilla_experimental)	/en-US/docs/Web/API/Touch_events/Mozilla_experimental_events

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -122344,17 +122344,6 @@
       "Bzbarsky"
     ]
   },
-  "Web/Guide/Events/Mouse_gesture_events": {
-    "modified": "2019-03-24T00:16:25.836Z",
-    "contributors": [
-      "Jeremie",
-      "Sheppy",
-      "ethertank",
-      "Nickolay",
-      "dflanagan",
-      "Midnightaz"
-    ]
-  },
   "Web/Guide/Events/Orientation_and_motion_data_explained": {
     "modified": "2020-01-18T20:53:28.435Z",
     "contributors": [
@@ -165619,7 +165608,20 @@
   "Web/API/ServiceWorkerGlobalScope/periodicsync": {
     "modified": "2020-10-15T22:33:55.780Z",
     "contributors": [
-      "Rumyra"
+      "Rumyra",
+      "hamishwillee"
+    ]
+  },
+  "Web/Events/Mouse_gesture_events": {
+    "modified": "2019-03-24T00:16:25.836Z",
+    "contributors": [
+      "Jeremie",
+      "Sheppy",
+      "ethertank",
+      "Nickolay",
+      "dflanagan",
+      "Midnightaz",
+      "hamishwillee"
     ]
   }
 }

--- a/files/en-us/web/events/index.html
+++ b/files/en-us/web/events/index.html
@@ -144,6 +144,24 @@ tags:
 		</td>
 	</tr>
 
+  <tr>
+		<td>Gestures</td>
+		<td>
+      <p><a href="/en-US/docs/Web/API/Touch_events">Touch events</a> are recommended for implementing gestures.</p>
+		</td>
+		<td>
+      <p>Events fired on <a href="/en-US/docs/Web/API/Document#touch_events"><code>Document</code></a>, <a href="/en-US/docs/Web/API/Element#touch_events"><code>Element</code></a>.</p>
+      <p>In addition there are a number of non-standard gesture events:</p>
+      <ul>
+        <li>Non-standard WebKit specific events on <a href="/en-US/docs/Web/API/Element#touch_events"><code>Element</code></a>: <a href="/en-US/docs/Web/API/Element/gesturestart_event"><code>gesturestart</code> event</a>, <a href="/en-US/docs/Web/API/Element/gesturechange_event"><code>gesturechange</code> event</a>, <a href="/en-US/docs/Web/API/Element/gestureend_event"><code>gestureend</code> event</a>.
+        </li>
+        <li>Non-standard IE specific events on <a href="/en-US/docs/Web/API/Element#touch_events"><code>Element</code></a>: <a href="/en-US/docs/Web/API/Element/MSGestureStart_event"><code>MSGestureStart</code></a>, <a href="/en-US/docs/Web/API/Element/MSGestureChange_event"><code>MSGestureChange</code></a>, <a href="/en-US/docs/Web/API/Element/MSGestureEnd_event"><code>MSGestureEnd</code></a>, <a href="/en-US/docs/Web/API/Element/MSGestureHold_event"><code>MSGestureHold</code></a>, <a href="/en-US/docs/Web/API/Element/MSGestureTap_event"><code>MSGestureTap</code></a>.</li>
+        <li>Deprecated/non-standard Mozilla touch events <a href="/en-US/docs/Web/Guide/Events/Touch_events_(Mozilla_experimental)">Touch events (Mozilla experimental)</a></li>
+        <li><a href="/en-US/docs/Web/Events/Mouse_gesture_events">Mouse gesture events for Firefox Addons</a></li>
+      </ul>
+		</td>
+	</tr>
+
 	<tr>
 		<td>History</td>
 		<td>

--- a/files/en-us/web/events/mouse_gesture_events/index.html
+++ b/files/en-us/web/events/mouse_gesture_events/index.html
@@ -1,6 +1,6 @@
 ---
 title: Mouse gesture events for Firefox Addons
-slug: Web/Guide/Events/Mouse_gesture_events
+slug: Web/Events/Mouse_gesture_events
 tags:
   - Advanced
   - DOM

--- a/files/en-us/web/guide/events/mouse_gesture_events/index.html
+++ b/files/en-us/web/guide/events/mouse_gesture_events/index.html
@@ -1,5 +1,5 @@
 ---
-title: Mouse gesture events
+title: Mouse gesture events for Firefox extensions
 slug: Web/Guide/Events/Mouse_gesture_events
 tags:
   - Advanced
@@ -8,10 +8,14 @@ tags:
 ---
 <div>{{non-standard_header}}</div>
 <p>Gecko 1.9.1 added support for several Mozilla-specific DOM events used to handle mouse gestures. These are special movements that can be made with a mouse or trackpad and can be interpreted to perform specific tasks.</p>
-<div class="note">
- <strong>Note:</strong> These gesture events are available to add-ons and other browser chrome code, but are never sent to regular web page content.</div>
-<div class="note">
- <strong>Note:</strong> Some operating systems, including Mac OS X and Windows 7, provide default actions when gesture events occur. If you handle a gesture event and wish to prevent the default action from taking place as well, be sure to call the event's {{domxref("event.preventDefault","preventDefault()")}} method.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>These gesture events are available to add-ons and other browser chrome code, but are never sent to regular web page content.</p>
+</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Some operating systems, including Mac OS X and Windows 7, provide default actions when gesture events occur. If you handle a gesture event and wish to prevent the default action from taking place as well, be sure to call the event's {{domxref("event.preventDefault","preventDefault()")}} method.</p>
+</div>
 <h2 id="Types_of_gesture_events">Types of gesture events</h2>
 <h3 id="MozSwipeGesture">MozSwipeGesture</h3>
 <p>The <code>MozSwipeGesture</code> event is sent when the user uses three fingers to "swipe" the trackpad.</p>
@@ -19,18 +23,26 @@ tags:
 <p>The <code>MozMagnifyGestureStart</code> event is sent when the user begins performing a "pinch" gesture, by using two fingers as the corners of a rectangle and moving them either closer together or farther apart. This is typically used to zoom in and out on content (this is the default behavior in Firefox, for example).</p>
 <h3 id="MozMagnifyGestureUpdate">MozMagnifyGestureUpdate</h3>
 <p>The <code>MozMagnifyGestureUpdate</code> event is sent periodically while processing a magnify gesture, to provide updated status information. The event's <code>delta</code> value represents the amount by which the gesture has moved since the <code>MozMagnifyGestureStart</code> or <code>MozMagnifyGestureUpdate</code> event.</p>
-<div class="note">
- <strong>Note:</strong> This event is sent whenever the movement of the user's fingers exceeds the number of pixels indicated by the <code>browser.gesture.pinch.threshold</code> preference.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This event is sent whenever the movement of the user's fingers exceeds the number of pixels indicated by the <code>browser.gesture.pinch.threshold</code> preference.</p>
+</div>
 <h3 id="MozMagnifyGesture">MozMagnifyGesture</h3>
 <p>The <code>MozMagnifyGesture</code> event is sent when the user completes a "pinch" gesture. If you only care about the end results of the pinch gesture, you can watch for this event; however, if you want to provide feedback during the handling of the gesture, you should also watch the <code>MozMagnifyGestureStart</code> and <code>MozMagnifyGestureUpdate</code> events.</p>
 <p>The <code>delta</code> value is the cumulative change over the course of handling the entire sequence of magnify gesture events.</p>
 <h3 id="MozRotateGestureStart">MozRotateGestureStart</h3>
 <p>The <code>MozRotateGestureStart</code> event is sent when the user begins performing a rotate gesture, by placing two fingers on the trackpad and rotating them around the center of the trackpad. Firefox uses this gesture to move backward and forward through the tabs in the current window.</p>
+
 <h3 id="MozRotateGestureUpdate">MozRotateGestureUpdate</h3>
 <p>The <code>MozRotateGestureUpdate</code> event is sent periodically while processing a rotate gesture, to provide updated status information. The event's <code>delta</code> value represents the amount by which the gesture has moved since the <code>MozRotateGestureStart</code> or <code>MozRotateGestureUpdate</code> event.</p>
-<div class="note">
- <strong>Note:</strong> This event is sent whenever the movement of the user's fingers exceeds the number of pixels indicated by the <code>browser.gesture.pinch.threshold</code> preference.</div>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This event is sent whenever the movement of the user's fingers exceeds the number of pixels indicated by the <code>browser.gesture.pinch.threshold</code> preference.</p>
+</div>
+
 <h3 id="MozRotateGesture">MozRotateGesture</h3>
+
 <p>The <code>MozRotateGesture</code> event is sent when the user completes a rotate gesture. If you only care about the end results of the rotate gesture, you can watch for this event; however, if you want to provide feedback during the handling of the gesture, you should also watch the <code>MozRotateGestureStart</code> and <code>MozRotateGestureUpdate</code> events.</p>
 <p>The <code>delta</code> value is the cumulative change over the course of handling the entire sequence of rotate gesture events.</p>
 <h2 id="Event_fields">Event fields</h2>
@@ -73,7 +85,9 @@ tags:
  <dd>
   Clockwise rotation.</dd>
 </dl>
+
 <h2 id="See_also">See also</h2>
+
 <ul>
  <li>{{domxref("event")}}</li>
  <li>Other <a href="/en-US/docs/Web/Events">DOM Events</a></li>

--- a/files/en-us/web/guide/events/mouse_gesture_events/index.html
+++ b/files/en-us/web/guide/events/mouse_gesture_events/index.html
@@ -1,5 +1,5 @@
 ---
-title: Mouse gesture events for Firefox extensions
+title: Mouse gesture events for Firefox Addons
 slug: Web/Guide/Events/Mouse_gesture_events
 tags:
   - Advanced


### PR DESCRIPTION
Moving https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Mouse_gesture_events out from the "events guide" as part of fixing #2245. 