### PR TITLE
Update Google URL for metadata checks

### DIFF
--- a/files/en-us/web/html/global_attributes/itemscope/index.html
+++ b/files/en-us/web/html/global_attributes/itemscope/index.html
@@ -240,7 +240,7 @@ tags:
 </table>
 
 <div class="note">
-<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://developers.google.com/structured-data/testing-tool/">Structured Data Testing Tool</a>. Try it on the HTML shown above.</p>
+<p><strong>Note</strong>: A handy tool for extracting microdata structures from HTML is Google's <a href="https://search.google.com/test/rich-results">Rich Results Testing Tool</a>. Try it on the HTML shown above.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Replace almost deprecated 'Structured Data Testing Tool' with 'Rich Results Test'.

![image](https://user-images.githubusercontent.com/45216083/114528552-083db080-9c41-11eb-9d6b-7d16b55d37a3.png)
