### PR TITLE
Remove specific line reference to script tag in HTML file

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
@@ -165,7 +165,7 @@ myName</pre>
   <p>First, make a local copy of our <a href="https://github.com/mdn/learning-area/blob/master/javascript/apis/client-side-storage/web-storage/personal-greeting.html">personal-greeting.html</a> file in a new directory on your computer.</p>
  </li>
  <li>
-  <p>Next, note how our HTML references a JavaScript file called <code>index.js</code> (see line 40). We need to create this and write our JavaScript code into it. Create an <code>index.js</code> file in the same directory as your HTML file. </p>
+  <p>Next, note how our HTML references a JavaScript file called <code>index.js</code> (see line 41). We need to create this and write our JavaScript code into it. Create an <code>index.js</code> file in the same directory as your HTML file. </p>
  </li>
  <li>
   <p>We'll start off by creating references to all the HTML features we need to manipulate in this example — we'll create them all as constants, as these references do not need to change in the lifecycle of the app. Add the following lines to your JavaScript file:</p>

--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
@@ -165,7 +165,7 @@ myName</pre>
   <p>First, make a local copy of our <a href="https://github.com/mdn/learning-area/blob/master/javascript/apis/client-side-storage/web-storage/personal-greeting.html">personal-greeting.html</a> file in a new directory on your computer.</p>
  </li>
  <li>
-   <p>Next, note how our HTML references a JavaScript file called <code>index.js</code>, with a line like <code><script src="index.js" defer></script></code>. We need to create this and write our JavaScript code into it. Create an <code>index.js</code> file in the same directory as your HTML file. </p>
+  <p>Next, note how our HTML references a JavaScript file called <code>index.js</code>, with a line like <code>&lt;script src="index.js" defer&gt;&lt;/script&gt;</code>. We need to create this and write our JavaScript code into it. Create an <code>index.js</code> file in the same directory as your HTML file. </p>
  </li>
  <li>
   <p>We'll start off by creating references to all the HTML features we need to manipulate in this example — we'll create them all as constants, as these references do not need to change in the lifecycle of the app. Add the following lines to your JavaScript file:</p>

--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.html
@@ -165,7 +165,7 @@ myName</pre>
   <p>First, make a local copy of our <a href="https://github.com/mdn/learning-area/blob/master/javascript/apis/client-side-storage/web-storage/personal-greeting.html">personal-greeting.html</a> file in a new directory on your computer.</p>
  </li>
  <li>
-  <p>Next, note how our HTML references a JavaScript file called <code>index.js</code> (see line 41). We need to create this and write our JavaScript code into it. Create an <code>index.js</code> file in the same directory as your HTML file. </p>
+   <p>Next, note how our HTML references a JavaScript file called <code>index.js</code>, with a line like <code><script src="index.js" defer></script></code>. We need to create this and write our JavaScript code into it. Create an <code>index.js</code> file in the same directory as your HTML file. </p>
  </li>
  <li>
   <p>We'll start off by creating references to all the HTML features we need to manipulate in this example — we'll create them all as constants, as these references do not need to change in the lifecycle of the app. Add the following lines to your JavaScript file:</p>


### PR DESCRIPTION
The documentation at https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage under the "A more involved example" tutorial currently refers to the index.js file at line 40 in file personal-greeting.html. However, it looks like the index.js file is actually being referenced on line 41.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
