### PR TITLE
Fix typos in Structures/Syntax_sections doc

### DIFF
--- a/files/en-us/mdn/structures/syntax_sections/index.html
+++ b/files/en-us/mdn/structures/syntax_sections/index.html
@@ -90,7 +90,7 @@ new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds);
 
 <p>Formal syntax notation (using <a href="https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form">BNF</a>) should not be used in the Syntax section — instead use the expanded multiple-line format <a href="#multiple_lines">described above</a>.</p>
 
-<p>While the formal notation provides a concise mechanism for describing complex syntax, it is not familiar to many developers, and can <em>conflict</em> with valid syntax for particular programming languages. For example, <code>[ ]</code> indictes both an "optional parameter" and a JavaScript {{jsxref("Array")}}. You can see this in the formal syntax for {{jsxref("Array.prototype.slice()")}} below:</p>
+<p>While the formal notation provides a concise mechanism for describing complex syntax, it is not familiar to many developers, and can <em>conflict</em> with valid syntax for particular programming languages. For example, "<code>[&nbsp;]</code>" indicates both an "optional parameter" and a JavaScript {{jsxref("Array")}}. You can see this in the formal syntax for {{jsxref("Array.prototype.slice()")}} below:</p>
 
 <pre class="brush: js">arr.slice([begin[, end]])</pre>
 
@@ -220,7 +220,7 @@ gainNode.gain.value = 0;</pre>
 
 <h2 id="HTML_reference_syntax">HTML reference syntax</h2>
 
-<p>HTML reference pages don't have "Syntax" sections — the syntax is always just the element name surrounded by angle brackets, so it isn't needed. the main thing you need to know about HTML elements is what attributes they take and what their values can be, and this is covered in a separate "Attributes" section. See {{htmlelement("ol")}} and {{htmlelement("video")}} for examples.</p>
+<p>HTML reference pages don't have "Syntax" sections — the syntax is always just the element name surrounded by angle brackets, so it isn't needed. The main thing you need to know about HTML elements is what attributes they take and what their values can be, and this is covered in a separate "Attributes" section. See {{htmlelement("ol")}} and {{htmlelement("video")}} for examples.</p>
 
 <h2 id="HTTP_reference_syntax">HTTP reference syntax</h2>
 


### PR DESCRIPTION
Along with fixing two typos, this change also adds an `&nbsp;` to prevent `"[ ]"` from confusingly getting broken across lines.