### PR TITLE
More updates to mark pages as deprecated

### DIFF
--- a/files/en-us/web/api/mediaquerylist/addlistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.html
@@ -10,7 +10,7 @@ tags:
   - Reference
   - addListener
 ---
-<p>{{APIRef("CSSOM")}}</p>
+<p>{{APIRef("CSSOM")}}{{Deprecated_Header}}</p>
 
 <p>The deprecated <code><strong>addListener()</strong></code> method of the
   {{DOMxRef("MediaQueryList")}} interface adds a listener to the

--- a/files/en-us/web/api/mediaquerylist/index.html
+++ b/files/en-us/web/api/mediaquerylist/index.html
@@ -34,9 +34,9 @@ tags:
 <p><em>The <code>MediaQueryList</code> interface inherits methods from its parent interface, {{DOMxRef("EventTarget")}}.</em></p>
 
 <dl>
- <dt>{{DOMxRef("MediaQueryList.addListener", "addListener()")}}</dt>
+ <dt>{{DOMxRef("MediaQueryList.addListener", "addListener()")}}{{deprecated_inline}}</dt>
  <dd>Adds to the <code>MediaQueryList</code> a callback which is invoked whenever the media query status—whether or not the document matches the media queries in the list—changes. This method exists primarily for backward compatibility; if possible, you should instead use {{domxref("EventTarget.addEventListener", "addEventListener()")}} to watch for the {{domxref("EventTarget.change_event", "change")}} event.</dd>
- <dt>{{DOMxRef("MediaQueryList.removeListener", "removeListener()")}}</dt>
+ <dt>{{DOMxRef("MediaQueryList.removeListener", "removeListener()")}}{{deprecated_inline}}</dt>
  <dd>Removes the specified listener callback from the callbacks to be invoked when the <code>MediaQueryList</code> changes media query status, which happens any time the document switches between matching and not matching the media queries listed in the <code>MediaQueryList</code>. This method has been kept for backward compatibility; if possible, you should generally use {{domxref("EventTarget.removeEventListener", "removeEventListener()")}} to remove change notification callbacks (which should have previously been added using <code>addEventListener()</code>).</dd>
 </dl>
 

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.html
@@ -10,7 +10,7 @@ tags:
   - Reference
   - removeListener
 ---
-<p>{{APIRef("CSSOM")}}</p>
+<p>{{APIRef("CSSOM")}}{{Deprecated_Header}}</p>
 
 <p>The <code><strong>removeListener()</strong></code> method of the
   {{DOMxRef("MediaQueryList")}} interface removes a listener from the

--- a/files/en-us/web/api/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/index.html
@@ -60,7 +60,7 @@ tags:
 
 <dl>
  <dt>{{domxref("MediaRecorder.isTypeSupported()")}}</dt>
- <dd>A static method which returns a {{domxref("Boolean")}} value indicating if the given MIME media type is supported by the current user agent. </dd>
+ <dd>A static method which returns a <code>true</code> or <code>false</code> value indicating if the given MIME media type is supported by the current user agent. </dd>
 </dl>
 
 <h2 id="Event_handlers">Event handlers</h2>
