### PR TITLE
Fix bad macro reference in "<video>"

### DIFF
--- a/files/en-us/web/html/element/video/index.html
+++ b/files/en-us/web/html/element/video/index.html
@@ -147,7 +147,7 @@ tags:
   </tr>
   <tr>
    <td>{{domxref("HTMLMediaElement.emptied_event", 'emptied')}}</td>
-   <td>The media has become empty; for example, this event is sent if the media has already been loaded (or partially loaded), and the <a href="/en-US/docs/XPCOM_Interface_Reference/NsIDOMHTMLMediaElement" rel="internal"><code>load()</code></a> method is called to reload it.</td>
+   <td>The media has become empty; for example, this event is sent if the media has already been loaded (or partially loaded), and the <a href="/en-US/docs/Web/API/HTMLMediaElement/load" rel="internal"><code>load()</code></a> method is called to reload it.</td>
   </tr>
   <tr>
    <td>{{domxref("HTMLMediaElement.ended_event", 'ended')}}</td>


### PR DESCRIPTION
Fixes #4130  

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The link to load() method was pointing to [XPCOM](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/NsIDOMHTMLMediaElement) interface instead of [WebApi](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load). Hence, updated the link to load() method.
> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
> Issue number (if there is an associated issue)
Fixes #4130 
> Anything else that could help us review it
