### PR TITLE
AvailableInWorkers supports replacement text

### DIFF
--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -176,7 +176,7 @@ tags:
 
 <h3 id="Indicating_that_a_feature_is_available_in_web_workers">Indicating that a feature is available in web workers</h3>
 
-<p>The <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs">AvailableInWorkers</a></code> macro inserts a localised note box indicating that a feature is available in a <a href="/en-US/docs/Web/API/Web_Workers_API">Web worker</a> context. The default text can be customised if needed by specifying a string argument.</p>
+<p>The <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs">AvailableInWorkers</a></code> macro inserts a localized note box indicating that a feature is available in a <a href="/en-US/docs/Web/API/Web_Workers_API">Web worker</a> context. The default text can be customized if needed by specifying a string argument.</p>
 
 <h5 id="Syntax">Syntax</h5>
 
@@ -188,4 +188,3 @@ tags:
 <div>{{AvailableInWorkers}}
   {{AvailableInWorkers("This feature is available in <a href='/en-US/docs/Web/API/Web_Workers_API'>Web workers</a> except for service workers")}}
 </div>
-

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -176,15 +176,15 @@ tags:
 
 <h3 id="Indicating_that_a_feature_is_available_in_web_workers">Indicating that a feature is available in web workers</h3>
 
-<p>The <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs">AvailableInWorkers</a></code> macro inserts a localized note box indicating that a feature is available in a <a href="/en-US/docs/Web/API/Web_Workers_API">Web worker</a> context. The default text can be customized if needed by specifying a string argument.</p>
+<p>The <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs">AvailableInWorkers</a></code> macro inserts a localized note box indicating that a feature is available in a <a href="/en-US/docs/Web/API/Web_Workers_API">Web worker</a> context. You can use the argument <code>notservice</code> to indicate that a feature works in web workers except for service workers.</p>
 
 <h5 id="Syntax">Syntax</h5>
 
 <pre>\{{AvailableInWorkers}}
-\{{AvailableInWorkers("Replacement text to display in note if default is not suitable")}}</pre>
+\{{AvailableInWorkers("notservice")}}</pre>
 
 <h5 id="Examples">Examples</h5>
 
 <div>{{AvailableInWorkers}}
-  {{AvailableInWorkers("This feature is available in <a href='/en-US/docs/Web/API/Web_Workers_API'>Web workers</a> except for Service workers")}}
+  {{AvailableInWorkers("notservice")}}
 </div>

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -186,5 +186,5 @@ tags:
 <h5 id="Examples">Examples</h5>
 
 <div>{{AvailableInWorkers}}
-  {{AvailableInWorkers("This feature is available in <a href='/en-US/docs/Web/API/Web_Workers_API'>Web workers</a> except for service workers")}}
+  {{AvailableInWorkers("This feature is available in <a href='/en-US/docs/Web/API/Web_Workers_API'>Web workers</a> except for Service workers")}}
 </div>

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -176,6 +176,16 @@ tags:
 
 <h3 id="Indicating_that_a_feature_is_available_in_web_workers">Indicating that a feature is available in web workers</h3>
 
-<p>The <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs">AvailableInWorkers</a></code> macro inserts a localised note box indicating that a feature is available in a <a href="/en-US/docs/Web/API/Web_Workers_API">Web worker</a> context.</p>
+<p>The <code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/AvailableInWorkers.ejs">AvailableInWorkers</a></code> macro inserts a localised note box indicating that a feature is available in a <a href="/en-US/docs/Web/API/Web_Workers_API">Web worker</a> context. The default text can be customised if needed by specifying a string argument.</p>
 
-<p>{{AvailableInWorkers}}</p>
+<h5 id="Syntax">Syntax</h5>
+
+<pre>\{{AvailableInWorkers}}
+\{{AvailableInWorkers("Replacement text to display in note if default is not suitable")}}</pre>
+
+<h5 id="Examples">Examples</h5>
+
+<div>{{AvailableInWorkers}}
+  {{AvailableInWorkers("This feature is available in <a href='/en-US/docs/Web/API/Web_Workers_API'>Web workers</a> except for service workers")}}
+</div>
+

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -37,7 +37,7 @@ tags:
 
 <dl>
  <dt id="xmlhttprequest-onreadystatechange">{{domxref("XMLHttpRequest.onreadystatechange")}}</dt>
