### PR TITLE
Demix Parentnode.children to Element, Document, DocumentFragment pages 

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1354,7 +1354,7 @@
 /en-US/docs/DOM/DocumentType	/en-US/docs/Web/API/DocumentType
 /en-US/docs/DOM/DynamicsCompressorNode	/en-US/docs/Web/API/DynamicsCompressorNode
 /en-US/docs/DOM/Element.childElementCount	/en-US/docs/Web/API/Element/childElementCount
-/en-US/docs/DOM/Element.children	/en-US/docs/Web/API/ParentNode/children
+/en-US/docs/DOM/Element.children	/en-US/docs/Web/API/Element/children
 /en-US/docs/DOM/Element.contentEditable	/en-US/docs/Web/API/HTMLElement/contentEditable
 /en-US/docs/DOM/Element.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/DOM/Element.getElementsByClassName	/en-US/docs/Web/API/Element/getElementsByClassName
@@ -2970,7 +2970,7 @@
 /en-US/docs/Document_Object_Model_(DOM)/DocumentTouch.createTouchList	/en-US/docs/Web/API/Document/createTouchList
 /en-US/docs/Document_Object_Model_(DOM)/DocumentType	/en-US/docs/Web/API/DocumentType
 /en-US/docs/Document_Object_Model_(DOM)/Element.childElementCount	/en-US/docs/Web/API/Element/childElementCount
-/en-US/docs/Document_Object_Model_(DOM)/Element.children	/en-US/docs/Web/API/ParentNode/children
+/en-US/docs/Document_Object_Model_(DOM)/Element.children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Document_Object_Model_(DOM)/Element.contentEditable	/en-US/docs/Web/API/HTMLElement/contentEditable
 /en-US/docs/Document_Object_Model_(DOM)/Element.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Document_Object_Model_(DOM)/Element.getElementsByClassName	/en-US/docs/Web/API/Element/getElementsByClassName
@@ -7505,7 +7505,7 @@
 /en-US/docs/Web/API/Document/baseURI	/en-US/docs/Web/API/Node/baseURI
 /en-US/docs/Web/API/Document/cancelFullscreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Web/API/Document/charset	/en-US/docs/Web/API/document/characterSet
-/en-US/docs/Web/API/Document/children	/en-US/docs/Web/API/ParentNode/children
+/en-US/docs/Web/API/Document/children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/Document/defaultView/popstate_event	/en-US/docs/Web/API/Window/popstate_event
 /en-US/docs/Web/API/Document/defaultView/resize_event	/en-US/docs/Web/API/Window/resize_event
 /en-US/docs/Web/API/Document/defaultView/storage_event	/en-US/docs/Web/API/Window/storage_event
@@ -7545,7 +7545,7 @@
 /en-US/docs/Web/API/DocumentFragment.DocumentFragment	/en-US/docs/Web/API/DocumentFragment/DocumentFragment
 /en-US/docs/Web/API/DocumentFragment.querySelector	/en-US/docs/Web/API/DocumentFragment/querySelector
 /en-US/docs/Web/API/DocumentFragment.querySelectorAll	/en-US/docs/Web/API/DocumentFragment/querySelectorAll
-/en-US/docs/Web/API/DocumentFragment/children	/en-US/docs/Web/API/ParentNode/children
+/en-US/docs/Web/API/DocumentFragment/children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/DocumentFragment/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/DocumentFragment/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/DocumentOrShadowRoot/activeElement	/en-US/docs/Web/API/Document/activeElement
@@ -7575,7 +7575,7 @@
 /en-US/docs/Web/API/DynamicsCompressorNode.threshold	/en-US/docs/Web/API/DynamicsCompressorNode/threshold
 /en-US/docs/Web/API/Element.attributes	/en-US/docs/Web/API/Element/attributes
 /en-US/docs/Web/API/Element.childElementCount	/en-US/docs/Web/API/Element/childElementCount
-/en-US/docs/Web/API/Element.children	/en-US/docs/Web/API/ParentNode/children
+/en-US/docs/Web/API/Element.children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/Element.clientLeft	/en-US/docs/Web/API/Element/clientLeft
 /en-US/docs/Web/API/Element.clientTop	/en-US/docs/Web/API/Element/clientTop
 /en-US/docs/Web/API/Element.closest	/en-US/docs/Web/API/Element/closest
