### PR TITLE
copy editing/finalizing 88 rel notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -7,40 +7,39 @@ tags:
   - Mozilla
   - Release
 ---
-<p>{{FirefoxSidebar}}{{draft}}</p>
+<p>{{FirefoxSidebar}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 88 that will affect developers. Firefox 88 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">April 20, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 88 that will affect developers. Firefox 88 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">April 19, 2021</a>.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 
 <h3 id="Developer_Tools">Developer Tools</h3>
 
 <ul>
-  <li> The toggle button for switching between raw and formatted response view has been implemented ({{bug(1693147)}}). For examples, see <a href="/en-US/docs/Tools/Network_Monitor/request_details#response_tab">Network request details > Response tab</a>.</li>
+  <li>The toggle button for switching between raw and formatted response views has been implemented ({{bug(1693147)}}). For examples, see <a href="/en-US/docs/Tools/Network_Monitor/request_details#response_tab">Network request details > Response tab</a>.</li>
 </ul>
-  
-<h4 id="removals_devtools">Removals</h4>
 
 <h3 id="HTML">HTML</h3>
 
-<h4 id="removals_html">Removals</h4>
+<p><em>No changes.</em></p>
 
 <h3 id="CSS">CSS</h3>
 
 <ul>
   <li>The {{cssxref(":user-valid")}} and {{cssxref(":user-invalid")}} pseudo-classes have been implemented ({{bug(1694141)}}).</li>
-  <li>The {{cssxref("image-set()","image-set()")}} functional notation is now implemented for {{cssxref("content")}} and {{cssxref("cursor")}} ({{bug(1695402)}}), and ({{bug(1695403)}}).</li>
-  <li>The {{cssxref("image-set()","image-set()")}} functional notation is now enabled ({{bug(1698133)}}).</li>
+  <li>The {{cssxref("image-set()","image-set()")}} functional notation is now implemented for {{cssxref("content")}} and {{cssxref("cursor")}} ({{bug(1695402)}} and {{bug(1695403)}}).</li>
+  <li>The {{cssxref("image-set()")}} functional notation is now enabled ({{bug(1698133)}}).</li>
   <li>The default <code>monospace</code> font for MacOS has been changed to Menlo ({{bug(1342741)}}).</li>
   <li>The <code>collapse</code> value of {{cssxref("visibility")}} is now implemented for ruby annotations ({{bug(1697529)}}).</li>
-  <li>The <code>alternate</code> value for {{cssxref("ruby-position")}} is now implemented, and is the new initial value for the property ({{bug(1694748)}}).</li>
+  <li>The <code>alternate</code> value for {{cssxref("ruby-position")}} has been implemented, and is the new initial value for the property ({{bug(1694748)}}).</li>
+  <li>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property has been removed. ({{bug(315209)}} and {{bug(1694146)}}.)</li>
 </ul>
 
 <h4 id="removals_css">Removals</h4>
 
 <ul>
-  <li>The {{cssxref(":-moz-submit-invalid")}} pseudo-class has been hidden behind a preference, therefore removing it from web content ({{bug(1694129)}}).</li>
-  <li>Default styling for the non-standard {{cssxref(":-moz-ui-invalid")}} and {{cssxref(":-moz-ui-valid")}} has been removed ({{bug(1693969)}}).</li>
+  <li>The {{cssxref(":-moz-submit-invalid")}} pseudo-class has been hidden behind a preference, thereby removing it from web content ({{bug(1694129)}}).</li>
+  <li>Default styling for the non-standard {{cssxref(":user-invalid")}} and {{cssxref(":-moz-ui-valid")}} has been removed ({{bug(1693969)}}).</li>
 </ul>
 
 <h3 id="JavaScript">JavaScript</h3>
@@ -50,47 +49,33 @@ tags:
   <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames"><code>Intl.DisplayNames()</code></a> and <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat"><code>Intl.ListFormat()</code></a> now have stricter checking that <code>options</code> passed to the constructor are <a href="/en-US/docs/Learn/JavaScript/Objects">objects</a>, and will throw an exception if a string or other primitive is used instead ({{bug(1696881)}}).</li>
 </ul>
 
-<h4 id="removals_js">Removals</h4>
-
 <h3 id="HTTP">HTTP</h3>
 
 <ul>
   <li>FTP has been disabled on all releases (preference <code>network.ftp.enabled</code> now defaults to <code>false</code>), with the intent of removing it altogether in Firefox 90 ({{bug(1691890)}}). Complementing this change, the extension setting <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/ftpProtocolEnabled">browserSettings.ftpProtocolEnabled</a> has been made read-only, and web extensions can now register themselves as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers">protocol handlers</a> for FTP ({{bug(1626365)}}).</li>
 </ul>
 
-<h4 id="removals_http">Removals</h4>
-
 <h3 id="Security">Security</h3>
 
-<h4 id="removals_sec">Removals</h4>
+<p><em>No changes.</em></p>
 
 <h3 id="APIs">APIs</h3>
 
 <h4 id="DOM">DOM</h4>
 
 <ul>
-  <li>Code can now use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted">aborted</a>. For more information see {{bug(1698468)}}.</li>
+  <li>Code can now use the new static method <a href="/en-US/docs/Web/API/AbortSignal/abort"><code>AbortSignal.abort()</code></a> to return an {{domxref("AbortSignal")}} that is already set as <a href="/en-US/docs/Web/API/AbortSignal/aborted"><code>aborted</code></a> ({{bug(1698468)}}).</li>
 </ul>
-
-<h4 id="Media_WebRTC_and_Web_Audio">Media, WebRTC, and Web Audio</h4>
-
-<h4 id="removals_media">Removals</h4>
-
-<h3 id="WebAssembly">WebAssembly</h3>
-
-<h4 id="removals_wasm">Removals</h4>
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
-<h4 id="removals_webdriver">Removals</h4>
+<p><em>No changes.</em></p>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
 <ul>
   <li><code>url</code> can now be used to limit the properties for which the {{WebExtAPIRef("tabs.onUpdated")}} event is triggered ({{bug(1680279)}}).</li>
 </ul>
-
-<h4 id="removals_webext">Removals</h4>
 
 <h2 id="Older_versions">Older versions</h2>
 


### PR DESCRIPTION
This finalizes the Firefox 88 rel notes in time for the release next Monday.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