- <dd>An {{domxref("EventHandler")}} that is called whenever the <code>readyState</code> attribute changes.</dd>
+ <dd>An <a href="/en-US/docs/Web/Events/Event_handlers">Event handler</a> that is called whenever the <code>readyState</code> attribute changes.</dd>
  <dt id="xmlhttprequest-readystate">{{domxref("XMLHttpRequest.readyState")}} {{readonlyinline}}</dt>
  <dd>Returns an <code>unsigned short</code>, the state of the request.</dd>
  <dt>{{domxref("XMLHttpRequest.response")}} {{readonlyinline}}</dt>
@@ -62,7 +62,7 @@ tags:
  <dt id="xmlhttprequest-timeout">{{domxref("XMLHttpRequest.timeout")}}</dt>
  <dd>Is an <code>unsigned long</code> representing the number of milliseconds a request can take before automatically being terminated.</dd>
  <dt id="xmlhttprequesteventtarget-ontimeout">{{domxref("XMLHttpRequestEventTarget.ontimeout")}}</dt>
- <dd>Is an {{domxref("EventHandler")}} that is called whenever the request times out. </dd>
+ <dd>Is an <a href="/en-US/docs/Web/Events/Event_handlers">Event handler</a> that is called whenever the request times out. </dd>
  <dt id="xmlhttprequest-upload">{{domxref("XMLHttpRequest.upload")}} {{readonlyinline}}</dt>
  <dd>Is an {{domxref("XMLHttpRequestUpload")}}, representing the upload process.</dd>
  <dt id="xmlhttprequest-withcredentials">{{domxref("XMLHttpRequest.withCredentials")}}</dt>
@@ -174,6 +174,6 @@ tags:
    <li><a href="/en-US/docs/Web/API/Fetch_API" title="Fetch API">Fetch API</a></li>
   </ul>
  </li>
- <li><a href="http://www.html5rocks.com/en/tutorials/file/xhr2/">HTML5 Rocks — New Tricks in XMLHttpRequest2</a></li>
+ <li><a href="https://www.html5rocks.com/en/tutorials/file/xhr2/">HTML5 Rocks — New Tricks in XMLHttpRequest2</a></li>
  <li>Feature-Policy directive {{httpheader("Feature-Policy/sync-xhr", "sync-xhr")}}</li>
 </ul>

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>If your communication needs to involve receiving event data or message data from a server, consider using <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> through the {{domxref("EventSource")}} interface. For full-duplex communication, <a href="/en-US/docs/Web/API/WebSockets_API">WebSockets</a> may be a better choice.</p>
 
-<p>{{AvailableInWorkers("This feature is available in <a href=\"/en-US/docs/Web/API/Web_Workers_API\">Web workers</a>, except for <a href=\"/en-US/docs/Web/API/Service_Worker_API\">service workers</a>")}}</p>
+<p>{{AvailableInWorkers("notservice")}}</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>If your communication needs to involve receiving event data or message data from a server, consider using <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> through the {{domxref("EventSource")}} interface. For full-duplex communication, <a href="/en-US/docs/Web/API/WebSockets_API">WebSockets</a> may be a better choice.</p>
 
-<p>{{AvailableInWorkers("This feature is available in <a href="/en-US/docs/Web/API/Web_Workers_API">Web workers</a>, except for <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a>")}}</p>
+<p>{{AvailableInWorkers("This feature is available in <a href=\"/en-US/docs/Web/API/Web_Workers_API\">Web workers</a>, except for <a href=\"/en-US/docs/Web/API/Service_Worker_API\">service workers</a>")}}</p>
 
 <h2 id="Constructor">Constructor</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -22,12 +22,7 @@ tags:
 
 <p>If your communication needs to involve receiving event data or message data from a server, consider using <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> through the {{domxref("EventSource")}} interface. For full-duplex communication, <a href="/en-US/docs/Web/API/WebSockets_API">WebSockets</a> may be a better choice.</p>
 
-<p>{{AvailableInWorkers}}</p>
-<div class="notecard note">
-  <h4>Note</h4>
-  <p>Not supported in service workers.</p>
-</div>
-
+<p>{{AvailableInWorkers("This feature is available in <a href="/en-US/docs/Web/API/Web_Workers_API">Web workers</a>, except for <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a>")}}</p>
 
 <h2 id="Constructor">Constructor</h2>
 


### PR DESCRIPTION
https://github.com/mdn/yari/pull/3530 adds support for having specific text in the `{{AvailableInWorkers}}` macro. This updates the "common macros" page with the change, and also uses it in the XMLHttpRequest page.

This won't be ready to merge until the change gets into content repo. Creating so I don't forget.