### PR TITLE
Change double brackets to single brackets

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/strings/index.html
@@ -191,7 +191,7 @@ let output = 'I like the song "' + song + '". I gave it a score of ' + (score/hi
 
 <pre class="brush: js">let examScore = 45;
 let examHighestScore = 70;
-examReport = `You scored ${ examScore }/${ examHighestScore } (${ Math.round((examScore/examHighestScore*100)) }%). ${ examScore &gt;= 49 ? 'Well done, you passed!' : 'Bad luck, you didn\'t pass this time.' }`;</pre>
+examReport = `You scored ${ examScore }/${ examHighestScore } (${ Math.round(examScore/examHighestScore*100) }%). ${ examScore &gt;= 49 ? 'Well done, you passed!' : 'Bad luck, you didn\'t pass this time.' }`;</pre>
 
 <ul>
  <li>The first two placeholders here are pretty simple, only including a simple value in the string.</li>


### PR DESCRIPTION
The expression Math.round((examScore/examHighestScore*100)) had double opening and closing brackets instead of single ones. The additional ones are redundant and could cause confusion. They should be changed to single opening and closing brackets.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The expression Math.round((examScore/examHighestScore*100)) had double opening and closing brackets instead of single ones. The additional ones are redundant and could cause confusion.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings

> Issue number (if there is an associated issue)

> Anything else that could help us review it
