### PR TITLE
Drop the ToC from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,6 @@ hosted within the [MDN Organization](https://github.com/mdn) on GitHub.
   for an overview of how to join, and [Contributing to MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute)
   for a filtered list of tasks.
 
-<!-- You can quickly regenerate this TOC by running:
-  npx markdown-toc@1.2.0 --bullets='-' --no-firsth1 README.md -->
-
-- [Code of Conduct](#code-of-conduct)
-- [License](#license)
-- [Making contributions](#making-contributions)
-  - [Setup](#setup)
-  - [Fundamental concepts](#fundamental-concepts)
-  - [Simple changes](#simple-changes)
-  - [More substantial changes](#more-substantial-changes)
-  - [Pull request etiquette](#pull-request-etiquette)
-  - [Adding a new document](#adding-a-new-document)
-  - [Moving one or more documents](#moving-one-or-more-documents)
-  - [Deleting a document](#deleting-a-document)
-  - [Redirecting a document](#redirecting-a-document)
-  - [Adding images](#adding-images)
-  - [Updating a browser compatibility table](#updating-a-browser-compatibility-table)
-  - [Adding code examples](#adding-code-examples)
-  - [Archiving and unarchiving pages](#archiving-and-unarchiving-pages)
-  - [Making a change that depends on a macro update](#making-a-change-that-depends-on-a-macro-update)
-- [Frequently asked questions (FAQ)](#frequently-asked-questions-faq)
-  - [When will my change show up on the production MDN site?](#when-will-my-change-show-up-on-the-production-mdn-site)
-  - [Can I copy content from other places to put on MDN?](#can-i-copy-content-from-other-sources-to-put-on-MDN)
-
 ## Code of Conduct
 
 Everyone participating in this project is expected to follow our


### PR DESCRIPTION
Per https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/ the GitHub UI now provides a button for displaying a generated ToC for all markdown files — making our in-document ToC somewhat redundant. So this change removes it.