### PR TITLE
Refactor “Loose equality using ==”

### DIFF
--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -201,10 +201,10 @@ console.log(obj === undefined); // false
 
 <p>The following example demonstrates loose equality comparisons involving the number primitive <code>0</code>, the bigint primitive <code>0n</code>, the string primitive <code>'0'</code>, and an object whose <code>toString()</code> value is <code>'0'</code>.</p>
 
-<pre class="brush: js">var num = 0;
-var big = 0n;
-var str = '0';
-var obj = new String('0');
+<pre class="brush: js">const num = 0;
+const big = 0n;
+const str = '0';
+const obj = new String('0');
 
 console.log(num == str); // true
 console.log(big == num); // true

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -199,7 +199,7 @@ console.log(obj === undefined); // false
 
 <p>In most cases, using loose equality is discouraged. The result of a comparison using strict equality is easier to predict, and may evaluate more quickly due to the lack of type coercion.</p>
 
-<h3 id="examples">Examples</h3>
+<h3 id="example">Example</h3>
 
 <p>The following example demonstrates loose equality comparisons involving the number primitive <code>0</code>, the bigint primitive <code>0n</code>, the string primitive <code>'0'</code>, and an object whose <code>toString()</code> value is <code>'0'</code>.</p>
 

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -66,129 +66,153 @@ console.log(obj === undefined); // false
 
 <h2 id="Loose_equality_using">Loose equality using ==</h2>
 
-<p>Loose equality compares two values for equality, <em>after</em> converting both values to a common type. After conversions (one or both sides may undergo conversions), the final equality comparison is performed exactly as <code>===</code> performs it. Loose equality is <em>symmetric</em>: <code>A == B</code> always has identical semantics to <code>B == A</code> for any values of <code>A</code> and <code>B</code> (except for the order of applied conversions).</p>
+<p>The behavior for performing loose equality using <code>==</code> is as follows:</h2>
 
-<p>The equality comparison is performed as follows for operands of the various types:</p>
+<ul>
+  <li>Loose equality compares two values for equality <em>after</em> converting both values to a common type. After conversions (one or both sides may undergo conversions), the final equality comparison is performed exactly as <code>===</code> performs it.</li>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="row"></th>
-   <th colspan="8" scope="col" style="text-align: center;">Operand B</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row"></th>
-   <td></td>
-   <td style="text-align: center;">Undefined</td>
-   <td style="text-align: center;">Null</td>
-   <td style="text-align: center;">Number</td>
-   <td style="text-align: center;">String</td>
-   <td style="text-align: center;">Boolean</td>
-   <td style="text-align: center;">Object</td>
-   <td style="text-align: center;">BigInt</td>
-  </tr>
-  <tr>
-   <th rowspan="7" scope="row">Operand A</th>
-   <td>Undefined</td>
-   <td style="text-align: center;"><code>true</code></td>
-   <td style="text-align: center;"><code>true</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-  </tr>
-  <tr>
-   <td>Null</td>
-   <td style="text-align: center;"><code>true</code></td>
-   <td style="text-align: center;"><code>true</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-  </tr>
-  <tr>
-   <td>Number</td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>A === B</code></td>
-   <td style="text-align: center;"><code>A === ToNumber(B)</code></td>
-   <td style="text-align: center;"><code>A === ToNumber(B)</code></td>
-   <td style="text-align: center;"><code>A == ToPrimitive(B)</code></td>
-   <td style="text-align: center;"><code>ℝ(A) = ℝ(B)</code></td>
-  </tr>
-  <tr>
-   <td>String</td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>ToNumber(A) === B</code></td>
-   <td style="text-align: center;"><code>A === B</code></td>
-   <td style="text-align: center;"><code>ToNumber(A) === ToNumber(B)</code></td>
-   <td style="text-align: center;"><code>A == ToPrimitive(B)</code></td>
-   <td style="text-align: center;"><code>StringToBigInt(A) === B</code></td>
-  </tr>
-  <tr>
-   <td>Boolean</td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>ToNumber(A) === B</code></td>
-   <td style="text-align: center;"><code>ToNumber(A) === ToNumber(B)</code></td>
-   <td style="text-align: center;"><code>A === B</code></td>
-   <td style="text-align: center;"><code>ToNumber(A) == ToPrimitive(B)</code></td>
-   <td style="text-align: center;"><code>ToNumber(A) == B</code></td>
-  </tr>
-  <tr>
-   <td>Object</td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>ToPrimitive(A) == B</code></td>
-   <td style="text-align: center;"><code>ToPrimitive(A) == B</code></td>
-   <td style="text-align: center;"><code>ToPrimitive(A) == ToNumber(B)</code></td>
-   <td style="text-align: center;"><code>A === B</code></td>
-   <td style="text-align: center;"><code>ToPrimitive(A) == B</code></td>
-  </tr>
-  <tr>
-   <td>BigInt</td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>false</code></td>
-   <td style="text-align: center;"><code>ℝ(A) = ℝ(B)</code></td>
-   <td style="text-align: center;"><code>A === StringToBigInt(B)</code></td>
-   <td style="text-align: center;"><code>A == ToNumber(B)</code></td>
-   <td style="text-align: center;"><code>A == ToPrimitive(B)</code></td>
-   <td style="text-align: center;"><code>A === B</code></td>
-  </tr>
- </tbody>
-</table>
+  <li>Loose equality is <em>symmetric</em>: <code>A == B</code> always has identical semantics to <code>B == A</code> for any values of <code>A</code> and <code>B</code> (except for the order of applied conversions).</li>
 
