### PR TITLE
fix fileHandle.kind usage

### DIFF
--- a/files/en-us/web/api/file_system_access_api/index.html
+++ b/files/en-us/web/api/file_system_access_api/index.html
@@ -56,9 +56,9 @@ async function getFile() {
   // open file picker
   [fileHandle] = await window.showOpenFilePicker();
 
-  if (fileHandle.type === 'file') {
+  if (fileHandle.kind === 'file') {
     // run file code
-  } else if (fileHandle.type === 'directory') {
+  } else if (fileHandle.kind === 'directory') {
     // run directory code
   }
 


### PR DESCRIPTION
The previous usage was wrong and not like how the API described it.
Also, it didn't work.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The previous usage was wrong and not like how the API described it.
Also, it didn't work.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API

> Issue number (if there is an associated issue)

> Anything else that could help us review it