@@ -69,7 +69,7 @@ tags:
  <dt>{{domxref("MediaRecorder.ondataavailable")}}</dt>
  <dd>Called to handle the {{event("dataavailable")}} event, which is periodically triggered each time <code>timeslice</code> milliseconds of media have been recorded (or when the entire media has been recorded, if <code>timeslice</code> wasn't specified). The event, of type {{domxref("BlobEvent")}}, contains the recorded media in its {{domxref("BlobEvent.data", "data")}} property. You can then collect and act upon that recorded media data using this event handler.</dd>
  <dt>{{domxref("MediaRecorder.onerror")}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("error")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording. The received event is based on the {{domxref("MediaRecorderErrorEvent")}} interface, whose {{domxref("MediaRecorderErrorEvent.error", "error")}} property contains a {{domxref("DOMException")}} that describes the actual error that occurred.</dd>
+ <dd>An {{domxref("EventHandler")}} called to handle the {{event("error")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording. The received event is based on the {{domxref("MediaRecorderErrorEvent")}} interface, whose {{domxref("MediaRecorderErrorEvent.error", "error")}} property contains a {{domxref("DOMException")}} that describes the actual error that occurred.</dd> 
  <dt>{{domxref("MediaRecorder.onpause")}}</dt>
  <dd>An {{domxref("EventHandler")}} called to handle the {{event("pause")}} event, which occurs when media recording is paused.</dd>
  <dt>{{domxref("MediaRecorder.onresume")}}</dt>
@@ -78,6 +78,9 @@ tags:
  <dd>An {{domxref("EventHandler")}} called to handle the {{event("start")}} event, which occurs when media recording starts.</dd>
  <dt>{{domxref("MediaRecorder.onstop")}}</dt>
  <dd>An {{domxref("EventHandler")}} called to handle the {{event("stop")}} event, which occurs when media recording ends, either when the {{domxref("MediaStream")}} ends — or after the {{domxref("MediaRecorder.stop()")}} method is called.</dd>
+
+ <dt>{{domxref("MediaRecorder.onwarning")}} {{deprecated_inline}}</dt>
+ <dd>An {{domxref("EventHandler")}} called to handle the {{event("warning")}} event, which occurs when media recording has a non-fatal error, or after the {{domxref("MediaRecorder.onwarning()")}} method is called.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>
@@ -88,6 +91,10 @@ tags:
  <dt><code><a href="/en-US/docs/Web/API/MediaRecorder/error_event">error</a></code></dt>
  <dd>Fired when an error occurs: for example because recording wasn't allowed or was attempted using an unsupported codec.<br>
  Also available via the <code><a href="/en-US/docs/Web/API/MediaRecorder/onerror">onerror</a></code> property.</dd>
+
+ <dt><code><a href="/en-US/docs/Web/API/MediaRecorder/warning_event">warning</a></code>{{deprecated_inline}}</dt>
+ <dd>Fired when a problem occurs that does not halt recording.<br>
+ Also available via the <code><a href="/en-US/docs/Web/API/MediaRecorder/onwarning">onwarning</a></code> property.</dd>
 </dl>
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/api/mediarecorder/onwarning/index.html
+++ b/files/en-us/web/api/mediarecorder/onwarning/index.html
@@ -18,9 +18,9 @@ tags:
 
 <p>The <strong><code>MediaRecorder.onwarning </code></strong>event handler (part of the <a
     href="/en-US/docs/Web/API/MediaStream_Recording_API">MediaRecorder API</a>) handles the
-  <code>recordingwarning</code> event, allowing you to run code in response to non-fatal
-  errors being thrown during media recording via a <code>MediaRecorder</code>, which don't
-  halt recording.</p>
+    recording <code>warning</code> event, allowing you to run code in response to non-fatal
+  errors being thrown during media recording via a <code>MediaRecorder</code> (errors that don't
+  halt recording).</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.html
@@ -34,7 +34,7 @@ tags:
 <dl>
   <dt><em><code>keyArg</code></em></dt>
   <dd>A modifier key value. The value must be one of the {{domxref("KeyboardEvent.key")}}
-    values which represent modifier keys or <code>"Accel"</code>. This is case-sensitive.
+    values which represent modifier keys or <code>"Accel"</code>{{deprecated_inline}}. This is case-sensitive.
   </dd>
 </dl>
 

--- a/files/en-us/web/api/navigator/oscpu/index.html
+++ b/files/en-us/web/api/navigator/oscpu/index.html
@@ -10,7 +10,7 @@ tags:
   - Property
   - Reference
 ---
-<p>{{ ApiRef("HTML DOM") }}</p>
+<p>{{ ApiRef("HTML DOM") }} {{Deprecated_Header}}</p>
 
 <p>The <code><strong>Navigator.oscpu</strong></code> property returns a string that identifies the current operating system.</p>
 

--- a/files/en-us/web/api/navigator/productsub/index.html
+++ b/files/en-us/web/api/navigator/productsub/index.html
@@ -9,7 +9,7 @@ tags:
 - Property
 - Read-only
 ---
-<div>{{ ApiRef("HTML DOM") }}</div>
+<div>{{ ApiRef("HTML DOM") }} {{Deprecated_Header}}</div>
 
 <p>The <code><strong>Navigator.productSub</strong></code> read-only property returns the
   build number of the current browser.</p>

--- a/files/en-us/web/api/navigator/vendorsub/index.html
+++ b/files/en-us/web/api/navigator/vendorsub/index.html
@@ -8,7 +8,7 @@ tags:
 - Property
 - Read-only
 ---
-<div>{{ApiRef}}</div>
+<div>{{ApiRef}} {{Deprecated_Header}}</div>
 
 <p>The value of the <code><strong>Navigator.vendorSub</strong></code> property is always
   the empty string, in any browser.</p>

--- a/files/en-us/web/api/navigatorid/appcodename/index.html
+++ b/files/en-us/web/api/navigatorid/appcodename/index.html
@@ -9,7 +9,7 @@ tags:
 - Property
 - Reference
 ---
-<div>{{APIRef("HTML DOM")}}</div>
+<div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 
 <p>The value of the <strong><code>NavigatorID.appCodeName</code></strong> property is
   always "<code>Mozilla</code>", in any browser. This property is kept only for

--- a/files/en-us/web/api/navigatorid/appname/index.html
+++ b/files/en-us/web/api/navigatorid/appname/index.html
@@ -9,14 +9,15 @@ tags:
 - Property
 - Reference
 ---
-<div>{{APIRef("HTML DOM")}}</div>
+<div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 
 <p>The value of the <strong><code>NavigatorID.appName</code></strong> property is always
   "<code>Netscape</code>", in any browser. This property is kept only for compatibility
   purposes.</p>
 
-<div class="note"><strong>Note:</strong> Do not rely on this property to return a real
-  browser name. All browsers return "<code>Netscape</code>" as the value of this property.
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Do not rely on this property to return a real browser name. All browsers return "<code>Netscape</code>" as the value of this property.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/navigatorid/appversion/index.html
+++ b/files/en-us/web/api/navigatorid/appversion/index.html
@@ -9,13 +9,15 @@ tags:
 - Reference
 - appVersion
 ---
-<p>{{APIRef("HTML DOM")}}</p>
+<p>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</p>
 
 <p>Returns either "<code>4.0</code>" or a string representing version information about
   the browser.</p>
 
-<div class="note"><strong>Note:</strong> Do not rely on this property to return the
-  correct browser version.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Do not rely on this property to return the correct browser version.</p>
+</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/navigatorid/platform/index.html
+++ b/files/en-us/web/api/navigatorid/platform/index.html
@@ -11,7 +11,7 @@ tags:
 - Reference
 - platform
 ---
-<p>{{ APIRef("HTML DOM") }}</p>
+<p>{{ APIRef("HTML DOM") }} {{Deprecated_Header}}</p>
 
 <p>Returns a string representing the platform of the browser. The specification allows
   browsers to always return the empty string, so don't rely on this property to get a
@@ -29,8 +29,7 @@ tags:
   <code>platform</code> is a string that must be an empty string or a string representing
   the platform on which the browser is executing.</p>
 
-<p>For example: "<code>MacIntel</code>", "<code>Win32</code>",
-  "<code>FreeBSD i386</code>", "<code>WebTV OS</code>"</p>
+<p>For example: "<code>MacIntel</code>", "<code>Win32</code>", "<code>FreeBSD i386</code>", "<code>WebTV OS</code>"</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/navigatorid/product/index.html
+++ b/files/en-us/web/api/navigatorid/product/index.html
@@ -8,14 +8,15 @@ tags:
 - Property
 - Reference
 ---
-<div>{{APIRef("HTML DOM")}}</div>
+<div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 
 <p>The value of the <strong><code>NavigatorID.product</code></strong> property is always
   "<code>Gecko</code>", in any browser. This property is kept only for compatibility
   purposes.</p>
 
-<div class="note"><strong>Note:</strong> Do not rely on this property to return a real
-  product name. All browsers return "<code>Gecko</code>" as the value of this property.
+
+<div class="notecard note">
+  <p>Do not rely on this property to return a real product name. All browsers return "<code>Gecko</code>" as the value of this property.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/index.html
@@ -94,9 +94,9 @@ tags:
 <p><em>Inherits methods from its parent, {{domxref("AudioNode")}}</em>.</p>
 
 <dl>
- <dt>{{domxref("PannerNode.setPosition()")}}</dt>
+ <dt>{{domxref("PannerNode.setPosition()")}} {{deprecated_inline}}</dt>
  <dd>Defines the position of the audio source relative to the listener (represented by an {{domxref("AudioListener")}} object stored in the {{domxref("BaseAudioContext.listener")}} attribute.)</dd>
- <dt>{{domxref("PannerNode.setOrientation()")}}</dt>
+ <dt>{{domxref("PannerNode.setOrientation()")}} {{deprecated_inline}}</dt>
  <dd>Defines the direction the audio source is playing in.</dd>
  <dt>{{domxref("PannerNode.setVelocity()")}} {{obsolete_inline}}</dt>
  <dd>Defines the velocity vector of the audio source — how fast it is moving and in what direction. In a previous version of the specification, the {{domxref("PannerNode")}} had a velocity that could pitch up or down {{domxref("AudioBufferSourceNode")}}s connected downstream. This feature was not clearly specified and had a number of issues, so it was removed from the specification.</dd>

--- a/files/en-us/web/api/pannernode/setorientation/index.html
+++ b/files/en-us/web/api/pannernode/setorientation/index.html
@@ -9,7 +9,7 @@ tags:
   - Web Audio API
   - setOrientation
 ---
-<p>{{ APIRef("Web Audio API") }}</p>
+<p>{{ APIRef("Web Audio API") }} {{Deprecated_Header}}</p>
 
 <div>
 <p>The <code>setOrientation()</code> method of the {{ domxref("PannerNode") }} Interface defines the direction the audio source is playing in.</p>

--- a/files/en-us/web/api/pannernode/setposition/index.html
+++ b/files/en-us/web/api/pannernode/setposition/index.html
@@ -9,7 +9,7 @@ tags:
   - Web Audio API
   - setPosition
 ---
-<p>{{ APIRef("Web Audio API") }}</p>
+<p>{{ APIRef("Web Audio API") }} {{Deprecated_Header}}</p>
 
 <div>
 <p>The <code>setPosition()</code> method of the {{ domxref("PannerNode") }} Interface defines the position of the audio source relative to the listener (represented by an {{domxref("AudioListener")}} object stored in the {{domxref("BaseAudioContext.listener")}} attribute.) The three parameters <code>x</code>, <code>y</code> and <code>z</code> are unitless and describe the source's position in 3D space using the right-hand Cartesian coordinate system.</p>

--- a/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
@@ -15,7 +15,15 @@ tags:
 - Reference
 - payment
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p> {{APIRef("Payment Request API")}} {{Deprecated_Header}}</p>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This property has been removed from the specification and should no longer be used;
+    the currency is now <em>always</em> specified using ISO 4127.</p>
+</div>
+
+<p>{{securecontext_header}}</p>
 
 <p><span class="seoSummary">The <em>obsolete</em> {{domxref("PaymentCurrencyAmount")}}
     property <strong><code>currencySystem</code></strong> is a string which specifies the
@@ -23,12 +31,6 @@ tags:
     "currency")}} the {{domxref("PaymentCurrencyAmount.value", "value")}} is specified
     in.</span> For example, the default is <code>urn:iso:std:iso:4217</code>, which
   specifies that the standard used is {{interwiki("wikipedia", "ISO 4217")}}.</p>
-
-<div class="notecard warning">
-  <p><strong>Warning:</strong> This property has been removed from the specification and
-    should no longer be used; the currency is now <em>always</em> specified using ISO
-    4127.</p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/api/performance/navigation/index.html
+++ b/files/en-us/web/api/performance/navigation/index.html
@@ -12,7 +12,7 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
 <div class="warning">
   <p>This property is deprecated in the <a

--- a/files/en-us/web/api/performancenavigation/index.html
+++ b/files/en-us/web/api/performancenavigation/index.html
@@ -14,10 +14,11 @@ tags:
   - Timing
   - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-<p>This interface is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
 <p>The legacy <strong><code>PerformanceNavigation</code></strong> interface represents information about how the navigation to the current document was done.</p>

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.html
@@ -12,13 +12,12 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.
+    Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
 <p>The legacy

--- a/files/en-us/web/api/performancenavigation/type/index.html
+++ b/files/en-us/web/api/performancenavigation/type/index.html
@@ -11,13 +11,12 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.
+    Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
 <p>The legacy

--- a/files/en-us/web/api/performancetiming/connectend/index.html
+++ b/files/en-us/web/api/performancetiming/connectend/index.html
@@ -11,12 +11,11 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/connectstart/index.html
+++ b/files/en-us/web/api/performancetiming/connectstart/index.html
@@ -12,12 +12,11 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.html
@@ -12,12 +12,11 @@ tags:
 - fetchStart
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.html
@@ -12,12 +12,11 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.html
@@ -12,12 +12,11 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
@@ -12,12 +12,11 @@ tags:
 - domContentLoadedEventEnd
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
@@ -12,12 +12,11 @@ tags:
 - domContentLoadedEventStart
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.html
@@ -12,12 +12,11 @@ tags:
 - domInteractive
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/domloading/index.html
+++ b/files/en-us/web/api/performancetiming/domloading/index.html
@@ -12,12 +12,11 @@ tags:
 - domxref
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.html
@@ -13,12 +13,11 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/index.html
+++ b/files/en-us/web/api/performancetiming/index.html
@@ -14,10 +14,11 @@ tags:
   - Timing
   - legacy
 ---
-<div>{{APIRef("Navigation Timing")}}</div>
+<div>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</div>
 
-<div class="warning">
-<p>This interface is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
 <p>The <strong><code>PerformanceTiming</code></strong> interface is a legacy interface kept for backwards compatibility and contains properties that offer performance timing information for various events which occur during the loading and use of the current page. You get a <code>PerformanceTiming</code> object describing your page using the {{domxref("Performance.timing", "window.performance.timing")}} property.</p>

--- a/files/en-us/web/api/performancetiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.html
@@ -13,14 +13,12 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface's  {{domxref("PerformanceNavigationTiming.loadEventEnd")}} read-only
-    property instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+    interface's {{domxref("PerformanceNavigationTiming.loadEventEnd")}} read-only property instead.</p>
 </div>
 
 <p>The legacy

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.html
@@ -12,14 +12,12 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface's  {{domxref("PerformanceNavigationTiming.loadEventStart")}} read-only
-    property instead..</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+    interface's {{domxref("PerformanceNavigationTiming.loadEventStart")}} read-only property instead.</p>
 </div>
 
 <p>The legacy

--- a/files/en-us/web/api/performancetiming/navigationstart/index.html
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.html
@@ -13,13 +13,12 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.
+    Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
 <p>The legacy

--- a/files/en-us/web/api/performancetiming/redirectend/index.html
+++ b/files/en-us/web/api/performancetiming/redirectend/index.html
@@ -12,12 +12,11 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.html
@@ -12,12 +12,11 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/requeststart/index.html
+++ b/files/en-us/web/api/performancetiming/requeststart/index.html
@@ -11,12 +11,11 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{ APIRef("PerformanceTiming") }}</p>
+<p>{{ APIRef("PerformanceTiming") }} {{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/responseend/index.html
+++ b/files/en-us/web/api/performancetiming/responseend/index.html
@@ -12,12 +12,11 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/responsestart/index.html
+++ b/files/en-us/web/api/performancetiming/responsestart/index.html
@@ -12,12 +12,11 @@ tags:
 - Reference
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
@@ -11,13 +11,12 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
-    interface instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
+      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.</p>
 </div>
 
 <p>The legacy

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.html
@@ -11,12 +11,11 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.html
@@ -11,12 +11,11 @@ tags:
 - Read-only
 - legacy
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
-<div class="warning">
-  <p>This interface of this property is deprecated in the <a
-      href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2
-      specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>This interface of this property is deprecated in the <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>. Please use the {{domxref("PerformanceNavigationTiming")}}
     interface instead.</p>
 </div>
 

--- a/files/en-us/web/api/point/index.html
+++ b/files/en-us/web/api/point/index.html
@@ -10,7 +10,7 @@ tags:
   - Point
   - Reference
 ---
-<div>{{APIRef("CSS3 Transforms")}}{{Non-standard_header}}</div>
+<div>{{APIRef("CSS3 Transforms")}}{{Deprecated_Header}}{{Non-standard_header}}</div>
 
 <p><strong><code>Point</code></strong> is an interface, which existed only briefly in the {{SpecName("CSS3 Transforms")}} specification, which represents a point in 2-dimensional space. It is non-standard, not broadly compatible, and should not be used.</p>
 
@@ -21,9 +21,9 @@ tags:
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt><code>x</code></dt>
+ <dt><code>x</code> {{deprecated_inline}}</dt>
  <dd>A floating-point value specifying the point's position with respect to the X (horizontal) axis.</dd>
- <dt><code>y</code></dt>
+ <dt><code>y</code> {{deprecated_inline}}</dt>
  <dd>A floating-point value specifying the point's position with respect to the Y (vertical) axis.</dd>
 </dl>
 

--- a/files/en-us/web/api/processinginstruction/index.html
+++ b/files/en-us/web/api/processinginstruction/index.html
@@ -23,7 +23,7 @@ tags:
 
 <dl>
  <dt><code>target</code> ({{domxref("DOMString")}}) {{readonlyInline}}</dt>
- <dd>A name identifying the application to which the instruction is targeted,</dd>
+ <dd>A name identifying the application to which the instruction is targeted.</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/range/comparenode/index.html
+++ b/files/en-us/web/api/range/comparenode/index.html
@@ -12,7 +12,7 @@ tags:
   - Reference
   - compareNode
 ---
-<p>{{APIRef("DOM")}}{{Non-standard_Header}}{{deprecated_header}}</p>
+<p>{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_Header}}</p>
 
 <p>The <strong><code>Range.compareNode()</code></strong> returns a constant indicating the
   position of the {{DOMxRef("Node")}}.</p>

--- a/files/en-us/web/api/screen/index.html
+++ b/files/en-us/web/api/screen/index.html
@@ -34,7 +34,7 @@ tags:
  <dd>Returns the {{DOMxRef("ScreenOrientation")}} instance associated with this screen.</dd>
  <dt>{{DOMxRef("Screen.pixelDepth")}}</dt>
  <dd>Gets the bit depth of the screen.</dd>
- <dt>{{DOMxRef("Screen.top")}} {{Non-standard_Inline}}</dt>
+ <dt>{{DOMxRef("Screen.top")}} {{deprecated_inline}}{{Non-standard_Inline}}</dt>
  <dd>Returns the distance in pixels from the top side of the current screen.</dd>
  <dt>{{DOMxRef("Screen.width")}}</dt>
  <dd>Returns the width of the screen.</dd>

--- a/files/en-us/web/api/screen/mozbrightness/index.html
+++ b/files/en-us/web/api/screen/mozbrightness/index.html
@@ -8,7 +8,7 @@ tags:
 - Non-standard
 - Property
 ---
-<p>{{APIRef("CSSOM")}}{{Non-standard_Header}}{{Deprecated_Header}}</p>
+<p>{{APIRef("CSSOM")}}{{Deprecated_Header}}{{Non-standard_Header}}</p>
 
 <p>Indicates how bright the screen's backlight is, on a scale from 0 (very dim) to 1 (full
   brightness); this value is a double-precision float.</p>