@@ -7613,7 +7613,6 @@
 /en-US/docs/Web/API/Element/animationiteration_event	/en-US/docs/Web/API/HTMLElement/animationiteration_event
 /en-US/docs/Web/API/Element/animationstart_event	/en-US/docs/Web/API/HTMLElement/animationstart_event
 /en-US/docs/Web/API/Element/cancel_event	/en-US/docs/Web/API/HTMLDialogElement/cancel_event
-/en-US/docs/Web/API/Element/children	/en-US/docs/Web/API/ParentNode/children
 /en-US/docs/Web/API/Element/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/Element/fullscreenchange	/en-US/docs/Web/API/Element/fullscreenchange_event
 /en-US/docs/Web/API/Element/gotpointercapture_event	/en-US/docs/Web/API/HTMLElement/gotpointercapture_event
@@ -8463,10 +8462,11 @@
 /en-US/docs/Web/API/PannerNode.setPosition	/en-US/docs/Web/API/PannerNode/setPosition
 /en-US/docs/Web/API/PannerNode.setVelocity	/en-US/docs/Web/API/PannerNode/setVelocity
 /en-US/docs/Web/API/ParentNode.childElementCount	/en-US/docs/Web/API/Element/childElementCount
-/en-US/docs/Web/API/ParentNode.children	/en-US/docs/Web/API/ParentNode/children
+/en-US/docs/Web/API/ParentNode.children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/ParentNode.firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/ParentNode.lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/ParentNode/childElementCount	/en-US/docs/Web/API/Element/childElementCount
+/en-US/docs/Web/API/ParentNode/children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/PasswordCredential/additionalData	/en-US/docs/Web/API/PasswordCredential
 /en-US/docs/Web/API/PasswordCredential/idName	/en-US/docs/Web/API/PasswordCredential
 /en-US/docs/Web/API/PasswordCredential/passwordName	/en-US/docs/Web/API/PasswordCredential

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7505,7 +7505,6 @@
 /en-US/docs/Web/API/Document/baseURI	/en-US/docs/Web/API/Node/baseURI
 /en-US/docs/Web/API/Document/cancelFullscreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Web/API/Document/charset	/en-US/docs/Web/API/document/characterSet
-/en-US/docs/Web/API/Document/children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/Document/defaultView/popstate_event	/en-US/docs/Web/API/Window/popstate_event
 /en-US/docs/Web/API/Document/defaultView/resize_event	/en-US/docs/Web/API/Window/resize_event
 /en-US/docs/Web/API/Document/defaultView/storage_event	/en-US/docs/Web/API/Window/storage_event
@@ -7545,7 +7544,6 @@
 /en-US/docs/Web/API/DocumentFragment.DocumentFragment	/en-US/docs/Web/API/DocumentFragment/DocumentFragment
 /en-US/docs/Web/API/DocumentFragment.querySelector	/en-US/docs/Web/API/DocumentFragment/querySelector
 /en-US/docs/Web/API/DocumentFragment.querySelectorAll	/en-US/docs/Web/API/DocumentFragment/querySelectorAll
-/en-US/docs/Web/API/DocumentFragment/children	/en-US/docs/Web/API/Element/children
 /en-US/docs/Web/API/DocumentFragment/firstElementChild	/en-US/docs/Web/API/ParentNode/firstElementChild
 /en-US/docs/Web/API/DocumentFragment/lastElementChild	/en-US/docs/Web/API/ParentNode/lastElementChild
 /en-US/docs/Web/API/DocumentOrShadowRoot/activeElement	/en-US/docs/Web/API/Document/activeElement

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -71025,35 +71025,6 @@
       "fscholz"
     ]
   },
