### PR TITLE
Remove button class

### DIFF
--- a/files/en-us/learn/accessibility/index.html
+++ b/files/en-us/learn/accessibility/index.html
@@ -41,8 +41,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/css/building_blocks/index.html
+++ b/files/en-us/learn/css/building_blocks/index.html
@@ -20,8 +20,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/css/css_layout/index.html
+++ b/files/en-us/learn/css/css_layout/index.html
@@ -29,8 +29,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/css/first_steps/index.html
+++ b/files/en-us/learn/css/first_steps/index.html
@@ -20,8 +20,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/css/index.html
+++ b/files/en-us/learn/css/index.html
@@ -23,8 +23,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/css/styling_text/index.html
+++ b/files/en-us/learn/css/styling_text/index.html
@@ -28,8 +28,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/forms/index.html
+++ b/files/en-us/learn/forms/index.html
@@ -22,8 +22,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/html/index.html
+++ b/files/en-us/learn/html/index.html
@@ -20,8 +20,8 @@ tags:
 	<p>We have put together a course that includes all the essential information you need to
 	  work towards your goal.</p>
 
-	<p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-	</p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
   </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/html/introduction_to_html/index.html
+++ b/files/en-us/learn/html/introduction_to_html/index.html
@@ -23,8 +23,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/html/multimedia_and_embedding/index.html
+++ b/files/en-us/learn/html/multimedia_and_embedding/index.html
@@ -34,8 +34,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/html/tables/index.html
+++ b/files/en-us/learn/html/tables/index.html
@@ -25,8 +25,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/index.html
+++ b/files/en-us/learn/index.html
@@ -32,8 +32,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Where_to_start">Where to start</h2>

--- a/files/en-us/learn/javascript/asynchronous/index.html
+++ b/files/en-us/learn/javascript/asynchronous/index.html
@@ -27,8 +27,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/javascript/building_blocks/index.html
+++ b/files/en-us/learn/javascript/building_blocks/index.html
@@ -28,8 +28,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/javascript/client-side_web_apis/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/index.html
@@ -27,8 +27,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/javascript/first_steps/index.html
+++ b/files/en-us/learn/javascript/first_steps/index.html
@@ -29,8 +29,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/javascript/index.html
+++ b/files/en-us/learn/javascript/index.html
@@ -22,8 +22,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/javascript/objects/index.html
+++ b/files/en-us/learn/javascript/objects/index.html
@@ -23,8 +23,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/index.html
@@ -40,8 +40,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Introductory_guides">Introductory guides</h2>

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/index.html
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/index.html
@@ -27,8 +27,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/tools_and_testing/github/index.html
+++ b/files/en-us/learn/tools_and_testing/github/index.html
@@ -36,8 +36,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/tools_and_testing/index.html
+++ b/files/en-us/learn/tools_and_testing/index.html
@@ -36,8 +36,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Prerequisites">Prerequisites</h2>

--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.html
@@ -30,8 +30,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Guides">Guides</h2>

--- a/files/en-us/mdn/guidelines/css_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/css_style_guide/index.html
@@ -19,16 +19,6 @@ tags:
 
 <p>This section lists the inline styles available for style content blocks on MDN.</p>
 
-<h3 id=".button"><code>.button</code></h3>
-
-<p>Gives any element MDN button styling. Usually used to style links ({{HTMLElement("button")}} elements are stripped from article source code, for security reasons.)</p>
-
-<p><a class="button" href="https://github.com/mdn/simple-web-worker/archive/gh-pages.zip">Download source code</a></p>
-
-<h4 id="Example_syntax">Example syntax</h4>
-
-<pre class="brush: html">&lt;a href="https://github.com/mdn/simple-web-worker/archive/gh-pages.zip" class="button"&gt;Download source code&lt;/a&gt;</pre>
-
 <h3 id=".hidden"><code>.hidden</code></h3>
 
 <p>Allows you to hide content in the final rendered view. Typically this is used to provide HTML, CSS, and JavaScript to the script that creates the live code samples while only displaying the relevant language to the reader.</p>

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.html
@@ -40,13 +40,12 @@ tags:
 
 <p>The example code found on this page is derived from <a href="https://glitch.com/~audioworkletnode-sample">this working example</a> which is available on <a href="https://glitch.me/">Glitch</a>. The example creates an oscillator node and adds white noise to it using an {{domxref("AudioWorkletNode")}} before playing the resulting sound out. Slider controls are available to allow controlling the gain of both the oscillator and the audio worklet's output.</p>
 