--- a/files/en-us/web/api/screen/mozenabled/index.html
+++ b/files/en-us/web/api/screen/mozenabled/index.html
@@ -10,7 +10,7 @@ tags:
 - Property
 - Reference
 ---
-<p>{{APIRef("CSSOM")}}{{Non-standard_Header}}{{Deprecated_Header}}</p>
+<p>{{APIRef("CSSOM")}}{{Deprecated_Header}}{{Non-standard_Header}}</p>
 
 <p>This Boolean attribute controls the device's screen. Setting it to <code>false</code>
   will turn off the screen.</p>

--- a/files/en-us/web/api/screen/top/index.html
+++ b/files/en-us/web/api/screen/top/index.html
@@ -11,7 +11,7 @@ tags:
 - Property
 - Window
 ---
-<p>{{APIRef("CSSOM")}}{{Non-standard_Header}}</p>
+<p>{{APIRef("CSSOM")}}{{deprecated_header}}{{Non-standard_Header}}</p>
 
 <p>Returns the distance in pixels from the top side of the current screen.</p>
 

--- a/files/en-us/web/api/shadowroot/delegatesfocus/index.html
+++ b/files/en-us/web/api/shadowroot/delegatesfocus/index.html
@@ -11,7 +11,7 @@ tags:
 - delegatesFocus
 - shadow dom
 ---
