### PR TITLE
hotfix to unbreak poetry in PR Review Companion

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -81,7 +81,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install deployer
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           cd yari/deployer
           poetry install


### PR DESCRIPTION
Part of #4165

I've never see this come up before. I googled the problem and lots of `poetry` users seem to get this and it's confusing. 
This PR will fix it but it would be nice to be able to cache the `poetry install` so I'm not going to close the issue yet. 