### PR TITLE
Fix the SpecName in ContactsManager doc

### DIFF
--- a/files/en-us/web/api/contactsmanager/index.html
+++ b/files/en-us/web/api/contactsmanager/index.html
@@ -86,8 +86,8 @@ async function getContacts() {
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('Contacts Picker API','#contacts-manager','ContactsManager')}}</td>
-   <td>{{Spec2('Contacts Picker API')}}</td>
+   <td>{{SpecName('Contact Picker API','#contacts-manager','ContactsManager')}}</td>
+   <td>{{Spec2('Contact Picker API')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>


### PR DESCRIPTION
Without this change, the spec name renders as “Unknown”, with a broken link.