### PR TITLE
Fix misstatement about <form> name being deprecated

### DIFF
--- a/files/en-us/web/html/element/form/index.html
+++ b/files/en-us/web/html/element/form/index.html
@@ -86,7 +86,7 @@ tags:
  </ul>
  </dd>
  <dt>{{htmlattrdef("name")}}</dt>
- <dd>The name of the form. Deprecated as of HTML 4 (use <code>id</code> instead). It must be unique among the forms in a document and not an empty string as of HTML5.</dd>
+ <dd>The name of the form. The value must not be the empty string, and must be unique among the <code>form</code> elements in the forms collection that it is in, if any.</dd>
  <dt>{{htmlattrdef("rel")}}</dt>
  <dd>Creates a hyperlink or annotation depending on the value, see the <a href="/en-US/docs/Web/HTML/Attributes/rel">{{htmlattrdef("rel")}}</a> attribute for details.</dd>
 </dl>


### PR DESCRIPTION
The `name` attribute of the `form` element is definitely not deprecated. Fixes https://github.com/mdn/content/issues/4079

---

This misstatement most likely crept in due to somebody making the wrong assumption that since the `name` attribute for the `a` element is deprecated, it must be deprecated for the `form` element too.