### PR TITLE
fix macro error

### DIFF
--- a/files/en-us/web/html/element/menu/index.html
+++ b/files/en-us/web/html/element/menu/index.html
@@ -198,7 +198,7 @@ tags:
   <tr>
    <td>{{SpecName("HTML WHATWG", "grouping-content.html#the-menu-element", "&lt;menu&gt;")}}</td>
    <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>No change from latest snapshot, {{SpecName("HTML5.3")}}</td>
+   <td>No change from latest snapshot, {{SpecName("HTML5.2")}}</td>
   </tr>
   <tr>
    <td>{{SpecName("HTML5.1", "interactive-elements.html#the-menu-element", "&lt;menu&gt;")}}</td>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There was a macro error in the Specifications section.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu

> Issue number (if there is an associated issue)

none