### PR TITLE
chore: remove broken / unmaintained shells

### DIFF
--- a/files/en-us/web/javascript/shells/index.html
+++ b/files/en-us/web/javascript/shells/index.html
@@ -21,8 +21,7 @@ tags:
  <li><a href="http://www.jsdb.org/">JSDB</a> - A standalone JavaScript shell, with compiled binaries for Windows, Mac, and Linux.</li>
  <li><a href="http://javalikescript.free.fr/">JavaLikeScript</a> - A standalone, extensible JavaScript shell including both native and JavaScript libraries.</li>
  <li><a href="http://gluescript.sourceforge.net/">GLUEscript</a> - A standalone JavaScript shell for writing cross-platform JavaScript applications.  It can use wxWidgets for GUI apps and was formerly called wxJavaScript.</li>
- <li><a href="http://jspl.msg.mx/">jspl</a> - A standalone JavaScript shell enhanced by Perl. Can use Perl modules directly from JavaScript: DBI for database integration, GTK2 for GUI apps, POSIX for system programming, etc. The best of CPAN now for JavaScript programmers.</li>
- <li><a href="http://shelljs.org">ShellJS</a> - Portable Unix shell commands for Node.js</li>
+ <li><a href="https://documentup.com/shelljs/shelljs">ShellJS</a> - Portable Unix shell commands for Node.js</li>
 </ul>
 
 <h2 id="List_of_JavaScript_shells">List of JavaScript shells</h2>
@@ -32,13 +31,8 @@ tags:
 <ul>
  <li>Firefox has a <a href="/en-US/docs/Tools/Web_Console/The_command_line_interpreter">built-in JavaScript console</a>, which support multi-line editing.</li>
  <li><a href="/en-US/docs/Mozilla/Projects/SpiderMonkey/Introduction_to_the_JavaScript_shell">JavaScript Shell</a> (<code>js</code>) - A command line interpreter for JavaScript</li>
- <li><a href="/en-US/docs/Mozilla/XPConnect/xpcshell">xpcshell</a> is an <a href="/en-US/docs/Mozilla/Tech/XPCOM/Language_bindings/XPConnect">XPConnect</a> - enabled shell, sometimes useful for Mozilla development.</li>
  <li><a href="http://babeljs.io/repl">Babel REPL</a> - A browser-based <a href="https://en.wikipedia.org/wiki/REPL">REPL</a> for experimenting with future JavaScript.</li>
  <li><a href="http://es6console.com">ES6Console.com</a> - An open-source JavaScript console to test ECMAScript 2015 code inside the browser.</li>
  <li><a href="http://jsconsole.com/">jsconsole.com</a> -- An open-source JavaScript console with the ability to easily link to particular expressions</li>
  <li><a href="http://www.squarefree.com/shell/">JavaScript Shell (web page)</a> - also available as part of the <a class="link-https" href="https://addons.mozilla.org/en-US/firefox/addon/7434">Extension Developer's Extension</a></li>
- <li><a href="http://billyreisinger.com/jash/">Jash: JavaScript Shell</a> - a DHTML based shell that gives you command line access to a web page.</li>
- <li><a href="http://hyperstruct.net/projects/mozrepl">MozRepl</a> - Connect to Firefox and other Mozilla apps, explore and modify them from the inside, while they're running.</li>
- <li><a class="external link-https" href="https://addons.mozilla.org/en-US/firefox/addon/execute-js/">Execute JS</a> - (No longer maintained) - Firefox-Extension which provides an enhanced JavaScript-Console, where you can comfortably enter and execute arbitrary JavaScript-Code and modify functions.</li>
- <li><a class="external link-https" href="https://addons.mozilla.org/addon/159546">xqjs</a> - Simple console for Firefox.</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I realized that the shelljs link goes to a gambling site. Upon further inspection, there were also a number of broken links to projects that seem otherwise unmaintained.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Shells

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

I've removed the broken links in addition to updating ShellJS. My belief is that it's probably a better experience for those looking for this content to have working examples vs. outdated/unmaintained examples. I'm happy to force push just a change to fix the ShellJS link if that's preferable to removing the broken links if that's preferable.
