### PR TITLE
Alarms API - info about exection context

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p><span class="seoSummary">Schedule code to run at a specific time in the future.</span> This is like <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout">setTimeout()</a></code> and <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval">setInterval()</a></code>, except that those functions don't work with background pages that are loaded on demand.</p>
 
-<p>Alarms do not persist across browser sessions. They are created globally across all contexts of a single extension. E.g. alarm created in background script will fire <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm"><code>onAlarm</code></a> event in background script, options page, popup page and extension tabs (and vice-versa). Alarms API is not available in <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#webextension_apis"><code>Content scripts</code></a>.</p>
+<p>Alarms do not persist across browser sessions. They are created globally across all contexts of a single extension. E.g. alarm created in background script will fire <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm"><code>onAlarm</code></a> event in background script, options page, popup page and extension tabs (and vice versa). Alarms API is not available in <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#webextension_apis"><code>Content scripts</code></a>.</p>
 
 <p>To use this API you need to have the "alarms" <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
@@ -12,7 +12,9 @@ tags:
 ---
 <div>{{AddonSidebar}}</div>
 
-<p><span class="seoSummary">Schedule code to run at a specific time in the future.</span> This is like <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout">setTimeout()</a></code> and <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval">setInterval()</a></code>, except that those functions don't work with background pages that are loaded on demand. Alarms do not persist across browser sessions.</p>
+<p><span class="seoSummary">Schedule code to run at a specific time in the future.</span> This is like <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout">setTimeout()</a></code> and <code><a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval">setInterval()</a></code>, except that those functions don't work with background pages that are loaded on demand.</p>
+
+<p>Alarms do not persist across browser sessions. They are created globally across all contexts of a single extension. E.g. alarm created in background script will fire <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm"><code>onAlarm</code></a> event in background script, options page, popup page and extension tabs (and vice-versa). Alarms API is not available in <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#webextension_apis"><code>Content scripts</code></a>.</p>
 
 <p>To use this API you need to have the "alarms" <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">permission</a>.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Missing info about execution context.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms

> Issue number (if there is an associated issue)
https://github.com/mdn/content/issues/3672

> Anything else that could help us review it
