### PR TITLE
Replaces HTTP or failing HTTPS call to placehold.it

### DIFF
--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.html
@@ -87,7 +87,7 @@ img {
 </pre>
 
 <pre class="brush: html">&lt;div class="media"&gt;
-    &lt;div class="image"&gt;&lt;img src="http://placehold.it/150x150" alt="placeholder"&gt;&lt;/div&gt;
+    &lt;div class="image"&gt;&lt;img src="https://via.placeholder.com/150x150" alt="placeholder"&gt;&lt;/div&gt;
     &lt;div class="text"&gt;This is a media object example. I am using floats for older browsers and grid for new ones.&lt;/div&gt;
 &lt;/div&gt;
 </pre>

--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -138,7 +138,7 @@ tags:
   &lt;area shape="circle" coords="75,75,75" href="left.html" alt="Click to go Left"&gt;
   &lt;area shape="circle" coords="275,75,75" href="right.html" alt="Click to go Right"&gt;
 &lt;/map&gt;
-&lt;img usemap="#primary" src="http://placehold.it/350x150" alt="350 x 150 pic"&gt;</pre>
+&lt;img usemap="#primary" src="https://via.placeholder.com/350x150" alt="350 x 150 pic"&gt;</pre>
 
 <h3 id="Result">Result</h3>
 

--- a/files/en-us/web/html/element/map/index.html
+++ b/files/en-us/web/html/element/map/index.html
@@ -65,7 +65,7 @@ tags:
   &lt;area shape="circle" coords="75,75,75" href="left.html"&gt;
   &lt;area shape="circle" coords="275,75,75" href="right.html"&gt;
 &lt;/map&gt;
-&lt;img usemap="#primary" src="https://placehold.it/350x150" alt="350 x 150 pic"&gt;
+&lt;img usemap="#primary" src="https://via.placeholder.com/350x150" alt="350 x 150 pic"&gt;
 </pre>
 
 <h3 id="Result">Result</h3>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map#result is currently failing since the TLS certificate for placehold.it has expired since 2021-04-01. This domain redirects to placeholder.com where HTTPS is OK.

While scanning the other URL, I decided to secure existing HTTP links to HTTPS.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
http://developer.mozilla.org/en-US/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement

> Issue number (if there is an associated issue)

> Anything else that could help us review it
