### PR TITLE
List missing ARIA roles in MDN. Refs #3924

### DIFF
--- a/rfcs/aria-roles.md
+++ b/rfcs/aria-roles.md
@@ -52,3 +52,59 @@ We need to write those pages.
 - Contact folks in the a11y community who might be willing to help write such
   pages. Get them working on pages.
 - Create a spreadsheet to track progress on each page.
+
+### Unwritten role pages
+
+Using [categorization of roles](https://www.w3.org/TR/wai-aria-1.1/#roles_categorization)
+as an exhaustive list, the following roles lack a page:
+
+* command (abstract, should not be used in content)
+* composite (abstract, should not be used in content)
+* input (abstract, should not be used in content)
+* landmark (abstract, should not be used in content)
+* range (abstract, should not be used in content)
+* roletype (abstract, should not be used in content)
+* section (abstract, should not be used in content)
+* sectionhead (abstract, should not be used in content)
+* select (abstract, should not be used in content)
+* structure (abstract, should not be used in content)
+* widget (abstract, should not be used in content)
+* window (abstract, should not be used in content)
+* menuitem (widget role)
+* menuitemcheckbox (widget role)
+* menuitemradio (widget role)
+* option (widget role)
+* scrollbar (widget role)
+* searchbox (widget role)
+* separator (when focusable, widget role)
+* spinbutton (widget role)
+* treeitem (widget role)
+* combobox (composite role)
+* menu (composite role)
+* menubar (composite role)
+* tablist (composite role)
+* tree (composite role)
+* treegrid (composite role)
+* columnheader (document structure role)
+* definition (document structure role)
+* directory (document structure role)
+* feed (document structure role)
+* math (document structure role)
+* none (document structure role)
+* note (document structure role)
+* rowheader (document structure role)
+* separator (when not focusable, document structure role)
+* term (document structure role)
+* tooltip (document structure role)
+* marquee (live region role)
+
+Don't forget to update the link in
+[MDN's list of ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques)
+once these pages were written!
+
+### Related issues
+
+Some role pages have opened issues already. This is a list to keep track of
+them, until the spreadsheet was created:
+
+- [ ] [Content suggestion: Aria tabpanel and tablist role #3924](https://github.com/mdn/content/issues/3924)


### PR DESCRIPTION
Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

@chrisdavidmills asked me to list all ARIA roles that lack a dedicated page in https://github.com/mdn/content/issues/3924#issuecomment-815559861.

> MDN URL of main page changed

N/A

> Issue number (if there is an associated issue)

#3924

> Anything else that could help us review it

I compared each role in https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#document_structure_roles with https://www.w3.org/TR/wai-aria-1.1/#roles_categorization