### PR TITLE
Update JS Array syntax sections to avoid BNF syntaxes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.html
@@ -24,7 +24,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>arr</var>[Symbol.iterator]()</code></pre>
+<pre class="brush: js">[Symbol.iterator]()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.html
@@ -14,10 +14,15 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">[<var>element0</var>, <var>element1</var>, ..., <var>elementN</var>]
+<pre class="brush: js">
+// literal constructor
+[element0, element1, ..., elementN]
 
-new Array(<var>element0</var>, <var>element1</var>[, ...[, <var>elementN</var>]])
-new Array(<var>arrayLength</var>)</pre>
+// construct from elements
+new Array(element0, element1, ..., elementN)
+
+// construct from array length
+new Array(arrayLength)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.html
@@ -21,7 +21,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">arr.at(index)</pre>
+<pre class="brush: js">at(index)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
@@ -21,9 +21,9 @@ tags:
 
 <pre class="brush: js">
 concat()
-concat(value1)
-concat(value1, value2)
-concat(value1, value2, valueN)
+concat(value0)
+concat(value0, value1)
+concat(value0, value1, ... , valueN)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.html
@@ -19,8 +19,12 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">const <var>new_array</var> = <var>old_array</var>.concat([<var>value1</var>[, <var>value2</var>[, ...[, <var>valueN</var>]]]])</pre>
+<pre class="brush: js">
+concat()
+concat(value1)
+concat(value1, value2)
+concat(value1, value2, valueN)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.html
@@ -19,7 +19,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.copyWithin(<var>target[, start[, end]]</var>)
+<pre class="brush: js">
+copyWithin(target)
+copyWithin(target, start)
+copyWithin(target, start, end)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/entries/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/entries/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.entries()</pre>
+<pre class="brush: js">entries()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.html
@@ -19,8 +19,22 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.every(<var>callback</var>(<var>element</var>[, <var>index</var>[, <var>array</var>]])[, <var>thisArg</var>])</pre>
+<pre class="brush: js">
+// Arrow function
+every((element) => { ... } )
+every((element, index) => { ... } )
+every((element, index, array) => { ... } )
+
+// Callback function
+every(callbackFn)
+every(callbackFn, thisArg)
+
+// Inline callback function
+every(function callbackFn(element) { ... })
+every(function callbackFn(element, index) { ... })
+every(function callbackFn(element, index, array){ ... })
+every(function callbackFn(element, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/fill/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/fill/index.html
@@ -20,7 +20,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.fill(<var>value[</var>, <var>start[<var>, <var>end]]</var>)</var></var>
+<pre class="brush: js">
+fill(value)
+fill(value, start)
+fill(value, start, end)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
@@ -19,9 +19,21 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let <var>newArray</var> = <var>arr</var>.filter(<var>callback</var>(<var>currentValue</var>[, <var>index</var>[<var>, array</var>]]) {
-  // return element for <var>newArray,</var> if true
-}[, <var>thisArg</var>]);
+<pre class="brush: js">
+// Arrow function
+filter((currentValue) => { ... } )
+filter((currentValue, index) => { ... } )
+filter((currentValue, index, array) => { ... } )
+
+// Callback function
+filter(callbackFn)
+filter(callbackFn, thisArg)
+
+// Inline callback function
+filter(function callbackFn(currentValue) { ... })
+filter(function callbackFn(currentValue, index) { ... })
+filter(function callbackFn(currentValue, index, array){ ... })
+filter(function callbackFn(currentValue, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -34,8 +34,22 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.find(<var>callback(element[, index[, array]])</var>[, <var>thisArg</var>])</pre>
+<pre class="brush: js">
+// Arrow function
+find((element) => { ... } )
+find((element, index) => { ... } )
+find((element, index, array) => { ... } )
+
+// Callback function
+find(callbackFn)
+find(callbackFn, thisArg)
+
+// Inline callback function
+find(function callbackFn(element) { ... })
+find(function callbackFn(element, index) { ... })
+find(function callbackFn(element, index, array){ ... })
+find(function callbackFn(element, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
@@ -25,7 +25,21 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.findIndex(<var>callback</var>( <var>element</var>[, <var>index</var>[, <var>array</var>]] )[, <var>thisArg</var>])
+<pre class="brush: js">
+// Arrow function
+findIndex((element) => { ... } )
+findIndex((element, index) => { ... } )
+findIndex((element, index, array) => { ... } )
+
+// Callback function
+findIndex(callbackFn)
+findIndex(callbackFn, thisArg)
+
+// Inline callback function
+findIndex(function callbackFn(element) { ... })
+findIndex(function callbackFn(element, index) { ... })
+findIndex(function callbackFn(element, index, array){ ... })
+findIndex(function callbackFn(element, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.html
@@ -20,9 +20,22 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>var new_array = arr</var>.flatMap(function <var>callback(currentValue[, index[, array]]) {
-    // return element for new_array
-}</var>[, <var>thisArg</var>])</pre>
+<pre class="brush: js">
+// Arrow function
+flatMap((currentValue) => { ... } )
+flatMap((currentValue, index) => { ... } )
+flatMap((currentValue, index, array) => { ... } )
+
+// Callback function
+flatMap(callbackFn)
+flatMap(callbackFn, thisArg)
+
+// Inline callback function
+flatMap(function callbackFn(currentValue) { ... })
+flatMap(function callbackFn(currentValue, index) { ... })
+flatMap(function callbackFn(currentValue, index, array){ ... })
+flatMap(function callbackFn(currentValue, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -18,9 +18,22 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.forEach(<var>callback(currentValue[, index[, array]]) {
-</var>  // execute something
-<var>}</var>[, <var>thisArg</var>]);</pre>
+<pre class="brush: js">
+// Arrow function
+forEach((currentValue) => { ... } )
+forEach((currentValue, index) => { ... } )
+forEach((currentValue, index, array) => { ... } )
+
+// Callback function
+forEach(callbackFn)
+forEach(callbackFn, thisArg)
+
+// Inline callback function
+forEach(function callbackFn(currentValue) { ... })
+forEach(function callbackFn(currentValue, index) { ... })
+forEach(function callbackFn(currentValue, index, array){ ... })
+forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.html
@@ -19,7 +19,21 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">Array.from(<var>arrayLike </var>[, <var>mapFn </var>[, <var>thisArg</var>]])
+<pre class="brush: js">
+// Arrow function
+Array.from(arrayLike, (currentValue) => { ... } )
+Array.from(arrayLike, (currentValue, index) => { ... } )
+Array.from(arrayLike, (currentValue, index, array) => { ... } )
+
+// Mapping function
+Array.from(arrayLike, mapFn)
+Array.from(arrayLike, mapFn, thisArg)
+
+// Inline mapping function
+Array.from(arrayLike, function mapFn(currentValue) { ... })
+Array.from(arrayLike, function mapFn(currentValue, index) { ... })
+Array.from(arrayLike, function mapFn(currentValue, index, array){ ... })
+Array.from(arrayLike, function mapFn(currentValue, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -22,7 +22,9 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.includes(<var>valueToFind</var>[, <var>fromIndex</var>])
+<pre class="brush: js">
+includes(valueToFind)
+includes(valueToFind, fromIndex)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/indexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/indexof/index.html
@@ -20,8 +20,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.indexOf(<var>searchElement</var>[, <var>fromIndex</var>])</pre>
+<pre class="brush: js">
+indexOf(searchElement)
+indexOf(searchElement, fromIndex)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/isarray/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/isarray/index.html
@@ -21,7 +21,7 @@ Array.isArray(undefined);  // false
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">Array.isArray(<var>value</var>)</pre>
+<pre class="brush: js">Array.isArray(value)</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/join/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/join/index.html
@@ -20,8 +20,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.join([<var>separator</var>])</pre>
+<pre class="brush: js">
+join()
+join(separator)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/keys/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/keys/index.html
@@ -20,7 +20,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.keys()</pre>
+<pre class="brush: js">keys()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.html
@@ -19,7 +19,9 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.lastIndexOf(<var>searchElement</var>[, <var>fromIndex</var>])
+<pre class="brush: js">
+lastIndexOf(searchElement)
+lastIndexOf(searchElement, fromIndex)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.html
@@ -21,9 +21,21 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let <var>newArray</var> = <var>arr</var>.map(<var>callback</var>(<var>currentValue</var>[, <var>index</var>[, <var>array</var>]]) {
-  // return element for <em>newArray,</em> after executing something
-}[, <var>thisArg</var>]);
+<pre class="brush: js">
+// Arrow function
+map((currentValue) => { ... } )
+map((currentValue, index) => { ... } )
+map((currentValue, index, array) => { ... } )
+
+// Callback function
+map(callbackFn)
+map(callbackFn, thisArg)
+
+// Inline callback function
+map(function callbackFn(currentValue) { ... })
+map(function callbackFn(currentValue, index) { ... })
+map(function callbackFn(currentValue, index, array){ ... })
+map(function callbackFn(currentValue, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.html
@@ -33,7 +33,7 @@ Array(1, 2, 3);    // [1, 2, 3]
 <pre class="brush: js">
 Array.of(element0)
 Array.of(element0, element1)
-Array.of(element0, element1, .., elementN)
+Array.of(element0, element1, ... , elementN)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.html
@@ -30,8 +30,11 @@ Array(1, 2, 3);    // [1, 2, 3]
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js">Array.of(<var>element0</var>[, <var>element1</var>[, ...[, <var>element<em>N</em></var>]]])</pre>
+<pre class="brush: js">
+Array.of(element0)
+Array.of(element0, element1)
+Array.of(element0, element1, .., elementN)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/pop/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.pop()</pre>
+<pre class="brush: js">pop()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.html
@@ -18,8 +18,11 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.push([<var>element1</var>[, ...[, <var>elementN</var>]]])</pre>
+<pre class="brush: js">
+push(element0)
+push(element0, element1)
+push(element0, element1, .., elementN)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.html
@@ -21,7 +21,7 @@ tags:
 <pre class="brush: js">
 push(element0)
 push(element0, element1)
-push(element0, element1, .., elementN)
+push(element0, element1, ... , elementN)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -35,8 +35,23 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.reduce(<var>callback</var>( <var>accumulator</var>, <var>currentValue, </var>[, <var>index</var>[, <var>array</var>]] )[, <var>initialValue</var>])</pre>
+<pre class="brush: js">
+// Arrow function
+reduce((accumulator, currentValue) => { ... } )
+reduce((accumulator, currentValue, index) => { ... } )
+reduce((accumulator, currentValue, index, array) => { ... } )
+reduce((accumulator, currentValue, index, array) => { ... }, initialValue)
+
+// Reducer function
+reduce(reducerFn)
+reduce(reducerFn, initialValue)
+
+// Inline reducer function
+reduce(function reducerFn(accumulator, currentValue) { ... })
+reduce(function reducerFn(accumulator, currentValue, index) { ... })
+reduce(function reducerFn(accumulator, currentValue, index, array){ ... })
+reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
@@ -21,8 +21,23 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.reduceRight(<var>callback</var>(<var>accumulator</var>, <var>currentValue</var>[, <var>index</var>[, <var>array</var>]])[, <var>initialValue</var>])</pre>
+<pre class="brush: js">
+// Arrow function
+reduceRight((accumulator, currentValue) => { ... } )
+reduceRight((accumulator, currentValue, index) => { ... } )
+reduceRight((accumulator, currentValue, index, array) => { ... } )
+reduceRight((accumulator, currentValue, index, array) => { ... }, initialValue)
+
+// Reducer function
+reduceRight(reducerFn)
+reduceRight(reducerFn, initialValue)
+
+// Inline reducer function
+reduceRight(function reducerFn(accumulator, currentValue) { ... })
+reduceRight(function reducerFn(accumulator, currentValue, index) { ... })
+reduceRight(function reducerFn(accumulator, currentValue, index, array){ ... })
+reduceRight(function reducerFn(accumulator, currentValue, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reverse/index.html
@@ -18,7 +18,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.reverse()</pre>
+<pre class="brush: js">reverse()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/shift/index.html
@@ -19,7 +19,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.shift()</pre>
+<pre class="brush: js">shift()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.html
@@ -21,8 +21,22 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.some(<var>callback</var>(<var>element</var>[, <var>index</var>[, <var>array</var>]])[, <var>thisArg</var>])</pre>
+<pre class="brush: js">
+// Arrow function
+some((element) => { ... } )
+some((element, index) => { ... } )
+some((element, index, array) => { ... } )
+
+// Callback function
+some(callbackFn)
+some(callbackFn, thisArg)
+
+// Inline callback function
+some(function callbackFn(element) { ... })
+some(function callbackFn(element, index) { ... })
+some(function callbackFn(element, index, array){ ... })
+some(function callbackFn(element, index, array) { ... }, thisArg)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.html
@@ -23,7 +23,18 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.sort(<var>[compareFunction]</var>)
+<pre class="brush: js">
+// Functionless
+sort()
+
+// Arrow function
+sort((firstEl, secondEl) => { ... } )
+
+// Compare function
+sort(compareFn)
+
+// Inline compare function
+sort(function compareFn(firstEl, secondEl) { ... })
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -22,7 +22,11 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">let <var>arrDeletedItems</var> = <var>arr</var>.splice(<var>start</var>[, <var>deleteCount</var>[, <var>item1</var>[, <var>item2</var>[, ...]]]])
+<pre class="brush: js">
+splice(start)
+splice(start, deleteCount)
+splice(start, deleteCount, item1)
+splice(start, deleteCount, item1, item2, itemN)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.html
@@ -19,7 +19,10 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.toLocaleString([<var>locales[</var>, <var>options]]</var>);
+<pre class="brush: js">
+toLocaleString();
+toLocaleString(locales);
+toLocaleString(locales, options);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/tosource/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.toSource()</pre>
+<pre class="brush: js">toSource()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/tostring/index.html
@@ -16,7 +16,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.toString()</pre>
+<pre class="brush: js">toString()</pre>
 
 <h3 id="Return_value">Return value</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.html
@@ -17,8 +17,11 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: js"><var>arr</var>.unshift(<var>element1</var>[, ...[, <var>elementN</var>]])</pre>
+<pre class="brush: js">
+unshift(element0)
+unshift(element0, element1)
+unshift(element0, element1, .., elementN)
+</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.html
@@ -20,7 +20,7 @@ tags:
 <pre class="brush: js">
 unshift(element0)
 unshift(element0, element1)
-unshift(element0, element1, .., elementN)
+unshift(element0, element1, ... , elementN)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.html
@@ -21,7 +21,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><var>arr</var>.values()</pre>
+<pre class="brush: js">values()</pre>
 
 <h3 id="Return_value">Return value</h3>
 


### PR DESCRIPTION
In this PR, I've tried to play through the new guidelines for MDN's syntax sections for the JS `Array` built-in. So, here I:
- got rid of a lot of `<var>` in `<pre>`
- used multiple lines to show optional parameters
- removed any formal syntax notations (BNF) 

See https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods for the new guidelines and https://github.com/openwebdocs/project/issues/26 and the discussion at https://github.com/mdn/content/issues/2202.

There are a few methods here that use callbacks and there we lack clear guidelines on what to do but I tried to make these better by demonstrating how to use it with arrow functions, functions, and inline functions. I'm especially looking for review feedback on this aspect.