-<div>{{APIRef("Shadow DOM")}}</div>
+<div>{{APIRef("Shadow DOM")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>delegatesFocus</code></strong> read-only property of the
   {{domxref("ShadowRoot")}} interface returns a boolean that indicates whether

--- a/files/en-us/web/api/shadowroot/index.html
+++ b/files/en-us/web/api/shadowroot/index.html
@@ -20,7 +20,7 @@ tags:
 <dl>
  <dt>{{domxref("ShadowRoot.activeElement")}} {{readonlyInline}}</dt>
  <dd>Returns the {{domxref('Element')}} within the shadow tree that has focus.</dd>
- <dt>{{domxref("ShadowRoot.delegatesFocus")}} {{readonlyinline}} {{non-standard_inline}}</dt>
+ <dt>{{domxref("ShadowRoot.delegatesFocus")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}</dt>
  <dd>Returns a boolean that indicates whether delegatesFocus was set when the shadow was attached (see {{domxref("Element.attachShadow()")}}).</dd>
  <dt>{{DOMxRef("ShadowRoot.fullscreenElement")}} {{ReadOnlyInline}}</dt>
  <dd>The element that's currently in full screen mode for this shadow tree.</dd>

--- a/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.html
+++ b/files/en-us/web/api/sharedworkerglobalscope/applicationcache/index.html
@@ -9,10 +9,11 @@ tags:
   - Web Workers
   - applicationCache
 ---
-<div>{{APIRef("Web Workers API")}}</div>
+<div>{{APIRef("Web Workers API")}}{{Deprecated_Header}} {{SecureContext_Header}}</div>
 
-<div class="warning">
-<p><strong>Important</strong>: Application Cache is deprecated as of Firefox 44, and is no longer available in insecure contexts from Firefox 60 onwards ({{bug(1354175)}}, currently Nightly/Beta only). Don't use it to make offline websites — consider using <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a> instead.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>Application Cache is deprecated as of Firefox 44, and is no longer available in insecure contexts from Firefox 60 onwards ({{bug(1354175)}}, currently Nightly/Beta only). Don't use it to make offline websites — consider using <a href="/en-US/docs/Web/API/Service_Worker_API">service workers</a> instead.</p>
 </div>
 
 <p>The <code><strong>applicationCache</strong></code> read-only property of the {{domxref("SharedWorkerGlobalScope")}} interface returns the {{domxref("ApplicationCache")}} object for the worker (see <a href="/en-US/docs/Web/HTML/Using_the_application_cache">Using the application cache</a>).</p>

--- a/files/en-us/web/api/speechrecognition/index.html
+++ b/files/en-us/web/api/speechrecognition/index.html
@@ -41,7 +41,7 @@ tags:
  <dd>Controls whether interim results should be returned (<code>true</code>) or not (<code>false</code>.) Interim results are results that are not yet final (e.g. the {{domxref("SpeechRecognitionResult.isFinal")}} property is <code>false</code>.)</dd>
  <dt>{{domxref("SpeechRecognition.maxAlternatives")}}</dt>
  <dd>Sets the maximum number of {{domxref("SpeechRecognitionAlternative")}}s provided per result. The default value is 1.</dd>
- <dt>{{domxref("SpeechRecognition.serviceURI")}}</dt>
+ <dt>{{domxref("SpeechRecognition.serviceURI")}} {{deprecated_inline}}</dt>
  <dd>Specifies the location of the speech recognition service used by the current <code>SpeechRecognition</code> to handle the actual recognition. The default is the user agent's default speech service.</dd>
 </dl>
 

--- a/files/en-us/web/api/speechrecognition/serviceuri/index.html
+++ b/files/en-us/web/api/speechrecognition/serviceuri/index.html
@@ -12,7 +12,7 @@ tags:
 - serviceURI
 - speech
 ---
-<div>{{APIRef("Web Speech API")}}{{SeeCompatTable}}</div>
+<div>{{APIRef("Web Speech API")}}{{Deprecated_Header}}{{SeeCompatTable}}</div>
 
 <p>The <strong><code>serviceURI</code></strong> property of the
   {{domxref("SpeechRecognition")}} interface specifies the location of the speech

--- a/files/en-us/web/api/svgaltglyphelement/index.html
+++ b/files/en-us/web/api/svgaltglyphelement/index.html
@@ -9,7 +9,7 @@ tags:
   - SVG
   - SVGAltGlyphElement
 ---
-<div>{{APIRef("SVG")}}{{Deprecated_header}}</div>
+<div>{{APIRef("SVG")}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>SVGAltGlyphElement</code></strong> interface represents an {{ SVGElement("altglyph") }} element. This interface makes it possible to implement more sophisticated and particular glyph characters. For some textal representations as: ligatures (e.g. æ, ß, etc ), special-purpose fonts (e.g. musical symbols) or even alternate glyphs such as Asian text strings it is required that a different set of glyphs be used than the normal given character data.</p>
 
@@ -18,9 +18,9 @@ tags:
 <p><em>This interface also inherits properties from its parent interface, {{domxref("SVGGraphicsElement")}}.</em></p>
 
 <dl>
- <dt>{{domxref("SVGAltGlyphElement.glyphRef")}}</dt>
+ <dt>{{domxref("SVGAltGlyphElement.glyphRef")}} {{deprecated_inline}}</dt>
  <dd>It corresponds to the attribute {{ SVGAttr("glyphRef") }} on the given element. It's data type is 'String'. It defines the glyph identifier, whose format is dependent on the ‘format’ of the given font.</dd>
- <dt>{{domxref("SVGAltGlyphElement.format")}}</dt>
+ <dt>{{domxref("SVGAltGlyphElement.format")}} {{deprecated_inline}}</dt>
  <dd>It corresponds to the attribute  {{ SVGAttr("format") }} on the given element. It's data type is 'String'. This property specifies the format of the given font.</dd>
 </dl>
 

--- a/files/en-us/web/api/svgviewelement/index.html
+++ b/files/en-us/web/api/svgviewelement/index.html
@@ -17,7 +17,7 @@ tags:
 <p><em>This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}.</em></p>
 
 <dl>
- <dt>{{domxref("SVGViewElement.viewTarget")}}</dt>
+ <dt>{{domxref("SVGViewElement.viewTarget")}} {{deprecated_inline}}</dt>
  <dd>An {{domxref("SVGStringList")}} corresponding to the {{SVGAttr("viewTarget")}} attribute of the given {{SVGElement("view")}} element. A list of {{domxref("DOMString")}} values which contain the names listed in the {{SVGAttr("viewTarget")}} attribute. Each of the <code>DOMString</code> values can be associated with the corresponding element using the {{domxref("Document.getElementById()", "getElementById()")}} method call.</dd>
 </dl>
 

--- a/files/en-us/web/api/uievent/index.html
+++ b/files/en-us/web/api/uievent/index.html
@@ -50,7 +50,7 @@ tags:
  <dd>Returns an instance of the <code>InputDeviceCapabilities</code> interface, which provides information about the physical device responsible for generating a touch event.</dd>
  <dt>{{domxref("UIEvent.view")}}{{readonlyinline}}</dt>
  <dd>Returns a {{domxref("WindowProxy")}} that contains the view that generated the event.</dd>
- <dt>{{domxref("UIEvent.which")}} {{Non-standard_inline}} {{readonlyinline}}</dt>
+ <dt>{{domxref("UIEvent.which")}} {{deprecated_inline}} {{Non-standard_inline}} {{readonlyinline}}</dt>
  <dd>Returns the numeric <code>keyCode</code> of the key pressed, or the character code (<code>charCode</code>) for an alphanumeric key pressed.</dd>
 </dl>
 

--- a/files/en-us/web/api/uievent/pagey/index.html
+++ b/files/en-us/web/api/uievent/pagey/index.html
@@ -9,7 +9,7 @@ tags:
 - Reference
 - UIEvent
 ---
-<p>{{APIRef("DOM Events")}} {{Non-standard_header}}</p>
+<p>{{APIRef("DOM Events")}} {{Deprecated_Header}} {{Non-standard_header}}</p>
 
 <p>The <code><strong>UIEvent.pageY</strong></code> read-only property returns the vertical
   coordinate of the event relative to the whole document.</p>

--- a/files/en-us/web/api/window/event/index.html
+++ b/files/en-us/web/api/window/event/index.html
@@ -10,7 +10,7 @@ tags:
   - Read-only
   - Window
 ---
-<div>{{APIRef("DOM")}}</div>
+<div>{{APIRef("DOM")}} {{Deprecated_Header}}</div>
 
 <p>The read-only {{domxref("Window")}} property <code><strong>event</strong></code> returns the {{domxref("Event")}} which is currently being handled by the site's code. Outside the context of an event handler, the value is always <code>undefined</code>.</p>
 

--- a/files/en-us/web/api/window/index.html
+++ b/files/en-us/web/api/window/index.html
@@ -79,7 +79,7 @@ tags:
  <dd>Returns a reference to a {{domxref("DOMRect")}} object, which represents a rectangle.</dd>
  <dt>{{domxref("Window.DOMRectReadOnly")}} {{readOnlyInline}} {{experimental_inline}}</dt>
  <dd>Returns a reference to a {{domxref("DOMRectReadOnly")}} object, which represents a rectangle.</dd>
- <dt>{{domxref("Window.event")}} {{readOnlyInline}}</dt>
+ <dt>{{domxref("Window.event")}} {{deprecated_inline}} {{readOnlyInline}}</dt>
  <dd>Returns the <strong>current event</strong>, which is the event currently being handled by the JavaScript code's context, or <code>undefined</code> if no event is currently being handled. The {{domxref("Event")}} object passed directly to event handlers should be used instead whenever possible.</dd>
  <dt>{{domxref("Window.frameElement")}} {{readOnlyInline}}</dt>
  <dd>Returns the element in which the window is embedded, or null if the window is not embedded.</dd>
@@ -151,11 +151,11 @@ tags:
  <dd>Returns an object reference to the window object itself.</dd>
  <dt>{{domxref("Window.sessionStorage")}}</dt>
  <dd>Returns a reference to the session storage object used to store data that may only be accessed by the origin that created it.</dd>
- <dt>{{domxref("Window.sidebar")}} {{non-standard_inline}} {{ReadOnlyInline}}</dt>
+ <dt>{{domxref("Window.sidebar")}} {{deprecated_inline}} {{non-standard_inline}} {{ReadOnlyInline}}</dt>
  <dd>Returns a reference to the window object of the sidebar.</dd>
  <dt>{{domxref("Window.speechSynthesis")}} {{ReadOnlyInline}}</dt>
  <dd>Returns a {{domxref("SpeechSynthesis")}} object, which is the entry point into using <a href="/en-US/docs/Web/API/Web_Speech_API">Web Speech API</a> speech synthesis functionality.</dd>
- <dt>{{domxref("Window.status")}}</dt>
+ <dt>{{domxref("Window.status")}} {{deprecated_inline}}</dt>
  <dd>Gets/sets the text in the statusbar at the bottom of the browser.</dd>
  <dt>{{domxref("Window.statusbar")}} {{readOnlyInline}}</dt>
  <dd>Returns the statusbar object, whose visibility can be toggled in the window.</dd>
@@ -485,7 +485,7 @@ tags:
  <dt>{{domxref("Window/languagechange_event", "languagechange")}}</dt>
  <dd>Fired at the global scope object when the user's preferred language changes.<br>
  Also available via the {{domxref("WindowEventHandlers/onlanguagechange", "onlanguagechange")}} property.</dd>
- <dt>{{domxref("Window/orientationchange_event", "orientationchange")}}</dt>
+ <dt>{{domxref("Window/orientationchange_event", "orientationchange")}} {{deprecated_inline}}</dt>
  <dd>Fired when the orientation of the device has changed.<br>
  Also available via the {{domxref("Window/onorientationchange", "onorientationchange")}} property.</dd>
  <dt>{{domxref("Window/devicemotion_event", "devicemotion")}}</dt>

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -207,11 +207,11 @@ function openRequestedPopup() {
 </div>
 
 <dl>
-  <dt><code>outerWidth</code> (only on Firefox, obsolete from Firefox 80)</dt>
+  <dt><code>outerWidth</code> {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)</dt>
   <dd>Specifies the width of the whole browser window in pixels. This
     <code>outerWidth</code> value includes the window vertical scrollbar (if present) and
     left and right window resizing borders.</dd>
-  <dt><code>outerHeight</code> (only on Firefox, obsolete from Firefox 80)</dt>
+  <dt><code>outerHeight</code> {{deprecated_inline}} (only on Firefox, obsolete from Firefox 80)</dt>
   <dd>Specifies the height of the whole browser window in pixels. This
     <code>outerHeight</code> value includes any/all present toolbar, window horizontal
     scrollbar (if present) and top and bottom window resizing borders. Minimal required

--- a/files/en-us/web/api/window/orientationchange_event/index.html
+++ b/files/en-us/web/api/window/orientationchange_event/index.html
@@ -9,7 +9,7 @@ tags:
   - Window
   - onorientationchange
 ---
-<div>{{APIRef}}</div>
+<div>{{APIRef}} {{Deprecated_Header}}</div>
 
 <p>The <code>orientationchange</code> event is fired when the orientation of the device has changed.</p>
 

--- a/files/en-us/web/api/window/requestfilesystem/index.html
+++ b/files/en-us/web/api/window/requestfilesystem/index.html
@@ -16,7 +16,7 @@ tags:
 - filesystem
 - requestFileSystem
 ---
-<p>{{APIRef("File System API")}}{{non-standard_header()}}</p>
+<p>{{APIRef("File System API")}} {{Deprecated_Header}} {{non-standard_header()}}</p>
 
 <p>The non-standard {{domxref("Window")}} method
   <strong><code>requestFileSystem()</code></strong> method is a Google Chrome-specific

--- a/files/en-us/web/api/window/sidebar/index.html
+++ b/files/en-us/web/api/window/sidebar/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - Window
 ---
-<div>{{APIRef}} {{Non-standard_header}}</div>
+<div>{{APIRef}} {{Deprecated_Header}} {{Non-standard_header}}</div>
 
 <p>Returns a sidebar object which contains several methods for registering add-ons with the browser.</p>
 

--- a/files/en-us/web/api/window/status/index.html
+++ b/files/en-us/web/api/window/status/index.html
@@ -10,7 +10,7 @@ tags:
 - Reference
 - Window
 ---
-<div>{{APIRef}}</div>
+<div>{{APIRef}} {{Deprecated_Header}}</div>
 
 <p><span class="seoSummary">The <code><strong>status</strong></code> property of the
     {{domxref("Window")}} interface was originally intended to set the text in the status

--- a/files/en-us/web/api/workerglobalscope/dump/index.html
+++ b/files/en-us/web/api/workerglobalscope/dump/index.html
@@ -9,7 +9,7 @@ tags:
   - WorkerGlobalScope
   - dump
 ---
-<div>{{APIRef("Web Workers API")}}{{Non-standard_header}}</div>
+<div>{{APIRef("Web Workers API")}} {{Deprecated_Header}} {{Non-standard_header}}</div>
 
 <p>The <code><strong>dump()</strong></code> method of the {{domxref("WorkerGlobalScope")}} interface allows you to write a message to stdout — i.e. in your terminal, in Firefox only. This is the same as Firefox's {{domxref("window.dump")}}, but for workers.</p>
 

--- a/files/en-us/web/api/workerglobalscope/index.html
+++ b/files/en-us/web/api/workerglobalscope/index.html
@@ -91,7 +91,7 @@ tags:
 <h3 id="Non-standard_methods">Non-standard methods</h3>
 
 <dl>
- <dt>{{domxref("WorkerGlobalScope.dump()")}} {{non-standard_inline}}</dt>
+ <dt>{{domxref("WorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}</dt>
  <dd>Allows you to write a message to stdout — i.e. in your terminal. This is the same as Firefox's {{domxref("window.dump")}}, but for workers.</dd>
 </dl>
 


### PR DESCRIPTION
This is is all remaining docs that are marked as deprecated in BCD but that did not have headers in MDN docs. 