### PR TITLE
Remove textbox from document structure roles.

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/index.html
@@ -84,7 +84,6 @@ tags:
  <li>separator</li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Table_Role">table</a></li>
  <li>term</li>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_toolbar_role">toolbar</a></li>
  <li>tooltip</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

https://www.w3.org/TR/wai-aria-1.1/#roles_categorization does not list `textbox` as document structure role.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#document_structure_roles

> Issue number (if there is an associated issue)

Fixes #4219

> Anything else that could help us review it
