### PR TITLE
updated link to bonsaiden.github.io

### DIFF
--- a/files/en-us/web/tutorials/index.html
+++ b/files/en-us/web/tutorials/index.html
@@ -179,7 +179,7 @@ tags:
  <dd>A comprehensive, regularly updated guide to JavaScript for all levels of learning from beginner to advanced.</dd>
  <dt><strong><a href="https://github.com/getify/You-Dont-Know-JS" rel="external">You Don't Know JS</a> </strong></dt>
  <dd>A series of books diving deep into the core mechanisms of the JavaScript language.</dd>
- <dt><strong><a href="https://bonsaiden.github.com/JavaScript-Garden/" rel="external">JavaScript Garden</a></strong></dt>
+ <dt><strong><a href="https://bonsaiden.github.io/JavaScript-Garden/" rel="external">JavaScript Garden</a></strong></dt>
  <dd>Documentation of the most quirky parts of JavaScript.</dd>
  <dt><strong><a href="http://exploringjs.com/es6/" rel="external">Exploring ES6</a> </strong></dt>
  <dd>Reliable and in-depth information on ECMAScript 2015.</dd>


### PR DESCRIPTION
[GitHub Pages will stop redirecting Pages sites from *.github.com after April 15, 2021](https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/)
