### PR TITLE
Clean up documentation about Alt-Svc HTTP header

### DIFF
--- a/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.html
+++ b/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.html
@@ -20,8 +20,6 @@ tags:
 
 <p class="summary">The target of an HTTP request is called a "resource", whose nature isn't defined further; it can be a document, a photo, or anything else. Each resource is identified by a Uniform Resource Identifier ({{Glossary("URI")}}) used throughout HTTP for identifying resources.</p>
 
-<p>The identity and the location of resources on the Web are mostly given by a single URL (Uniform Resource Locator, a kind of URI). There are sometimes reasons identity and location are not given by the same URI: HTTP uses a specific HTTP header, {{HTTPHeader("Alt-Svc")}} when the resource requested wants the client to access it at another location.</p>
-
 <h2 id="URLs_and_URNs">URLs and URNs</h2>
 
 <h3 id="URLs">URLs</h3>

--- a/files/en-us/web/http/basics_of_http/index.html
+++ b/files/en-us/web/http/basics_of_http/index.html
@@ -25,8 +25,6 @@ tags:
  <dd>A specific kind of URI that directly embeds the resource it represents. Data URIs are very convenient, but have some caveats.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Resource_URLs">Resource URLs</a> {{Non-standard_Inline}}</dt>
  <dd>Resource URLs, those prefixed with the <code>resource</code> scheme are used by Firefox and Firefox browser extensions to load resources internally, but is also available to some sites the browser connects to as well.</dd>
- <dt>Separating identity and location of a resource: The Alt-Svc HTTP header</dt>
- <dd>Most of the time the identity and location of a web resource are shared, this can be changed with the {{HTTPHeader("Alt-Svc")}} header.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME types</a></dt>
  <dd>Since HTTP/1.0, different types of content can be transmitted. This article explains how this is accomplished using the {{HTTPHeader("Content-Type")}} header and the MIME standard.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs">Choosing between www and non-www URLs</a></dt>
@@ -43,4 +41,6 @@ tags:
  <dd>HTTP/2 completely revisited how connections are created and maintained. This article explains how HTTP frames allow multiplexing and solve the 'head-of-line' blocking problem of former HTTP versions.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Content_negotiation">Content Negotiation</a></dt>
  <dd>HTTP introduces a set of headers, starting with <code><a href="/en-US/docs/Web/HTTP/Headers/Accept">Accept</a></code> as a way for a browser to announce the format, language, or encoding it prefers. This article explains how this advertisement happens, how the server is expected to react, and how it chooses the most adequate response.</dd>
+ <dt>Specifying an alternative server for a resource: the Alt-Svc HTTP header</dt>
+ <dd>Sometimes a server wants to indicate that a particular resource should be loaded from a different server — while still appearing to the user as if were loaded from the same server. That can be accomplished using the {{HTTPHeader("Alt-Svc")}} header.</dd>
 </dl>

--- a/files/en-us/web/http/basics_of_http/index.html
+++ b/files/en-us/web/http/basics_of_http/index.html
@@ -41,6 +41,4 @@ tags:
  <dd>HTTP/2 completely revisited how connections are created and maintained. This article explains how HTTP frames allow multiplexing and solve the 'head-of-line' blocking problem of former HTTP versions.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Content_negotiation">Content Negotiation</a></dt>
  <dd>HTTP introduces a set of headers, starting with <code><a href="/en-US/docs/Web/HTTP/Headers/Accept">Accept</a></code> as a way for a browser to announce the format, language, or encoding it prefers. This article explains how this advertisement happens, how the server is expected to react, and how it chooses the most adequate response.</dd>
- <dt>Specifying an alternative server for a resource: the Alt-Svc HTTP header</dt>
- <dd>Sometimes a server wants to indicate that a particular resource should be loaded from a different server — while still appearing to the user as if were loaded from the same server. That can be accomplished using the {{HTTPHeader("Alt-Svc")}} header.</dd>
 </dl>

--- a/files/en-us/web/http/headers/alt-svc/index.html
+++ b/files/en-us/web/http/headers/alt-svc/index.html
@@ -9,9 +9,7 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <strong><code style="white-space: nowrap;">Alt-Svc</code></strong> HTTP response
-  header is used to advertise alternative services through which the same resource can be
-  reached. An alternative service is defined by a protocol/host/port combination.</p>
+<p>The {{HTTPHeader("Alt-Svc")}} HTTP header allows a server to indicate that a particular resource should be loaded from a different server — while still appearing to the user as if were loaded from the same server.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -84,7 +82,5 @@ Alt-Svc: h3-25=":443"; ma=3600, h2=":443"; ma=3600</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a
-      href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web">Identifying
-      resources on the Web</a></li>
+  <li><a href="https://www.mnot.net/blog/2016/03/09/alt-svc"> Alternative Services</a> (article about <code>Alt-Svc</code> by HTTP Working Group chair Mark Nottingham)</li>
 </ul>

--- a/files/en-us/web/http/resources_and_uris/index.html
+++ b/files/en-us/web/http/resources_and_uris/index.html
@@ -27,6 +27,4 @@ tags:
  <dd>MIME media types define what kind of document a specific resource is. This article presents both the syntax and the most useful MIME types for use on the Web.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types">Common MIME types</a></dt>
  <dd>List of common MIME types useful for Web developers.</dd>
- <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Separating_identity_and_location_of_a_resource">Separating identity and location of a resource: the Alt-Svc header</a></dt>
- <dd>Even if identity and location are both described using a {{Glossary("URL")}}, they are two different concepts and it is useful sometimes to distinguished between them. This article introduces the {{HTTPHeader("Alt-Svc")}} header.</dd>
 </dl>


### PR DESCRIPTION
Some content had been added that described the `Alt-Svc` header as having the purpose of *“separating the identity and location of a resource”*.  But that’s a misleading description — because what the `Alt-Svc` header is really about is, allowing a server to indicate that a particular resource should be loaded from a different server — while still appearing to the user as if were loaded from the same server.

See https://www.mnot.net/blog/2016/03/09/Alt-Svc for a great overview.

So this change:

* Replaces the summary in the `Alt-Svc` article itself, while adding a See Also link to  https://www.mnot.net/blog/2016/03/09/Alt-Svc

* Rewrites the description of `Alt-Svc` in the “Basics of HTTP” article.

* Removes mention of `Alt-Svc` from the “Identifying resources on the Web” article. That article is entirely about URLs and their constituent parts; e.g., their path parts. `Alt-Svc` is not about URLs — it is about origins (host/protocol/port) and has nothing do with, e.g., path parts. So `Alt-Svc` doesn’t belong there; it’s a non sequitur there.

* Removes mention of `Alt-Svc` from the “Resources and URIs” article, for reasons similar to the reasons for removing it from the “Identifying resources on the Web” article.

Fixes https://github.com/mdn/content/issues/4125

---

It seems like whoever added the language about `Alt-Svc` to the “Identifying resources on the Web” and “Resources and URIs” articles either had a misunderstanding about it, or else had a very idiosyncratic notion about it that’s very different from what the actual purpose of `Alt-Svc` is.

I think mnot’s https://www.mnot.net/blog/2016/03/09/Alt-Svc makes the intended purpose of `Alt-Svc` very clear — and *“separating the identity and location of a resource”* is clearly not a great description of that purpose.