### PR TITLE
Add link to “Global object” page from “globalThis”

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/globalthis/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/globalthis/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{jsSidebar("Objects")}}</div>
 
-<p><span class="seoSummary">The global <code><strong>globalThis</strong></code> property contains the global <code>this</code> value, which is akin to the global object.</span></p>
+<p><span class="seoSummary">The global <code><strong>globalThis</strong></code> property contains the global <code>this</code> value, which is akin to the <a href="/en-US/docs/Glossary/Global_object">global object</a>.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-globalthis.html","shorter")}}</div>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was no link to explain what the global object is.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it

None
