### PR TITLE
Fix content/display bug on videoWidth page

### DIFF
--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.html
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.html
@@ -39,8 +39,6 @@ tags:
 <p>{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "About intrinsic width and
   height", 0, 1)}}</p>
 
-<p>{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "Example", 0, 1)}}</p>
-
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.html
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.html
@@ -21,7 +21,7 @@ tags:
 <p><span class="seoSummary">The {{domxref("HTMLVideoElement")}} interface's read-only
     <code><strong>videoWidth</strong></code> property indicates the <strong>intrinsic
       width</strong> of the video, expressed in CSS pixels. In simple terms, this is the
-    width of the media in its natural size.</span> See {{Glossary("Intrinsic size")}} for more details.</p>
+    width of the media in its natural size.</span> See {{Glossary("Intrinsic Size")}} for more details.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -35,8 +35,7 @@ tags:
   <code>HTMLMediaElement.HAVE_NOTHING</code>, then the value of this property is 0,
   because neither video nor poster frame size information is yet available.</p>
 
-<p>{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "About intrinsic width and
-  height", 0, 1)}}</p>
+<p>{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "Example", 0, 1)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.html
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.html
@@ -35,7 +35,7 @@ tags:
   <code>HTMLMediaElement.HAVE_NOTHING</code>, then the value of this property is 0,
   because neither video nor poster frame size information is yet available.</p>
 
-<p>{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "Example", 0, 1)}}</p>
+<p>{{page("/en-US/docs/Web/API/HTMLVideoElement/videoHeight", "Example")}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.html
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.html
@@ -21,8 +21,7 @@ tags:
 <p><span class="seoSummary">The {{domxref("HTMLVideoElement")}} interface's read-only
     <code><strong>videoWidth</strong></code> property indicates the <strong>intrinsic
       width</strong> of the video, expressed in CSS pixels. In simple terms, this is the
-    width of the media in its natural size.</span> See {{anch("About intrinsic width and
-  height")}} for more details.</p>
+    width of the media in its natural size.</span> See {{Glossary("Intrinsic size")}} for more details.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

- Page had broken anchor tag. 
- Page had duplicate macro that incorrectly showed up as macro text itself

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoWidth

> Issue number (if there is an associated issue)

Resolves: #1657

> Anything else that could help us review it

Have a question: Do you not run the content repo locally? I was wondering how to test what macros look like? For this PR, I grepped the repo for what I think I wanted. 