-  "Web/API/ParentNode/children": {
-    "modified": "2020-10-15T21:05:52.672Z",
-    "contributors": [
-      "Zearin_Galaurum",
-      "mfluehr",
-      "ExE-Boss",
-      "Sheppy",
-      "Pbb",
-      "jackblackevo",
-      "Delapouite",
-      "idontusenumbers",
-      "K-Gun",
-      "jonkee",
-      "vedmack",
-      "Robg1",
-      "fscholz",
-      "Prome",
-      "ziyunfei",
-      "danburzo",
-      "Kartik_Chadha",
-      "teoli",
-      "Krinkle",
-      "Dan-Dascalescu",
-      "fryn",
-      "Philip Chee",
-      "paul.irish",
-      "janmoesen"
-    ]
-  },
   "Web/API/ParentNode/firstElementChild": {
     "modified": "2020-10-15T21:06:48.193Z",
     "contributors": [
@@ -165632,6 +165603,35 @@
       "trevorh",
       "ziyunfei",
       "Jürgen Jeka"
+    ]
+  },
+  "Web/API/Element/children": {
+    "modified": "2020-10-15T21:05:52.672Z",
+    "contributors": [
+      "Zearin_Galaurum",
+      "mfluehr",
+      "ExE-Boss",
+      "Sheppy",
+      "Pbb",
+      "jackblackevo",
+      "Delapouite",
+      "idontusenumbers",
+      "K-Gun",
+      "jonkee",
+      "vedmack",
+      "Robg1",
+      "fscholz",
+      "Prome",
+      "ziyunfei",
+      "danburzo",
+      "Kartik_Chadha",
+      "teoli",
+      "Krinkle",
+      "Dan-Dascalescu",
+      "fryn",
+      "Philip Chee",
+      "paul.irish",
+      "janmoesen"
     ]
   }
 }

--- a/files/en-us/web/api/document/children/index.html
+++ b/files/en-us/web/api/document/children/index.html
@@ -1,0 +1,76 @@
+---
+title: Document.children
+slug: Web/API/Document/children
+tags:
+  - API
+  - DOM
+  - Element
+  - HTMLCollection
+  - Property
+  - children
+---
+<div>{{ APIRef("DOM") }}</div>
+
+<p>The read-only <code><strong>children</strong></code> property returns a live {{domxref("HTMLCollection")}}
+which contains all of the child {{domxref("Element", "elements")}} of the document upon which it was called.</p>
+
+<p>For HTML documents, this is usually only the root <code>&lt;html&gt;</code> element.</p>
+
+<p>See {{domxref("Element.children")}} for child elements of specific HTML elements within the document.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">
+// Getter
+collection = document.children;
+
+// No setter; read-only property
+</pre>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>An {{ domxref("HTMLCollection") }} which is a live, ordered collection of the DOM
+  elements which are children of the current document. You can access the
+  individual child nodes in the collection by using either the
+  {{domxref("HTMLCollection.item()", "item()")}} method on the collection, or by using
+  JavaScript array-style notation.</p>
+
+<p>If the document has no element children, then <code>children</code> is an empty list with a
+  <code>length</code> of <code>0</code>.</p>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush: js">
+document.children;
+// HTMLCollection [&lt;html&gt;]
+// Usually only contains the root &lt;html&gt; element, the document's only direct child
+</pre>
+
+<p>See {{domxref("Element.children")}} for child elements of specific HTML elements within the document.</p>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-children', 'ParentNode.children')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.Document.children")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>{{domxref("Element.children")}}</li>
+  <li>{{domxref("Node.childNodes")}}</li>
+</ul>

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -36,6 +36,8 @@ tags:
  <dd>Returns the character set being used by the document.</dd>
  <dt>{{domxref("Document.childElementCount")}} {{readonlyInline}}</dt>
  <dd>Returns the number of child elements of the current document.</dd>
