### PR TITLE
Drop unhelpful note about CSRF from CORS doc

### DIFF
--- a/files/en-us/web/http/cors/index.html
+++ b/files/en-us/web/http/cors/index.html
@@ -91,11 +91,6 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>These are the same kinds of cross-site requests that web content can already issue, and no response data is released to the requester unless the server sends an appropriate header. Therefore, sites that prevent cross-site request forgery have nothing new to fear from HTTP access control.</p>
-</div>
-
-<div class="notecard note">
-  <h4>Note</h4>
   <p>WebKit Nightly and Safari Technology Preview place additional restrictions on the values allowed in the {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}}, and {{HTTPHeader("Content-Language")}} headers. If any of those headers have ”nonstandard” values, WebKit/Safari does not consider the request to be a “simple request”. What values WebKit/Safari consider “nonstandard” is not documented, except in the following WebKit bugs:</p>
 
 <ul>


### PR DESCRIPTION
If we’re going to mention CSRF in the CORS article, we would need to say quite a lot more than what this note says. And since this note is wrongly saying that you don’t need to worry at all about CSRF in a specific subset of cases (simple requests), it may give the very wrong impression that CORS overall doesn’t create any additional CSRF risk.

So it’s better to mention nothing at all about CSRF in this CORS article than it is to have this one mention in this one odd note.

Fixes https://github.com/mdn/content/issues/4111