### PR TITLE
fix “fit-content()” link

### DIFF
--- a/files/en-us/web/css/css_grid_layout/index.html
+++ b/files/en-us/web/css/css_grid_layout/index.html
@@ -119,7 +119,7 @@ tags:
 <ul>
  <li>{{CSSxRef("repeat", "repeat()")}}</li>
  <li>{{CSSxRef("minmax", "minmax()")}}</li>
- <li>{{CSSxRef("fit-content", "fit-content()")}}</li>
+ <li>{{CSSxRef("fit-content()", "fit-content()")}}</li>
 </ul>
 </div>
 


### PR DESCRIPTION
The link to the CSS function `fit-content` should now go to the correct document, instead of the document for the `fit-content` keyword.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed?

The CSS `fit-content` link went to the document for the keyword rather than the function of the same name.

> MDN URL of main page changed

[/en-US/docs/Web/CSS/CSS_Grid_Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout)