### PR TITLE
Add info about when fetch promise is resolved exactly

### DIFF
--- a/files/en-us/web/api/fetch_api/index.html
+++ b/files/en-us/web/api/fetch_api/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>For making a request and fetching a resource, use the {{DOMxRef("WindowOrWorkerGlobalScope.fetch()")}} method. It is implemented in multiple interfaces, specifically {{DOMxRef("Window")}} and {{DOMxRef("WorkerGlobalScope")}}. This makes it available in pretty much any context you might want to fetch resources in.</p>
 
-<p>The <code>fetch()</code> method takes one mandatory argument, the path to the resource you want to fetch. It returns a {{JSxRef("Promise")}} that resolves to the {{DOMxRef("Response")}} to that request, whether it is successful or not. You can also optionally pass in an <code>init</code> options object as the second argument (see {{DOMxRef("Request")}}).</p>
+<p>The <code>fetch()</code> method takes one mandatory argument, the path to the resource you want to fetch. It returns a {{JSxRef("Promise")}} that resolves to the {{DOMxRef("Response")}} to that request (as soon as the server responds with headers), whether it is successful or not. You can also optionally pass in an <code>init</code> options object as the second argument (see {{DOMxRef("Request")}}).</p>
 
 <p>Once a {{DOMxRef("Response")}} is retrieved, there are a number of methods available to define what the body content is and how it should be handled (see {{DOMxRef("Body")}}).</p>
 

--- a/files/en-us/web/api/fetch_api/index.html
+++ b/files/en-us/web/api/fetch_api/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>For making a request and fetching a resource, use the {{DOMxRef("WindowOrWorkerGlobalScope.fetch()")}} method. It is implemented in multiple interfaces, specifically {{DOMxRef("Window")}} and {{DOMxRef("WorkerGlobalScope")}}. This makes it available in pretty much any context you might want to fetch resources in.</p>
 
-<p>The <code>fetch()</code> method takes one mandatory argument, the path to the resource you want to fetch. It returns a {{JSxRef("Promise")}} that resolves to the {{DOMxRef("Response")}} to that request (as soon as the server responds with headers), whether it is successful or not. You can also optionally pass in an <code>init</code> options object as the second argument (see {{DOMxRef("Request")}}).</p>
+<p>The <code>fetch()</code> method takes one mandatory argument, the path to the resource you want to fetch. It returns a {{JSxRef("Promise")}} that resolves to the {{DOMxRef("Response")}} to that request — as soon as the server responds with headers — <strong>even if the server response is an HTTP error status</strong>. You can also optionally pass in an <code>init</code> options object as the second argument (see {{DOMxRef("Request")}}).</p>
 
 <p>Once a {{DOMxRef("Response")}} is retrieved, there are a number of methods available to define what the body content is and how it should be handled (see {{DOMxRef("Body")}}).</p>
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -24,7 +24,7 @@ tags:
 <p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in the following significant ways:</p>
 
 <ul>
- <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, it will resolve normally (with <code>ok</code> status set to false), and it will only reject on network failure or if anything prevented the request from completing.</li>
+ <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers it will resolve normally (with <code>ok</code> status set to false), and it will only reject on network failure or if anything prevented the request from completing.</li>
  <li><code>fetch()</code> <strong>won’t send cross-origin cookies</strong> unless you set the <em>credentials</em> <a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters">init option</a>. (Since <a href="https://github.com/whatwg/fetch/pull/585" rel="nofollow noopener">April 2018</a>. The spec changed the default credentials policy to <code>same-origin</code>. Firefox changed since 61.0b13.)</li>
 </ul>
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -24,7 +24,7 @@ tags:
 <p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in the following significant ways:</p>
 
 <ul>
- <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers it will resolve normally (with <code>ok</code> status set to false), and it will only reject on network failure or if anything prevented the request from completing.</li>
+ <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with {{domxref("Response/ok", "ok")}} set to false if the response isn’t in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.</li>
  <li><code>fetch()</code> <strong>won’t send cross-origin cookies</strong> unless you set the <em>credentials</em> <a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters">init option</a>. (Since <a href="https://github.com/whatwg/fetch/pull/585" rel="nofollow noopener">April 2018</a>. The spec changed the default credentials policy to <code>same-origin</code>. Firefox changed since 61.0b13.)</li>
 </ul>
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.html
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.html
@@ -24,7 +24,7 @@ tags:
 <p>The <code>fetch</code> specification differs from <code>jQuery.ajax()</code> in the following significant ways:</p>
 
 <ul>
- <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with {{domxref("Response/ok", "ok")}} set to false if the response isn’t in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.</li>
+ <li>The Promise returned from <code>fetch()</code> <strong>won’t reject on HTTP error status</strong> even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the {{domxref("Response/ok", "ok")}} property of the response set to false if the response isn’t in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.</li>
  <li><code>fetch()</code> <strong>won’t send cross-origin cookies</strong> unless you set the <em>credentials</em> <a href="/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters">init option</a>. (Since <a href="https://github.com/whatwg/fetch/pull/585" rel="nofollow noopener">April 2018</a>. The spec changed the default credentials policy to <code>same-origin</code>. Firefox changed since 61.0b13.)</li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There're no details **when** a promise returned from `fetch` is resolved exactly or this info is obscure and unclear.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch