### PR TITLE
Remove Note macro

### DIFF
--- a/files/en-us/mozilla/developer_guide/build_instructions/adding_files_to_the_build/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/adding_files_to_the_build/index.html
@@ -7,7 +7,10 @@ tags:
 ---
 <p>All platforms are using the same set of makefiles for the build so all you have to do is edit <code>Makefile.in</code> files (and possibly <code>toolkit/toolkit-tiers.mk</code> if you add new makefiles).</p>
 
-<p>{{ Note("Don\'t forget to check TreeHerder after you check in!") }}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Don't forget to check TreeHerder after you check in!</p>
+</div>
 
 <h2 id="Adding_files_to_the_build">Adding files to the build</h2>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/building_with_profile-guided_optimization/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/building_with_profile-guided_optimization/index.html
@@ -18,8 +18,17 @@ tags:
 
 <p>The Mozilla build system will run the <code>pgo-profile-run</code> make rule from <code>testing/testsuite-targets.mk</code>, which in turn runs the <code>build/pgo/profileserver.py</code> script. You can customize any of these two if you need the profile generation to happen differently from the default.</p>
 
-<h2 id="Building"><a name="Building"></a>Building</h2>
+<h2 id="Building">Building</h2>
 
-<p>PGO builds require you to start your build from a different target in client.mk. Instead of the usual <code>make -f client.mk build</code>, you do <code>make -f client.mk profiledbuild</code>. {{ Note("PGO builds will take much longer than normal builds! With GCC, you will wind up doing two complete clobber builds. With MSVC, you will only do one full build, and then another pass of re-linking, but re-linking libxul can take over a half hour on a fast machine, and use over one gigabyte of RAM.") }}</p>
+<p>PGO builds require you to start your build from a different target in client.mk. Instead of the usual <code>make -f client.mk build</code>, you do <code>make -f client.mk profiledbuild</code>.</p>
 
-<div class="warning">Linking a PGO build is known to exhaust the 32 bit address space on Win32.  To work around this either use a 64 bit compiler or use the /3GB boottime switch to give the linker more address space.  See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=543034">Bug 543034</a> for details.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>PGO builds will take much longer than normal builds! With GCC, you will wind up doing two complete clobber builds. With MSVC, you will only do one full build, and then another pass of re-linking, but re-linking libxul can take over a half hour on a fast machine, and use over one gigabyte of RAM.</p>
+</div>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>Linking a PGO build is known to exhaust the 32 bit address space on Win32.  To work around this either use a 64 bit compiler or use the /3GB boottime switch to give the linker more address space.  See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=543034">Bug 543034</a> for details.</p>
+</div>
+

--- a/files/en-us/mozilla/developer_guide/build_instructions/cross-compiling_mozilla/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/cross-compiling_mozilla/index.html
@@ -43,7 +43,10 @@ tags:
 
 <p>GCC and binutils will expect to find the system headers and libraries under ${xprefix}/${xtarget_arch} so you will need to copy those files from the target system, preserving directory structure and modify any scripts as necessary. You should copy over the X11 lib and include dirs as well.</p>
 
-<p>{{ Note("If your target system uses glibc, you must take special care to modify the local copy of the target\'s <code>/usr/lib/libc.so</code> file (which is actually a script) so that it looks for its files under $xprefix/$target_arch rather than /usr.") }}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>If your target system uses glibc, you must take special care to modify the local copy of the target\'s <code>/usr/lib/libc.so</code> file (which is actually a script) so that it looks for its files under $xprefix/$target_arch rather than /usr.</p>
+</div>
 
 <p>If you already have rpms for the target system and rpm installed on the build system, then you can use this <a class="external" href="https://www.mozilla.org/build/setup-xrpms.sh.txt">shortcut script</a> which should install the rpms into $xprefix/$xtarget_arch using rpm2cpio.</p>
 

--- a/files/en-us/mozilla/developer_guide/build_instructions/system_headers/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/system_headers/index.html
@@ -5,11 +5,18 @@ tags:
   - Build documentation
   - Developing Mozilla
 ---
