### PR TITLE
Update Web/CSS/CSS_Houdini

### DIFF
--- a/files/en-us/web/css/css_houdini/index.html
+++ b/files/en-us/web/css/css_houdini/index.html
@@ -70,7 +70,7 @@ tags:
 <ul>
   <li><a href="/en-US/docs/Web/API/CSS_Properties_and_Values_API/guide">Properties and Values API Guide</a></li>
   <li><a href="/en-US/docs/Web/API/CSS_Typed_OM_API/Guide">Typed OM API Guide</a></li>
-  <li><a href="/en-US/docs/Web/API/CSS_Painting_API/Guide">Properties and Values API Guide</a></li>
+  <li><a href="/en-US/docs/Web/API/CSS_Painting_API/Guide">Using the CSS Painting API</a></li>
 </ul>
 
 <h2 id="External_resources">External resources</h2>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The link name of "Properties and Values API Guide" seems incorrect.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Houdini

> Issue number (if there is an associated issue)

> Anything else that could help us review it
