### PR TITLE
[Markdown] Remove inline styles from JS reference

### DIFF
--- a/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
+++ b/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
@@ -7,154 +7,154 @@ tags:
 ---
 <div>{{JsSidebar("More")}}</div>
 
-<p>Enumerable properties are those properties whose internal enumerable flag is set to true, which is the default for properties created via simple assignment or via a property initializer (properties defined via <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty">Object.defineProperty</a> and such default enumerable to false). Enumerable properties show up in <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for...in</a> loops unless the property's key is a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol">Symbol</a>. Ownership of properties is determined by whether the property belongs to the object directly and not to its prototype chain. Properties of an object can also be retrieved in total. There are a number of built-in means of detecting, iterating/enumerating, and retrieving object properties, with the chart showing below which are available. Some sample code follows which demonstrates how to obtain the missing categories.</p>
+<p>Enumerable properties are those properties whose internal enumerable flag is set to true, which is the default for properties created via simple assignment or via a property initializer. Properties defined via <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty">Object.defineProperty</a> and such default enumerable to false.</p>
 
-<div style="overflow: auto; width: 100%;">
+<p>Enumerable properties show up in <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for...in</a> loops unless the property's key is a <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol">Symbol</a>. Ownership of properties is determined by whether the property belongs to the object directly and not to its prototype chain. Properties of an object can also be retrieved in total.<p>
+
+<h2>Detecting, retrieving, and enumerating object properties</h2>
+
+<p>There are a number of built-in means of detecting, iterating/enumerating, and retrieving object properties. These are summarized in the tables below.</p>
+
+<h3>Detection</h3>
+
 <table>
- <caption>Property enumerability and ownership - built-in methods of detection, retrieval, and iteration</caption>
- <tbody>
-  <tr>
-   <th>Functionality</th>
-   <th>Own object</th>
-   <th>Own object and its prototype chain</th>
-   <th>Prototype chain only</th>
-  </tr>
-  <tr>
-   <td>Detection</td>
-   <td>
-    <table>
-     <thead>
-      <tr>
-       <th scope="col">Enumerable</th>
-       <th scope="col">Nonenumerable</th>
-       <th scope="col">Enumerable and Nonenumerable</th>
-      </tr>
-     </thead>
-     <tbody>
-      <tr>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty">hasOwnProperty</a></code></p>
-       </td>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty">hasOwnProperty</a></code> – filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></p>
-       </td>
-       <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty">hasOwnProperty</a></code></td>
-      </tr>
-     </tbody>
-    </table>
-   </td>
-   <td>
-    <table>
-     <thead>
-      <tr>
-       <th scope="col">Enumerable</th>
-       <th scope="col">Nonenumerable</th>
-       <th scope="col">Enumerable and Nonenumerable</th>
-      </tr>
-     </thead>
-     <tbody>
-      <tr>
-       <td>Not available without extra code</td>
-       <td>Not available without extra code</td>
-       <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/in">in</a></code></td>
-      </tr>
-     </tbody>
-    </table>
-   </td>
-   <td>Not available without extra code</td>
-  </tr>
-  <tr>
-   <td>Retrieval</td>
-   <td>
-    <table>
-     <thead>
-      <tr>
-       <th scope="col">Enumerable</th>
-       <th scope="col">Nonenumerable</th>
-       <th scope="col">Enumerable and Nonenumerable</th>
-      </tr>
-     </thead>
-     <tbody>
-      <tr>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys">Object.keys</a></code></p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code> </p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
-       </td>
-       <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a> </code>– filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code></p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-   </td>
-   <td>Not available without extra code</td>
-   <td>Not available without extra code</td>
-  </tr>
-  <tr>
-   <td>Iterable</td>
-   <td>
-    <table>
-     <thead>
-      <tr>
-       <th scope="col">Enumerable</th>
-       <th scope="col">Nonenumerable</th>
-       <th scope="col">Enumerable and Nonenumerable</th>
-      </tr>
-     </thead>
-     <tbody>
-      <tr>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys">Object.keys</a></code></p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code> </p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
-       </td>
-       <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code> – filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code></p>
-
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
-       </td>
-      </tr>
-     </tbody>
-    </table>
-   </td>
-   <td>
-    <table>
-     <thead>
-      <tr>
-       <th scope="col">Enumerable</th>
-       <th scope="col">Nonenumerable</th>
-       <th scope="col">Enumerable and Nonenumerable</th>
-      </tr>
-     </thead>
-     <tbody>
-      <tr>
-       <td>
-        <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for..in</a></code></p>
-
-        <p>(excluding symbols)</p>
-       </td>
-       <td>Not available without extra code</td>
-       <td>Not available without extra code</td>
-      </tr>
-     </tbody>
-    </table>
-   </td>
-   <td>Not available without extra code</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Own object</th>
+      <th>Own object and prototype chain</th>
+      <th>Prototype chain only</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        Enumerable
+      </th>
+      <td>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></p>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty">hasOwnProperty</a></code></p>
+      </td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+    <tr>
+      <th>
+        Nonenumerable
+      </th>
+      <td>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty">hasOwnProperty</a></code> – filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></p>
+      </td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+    <tr>
+      <th>
+        Enumerable and Nonenumerable
+      </th>
+      <td>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty">hasOwnProperty</a></code></p>
+      </td>
+      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/in">in</a></code></td>
+      <td>Not available without extra code</td>
+    </tr>
+  </tbody>
 </table>
-</div>
+
+<h3>Retrieval</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Own object</th>
+      <th>Own object and prototype chain</th>
+      <th>Prototype chain only</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        Enumerable
+      </th>
+      <td>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys">Object.keys</a></code></p>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code> </p>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
+      </td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+    <tr>
+      <th>
+        Nonenumerable
+      </th>
+      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a> </code>– filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+    <tr>
+      <th>
+        Enumerable and Nonenumerable
+      </th>
+      <td>
+         <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code></p>
+         <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
+      </td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Iteration</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Own object</th>
+      <th>Own object and prototype chain</th>
+      <th>Prototype chain only</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        Enumerable
+      </th>
+      <td>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys">Object.keys</a></code></p>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code> </p>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
+      </td>
+      <td>
+       <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for..in</a></code></p>
+       <p>(excluding symbols)</p>
+      </td>
+      <td>Not available without extra code</td>
+    </tr>
+    <tr>
+      <th>
+        Nonenumerable
+      </th>
+      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a> </code>– filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+    <tr>
+      <th>
+        Enumerable and Nonenumerable
+      </th>
+      <td>
+         <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code></p>
+         <p><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code></p>
+      </td>
+      <td>Not available without extra code</td>
+      <td>Not available without extra code</td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="Obtaining_properties_by_enumerabilityownership">Obtaining properties by enumerability/ownership</h2>
 
@@ -230,91 +230,93 @@ tags:
 
 <h2 id="Detection_Table">Detection Table</h2>
 
-<div style="overflow: auto; width: 100%;">
 <table>
- <thead>
-  <tr>
-   <th scope="row"></th>
-   <th scope="col"><code>in</code></th>
-   <th scope="col"><code>for..in</code></th>
-   <th scope="col"><code>obj.hasOwnProperty</code></th>
-   <th scope="col"><code>obj.propertyIsEnumerable</code></th>
-   <th scope="col"><code>Object.keys</code></th>
-   <th scope="col"><code>Object.getOwnPropertyNames</code></th>
-   <th scope="col"><code>Object.getOwnPropertyDescriptors</code></th>
-   <th scope="col"><code>Reflect.ownKeys()</code></th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Enumerable</th>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-  </tr>
-  <tr>
-   <th scope="row">Nonenumerable</th>
-   <td>true</td>
-   <td>false</td>
-   <td>true</td>
-   <td>false</td>
-   <td>false</td>
-   <td>true</td>
-   <td>true</td>
-   <td>true</td>
-  </tr>
-  <tr>
-   <th scope="row">Symbols keys</th>
-   <td>true</td>
-   <td>false</td>
-   <td>true</td>
-   <td>true</td>
-   <td>false</td>
-   <td>false</td>
-   <td>true</td>
-   <td>true</td>
-  </tr>
-  <tr>
-   <th scope="row">Inherited Enumerable</th>
-   <td>true</td>
-   <td>true</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-  </tr>
-  <tr>
-   <th scope="row">Inherited Nonenumerable</th>
-   <td>true</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-  </tr>
-  <tr>
-   <th scope="row">Inherited Symbols keys</th>
-   <td>true</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-   <td>false</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th></th>
+      <th>Enumerable</th>
+      <th>Nonenumerable</th>
+      <th>Symbols keys</th>
+      <th>Inherited Enumerable</th>
+      <th>Inherited Nonenumerable</th>
+      <th>Inherited Symbols keys</th>
+   </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th><code>in</code></th>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+    </tr>
+    <tr>
+      <th><code>for..in</code></th>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <th><code>obj.hasOwnProperty</code></th>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <th><code>obj.propertyIsEnumerable</code></th>
+      <td>true</td>
+      <td>false</td>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <th><code>Object.keys</code></th>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <th><code>Object.getOwnPropertyNames</code></th>
+      <td>true</td>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <th><code>Object.getOwnPropertyDescriptors</code></th>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+    <tr>
+      <th><code>Reflect.ownKeys()</code></th>
+      <td>true</td>
+      <td>true</td>
+      <td>true</td>
+      <td>false</td>
+      <td>false</td>
+      <td>false</td>
+    </tr>
+  </tbody>
 </table>
-</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/javascript/eventloop/index.html
+++ b/files/en-us/web/javascript/eventloop/index.html
@@ -21,7 +21,7 @@ tags:
 
 <h3 id="Visual_representation">Visual representation</h3>
 
-<p style="text-align: center;"><img alt="Stack, heap, queue" src="the_javascript_runtime_environment_example.svg"></p>
+<p><img alt="Stack, heap, queue" src="the_javascript_runtime_environment_example.svg"></p>
 
 <h3 id="Stack">Stack</h3>
 

--- a/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
+++ b/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
@@ -100,14 +100,10 @@ tags:
 
 <p>The remainder of this chapter uses the employee hierarchy shown in the following figure.</p>
 
-<div style="display: table-row;">
-<div style="display: table-cell; width: 350px; text-align: center; vertical-align: middle; padding: 10px;">
-<p>A simple object hierarchy with the following objects:</p>
-
 <p><img alt="" src="figure8.1.png"></p>
-</div>
 
-<div style="display: table-cell; vertical-align: middle; padding: 10px;">
+<p>This shows an object hierarchy with the following objects:</p>
+
 <ul>
  <li><code>Employee</code> has the properties <code>name</code> (whose value defaults to the empty string) and <code>dept</code> (whose value defaults to "general").</li>
  <li><code>Manager</code> is based on <code>Employee</code>. It adds the <code>reports</code> property (whose value defaults to an empty array, intended to have an array of <code>Employee</code> objects as its value).</li>
@@ -115,8 +111,7 @@ tags:
  <li><code>SalesPerson</code> is based on <code>WorkerBee</code>. It adds the <code>quota</code> property (whose value defaults to 100). It also overrides the <code>dept</code> property with the value "sales", indicating that all salespersons are in the same department.</li>
  <li><code>Engineer</code> is based on <code>WorkerBee</code>. It adds the <code>machine</code> property (whose value defaults to the empty string) and also overrides the <code>dept</code> property with the value "engineering".</li>
 </ul>
-</div>
-</div>
+
 
 <h2 id="Creating_the_hierarchy">Creating the hierarchy</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
@@ -145,41 +145,6 @@ let min = minOfArray([5, 6, 2, 3, 7]);
 };
 </pre>
 
