### PR TITLE
Improve PerformanceObserver example.

### DIFF
--- a/files/en-us/web/api/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/index.html
@@ -46,8 +46,8 @@ tags:
 <pre class="brush: js">function perf_observer(list, observer) {
    // Process the "measure" event
 }
-var observer2 = new PerformanceObserver(perf_observer);
-observer2.observe({entryTypes: ["measure"]});</pre>
+let observer = new PerformanceObserver(perf_observer);
+observer.observe({entryTypes: ["measure"]});</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/index.html
@@ -43,10 +43,10 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">function perf_observer(list, observer) {
+<pre class="brush: js">function observer_callback(list, observer) {
    // Process the "measure" event
 }
-let observer = new PerformanceObserver(perf_observer);
+let observer = new PerformanceObserver(observer_callback);
 observer.observe({entryTypes: ["measure"]});</pre>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
var -> let
observer2 -> observer

> What was wrong/why is this fix needed? (quick summary only)
Example was a bit odd.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver

> Issue number (if there is an associated issue)

> Anything else that could help us review it
