### PR TITLE
Clarify in JS “static” doc: class fields are a proposal

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.html
@@ -219,6 +219,8 @@ new ClassWithPrivateAccessor();
 <ul>
   <li><a href="/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields">Public
       class fields</a></li>
+  <li><a href="https://v8.dev/features/class-fields">Public and private class fields</a> article at the v8.dev site.</a></li>
+  <li><a href="https://github.com/tc39/proposal-class-fields#class-field-declarations-for-javascript">Class field declarations for JavaScript</a> explainer, by the <a href="https://github.com/tc39/proposal-class-fields">Public and private instance fields</a> authors</li>
   <li><a
       href="https://rfrn.org/~shu/2018/05/02/the-semantics-of-all-js-class-elements.html">The
       Semantics of All JS Class Elements</a></li>

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.html
@@ -295,6 +295,8 @@ console.log(instance.msg)
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="https://v8.dev/features/class-fields">Public and private class fields</a> article at the v8.dev site.</a></li>
+  <li><a href="https://github.com/tc39/proposal-class-fields#class-field-declarations-for-javascript">Class field declarations for JavaScript</a> explainer, by the <a href="https://github.com/tc39/proposal-class-fields">Public and private instance fields</a> authors</li>
   <li><a
       href="https://rfrn.org/~shu/2018/05/02/the-semantics-of-all-js-class-elements.html">The
       Semantics of All JS Class Elements</a></li>

--- a/files/en-us/web/javascript/reference/classes/static/index.html
+++ b/files/en-us/web/javascript/reference/classes/static/index.html
@@ -19,6 +19,8 @@ tags:
 or clone objects, whereas static properties are useful for caches, fixed-configuration,
 or any other data you don't need to be replicated across instances.</p>
 
+<p>Note that the examples throughout this article use <a href="/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields">public class fields</a> (including static public class fields), which are not yet part of the ECMAScript specification, but are instead specified in a <a href="https://tc39.es/proposal-class-fields/">Public and private instance fields</a> proposal at <a href="https://tc39.es/">TC39</a>.</p>
+
 <div>{{EmbedInteractiveExample("pages/js/classes-static.html")}}</div>
 
 
@@ -135,7 +137,7 @@ StaticMethodCall.anotherStaticMethod();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("javascript.classes.static")}}</p>
+<p>{{Compat("javascript.classes", "2")}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
This change adds a statement to the beginning of the article on the “static” keyword to alert readers to the fact that the examples throughout the article use public class fields, which are not yet part of the ES spec but instead are in a proposal document. Fixes https://github.com/mdn/content/issues/4097.

The change also updates the compat table on the page to show support data for the entire JS Class hierarchy, including public class fields and static class fields — to help readers understand what the level of browser support is for the syntax used in the article.

Additionally, the change updates the “Public class fields” and “Private class fields” articles with See Also links to the following:

* https://v8.dev/features/class-fields
* https://github.com/tc39/proposal-class-fields#class-field-declarations-for-javascript