### PR TITLE
Fix `chrome-extension://[extensionID]`

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.html
@@ -342,7 +342,7 @@ setCookie.then(logCookie, logError);</pre>
 
 <dl>
  <dt>On Linux and Mac</dt>
- <dd>Chrome passes one argument to the native app, which is the origin of the extension that started it, in the form: <code>chrome-extension://«<var>extensionID</var>»</code>. This enables the app to identify the extension.</dd>
+ <dd>Chrome passes one argument to the native app, which is the origin of the extension that started it, in the form: <code>chrome-extension://«<var>extensionID/</var>»</code> (trailing slash required). This enables the app to identify the extension.</dd>
  <dt>On Windows</dt>
  <dd>
  <p>Chrome passes two arguments:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
@@ -172,7 +172,7 @@ python -u "c:\\path\\to\\native-messaging\\app\\ping_pong.py"</pre>
 <p>Chrome  handles the passed arguments differently:</p>
 
 <ul>
- <li>On Linux and Mac, Chrome passes <em>one</em> argument: the origin of the extension that started it (in the form <code>chrome-extension://[extensionID]/</code> – the trailing slash is required). This enables the app to identify the extension.</li>
+ <li>On Linux and Mac, Chrome passes <em>one</em> argument: the origin of the extension that started it (in the form <code>chrome-extension://[extensionID]</code>). This enables the app to identify the extension.</li>
  <li>On Windows, Chrome passes <em>two</em> arguments: the first is the origin of the extension, and the second is a handle to the Chrome native window that started the app.</li>
 </ul>
 </div>

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.html
@@ -172,7 +172,7 @@ python -u "c:\\path\\to\\native-messaging\\app\\ping_pong.py"</pre>
 <p>Chrome  handles the passed arguments differently:</p>
 
 <ul>
- <li>On Linux and Mac, Chrome passes <em>one</em> argument: the origin of the extension that started it (in the form <code>chrome-extension://[extensionID]</code>). This enables the app to identify the extension.</li>
+ <li>On Linux and Mac, Chrome passes <em>one</em> argument: the origin of the extension that started it (in the form <code>chrome-extension://[extensionID]/</code> – the trailing slash is required). This enables the app to identify the extension.</li>
  <li>On Windows, Chrome passes <em>two</em> arguments: the first is the origin of the extension, and the second is a handle to the Chrome native window that started the app.</li>
 </ul>
 </div>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Omitting the trailing slash leads to "Specified native messaging host not found." error in Chrome.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging

> Issue number (if there is an associated issue)

Fixes #4224
