### PR TITLE
fixed link flaw in Web/JavaScript/Reference/Operators

### DIFF
--- a/files/en-us/web/javascript/reference/operators/index.html
+++ b/files/en-us/web/javascript/reference/operators/index.html
@@ -213,7 +213,7 @@ tags:
 <dl>
  <dt>{{JSxRef("Operators/Optional_chaining", "?.")}}</dt>
  <dd>
- <p>The optional chaining operator returns <code>undefined</code> instead of causing an error if a reference is <a href="/en-US/docs/Glossary/nullish">nullish</a> (<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/null"><code>null</code></a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined"><code>undefined</code></a>).</p>
+ <p>The optional chaining operator returns <code>undefined</code> instead of causing an error if a reference is <a href="/en-US/docs/Glossary/Nullish">nullish</a> (<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/null"><code>null</code></a> or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined"><code>undefined</code></a>).</p>
  </dd>
 </dl>
 
@@ -271,10 +271,12 @@ tags:
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
    <th scope="col">Specification</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td>{{SpecName('ESDraft', '#sec-ecmascript-language-expressions', 'ECMAScript Language: Expressions')}}</td>
   </tr>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There's a link flaw

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators

> Issue number (if there is an associated issue)

> Anything else that could help us review it