-<p>In the above table:</p>
+  <li><code>undefined</code> and <code>null</code> are loosely equal; that is, <code>undefined&nbsp;==&nbsp;null</code> is true, and <code>null&nbsp;==&nbsp;undefined</code> is true</li>
+</ul>
+
+<p>Traditionally, and according to ECMAScript, all primitives and objects are loosely unequal to <code>undefined</code> and <code>null</code>. But most browsers permit a very narrow class of objects (specifically, the <code>document.all</code> object for any page), in some contexts, to act as if they <em>emulate</em> the value <code>undefined</code>. Loose equality is one such context: <code>null == A</code> and <code>undefined == A</code> evaluate to true if, and only if, A is an object that <em>emulates</em> <code>undefined</code>. In all other cases an object is never loosely equal to <code>undefined</code> or <code>null</code>.</p>
+
+<p>Loose equality comparisons among other combinations of operand types are performed as shown in the tables below. The following notations are used in the tables:</p>
+
 <ul>
   <li><code>ToNumber(A)</code> attempts to convert its argument to a number before comparison. Its behavior is equivalent to <code>+A</code> (the unary + operator).</li>
-  <li><code>ToPrimitive(A)</code> attempts to convert its object argument to a primitive value, by invoking varying sequences of <code>A.toString</code> and <code>A.valueOf</code> methods on <code>A</code>.</li>
+  <li><code>ToPrimitive(A)</code> attempts to convert its object argument to a primitive value, by invoking varying sequences of <code>A.toString()</code> and <code>A.valueOf()</code> methods on <code>A</code>.</li>
   <li><code>ℝ(A)</code> attempts to convert its argument to an ECMAScript <a href="https://tc39.es/ecma262/#mathematical-value">mathematical value</a>.</li>
   <li><code>StringToBigInt(A)</code> attempts to convert its argument to a <code>BigInt</code> by applying the ECMAScript <a href="https://tc39.es/ecma262/#sec-stringtobigint"><code>StringToBigInt</code></a> algorithm.</li>
 </ul>
 
