### PR TITLE
Fix "301" description in Location header doc

### DIFF
--- a/files/en-us/web/http/headers/location/index.html
+++ b/files/en-us/web/http/headers/location/index.html
@@ -22,7 +22,7 @@ tags:
     {{HTTPMethod("GET")}} method, {{HTTPStatus("307")}} (Temporary Redirect) and
     {{HTTPStatus("308")}} (Permanent Redirect) don't change the method used in the
     original request;</li>
-  <li>{{HTTPStatus("301")}} (Permanent Redirect) and {{HTTPStatus("302")}} (Found) doesn't
+  <li>{{HTTPStatus("301")}} (Moved Permanently) and {{HTTPStatus("302")}} (Found) doesn't
     change the method most of the time, though older user-agents may (so you basically
     don't know).</li>
 </ul>


### PR DESCRIPTION
"301" is not "Permanent Redirect".  
It's mean "Moved Permanently".  
reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301