-<p>In the Mozilla codebase, the compiler, at least recent version of gcc, is set to default to hidden symbols, in order to avoid a some problems. </p><p>{{ Note("Include the whole rationale here") }}
-</p><p>For this reason any system header included in the build has to be wrapped to make the symbols it defines visible. These so called system headers are listed in &lt;tt&gt;mozilla/config/system-headers&lt;/tt&gt;
-</p><p>The main symptom of the problem is if you get a message like this at link time:
-</p>
+<p>In the Mozilla codebase, the compiler, at least recent version of gcc, is set to default to hidden symbols, in order to avoid a some problems. </p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Include the whole rationale here</p>
+</div>
+
+<p>For this reason any system header included in the build has to be wrapped to make the symbols it defines visible. These so called system headers are listed in &lt;tt&gt;mozilla/config/system-headers&lt;/tt&gt;</p>
+
+<p>The main symptom of the problem is if you get a message like this at link time:</p>
+
 <pre class="eval">/usr/lib/gcc/i586-suse-linux/4.3/../../../../i586-suse-linux/bin/ld: libwidget_gtk2.so: hidden symbol `gtk_tree_view_new' isn't defined
 </pre>
-<p>This means that the header that declares &lt;tt&gt;gtk_tree_view_new()&lt;/tt&gt;, &lt;tt&gt;gtk/gtktreeview.h&lt;/tt&gt; in this case, is not in &lt;tt&gt;mozilla/config/system-headers&lt;/tt&gt;.
-</p>
+
+<p>This means that the header that declares &lt;tt&gt;gtk_tree_view_new()&lt;/tt&gt;, &lt;tt&gt;gtk/gtktreeview.h&lt;/tt&gt; in this case, is not in &lt;tt&gt;mozilla/config/system-headers&lt;/tt&gt;.</p>

--- a/files/en-us/mozilla/developer_guide/build_instructions/windows_build_prerequisites_using_cygwin/index.html
+++ b/files/en-us/mozilla/developer_guide/build_instructions/windows_build_prerequisites_using_cygwin/index.html
@@ -8,9 +8,18 @@ tags:
 ---
 <div>{{page("/en-US/docs/Build_Documentation/TOC")}}</div>
 
-<h2 id="This_document_is_for_historical_use_only">This document is for historical use only</h2>
 
-<p>{{Note('This document is a guide to the build prerequisites for building the Mozilla 1.9 codebase before the introduction of the MozillaBuild system in March 2007. If you are building Firefox 3 or greater, please see the standard <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites" title="Windows Build Prerequisites">Windows Build Prerequisites</a>. <strong>For building Firefox 2, Firefox 1.5, and other Mozilla products based on pre-1.9 branches, see the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Build_Prerequisites_(1.7_and_1.8_Branches)" title="Windows Build Prerequisites (1.7 and 1.8 Branches)">Windows Build Prerequisites on the 1.7 and 1.8 Branches</a>.</strong>')}}</p>
+<h2 id="This_document_is_for_historical_use_only"></h2>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This document is for historical use only.</p>
+</div>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This document is a guide to the build prerequisites for building the Mozilla 1.9 codebase before the introduction of the MozillaBuild system in March 2007. If you are building Firefox 3 or greater, please see the standard <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites" title="Windows Build Prerequisites">Windows Build Prerequisites</a>. For building Firefox 2, Firefox 1.5, and other Mozilla products based on pre-1.9 branches, see the <a href="/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Build_Prerequisites_(1.7_and_1.8_Branches)" title="Windows Build Prerequisites (1.7 and 1.8 Branches)">Windows Build Prerequisites on the 1.7 and 1.8 Branches</a>.</p>
+</div>
 
 <p>If you are building very old versions of the Mozilla source code, from the 1.0 branch and earlier, follow the <a class="external" href="https://www.mozilla.org/build/win32-nmake.html">nmake build instructions</a>.</p>
 

--- a/files/en-us/mozilla/developer_guide/interface_development_guide/commenting_idl_for_better_documentation/index.html
+++ b/files/en-us/mozilla/developer_guide/interface_development_guide/commenting_idl_for_better_documentation/index.html
@@ -8,8 +8,12 @@ tags:
 ---
 <p>Doxygen is a system of generating documentation from source code. The documentation team has tools that convert comments from the Doxygen format into the standard reference article format we use here on MDN, with certain limitations. This article will help you understand how you can format your comments to help ensure that the conversion process can be automated as much as possible in order to ensure that your interface gets properly documented.</p>
 <p>Happily, following these recommendations will also help ensure your comments are extremely human-readable, too.</p>
+
 <h2 id="Don't_worry!">Don't worry!</h2>
+
 <p>You don't need to write perfect documentation. That is why Mozilla has a couple of writers on-staff as well as a horde of happy volunteers. We will take your comments and notes and turn them into beautiful, easy to search and read documentation. But by following the guidelines here, you can help make sure that our tools can generate a "good start" version of the documentation for your interfaces, and that the writers will be able to easily figure out what the tools are not able to do automatically.</p>
+
+
 <h2 id="Comment_format">Comment format</h2>
 <p>Doxygen supports several comment formats; for style and consistency reasons, we use the following:</p>
 <pre class="eval">/**
@@ -20,14 +24,42 @@ tags:
 <p>Following the rules below will ensure that our tools are able to produce the best possible results, and will have the added bonus of making your comments easier to read!</p>
 <ul> <li>Include documentation comments for everything, even if you think it is obvious what it means. Automatic documentation generation tools can not see what is obvious to human brains. Plus, what is obvious to you is likely not obvious to everyone.</li> <li>Use Doxygen style comments <strong>only</strong> for information that is directly useful to someone using or implementing the interface. This helps keep the documentation tidy.</li> <li>Be concise and to the point. Writers will expand upon your documentation if necessary.</li> <li>Keep in mind that people for whom English is not their native language will be reading your comments (as well as the generated documentation), so try to avoid slang and abbreviations when possible.</li> <li>If possible, avoid putting comments in the middle of the definitions of APIs.</li> <li>If an interface is used as a parameter or as the type of the value returned by a method, please use the full name of the interface in the description of the method. This will help the tools generate proper links to help make the documentation easier to read and browse through.</li>
 </ul>
+
 <h2 id="Special_commands">Special commands</h2>
+
 <p>You can use special commands in your Doxygen comments; the ones listed below are interpreted by our tools. Using these will help generate much higher quality documentation, faster, with less human intervention required.</p>
-<table class="standard-table"> <tbody> <tr> <td class="header">Command</td> <td class="header">Details</td> </tr> <tr> <td>@brief <em>description</em></td> <td>Please only use this to provide a brief description of the interface, keep it short and to the point. Do not include more than one brief per interface.</td> </tr> <tr> <td>@param <em>parameter</em> <em>description</em></td> <td>Every parameter of a method should be documented, only use the parameter name, leave out things like [in]/[out].</td> </tr> <tr> <td>@returns <em>description</em></td> <td>If the method returns something then this should be included.</td> </tr> <tr> <td>@throws <em>ERROR</em> <em>description</em></td> <td>The error should be the actual name of the error constant, in all caps.</td> </tr> <tr> <td>@note <em>description</em></td> <td>Used to include a note styled paragraph.</td> </tr> <tr> <td>@remarks <em>remark</em></td> <td> <p>A remark paragraph to be included in the Remarks section of the documentation.</p> {{ note("This is not yet supported by our documentation tool. Using it will make it easier for documenters.") }}</td> </tr> <tr> <td>@see <em>description</em></td> <td> <p>Either an interface or a HTML link.</p> {{ note("This is not yet supported by our documentation tool. Using it will make it easier for documenters.") }}</td> </tr> <tr> <td>- or .</td> <td>Used at the beginning of a comment line to indicate an unordered list item. There must be a space between the list marker and the item. Nested lists should be indented from the previous level by two spaces.</td> </tr> <tr> <td>-#</td> <td>Used at the beginning of a comment line to indicate an ordered list item. There must be a space between the list marker and the item. Nested lists should be indented from the previous level by two spaces.</td> </tr> </tbody>
+
+<table class="standard-table"> <tbody> <tr> <td class="header">Command</td> <td class="header">Details</td> </tr> <tr> <td>@brief <em>description</em></td> <td>Please only use this to provide a brief description of the interface, keep it short and to the point. Do not include more than one brief per interface.</td> </tr> <tr> <td>@param <em>parameter</em> <em>description</em></td> <td>Every parameter of a method should be documented, only use the parameter name, leave out things like [in]/[out].</td> </tr> <tr> <td>@returns <em>description</em></td> <td>If the method returns something then this should be included.</td> </tr> <tr> <td>@throws <em>ERROR</em> <em>description</em></td> <td>The error should be the actual name of the error constant, in all caps.</td> </tr> <tr> <td>@note <em>description</em></td> <td>Used to include a note styled paragraph.</td> </tr> 
+  <tr>
+    <td>@remarks <em>remark</em></td>
+    <td>
+      <p>A remark paragraph to be included in the Remarks section of the documentation.</p>
+      <div class="notecard note">
+        <h4>Note</h4>
+        <p>This is not yet supported by our documentation tool. Using it will make it easier for documenters.</p>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td>@see <em>description</em></td>
+    <td>
+      <p>Either an interface or a HTML link.</p>
+      <div class="notecard note">
+        <h4>Note</h4>
+        <p>This is not yet supported by our documentation tool. Using it will make it easier for documenters.</p>
+      </div>
+    </td> 
+  </tr> 
+  <tr> <td>- or .</td> <td>Used at the beginning of a comment line to indicate an unordered list item. There must be a space between the list marker and the item. Nested lists should be indented from the previous level by two spaces.</td> </tr> <tr> <td>-#</td> <td>Used at the beginning of a comment line to indicate an ordered list item. There must be a space between the list marker and the item. Nested lists should be indented from the previous level by two spaces.</td>
+  </tr> 
+  </tbody>
 </table>
+
 <h2 id="Other_tips">Other tips</h2>
 <p>Some other helpful writing style tips that will help you make your comments cleaner and easier to read and understand:</p>
 <ul> <li>You don't need to include what a method returns in the description. Just include the @returns line. This helps avoid repetition and keeps your comment more streamlined.</li> <li>Everything in the Doxygen comment before a method, attribute, constant, or whatnot will be used as part of its description when the automatic documentation generator tool scans your IDL, so if you don't want it in the docs, you probably shouldn't put it there. Use a different format of comment instead, such as <code>/* ... */</code> or even <code>// comment</code>.</li>
 </ul>
+
 <h2 id="Example">Example</h2>
 <p>This is an example of what the <a href="/Project:en/Sample_interface_document" title="Project:En/Sample interface document">Sample interface document</a> IDL would look like:</p>
 <pre class="eval">/**

--- a/files/en-us/mozilla/developer_guide/source_code/cvs/index.html
+++ b/files/en-us/mozilla/developer_guide/source_code/cvs/index.html
@@ -2,10 +2,14 @@
 title: Getting Mozilla Source Code Using CVS
 slug: Mozilla/Developer_guide/Source_Code/CVS
 ---
-<div class="note">Note: This document describes how to get source code for older versions of the code, Gecko 1.9.0, Firefox 3 or earlier, and older versions of NSS and NSPR. Development for Gecko 1.9.1/Firefox 3.5 and beyond, and recent versions of NSS and NSPR, uses the <a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial">Mercurial</a> source code control system.</div>
+<div class="notecard note">
+    <h4>Note</h4>
+    <p>This document describes how to get source code for older versions of the code, Gecko 1.9.0, Firefox 3 or earlier, and older versions of NSS and NSPR. Development for Gecko 1.9.1/Firefox 3.5 and beyond, and recent versions of NSS and NSPR, uses the <a class="internal" href="/en-US/docs/Mozilla/Developer_guide/Source_Code/Mercurial">Mercurial</a> source code control system.</p>
+</div>
 
-<div class="warning">
-<p>As of July 2015, CVS services are no longer operated at Mozilla. For access to CVS Archives, please see <a href="https://web.archive.org/web/20160629020307/https://blog.mozilla.org/it/2015/07/28/vcs-decom-status/">the blog post</a> announcing the change.</p>
+<div class="notecard warning">
+    <h4>Warning</h4>
+    <p>As of July 2015, CVS services are no longer operated at Mozilla. For access to CVS Archives, please see <a href="https://web.archive.org/web/20160629020307/https://blog.mozilla.org/it/2015/07/28/vcs-decom-status/">the blog post</a> announcing the change.</p>
 </div>
 
 <p>Those doing active development can check out the latest source using CVS. This is the preferred method if you plan to provide patches and fix bugs, as it lets you get up-to-the-minute changes and merge them with your own.</p>
@@ -94,7 +98,10 @@ slug: Mozilla/Developer_guide/Source_Code/CVS
  </dd>
 </dl>
 
-<p>{{ Note("The last version of Thunderbird on the HEAD was a post-3.0a2 nightly build. The last version of SeaMonkey on the HEAD was a 2.0a1pre nightly build. No further development of Thunderbird or SeaMonkey is taking place on the HEAD of CVS") }}</p>
+<div class="notecard note">
+    <h4>Note</h4>
+    <p>The last version of Thunderbird on the HEAD was a post-3.0a2 nightly build. The last version of SeaMonkey on the HEAD was a 2.0a1pre nightly build. No further development of Thunderbird or SeaMonkey is taking place on the HEAD of CVS"</p>
+</div>
 
 <h4 id="Specific_Branch">Specific Branch</h4>
 
@@ -117,7 +124,10 @@ $ make -f client.mk checkout MOZ_CO_PROJECT=<em>option,option</em>
 
 <p>As mentioned above, if you are using a custom <code>.mozconfig</code> file where you have already specified the <code>MOZ_CO_PROJECT</code> variable, you do not need to repeat it here on command line.</p>
 
-<div class="note">Always use <code>client.mk</code> to checkout the Mozilla sources: do not check out the <code>mozilla/</code> module directly. Various subprojects such as NSS, NSPR, and LDAP C SDK are pulled from stable release tags, even when regular mozilla development occurs on the trunk.</div>
+<div class="notecard note">
+    <h4>Note</h4>
+    <p>Always use <code>client.mk</code> to checkout the Mozilla sources: do not check out the <code>mozilla/</code> module directly. Various subprojects such as NSS, NSPR, and LDAP C SDK are pulled from stable release tags, even when regular mozilla development occurs on the trunk.</p>
+</div>
 
 <h4 id="Specific_Time">Specific Time</h4>
 

--- a/files/en-us/web/api/console/warn/index.html
+++ b/files/en-us/web/api/console/warn/index.html
@@ -13,8 +13,11 @@ tags:
 
 <p>Outputs a warning message to the Web Console.</p>
 
-<p>{{AvailableInWorkers}}{{Note("In Chrome and Firefox, warnings have a small exclamation
-  point icon next to them in the Web Console log.")}}</p>
+<p>{{AvailableInWorkers}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>In Chrome and Firefox, warnings have a small exclamation point icon next to them in the Web Console log.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/fileerror/index.html
+++ b/files/en-us/web/api/fileerror/index.html
@@ -12,8 +12,9 @@ tags:
 
 <p>Represents an error that occurs while using the {{domxref("FileReader")}} interface.</p>
 
-<div class="note">
-<p><strong>Note:</strong> This interface is obsolete per the latest specification. Use the new DOM4 {{domxref("DOMError")}} interface instead.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This interface is obsolete per the latest specification. Use the new DOM4 {{domxref("DOMError")}} interface instead.</p>
 </div>
 
 <p>In the <a href="/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction">File System API</a>, a <code>FileError</code> represents error conditions that you might encounter while accessing the file system using the asynchronous API. It extends the <code>FileError</code> interface described in <a href="http://dev.w3.org/2009/dap/file-system/pub/FileSystem/#bib-FILE-WRITER">File Writer</a> and adds several new error codes.</p>
@@ -53,7 +54,10 @@ tags:
 
 <h2 id="Error_codes">Error codes</h2>
 
-<p>{{Note("Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
+</div>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/api/fileexception/index.html
+++ b/files/en-us/web/api/fileexception/index.html
@@ -53,7 +53,10 @@ var fileEntry = fs.root.getFile('log.txt', {create: true, exclusive:true}0;
 
 <h2 id="Constants">Constants</h2>
 
-<p>{{Note("Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
+</div>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/api/idbdatabaseexception/index.html
+++ b/files/en-us/web/api/idbdatabaseexception/index.html
@@ -6,10 +6,11 @@ tags:
   - Obsolete
   - Reference
 ---
-<div>{{APIRef("IndexedDB")}}</div>
+<div>{{APIRef("IndexedDB")}} {{Obsolete_Header}}</div>
 
-<div class="warning style-wrap">
-<p><strong>Obsolete:</strong> This interface was removed from the specification and was replaced by usage of {{ domxref("DOMException") }}.</p>
+<div class="notecard warning">
+  <h4>Obsolete</h4>
+  <p>This interface was removed from the specification and was replaced by usage of {{ domxref("DOMException") }}.</p>
 </div>
 
 <p>In the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a>, an <code>IDBDatabaseException</code> object represents exception conditions that can be encountered while performing database operations.</p>
@@ -40,7 +41,10 @@ tags:
 
 <h2 id="Constants">Constants</h2>
 
-<p>{{ Note("Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead. ") }}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p>
+</div>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/api/idbenvironmentsync/index.html
+++ b/files/en-us/web/api/idbenvironmentsync/index.html
@@ -11,8 +11,9 @@ tags:
 ---
 <p>{{APIRef("IndexedDB")}} {{ draft() }}</p>
 
-<div class="warning">
-<p><strong>Important</strong>: The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
+<div class="notecard warning">
+  <h4>Important</h4>
+  <p>The synchronous version of the IndexedDB API was originally intended for use only with <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers</a>, and was eventually removed from the spec because its need was questionable. It may however be reintroduced in the future if there is enough demand from web developers.</p>
 </div>
 
 <p>The {{ unimplemented_inline() }} <code>IDBEnvironmentSync</code> interface of the <a href="/en-US/docs/Web/API/IndexedDB_API">IndexedDB API</a> will be implemented by <a href="/en-US/docs/Web/API/Worker">worker</a> objects.</p>
@@ -31,7 +32,12 @@ tags:
   <tr>
    <td><code><a name="indexedDBSync">indexedDBSync</a></code></td>
    <td><code>readonly <a href="/en-US/docs/Web/API/IDBFactorySync">IDBFactorySync</a></code></td>
-   <td>Provides a synchronous means of accessing the capabilities of indexed databases. {{ Note("Until the Indexed Database API specification is finalized, this attribute should be accessed as <code>moz_indexedDBSync</code>.") }}</td>
+   <td>Provides a synchronous means of accessing the capabilities of indexed databases. 
+     <div class="notecard note">
+       <h4>Note</h4>
+       <p>Until the Indexed Database API specification is finalized, this attribute should be accessed as <code>moz_indexedDBSync</code>.</p>
+     </div>  
+    </td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/api/idbobjectstore/get/index.html
+++ b/files/en-us/web/api/idbobjectstore/get/index.html
@@ -23,10 +23,11 @@ tags:
   the <code><a href="/en-US/docs/Web/API/IDBRequest#attr_result">result</a></code> of the
   request object.</p>
 
-<p>{{ Note("This method produces the same result for: a) a record that doesn't exist in
-  the database and b) a record that has an undefined value. To tell these situations
-  apart, call the <code>openCursor()</code> method with the same key. That method provides
-  a cursor if the record exists, and no cursor if it does not.") }}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>This method produces the same result for: a) a record that doesn't exist in the database and b) a record that has an undefined value.
+    To tell these situations apart, call the <code>openCursor()</code> method with the same key. That method provides a cursor if the record exists, and no cursor if it does not.</p>
+</div>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/en-us/web/api/navigator/mozislocallyavailable/index.html
+++ b/files/en-us/web/api/navigator/mozislocallyavailable/index.html
@@ -8,13 +8,15 @@ tags:
 - Non-standard
 - Obsolete
 ---
-<div>{{APIRef("HTML DOM")}}{{non-standard_header}}{{deprecated_header}}</div>
+<div>{{APIRef("HTML DOM")}} {{non-standard_header}}{{deprecated_header}}</div>
 
 <p>The <strong><code>Navigator.mozIsLocallyAvailable()</code></strong> method allows
   add-ons to determine whether or not a given resource is available.</p>
 
-<p>{{Note("Security exceptions can occur if the requested URI is not from the same
-  origin.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Security exceptions can occur if the requested URI is not from the same origin.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigator/registercontenthandler/index.html
+++ b/files/en-us/web/api/navigator/registercontenthandler/index.html
@@ -2,22 +2,24 @@
 title: Navigator.registerContentHandler()
 slug: Web/API/Navigator/registerContentHandler
 tags:
-- API
-- MIME
-- Method
-- Navigator
-- Obsolete
-- Web-Based Protocol Handlers
-- registerContentHandler
+  - API
+  - MIME
+  - Method
+  - Navigator
+  - Obsolete
+  - Web-Based Protocol Handlers
+  - registerContentHandler
 ---
 <div>{{ApiRef("HTML DOM")}}{{deprecated_header}}</div>
 
 <p><span class="seoSummary">Allows web sites to register themselves as possible handlers
     for content of a particular MIME type.</span></p>
 
-<p>{{Note("Web sites may only register content handlers for themselves. For security
-  reasons, it\'s not possible for an extension or web site to register content handlers
-  targeting other sites.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Web sites may only register content handlers for themselves.
+    For security reasons, it's not possible for an extension or web site to register content handlers targeting other sites.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -41,7 +43,7 @@ tags:
 
 <h2 id="Notes">Notes</h2>
 
-<p>For <a href="/en-US/docs/Firefox_2_for_developers">Firefox 2</a> and above, only the
+<p>For <a href="/en-US/docs/Mozilla/Firefox/Releases/2">Firefox 2</a> and above, only the
   <code>application/vnd.mozilla.maybe.feed</code>, <code>application/atom+xml</code>, and
   <code>application/rss+xml</code> MIME types are supported. All values have the same
   effect, and the registered handler will receive feeds in all Atom and RSS versions (see
@@ -79,7 +81,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web-based_protocol_handlers"
+  <li><a href="/en-US/docs/Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers"
       title="Web-based_protocol_handlers">Web-based protocol handlers</a></li>
   <li>{{domxref("Navigator.registerProtocolHandler()")}}</li>
   <li><a href="/en-US/docs/WebAPI/Web_Activities">Web activities</a>, particularly view

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.html
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.html
@@ -20,8 +20,9 @@ tags:
  <br>
  The previous attempt — <a href="/en-US/docs/Web/HTML/Using_the_application_cache">AppCache</a> — seemed to be a good idea because it allowed you to specify assets to cache really easily. However, it made many assumptions about what you were trying to do and then broke horribly when your app didn’t follow those assumptions exactly. Read Jake Archibald's (unfortunately-titled but well-written) <a href="https://alistapart.com/article/application-cache-is-a-douchebag">Application Cache is a Douchebag</a> for more details.</p>
 
-<div class="note">
-<p><strong>Note</strong>: From Firefox 84, AppCache has been removed ({{bug("1619673")}}). It is also planned for removal in Chomium 90, and is deprecated in Safari.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>From Firefox 84, AppCache has been removed ({{bug("1619673")}}). It is also planned for removal in Chomium 90, and is deprecated in Safari.</p>
 </div>
 
 <p>Service workers should finally fix these issues. Service worker syntax is more complex than that of AppCache, but the trade off is that you can use JavaScript to control your AppCache-implied behaviors with a fine degree of granularity, allowing you to handle this problem and many more. Using a Service worker you can easily set an app up to use cached assets first, thus providing a default experience even when offline, before then getting more data from the network (commonly known as <a href="http://offlinefirst.org/">Offline First</a>). This is already available with native apps, which is one of the main reasons native apps are often chosen over web apps.</p>
@@ -81,7 +82,11 @@ tags:
  <br>
  Instead, we could build our own promise to handle this kind of case. (See our <a href="https://github.com/mdn/js-examples/tree/master/promises-test">Promises test</a> example for the source code, or <a href="https://mdn.github.io/js-examples/promises-test/">look at it running live</a>.)</p>
 
-<p>{{note("A real service worker implementation would use caching and onfetch rather than the XMLHttpRequest API. Those features are not used here so that you can focus on understanding Promises.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>A real service worker implementation would use caching and onfetch rather than the XMLHttpRequest API. Those features are not used here so that you can focus on understanding Promises.</p>
+</div>
+
 
 <pre class="brush: js">const imgLoad = (url) =&gt; {
   return new Promise((resolve, reject) =&gt; {

--- a/files/en-us/web/api/window/showmodaldialog/index.html
+++ b/files/en-us/web/api/window/showmodaldialog/index.html
@@ -8,18 +8,17 @@ tags:
 - Method
 - Window
 ---
-<div>{{deprecated_header}}{{APIRef}}</div>
+<div>{{deprecated_header}}{{APIRef}}</div> 
 
-<div class="warning">
-  <p><strong><em>This feature has been removed. Please fix your Web sites and
-        applications</em></strong>.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This feature has been removed. Please fix your Web sites and applications.</p>
 
   <p>This method was removed in Chrome 43 and Firefox 56.</p>
 </div>
 
 <p><span class="seoSummary">The <strong><code>Window.showModalDialog()</code></strong>
-    created and displayed a modal dialog box containing a specified HTML document.</span>
-</p>
+    created and displayed a modal dialog box containing a specified HTML document.</span></p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -80,8 +79,10 @@ tags:
   </tbody>
 </table>
 
-<p>{{Note("Firefox does not implement the <code>dialogHide</code>, <code>edge</code>,
-  <code>status</code>, or <code>unadorned</code> arguments.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Firefox does not implement the <code>dialogHide</code>, <code>edge</code>, <code>status</code>, or <code>unadorned</code> arguments.</p>
+</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/exslt/math/highest/index.html
+++ b/files/en-us/web/exslt/math/highest/index.html
@@ -12,8 +12,6 @@ tags:
 
 <p>A node has this maximum value if converting its string value to a number equals the maximum value.</p>
 
-<p>{{Note("???")}}</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">math:highest(<em>nodeSet</em>)

--- a/files/en-us/web/exslt/math/min/index.html
+++ b/files/en-us/web/exslt/math/min/index.html
@@ -13,8 +13,6 @@ tags:
 
 <p>To compute the minimum value of the node-set, the node set is sorted into ascending order as it would be using <code><a href="/en-US/XSLT/sort">xsl:sort()</a></code> with a data type of <code>number</code>. The minimum value is then the first node in the sorted list, converted into a number.</p>
 
-<p>{{Note()}}</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="eval">math:min(<em>nodeSet</em>)

--- a/files/en-us/web/html/element/optgroup/index.html
+++ b/files/en-us/web/html/element/optgroup/index.html
@@ -50,7 +50,10 @@ tags:
  </tbody>
 </table>
 
-<p>{{Note("Optgroup elements may not be nested.")}}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Optgroup elements may not be nested.</p>
+</div>
 
 <h2 id="Attributes">Attributes</h2>
 

--- a/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.html
+++ b/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.html
@@ -10,16 +10,17 @@ tags:
 
 <p>To start, you need to create an {{domxref("XSLTProcessor")}} object:</p>
 
-<div style="overflow: hidden;">
-<pre class="brush: js">var processor = new XSLTProcessor();
-</pre>
-</div>
+
+<pre class="brush: js">var processor = new XSLTProcessor();</pre>
 
 <h3 id="Specifying_the_stylesheet">Specifying the stylesheet</h3>
 
 <p>Before you can use it, you must import a stylesheet with the {{domxref("XSLTProcessor.importStylesheet()")}} method. It has a single parameter, which is the DOM Node of the XSLT stylesheet to import.</p>
 
-<p>{{ note("The import is live, meaning that if you alter the stylesheet DOM after importing it, this will be reflected in the processing. Rather than modifying the DOM it is recommended to use stylesheet parameters which are usually easier and can give better performance.") }}</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The import is live, meaning that if you alter the stylesheet DOM after importing it, this will be reflected in the processing. Rather than modifying the DOM it is recommended to use stylesheet parameters which are usually easier and can give better performance.</p>
+</div>
 
 <pre class="brush: js">var testTransform = document.implementation.createDocument("", "test", null);
 // just an example to get a transform into a script as a DOM


### PR DESCRIPTION
This removes all uses in the docs of the `{{Note}}` macro. The right way to do notes in docs in using the div with class notecard note. 

This started out as fixing #4138. Both those were this kind of note, and both were empty. They have just been deleted.

> Issue number (if there is an associated issue)

Fixes #4138

> Anything else that could help us review it