-<p>Traditionally, and according to ECMAScript, all objects are loosely unequal to <code>undefined</code> and <code>null</code>. But most browsers permit a very narrow class of objects (specifically, the <code>document.all</code> object for any page), in some contexts, to act as if they <em>emulate</em> the value <code>undefined</code>. Loose equality is one such context: <code>null == A</code> and <code>undefined == A</code> evaluate to true if, and only if, A is an object that <em>emulates</em> <code>undefined</code>. In all other cases an object is never loosely equal to <code>undefined</code> or <code>null</code>.</p>
+<p><strong>number</strong> primitive <code>A</code> compared to operand <code>B</code>:</p>
+<table class="standard-table">
+  <thead>
+    <tr>
+      <td>number</td>
+      <td>bigint</td>
+      <td>string</td>
+      <td>boolean</td>
+      <td>Object</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>A&nbsp;===&nbsp;B</code></td>
+      <td><code>ℝ(A)&nbsp;=&nbsp;ℝ(B)</code></td>
+      <td><code>A&nbsp;===&nbsp;ToNumber(B)</code></td>
+      <td><code>A&nbsp;===&nbsp;ToNumber(B)</code></td>
+      <td><code>A&nbsp;==&nbsp;ToPrimitive(B)</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p><strong>bigint</strong> primitive <code>A</code> compared to operand <code>B</code>:</p>
+<table class="standard-table">
+  <thead>
+    <tr>
+      <td>number</td>
+      <td>bigint</td>
+      <td>string</td>
+      <td>boolean</td>
+      <td>Object</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>ℝ(A)&nbsp;=&nbsp;ℝ(B)</code></td>
+      <td><code>A&nbsp;===&nbsp;B</code></td>
+      <td><code>A&nbsp;===&nbsp;StringToBigInt(B)</code></td>
+      <td><code>A&nbsp;==&nbsp;ToNumber(B)</code></td>
+      <td><code>A&nbsp;==&nbsp;ToPrimitive(B)</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p><strong>string</strong> primitive <code>A</code> compared to operand <code>B</code>:</p>
+<table class="standard-table">
+  <thead>
+    <tr>
+      <td>number</td>
+      <td>bigint</td>
+      <td>string</td>
+      <td>boolean</td>
+      <td>Object</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>ToNumber(A)&nbsp;===&nbsp;B</code></td>
+      <td><code>StringToBigInt(A)&nbsp;===&nbsp;B</code></td>
+      <td><code>A&nbsp;===&nbsp;B</code></td>
+      <td><code>ToNumber(A)&nbsp;===&nbsp;ToNumber(B)</code></td>
+      <td><code>A&nbsp;==&nbsp;ToPrimitive(B)</code></td>
+    </tr>
+ </tbody>
+</table>
+
+<p><strong>boolean</strong> primitive <code>A</code> compared to operand <code>B</code>:</p>
+<table class="standard-table">
+  <thead>
+    <tr>
+      <td>number</td>
+      <td>bigint</td>
+      <td>string</td>
+      <td>boolean</td>
+      <td>Object</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>ToNumber(A)&nbsp;===&nbsp;B</code></td>
+      <td><code>ToNumber(A)&nbsp;==&nbsp;B</code></td>
+      <td><code>ToNumber(A)&nbsp;===&nbsp;ToNumber(B)</code></td>
+      <td><code>A&nbsp;===&nbsp;B</code></td>
+      <td><code>ToNumber(A)&nbsp;==&nbsp;ToPrimitive(B)</code></td>
+    </tr>
+ </tbody>
+</table>
+
+<p><strong>Object</strong> <code>A</code> compared to operand <code>B</code>:</p>
+<table class="standard-table">
+  <thead>
+    <tr>
+      <td>number</td>
+      <td>bigint</td>
+      <td>string</td>
+      <td>boolean</td>
+      <td>Object</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>ToPrimitive(A)&nbsp;==&nbsp;B</code></td>
+      <td><code>ToPrimitive(A)&nbsp;==&nbsp;B</code></td>
+      <td><code>ToPrimitive(A)&nbsp;==&nbsp;B</code></td>
+      <td><code>ToPrimitive(A)&nbsp;==&nbsp;ToNumber(B)</code></td>
+      <td><code>A&nbsp;===&nbsp;B</code></td>
+    </tr>
+ </tbody>
+</table>
+
+<h3 id="examples">Examples</h3>
+
+<p>The following example demonstrates loose equality comparisons involving the number primitive <code>0</code>, the bigint primitive <code>0n</code>, the string primitive <code>'0'</code>, and an object whose <code>toString()</code> value is <code>'0'</code>.</p>
 
 <pre class="brush: js">var num = 0;
-var obj = new String('0');
+var big = 0n;
 var str = '0';
+var obj = new String('0');
 
-console.log(num == num); // true
-console.log(obj == obj); // true
-console.log(str == str); // true
+console.log(num == str); // true
+console.log(big == num); // true
+console.log(str == big); // true
 
 console.log(num == obj); // true
-console.log(num == str); // true
-console.log(obj == str); // true
-console.log(null == undefined); // true
-
-// both false, except in rare cases
-console.log(obj == null);
-console.log(obj == undefined);
+console.log(big == obj); // true
+console.log(str == obj); // true
 </pre>
 
 <p>In most cases, using loose equality is discouraged. The result of a comparison using strict equality is easier to predict, and may evaluate more quickly due to the lack of type coercion.</p>

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -91,11 +91,11 @@ console.log(obj === undefined); // false
 <table class="standard-table">
   <thead>
     <tr>
-      <td>number</td>
-      <td>bigint</td>
-      <td>string</td>
-      <td>boolean</td>
-      <td>Object</td>
+      <th>number</th>
+      <th>bigint</th>
+      <th>string</th>
+      <th>boolean</th>
+      <th>Object</th>
     </tr>
   </thead>
   <tbody>
@@ -113,11 +113,11 @@ console.log(obj === undefined); // false
 <table class="standard-table">
   <thead>
     <tr>
-      <td>number</td>
-      <td>bigint</td>
-      <td>string</td>
-      <td>boolean</td>
-      <td>Object</td>
+      <th>number</th>
+      <th>bigint</th>
+      <th>string</th>
+      <th>boolean</th>
+      <th>Object</th>
     </tr>
   </thead>
   <tbody>
