### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/image_gallery/index.html
+++ b/files/en-us/learn/javascript/building_blocks/image_gallery/index.html
@@ -107,7 +107,7 @@ tags:
 <ol>
  <li>Checks the current class name set on the <code>&lt;button&gt;</code> — you can again achieve this by using <code>getAttribute()</code>.</li>
  <li>If the class name is <code>"dark"</code>, changes the <code>&lt;button&gt;</code> class to <code>"light"</code> (using <code><a href="/en-US/docs/Web/API/Element/setAttribute">setAttribute()</a></code>), its text content to "Lighten", and the {{cssxref("background-color")}} of the overlay <code>&lt;div&gt;</code> to <code>"rgba(0,0,0,0.5)"</code>.</li>
- <li>If the class name not <code>"dark"</code>, changes the <code>&lt;button&gt;</code> class to <code>"dark"</code>, its text content back to "Darken", and the {{cssxref("background-color")}} of the overlay <code>&lt;div&gt;</code> to <code>"rgba(0,0,0,0)"</code>.</li>
+ <li>If the class name is not <code>"dark"</code>, changes the <code>&lt;button&gt;</code> class to <code>"dark"</code>, its text content back to "Darken", and the {{cssxref("background-color")}} of the overlay <code>&lt;div&gt;</code> to <code>"rgba(0,0,0,0)"</code>.</li>
 </ol>
 
 <p>The following lines provide a basis for achieving the changes stipulated in points 2 and 3 above.</p>


### PR DESCRIPTION
Issue: A missing "is" on this MDN page: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Image_gallery

I am not quite sure what the etiquette for very small changes like this ought to be but as far as I could tell from the contributing.md file, this ought to be fine. 