-<div class="note" style="height: 250px; overflow: auto;">
-<p><strong>Note:</strong> The <code>Object.create()</code> method used above is relatively new. For alternative methods, please consider one of the following approaches:</p>
-
-<p>Using {{jsxref("Object/proto", "Object.__proto__")}}:</p>
-
-<pre class="brush: js">Function.prototype.construct = function (aArgs) {
-  let oNew = {};
-  oNew.__proto__ = this.prototype;
-  this.apply(oNew, aArgs);
-  return oNew;
-};
-</pre>
-
-<p>Using <a href="/en-US/docs/Web/JavaScript/Closures">closures</a>:</p>
-
-<pre class="brush: js">Function.prototype.construct = function(aArgs) {
-  let fConstructor = this, fNewConstr = function() {
-    fConstructor.apply(this, aArgs);
-  };
-  fNewConstr.prototype = fConstructor.prototype;
-  return new fNewConstr();
-};</pre>
-
-<p>Using the {{jsxref("Function")}} constructor:</p>
-
-<pre class="brush: js">Function.prototype.construct = function (aArgs) {
-  let fNewConstr = new Function("");
-  fNewConstr.prototype = this.prototype;
-  let oNew = new fNewConstr();
-  this.apply(oNew, aArgs);
-  return oNew;
-};
-</pre>
-</div>
-
 <p>Example usage:</p>
 
 <pre class="brush: js">function MyConstructor() {

--- a/files/en-us/web/javascript/reference/global_objects/math/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/index.html
@@ -139,7 +139,7 @@ function radToDeg(rad) {
 
 <p>If we want to calculate the height of an equilateral triangle, and we know its side length is 100, we can use the formulae <em>length of the adjacent multiplied by the tangent of the angle is equal to the opposite.</em></p>
 
-<p><img alt="" src="trigonometry.png" style="display: block; margin: 0 auto;"></p>
+<p><img alt="" src="trigonometry.png"></p>
 
 <p>In JavaScript, we can do this with the following:</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log1p/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log1p/index.html
@@ -71,15 +71,12 @@ tags:
 
 <p>When you calculate log(1 + x), you should get an answer very close to x, if x is small
 	(that's why these are called 'natural' logarithms).  If you calculate Math.log(1 +
-	1.1111111111e-15) you should get an answer close to 1.1111111111e-15.  Instead, <span
-		style="line-height: 1.5;">you will end up taking the logarithm of </span><span
-		style="line-height: 1.5;">1.00000000000000111022 (the roundoff is in binary so
-		sometimes it gets ugly)</span><span style="line-height: 1.5;">, so you
-		get </span><span style="line-height: 1.5;">the answer 1.11022...e-15, with only  3
-		correct digits.  If, instead, you calculate
-		Math.log1p(</span>1.1111111111e-15<span style="line-height: 1.5;">) you will get a
+	1.1111111111e-15) you should get an answer close to 1.1111111111e-15.  Instead,
+	you will end up taking the logarithm of 1.00000000000000111022 (the roundoff is in binary so
+	sometimes it gets ugly), so you	get the answer 1.11022...e-15, with only  3
+	correct digits.  If, instead, you calculate Math.log1p(1.1111111111e-15) you will get a
 		much more accurate answer 1.1111111110999995e-15 with 15 correct digits of
-		precision (actually 16 in this case).</span></p>
+		precision (actually 16 in this case).</p>
 
 <p>If the value of <code>x</code> is less than -1, the return value is always
 	{{jsxref("NaN")}}.</p>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -67,12 +67,11 @@ let re = /quick\s(brown).+?(jumps)/igd;
 let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
 </pre>
 
-<p>The following table shows the results for this script:</p>
+<p>The following table shows the state of <code>result</code> after running this script:</p>
 
-<table class="fullwidth-table standard-table">
+<table class="standard-table">
   <thead>
     <tr>
-      <th scope="row">Object</th>
       <th scope="col">Property/Index</th>
       <th scope="col">Description</th>
       <th scope="col">Example</th>
@@ -80,7 +79,6 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
   </thead>
   <tbody>
     <tr>
-      <th rowspan="5" scope="row" style="vertical-align: top;"><code>result</code></th>
       <td><code>[0]</code></td>
       <td>The full string of characters matched</td>
       <td><code>"Quick Brown Fox Jumps"</code></td>
@@ -128,8 +126,21 @@ let result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
       <td>The original string that was matched against.</td>
       <td><code>The Quick Brown Fox Jumps Over The Lazy Dog</code></td>
     </tr>
+  </tbody>
+</table>
+
+<p>The following table shows the state of <code>re</code> after running this script:</p>
+
+<table class="standard-table">
+  <thead>
     <tr>
-      <th rowspan="9" scope="row" style="vertical-align: top;"><code>re</code></th>
+      <th scope="col">Property/Index</th>
+      <th scope="col">Description</th>
+      <th scope="col">Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
       <td><code>lastIndex</code></td>
       <td>
         <p>The index at which to start the next match.</p>

--- a/files/en-us/web/javascript/typed_arrays/index.html
+++ b/files/en-us/web/javascript/typed_arrays/index.html
@@ -97,7 +97,7 @@ tags:
   </tr>
   <tr>
    <td>{{jsxref("Float32Array")}}</td>
-   <td><code>1.2</code><span style="font-size: 1rem; letter-spacing: -0.00278rem;">×</span><code>10<sup>-38</sup></code> to <code>3.4</code><span style="font-size: 1rem; letter-spacing: -0.00278rem;">×</span><code>10<sup>38</sup></code></td>
+   <td><code>1.2</code>×<code>10<sup>-38</sup></code> to <code>3.4</code>×<code>10<sup>38</sup></code></td>
    <td>4</td>
    <td>32-bit IEEE floating point number (7 significant digits e.g., <code>1.123456</code>)</td>
    <td><code>unrestricted float</code></td>
@@ -105,7 +105,7 @@ tags:
   </tr>
   <tr>
    <td>{{jsxref("Float64Array")}}</td>
-   <td><code>5.0</code><span style="font-size: 1rem; letter-spacing: -0.00278rem;">×</span><code>10<sup>-324</sup></code> to <code>1.8</code><span style="font-size: 1rem; letter-spacing: -0.00278rem;">×</span><code>10<sup>308</sup></code></td>
+   <td><code>5.0</code>×<code>10<sup>-324</sup></code> to <code>1.8</code>×<code>10<sup>308</sup></code></td>
    <td>8</td>
    <td>64-bit IEEE floating point number (16 significant digits e.g., <code>1.123...15</code>)</td>
    <td><code>unrestricted double</code></td>


### PR DESCRIPTION
This PR is intended to remove all uses of the `style` attribute from the JS docs (with one exception).

According to my script, these are all the files in the JS docs that use the `style` attribute:

https://github.com/mdn/content/tree/main/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html            
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/eventloop/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/reference/global_objects/function/apply/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/reference/global_objects/math/cos/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/reference/global_objects/math/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/reference/global_objects/math/log1p/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.html
https://github.com/mdn/content/tree/main/files/en-us/web/javascript/typed_arrays/index.html

In most cases just removing the style seemed to have no effect or didn't make the pages any worse.

In one case (the long note inside https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_to_chain_constructors) I just removed the whole note, as it said "The Object.create() method used above is relatively new...." which I don't think is true any more.

The most involved case was https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties, which uses inline styles to stop the layout from breaking when you have huge tables. I've reorganized and broken up the tables to avoid this (and I think the result is much clearer although I still find this page a bit baffling). I hope I didn't introduce any errors here, it's a bit intricate.

The case I didn't address was https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness. One excuse is that the styles are all inside tables, and I expect that we will keep at least some tables in HTML even when we are in Markdown, so we don't need to fix them now. But perhaps I should try to attack it anyway, inline styles are not a good idea anyway.

