### PR TITLE
Drop parameter from example location.reload() call

### DIFF
--- a/files/en-us/web/api/window/location/index.html
+++ b/files/en-us/web/api/window/location/index.html
@@ -51,10 +51,9 @@ location = <var>newLocation</var>;
 location = "http://www.mozilla.org";
 </pre>
 
-<h3 id="Example_2_Force_reloading_the_current_page_from_the_server">Example #2: Force
-  reloading the current page from the server</h3>
+<h3 id="Example_2_reloading_the_current_page">Example #2: Reloading the current page</h3>
 
-<pre class="brush: js">location.reload(true);</pre>
+<pre class="brush: js">location.reload();</pre>
 
 <h3 id="Example_3">Example #3</h3>
 


### PR DESCRIPTION
This change drops the parameter from the `location.reload()` call in an example in the window.location article, and re-titles the example.  Fixes https://github.com/mdn/content/issues/4143.

Standard `location.reload()` doesn’t take a parameter, and doesn’t cause a force reload — it may reload the document from the browser cache, rather than re-fetching it over the network.