### PR TITLE
FileSystemHandle.p.queryPermission() throws for bad mode param

### DIFF
--- a/files/en-us/web/api/filesystemhandle/querypermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.html
@@ -48,7 +48,7 @@ tags:
 
 <dl>
   <dt><code>TypeError</code></dt>
-  <dd>No parameter is specified or the <code>mode</code> is not that of
+  <dd>If <code>mode</code> is specified with a value other than
     <code>'read'</code> or <code>'readwrite'</code></dd>
 </dl>
 

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.html
@@ -46,7 +46,11 @@ tags:
 
 <h3 id="Exceptions">Exceptions</h3>
 
-<p>None.</p>
+<dl>
+  <dt><code>TypeError</code></dt>
+  <dd>No parameter is specified or the <code>mode</code> is not that of
+    <code>'read'</code> or <code>'readwrite'</code></dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Added a desciption for the exception of FileSystemHandle.queryPermission() method.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The previous version didn't describe any exceptions for the method FileSystemHandle.queryPermission().
I added a description for the exception.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/queryPermission

> Issue number (if there is an associated issue)

> Anything else that could help us review it
