### PR TITLE
Fix broken links to the attribute info in <input type=radio> doc

### DIFF
--- a/files/en-us/web/html/element/input/radio/index.html
+++ b/files/en-us/web/html/element/input/radio/index.html
@@ -50,7 +50,7 @@ browser-compat: html.elements.input.input-radio
   </tr>
   <tr>
    <td><strong>Supported common attributes</strong></td>
-   <td><code>{{anch("htmlattrdefchecked")}}</code>, <code>{{anch("value")}}</code> and <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code></td>
+   <td><code>{{anch("htmlattrdefchecked","checked")}}</code>, <code>{{anch("value")}}</code> and <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code></td>
   </tr>
   <tr>
    <td><strong>IDL attributes</strong></td>

--- a/files/en-us/web/html/element/input/radio/index.html
+++ b/files/en-us/web/html/element/input/radio/index.html
@@ -50,11 +50,11 @@ browser-compat: html.elements.input.input-radio
   </tr>
   <tr>
    <td><strong>Supported common attributes</strong></td>
-   <td><code>{{anch("checked")}}</code>, <code>{{anch("value")}}</code> and <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code></td>
+   <td><code>{{anch("htmlattrdefchecked")}}</code>, <code>{{anch("value")}}</code> and <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code></td>
   </tr>
   <tr>
    <td><strong>IDL attributes</strong></td>
-   <td><code>{{anch("checked")}}</code> and <code>{{anch("value")}}</code></td>
+   <td><code>{{anch("htmlattrdefchecked")}}</code> and <code>{{anch("value")}}</code></td>
   </tr>
   <tr>
    <td><strong>Methods</strong></td>
@@ -170,7 +170,7 @@ form.addEventListener("submit", function(event) {
  </thead>
  <tbody>
   <tr>
-   <td><code>{{anch("checked")}}</code></td>
+   <td><code>{{anch("htmlattrdefchecked")}}</code></td>
    <td>A Boolean indicating whether or not this radio button is the default-selected item in the group</td>
   </tr>
   <tr>

--- a/files/en-us/web/html/element/input/radio/index.html
+++ b/files/en-us/web/html/element/input/radio/index.html
@@ -50,11 +50,11 @@ browser-compat: html.elements.input.input-radio
   </tr>
   <tr>
    <td><strong>Supported common attributes</strong></td>
-   <td><code>{{anch("htmlattrdefchecked","checked")}}</code>, <code>{{anch("value")}}</code> and <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code></td>
+   <td><code><a href="#attr-checked">checked</a></code>, <code><a href="#attr-value">value</a></code> and <code><a href="/en-US/docs/Web/HTML/Attributes/required">required</a></code></td>
   </tr>
   <tr>
    <td><strong>IDL attributes</strong></td>
-   <td><code>{{anch("htmlattrdefchecked")}}</code> and <code>{{anch("value")}}</code></td>
+   <td><code>checked</code> and <code>value</code></td>
   </tr>
   <tr>
    <td><strong>Methods</strong></td>
@@ -73,7 +73,7 @@ browser-compat: html.elements.input.input-radio
 
 <p>You can have as many radio groups on a page as you like, as long as each has its own unique <code>name</code>.</p>
 
-<p>For example, if your form needs to ask the user for their preferred contact method, you might create three radio buttons, each with the <code>name</code> property set to <code>contact</code> but one with the {{htmlattrxref("value", "input")}} <code>email</code>, one with the value <code>phone</code>, and one with the value <code>mail</code>. The user never sees the <code>value</code> or the <code>name</code> (unless you expressly add code to display it).</p>
+<p>For example, if your form needs to ask the user for their preferred contact method, you might create three radio buttons, each with the <code>name</code> property set to <code>contact</code> but one with the value <code>email</code>, one with the value <code>phone</code>, and one with the value <code>mail</code>. The user never sees the <code>value</code> or the <code>name</code> (unless you expressly add code to display it).</p>
 
 <p>The resulting HTML looks like this:</p>
 
@@ -170,23 +170,23 @@ form.addEventListener("submit", function(event) {
  </thead>
  <tbody>
   <tr>
-   <td><code>{{anch("htmlattrdefchecked")}}</code></td>
+   <td><code><a href="#attr-checked">checked</a></td>
    <td>A Boolean indicating whether or not this radio button is the default-selected item in the group</td>
   </tr>
   <tr>
-   <td><code>{{anch("value")}}</code></td>
+   <td><code><a href="#attr-value">value</a></code></td>
    <td>The string to use as the value of the radio when submitting the form, if the radio is currently toggled on</td>
   </tr>
  </tbody>
 </table>
 
-<h3 id="htmlattrdefchecked">{{htmlattrdef("checked")}}</h3>
+<h3 id="attr-checked"><code>checked</code></h3>
 
 <p>A Boolean attribute which, if present, indicates that this radio button is the default selected one in the group.</p>
 
 <p>Unlike other browsers, Firefox by default <a href="https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing">persists the dynamic checked state</a> of an <code>&lt;input&gt;</code> across page loads. Use the {{htmlattrxref("autocomplete","input")}} attribute to control this feature.</p>
 
-<h3 id="htmlattrdefvalue">{{htmlattrdef("value")}}</h3>
+<h3 id="attr-value"><code>value</code></h3>
 
 <p>The <code>value</code> attribute is one which all {{HTMLElement("input")}}s share; however, it serves a special purpose for inputs of type <code>radio</code>: when a form is submitted, only radio buttons which are currently checked are submitted to the server, and the reported value is the value of the <code>value</code> attribute. If the <code>value</code> is not otherwise specified, it is the string <code>on</code> by default. This is demonstrated in the section {{anch("Value")}} above.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Links on that page pointing to <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#checked> not working.

> MDN URL of main page changed

<https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio>

> Issue number (if there is an associated issue)

No issue (at least not by me)

> Anything else that could help us review it

Not sure if my changes are the correct fix, since `anch()` appears to fill the content as well, but the links are not working since there is no `id="checked"`.