### PR TITLE
cache the poetry install based on the action version

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -78,13 +78,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: yari/deployer/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          # Make sure to reflect the version of `snok/install-poetry` in the key
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-v1.1.3
 
       - name: Install deployer
-        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           cd yari/deployer
-          poetry install
+          poetry install --no-interaction --no-root
 
       - name: Deploy and analyze built content
         env:


### PR DESCRIPTION
Fixes #4165

@Elchi3 Watch out! I'm going to self-merge this and see if it solves all the problems. 
I got the tip for this smart solution in https://github.com/snok/install-poetry/issues/29
We were caching the virtualenv across two different versions. This might bite us again on the next release. But my mitigation is to add a code comment to remind us of what needs to be done when a new version comes out. 