### PR TITLE
Fix typo in "Feature-Policy: vr"

### DIFF
--- a/files/en-us/web/http/headers/feature-policy/vr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vr/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
-<p class="warning">The <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has been replced with the <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a> and is currently being removed from the web platform. Use the feature identifier {{HTTPHeader("Feature-Policy/xr-spatial-tracking","xr-spatial-tracking")}} for WebXR Device API instead.</p>
+<p class="warning">The <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has been replaced with the <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR Device API</a> and is currently being removed from the web platform. Use the feature identifier {{HTTPHeader("Feature-Policy/xr-spatial-tracking","xr-spatial-tracking")}} for WebXR Device API instead.</p>
 
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header <code>vr</code> directive controls whether the current document is allowed to use the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a>. When this policy is enabled, the {{JSxRef("Promise")}} returned by {{DOMxRef("Navigator.getVRDisplays","Navigator.getVRDisplays()")}} will reject with a {{DOMxRef("DOMException")}}.</span></p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Typo (`replced` should be `replaced`) in "Feature-Policy: vr".

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/vr