@@ -135,11 +135,11 @@ console.log(obj === undefined); // false
 <table class="standard-table">
   <thead>
     <tr>
-      <td>number</td>
-      <td>bigint</td>
-      <td>string</td>
-      <td>boolean</td>
-      <td>Object</td>
+      <th>number</th>
+      <th>bigint</th>
+      <th>string</th>
+      <th>boolean</th>
+      <th>Object</th>
     </tr>
   </thead>
   <tbody>
@@ -157,11 +157,11 @@ console.log(obj === undefined); // false
 <table class="standard-table">
   <thead>
     <tr>
-      <td>number</td>
-      <td>bigint</td>
-      <td>string</td>
-      <td>boolean</td>
-      <td>Object</td>
+      <th>number</th>
+      <th>bigint</th>
+      <th>string</th>
+      <th>boolean</th>
+      <th>Object</th>
     </tr>
   </thead>
   <tbody>
@@ -179,11 +179,11 @@ console.log(obj === undefined); // false
 <table class="standard-table">
   <thead>
     <tr>
-      <td>number</td>
-      <td>bigint</td>
-      <td>string</td>
-      <td>boolean</td>
-      <td>Object</td>
+      <th>number</th>
+      <th>bigint</th>
+      <th>string</th>
+      <th>boolean</th>
+      <th>Object</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -101,7 +101,7 @@ console.log(obj === undefined); // false
   <tbody>
     <tr>
       <td><code>A&nbsp;===&nbsp;B</code></td>
-      <td><code>ℝ(A)&nbsp;=&nbsp;ℝ(B)</code></td>
+      <td><code>ℝ(A)&nbsp;equals&nbsp;ℝ(B)</code></td>
       <td><code>A&nbsp;===&nbsp;ToNumber(B)</code></td>
       <td><code>A&nbsp;===&nbsp;ToNumber(B)</code></td>
       <td><code>A&nbsp;==&nbsp;ToPrimitive(B)</code></td>
@@ -122,7 +122,7 @@ console.log(obj === undefined); // false
   </thead>
   <tbody>
     <tr>
-      <td><code>ℝ(A)&nbsp;=&nbsp;ℝ(B)</code></td>
+      <td><code>ℝ(A)&nbsp;equals&nbsp;ℝ(B)</code></td>
       <td><code>A&nbsp;===&nbsp;B</code></td>
       <td><code>A&nbsp;===&nbsp;StringToBigInt(B)</code></td>
       <td><code>A&nbsp;==&nbsp;ToNumber(B)</code></td>

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -197,6 +197,8 @@ console.log(obj === undefined); // false
  </tbody>
 </table>
 
+<p>In most cases, using loose equality is discouraged. The result of a comparison using strict equality is easier to predict, and may evaluate more quickly due to the lack of type coercion.</p>
+
 <h3 id="examples">Examples</h3>
 
 <p>The following example demonstrates loose equality comparisons involving the number primitive <code>0</code>, the bigint primitive <code>0n</code>, the string primitive <code>'0'</code>, and an object whose <code>toString()</code> value is <code>'0'</code>.</p>
@@ -214,8 +216,6 @@ console.log(num == obj); // true
 console.log(big == obj); // true
 console.log(str == obj); // true
 </pre>
-
-<p>In most cases, using loose equality is discouraged. The result of a comparison using strict equality is easier to predict, and may evaluate more quickly due to the lack of type coercion.</p>
 
 <h2 id="Same-value_equality">Same-value equality</h2>
 


### PR DESCRIPTION
This change refactors the entire “Loose equality using ==” section in the “Equality comparisons and sameness” article — with the goal of improving its usability, and at the same time fixing some technical problems with it.

* Split the giant loose-equality table into a series of individual tables

* Use `&nsbp;` in comparison formulas, to prevent bad/ugly breaks that otherwise occur in the tables.

* Remove all the style attributes from the loose-equality tables (they are unnecessary, and we’d not be able to have styles in it when we move the table source to being markdown).

* Make it explicit that the comparisons are to the number, bigint, and string *primitives* — not their corresponding objects. (Otherwise, especially because it has Number, BigInt, String, and Boolean in titlecase, it looked like it was about the objects, not the primitives).

* Remove unnecessary redundancy/over-emphasis about comparisons to undefined and null: It’s simple:<br> `undefined == null` is true, but undefined or null loosely compared to anything else is false – other than the one exception of document.all, which we deal with in prose.

* Update the accompanying example to include bigint, and to remove unnecessary and distracting null and undefined comparisons (obviously `new String('0') == null` and `new String('0') == undefined` are false; we don’t need to show an example of that).