### PR TITLE
Update Web/HTTP/Resources_and_URIs

### DIFF
--- a/files/en-us/web/http/resources_and_uris/index.html
+++ b/files/en-us/web/http/resources_and_uris/index.html
@@ -26,7 +26,7 @@ tags:
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME Types</a></dt>
  <dd>MIME media types define what kind of document a specific resource is. This article presents both the syntax and the most useful MIME types for use on the Web.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types">Common MIME types</a></dt>
- <dd>Common list of MIME types useful for Web developers.</dd>
+ <dd>List of common MIME types useful for Web developers.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Separating_identity_and_location_of_a_resource">Separating identity and location of a resource: the Alt-Svc header</a></dt>
  <dd>Even if identity and location are both described using a {{Glossary("URL")}}, they are two different concepts and it is useful sometimes to distinguished between them. This article introduces the {{HTTPHeader("Alt-Svc")}} header.</dd>
 </dl>

--- a/files/en-us/web/http/resources_and_uris/index.html
+++ b/files/en-us/web/http/resources_and_uris/index.html
@@ -25,8 +25,8 @@ tags:
  <dd>Advice on using a www-prefixed domain or not, this article explains the consequences of the choice as well as how to make it.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME Types</a></dt>
  <dd>MIME media types define what kind of document a specific resource is. This article presents both the syntax and the most useful MIME types for use on the Web.</dd>
- <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types">Complete list of MIME types</a></dt>
- <dd>Comprehensive list of MIME types useful for Web developers.</dd>
+ <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types">Common MIME types</a></dt>
+ <dd>Common list of MIME types useful for Web developers.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/Separating_identity_and_location_of_a_resource">Separating identity and location of a resource: the Alt-Svc header</a></dt>
  <dd>Even if identity and location are both described using a {{Glossary("URL")}}, they are two different concepts and it is useful sometimes to distinguished between them. This article introduces the {{HTTPHeader("Alt-Svc")}} header.</dd>
 </dl>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

A link name and its description are incorrect.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Resources_and_URIs

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it