+ <dt>{{domxref("Document.children")}} {{readonlyInline}}</dt>
+ <dd>Returns the child elements of the current document.</dd>
  <dt>{{DOMxRef("Document.compatMode")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>
  <dd>Indicates whether the document is rendered in <em>quirks</em> or <em>strict</em> mode.</dd>
  <dt>{{DOMxRef("Document.contentType")}} {{Experimental_Inline}}{{ReadOnlyInline}}</dt>

--- a/files/en-us/web/api/documentfragment/children/index.html
+++ b/files/en-us/web/api/documentfragment/children/index.html
@@ -1,0 +1,74 @@
+---
+title: DocumentFragment.children
+slug: Web/API/DocumentFragment/children
+tags:
+  - API
+  - DOM
+  - Element
+  - HTMLCollection
+  - Property
+  - children
+---
+<div>{{ APIRef("DOM") }}</div>
+
+<p>The read-only <code><strong>children</strong></code> property returns a live {{domxref("HTMLCollection")}}
+which contains all of the child {{domxref("Element", "elements")}} of the document fragment upon which it was called.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">
+// Getter
+collection = myFragment.children;
+
+// No setter; read-only property
+</pre>
+
+<h3 id="Return_value">Return value</h3>
+
+<p>An {{ domxref("HTMLCollection") }} which is a live, ordered collection of the DOM
+  elements which are children of the document fragment. You can access the
+  individual child nodes in the collection by using either the
+  {{domxref("HTMLCollection.item()", "item()")}} method on the collection, or by using
+  JavaScript array-style notation.</p>
+
+<p>If the document fragment has no element children, then <code>children</code> is an empty list with a
+  <code>length</code> of <code>0</code>.</p>
+
+<h2 id="Example">Example</h2>
+
+<pre class="brush: js">
+let fragment = new DocumentFragment()
+fragment.children; // HTMLCollection []
+
+let paragraph = document.createElement('p')
+fragment.appendChild(paragraph)
+
+fragment.children; // HTMLCollection [&lt;p&gt;]
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-children', 'ParentNode.children')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.DocumentFragment.children")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li>
+    {{domxref("Node.childNodes")}}
+  </li>
+</ul>

--- a/files/en-us/web/api/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/index.html
@@ -28,7 +28,7 @@ tags:
 <dl>
  <dt>{{ domxref("DocumentFragment.childElementCount") }} {{readonlyInline}} </dt>
  <dd>Returns the amount of child {{domxref("Element","elements")}} the <code>DocumentFragment</code> has.</dd>
- <dt>{{ domxref("ParentNode.children") }} {{readonlyInline}}{{experimental_inline}}</dt>
+ <dt>{{ domxref("DocumentFragment.children") }} {{readonlyInline}}</dt>
  <dd>Returns a live {{domxref("HTMLCollection")}} containing all objects of type {{domxref("Element")}} that are children of the <code>DocumentFragment</code> object.</dd>
  <dt>{{ domxref("ParentNode.firstElementChild") }} {{readonlyInline}}{{experimental_inline}}</dt>
  <dd>Returns the {{domxref("Element")}} that is the first child of the <code>DocumentFragment</code> object, or <code>null</code> if there is none.</dd>

--- a/files/en-us/web/api/element/children/index.html
+++ b/files/en-us/web/api/element/children/index.html
@@ -1,30 +1,29 @@
 ---
-title: ParentNode.children
+title: Element.children
 slug: Web/API/Element/children
 tags:
   - API
-  - Child
-  - Child Nodes
   - DOM
+  - Element
   - HTMLCollection
-  - Node
-  - ParentNode
   - Property
   - children
 ---
 <div>{{ APIRef("DOM") }}</div>
 
-<p><span class="seoSummary">The {{domxref("ParentNode")}} property
-    <code><strong>children</strong></code> is a read-only property that returns a live
-    {{domxref("HTMLCollection")}} which contains all of the child {{domxref("Element",
-    "elements")}} of the node upon which it was called.</span></p>
+<p>The read-only <code><strong>children</strong></code> property returns a live {{domxref("HTMLCollection")}}
+which contains all of the child {{domxref("Element", "elements")}} of the element upon which it was called.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">let <var>children</var> = <var>node</var>.children;</pre>
+<pre class="brush: js">
+// Getter
+collection = myElement.children;
 
-<h3 id="Value">Value</h3>
+// No setter; read-only property
+</pre>
+
+<h3 id="Return_value">Return value</h3>
 
 <p>An {{ domxref("HTMLCollection") }} which is a live, ordered collection of the DOM
   elements which are children of <code><var>node</var></code>. You can access the
@@ -32,39 +31,15 @@ tags:
   {{domxref("HTMLCollection.item()", "item()")}} method on the collection, or by using
   JavaScript array-style notation.</p>
 
-<p>If the node has no element children, then <code>children</code> is an empty list with a
+<p>If the element has no element children, then <code>children</code> is an empty list with a
   <code>length</code> of <code>0</code>.</p>
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">const foo = document.getElementById('foo');
-for (let i = 0; i &lt; foo.children.length; i++) {
-  console.log(foo.children[i].tagName);
+<pre class="brush: js">const myElement = document.getElementById('foo');
+for (let i = 0; i &lt; myElement.children.length; i++) {
+  console.log(myElement.children[i].tagName);
 }
-</pre>
-
-<h2 id="Polyfill">Polyfill</h2>
-
-<pre class="brush: js">// Overwrites native 'children' prototype.
-// Adds Document &amp; DocumentFragment support for IE9 &amp; Safari.
-// Returns array instead of HTMLCollection.
-;(function(constructor) {
-  if (constructor &amp;&amp;
-    constructor.prototype &amp;&amp;
-    constructor.prototype.children == null) {
-    Object.defineProperty(constructor.prototype, 'children', {
-      get: function() {
-        let i = 0, node, nodes = this.childNodes, children = [];
-        while (node = nodes[i++]) {
-          if (node.nodeType === 1) {
-            children.push(node);
-          }
-        }
-        return children;
-      }
-    });
-  }
-})(window.Node || window.Element);
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
@@ -73,33 +48,22 @@ for (let i = 0; i &lt; foo.children.length; i++) {
   <thead>
     <tr>
       <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-children', 'ParentNode.children')}}
-      </td>
-      <td>{{Spec2('DOM WHATWG')}}</td>
-      <td>Initial definition.</td>
+      <td>{{SpecName('DOM WHATWG', '#dom-parentnode-children', 'ParentNode.children')}}</td>
     </tr>
   </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ParentNode.children")}}</p>
+<p>{{Compat("api.Element.children")}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>The {{domxref("ParentNode")}} and {{domxref("ChildNode")}} interfaces.</li>
-  <li>
-    Object types implementing this interface:
-    {{domxref("Document")}}, {{domxref("Element")}}, and
-    {{domxref("DocumentFragment")}}.
-  </li>
   <li>
     {{domxref("Node.childNodes")}}
   </li>

--- a/files/en-us/web/api/element/children/index.html
+++ b/files/en-us/web/api/element/children/index.html
@@ -14,6 +14,8 @@ tags:
 <p>The read-only <code><strong>children</strong></code> property returns a live {{domxref("HTMLCollection")}}
 which contains all of the child {{domxref("Element", "elements")}} of the element upon which it was called.</p>
 
+<p><code>Element.children</code> includes only element nodes. To get all child nodes, including non-element nodes like text and comment nodes, use {{domxref("Node.childNodes")}}.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">

--- a/files/en-us/web/api/element/children/index.html
+++ b/files/en-us/web/api/element/children/index.html
@@ -1,16 +1,16 @@
 ---
 title: ParentNode.children
-slug: Web/API/ParentNode/children
+slug: Web/API/Element/children
 tags:
-- API
-- Child
-- Child Nodes
-- DOM
-- HTMLCollection
-- Node
-- ParentNode
-- Property
-- children
+  - API
+  - Child
+  - Child Nodes
+  - DOM
+  - HTMLCollection
+  - Node
+  - ParentNode
+  - Property
+  - children
 ---
 <div>{{ APIRef("DOM") }}</div>
 

--- a/files/en-us/web/api/element/index.html
+++ b/files/en-us/web/api/element/index.html
@@ -29,6 +29,8 @@ tags:
  <dd>Returns a {{DOMxRef("NamedNodeMap")}} object containing the assigned attributes of the corresponding HTML element.</dd>
  <dt>{{domxref("Element.childElementCount")}} {{readonlyInline}}</dt>
  <dd>Returns the number of child elements of this element.</dd>
+ <dt>{{domxref("Element.children")}} {{readonlyInline}}</dt>
+ <dd>Returns the child elements of this element.</dd>
  <dt>{{DOMxRef("Element.classList")}} {{readOnlyInline}}</dt>
  <dd>Returns a {{DOMxRef("DOMTokenList")}} containing the list of class attributes.</dd>
  <dt>{{DOMxRef("Element.className")}}</dt>

--- a/files/en-us/web/api/node/childnodes/index.html
+++ b/files/en-us/web/api/node/childnodes/index.html
@@ -60,7 +60,7 @@ while (box.firstChild) {
 
 <p><code>childNodes</code> includes <em>all</em> child nodes—including non-element nodes
   like text and comment nodes. To get a collection of only elements, use
-  {{domxref("ParentNode.children")}} instead.</p>
+  {{domxref("Element.children")}} instead.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -108,5 +108,5 @@ while (box.firstChild) {
   <li>{{domxref("Node.lastChild")}}</li>
   <li>{{domxref("Node.nextSibling")}}</li>
   <li>{{domxref("Node.previousSibling")}}</li>
-  <li>{{domxref("ParentNode.children")}}</li>
+  <li>{{domxref("Element.children")}}</li>
 </ul>


### PR DESCRIPTION
Here we are again, refactoring mixin pages.

Now:
https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/children

After:
https://developer.mozilla.org/en-US/docs/Web/API/Element/children
https://developer.mozilla.org/en-US/docs/Web/API/Document/children
https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment/children

IDL:

```webidl
interface mixin ParentNode {
  [SameObject] readonly attribute HTMLCollection children;
};
Document includes ParentNode;
DocumentFragment includes ParentNode;
Element includes ParentNode;
```