### PR TITLE
Add Compat table to SVG “transform-origin” doc

### DIFF
--- a/files/en-us/web/svg/attribute/transform-origin/index.html
+++ b/files/en-us/web/svg/attribute/transform-origin/index.html
@@ -83,3 +83,7 @@ tags:
   </tr>
  </tbody>
 </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("svg.attributes.presentation.transform-origin")}}</p>


### PR DESCRIPTION
Related: https://github.com/mdn/browser-compat-data/issues/9834