### PR TITLE
Fix link flaws in Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters

### DIFF
--- a/files/en-us/web/css/css_lists_and_counters/using_css_counters/index.html
+++ b/files/en-us/web/css/css_lists_and_counters/using_css_counters/index.html
@@ -22,11 +22,11 @@ tags:
 
 <h3 id="Displaying_a_counter">Displaying a counter</h3>
 
-<p>The value of a counter can be displayed using either the {{cssxref("counter", "counter()")}} or {{cssxref("counters", "counters()")}} function in a {{cssxref("content")}} property.</p>
+<p>The value of a counter can be displayed using either the {{cssxref("counter()", "counter()")}} or {{cssxref("counters()", "counters()")}} function in a {{cssxref("content")}} property.</p>
 
-<p>The {{cssxref("counter")}} function has two forms: 'counter(<var>name</var>)' or 'counter(<var>name</var>, <var>style</var>)'. The generated text is the value of the innermost counter of the given name in scope at the given pseudo-element.The counter is rendered in the specified style (<code>decimal</code> by default).</p>
+<p>The {{cssxref("counter()")}} function has two forms: 'counter(<var>name</var>)' or 'counter(<var>name</var>, <var>style</var>)'. The generated text is the value of the innermost counter of the given name in scope at the given pseudo-element.The counter is rendered in the specified style (<code>decimal</code> by default).</p>
 
-<p>The {{cssxref("counters")}} function also has two forms: 'counters(<var>name</var>, <var>string</var>)' or 'counters(<var>name</var>, <var>string</var>, <var>style</var>)'. The generated text is the value of all counters with the given name in scope at the given pseudo-element, from outermost to innermost, separated by the specified string. The counters are rendered in the specified style (<code>decimal</code> by default).</p>
+<p>The {{cssxref("counters()")}} function also has two forms: 'counters(<var>name</var>, <var>string</var>)' or 'counters(<var>name</var>, <var>string</var>, <var>style</var>)'. The generated text is the value of all counters with the given name in scope at the given pseudo-element, from outermost to innermost, separated by the specified string. The counters are rendered in the specified style (<code>decimal</code> by default).</p>
 
 <h3 id="Basic_example">Basic example</h3>
 
@@ -86,7 +86,7 @@ a[href]:empty::after {
 
 <h2 id="Nesting_counters">Nesting counters</h2>
 
-<p>A CSS counter can be especially useful for making outlined lists, because a new instance of the counter is automatically created in child elements. Using the {{cssxref("counters")}} function, separating text can be inserted between different levels of nested counters.</p>
+<p>A CSS counter can be especially useful for making outlined lists, because a new instance of the counter is automatically created in child elements. Using the {{cssxref("counters()")}} function, separating text can be inserted between different levels of nested counters.</p>
 
 <h3 id="Example_of_a_nested_counter">Example of a nested counter</h3>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are link flaws.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