-<div class="threecolumns" style="width: 42em;">
-<p><a class="button ignore-extermal" href="https://glitch.com/~audioworkletnode-sample">Glitch Project Page</a></p>
 
-<p style="text-align: center;"><a class="button ignore-extermal" href="https://glitch.com/edit/#!/audioworkletnode-sample">See the Code</a></p>
+<p><a href="https://glitch.com/~audioworkletnode-sample"><strong>Glitch Project Page</strong></a></p>
 
-<p style="text-align: right;"><a class="button ignore-extermal" href="https://audioworkletnode-sample.glitch.me/" style="text-align: right;">Try it Live</a></p>
-</div>
+<p><a href="https://glitch.com/edit/#!/audioworkletnode-sample"><strong>See the Code</strong></a></p>
+
+<p><a href="https://audioworkletnode-sample.glitch.me/"><strong>Try it Live</strong></a></p>
 
 <h2 id="Creating_an_audio_worklet_processor">Creating an audio worklet processor</h2>
 

--- a/files/en-us/web/css/index.html
+++ b/files/en-us/web/css/index.html
@@ -40,8 +40,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 class="Documentation" id="Tutorials">Tutorials</h2>

--- a/files/en-us/web/html/index.html
+++ b/files/en-us/web/html/index.html
@@ -38,8 +38,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 class="Tools" id="Beginners_tutorials">Beginner's tutorials</h2>

--- a/files/en-us/web/javascript/index.html
+++ b/files/en-us/web/javascript/index.html
@@ -25,8 +25,8 @@ tags:
   <p>We have put together a course that includes all the essential information you need to
     work towards your goal.</p>
 
-  <p><a class="button primary" href="/en-US/docs/Learn/Front-end_web_developer">Get started</a>
-  </p>
+  <p><a href="/en-US/docs/Learn/Front-end_web_developer"><strong>Get started</strong></a></p>
+
 </div>
 
 <h2 id="Tutorials">Tutorials</h2>

--- a/files/en-us/web/svg/applying_svg_effects_to_html_content/index.html
+++ b/files/en-us/web/svg/applying_svg_effects_to_html_content/index.html
@@ -183,8 +183,6 @@ pre.target:hover { filter:url(#f3); }
 
 <p>{{EmbedLiveSample('Example_Filtering', 650, 200)}}</p>
 
-<p style="display: none;"><a class="button liveSample" href="/files/3329/filterdemo.xhtml">View this example live</a></p>
-
 <h3 id="Example_Blurred_Text">Example: Blurred Text</h3>
 
 <p>In order to blur text, Webkit based browsers have a (prefixed) CSS filter called blur (see also <a href="/en-US/docs/Web/CSS/filter#blur%28%29_2">CSS filter</a>). You can achieve the same effect using SVG filters.</p>

--- a/files/en-us/web/svg/namespaces_crash_course/example/index.html
+++ b/files/en-us/web/svg/namespaces_crash_course/example/index.html
@@ -7,7 +7,7 @@ tags:
 ---
 <p>In this example, we use <a href="/en-US/docs/Glossary/XHTML">XHTML</a>, <a href="/en-US/docs/Web/SVG">SVG</a>, <a href="/en-US/docs/Web/JavaScript">JavaScript</a>, and the <a href="/en-US/docs/Web/API/Document_Object_Model">DOM</a> to animate a swarm of "motes". These motes are governed by two simple principles. First, each mote tries to move towards the mouse cursor, and second each mote tries to move away from the average mote position. Combined, we get this very natural-looking behavior.</p>
 <p>This is done completely in W3C Standards–XHTML, SVG, and JavaScript–no Flash or any vendor-specific extensions. This example should work in Firefox 1.5 and above.</p>
-<p><a class="internal button liveSample" href="https://media.prod.mdn.mozit.cloud/samples/svg/swarm-of-motes.xhtml">View the example</a></p>
+<p><a href="https://media.prod.mdn.mozit.cloud/samples/svg/swarm-of-motes.xhtml">View the example</a></p>
 <pre class="brush:xml">&lt;?xml version='1.0'?&gt;
 &lt;html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:svg="http://www.w3.org/2000/svg"&gt;


### PR DESCRIPTION
As discussed in https://github.com/mdn/content/issues/3927, this PR changes all occurrences of `class="button"` into simple links, except for one where the content was not displayed, so I just removed it.

I've also removed the documentation for `.button` from the CSS style guide.
