### PR TITLE
Fix minor typo on the CSS Functional Notation page

### DIFF
--- a/files/en-us/web/css/css_functions/index.html
+++ b/files/en-us/web/css/css_functions/index.html
@@ -153,7 +153,7 @@ tags:
 
 <h2 id="Color_functions">Color functions</h2>
 
-<p>Functions which specify different color representations. THese may be used anywhere a {{cssxref("&lt;color_value&gt;","&lt;color&gt;")}} is valid.</p>
+<p>Functions which specify different color representations. These may be used anywhere a {{cssxref("&lt;color_value&gt;","&lt;color&gt;")}} is valid.</p>
 
 <dl>
   <dt>{{cssxref("color_value/color()", "color()")}} {{Experimental_Inline}}</dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A minor typo was present in the word "THese". This pull request corrects it.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions