### PR TITLE
Fix PerformanceElementTiming subpages SpecName

### DIFF
--- a/files/en-us/web/api/element_timing_api/index.html
+++ b/files/en-us/web/api/element_timing_api/index.html
@@ -53,8 +53,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
    <th scope="col">Comment</th>
   </tr>
   <tr>
-   <td>{{SpecName('Element Timing')}}</td>
-   <td>{{Spec2('Element Timing')}}</td>
+   <td>{{SpecName('Element Timing API')}}</td>
+   <td>{{Spec2('Element Timing API')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>

--- a/files/en-us/web/api/performanceelementtiming/element/index.html
+++ b/files/en-us/web/api/performanceelementtiming/element/index.html
@@ -46,8 +46,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-element','PerformanceElementTiming.element')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-element','PerformanceElementTiming.element')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/id/index.html
+++ b/files/en-us/web/api/performanceelementtiming/id/index.html
@@ -46,8 +46,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-id','PerformanceElementTiming.id')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-id','PerformanceElementTiming.id')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.html
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.html
@@ -46,8 +46,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-identifier','PerformanceElementTiming.identifier')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-identifier','PerformanceElementTiming.identifier')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
@@ -48,8 +48,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-intersectionrect','PerformanceElementTiming.intersectionRect')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-intersectionrect','PerformanceElementTiming.intersectionRect')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.html
@@ -46,8 +46,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-loadtime','PerformanceElementTiming.loadTime')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-loadtime','PerformanceElementTiming.loadTime')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
@@ -46,8 +46,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-naturalheight','PerformanceElementTiming.naturalHeight')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-naturalheight','PerformanceElementTiming.naturalHeight')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
@@ -45,8 +45,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-naturalwidth','PerformanceElementTiming.naturalWidth')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-naturalwidth','PerformanceElementTiming.naturalWidth')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.html
@@ -50,8 +50,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-rendertime','PerformanceElementTiming.renderTime')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-rendertime','PerformanceElementTiming.renderTime')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.html
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.html
@@ -50,8 +50,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-tojson','PerformanceElementTiming.toJson()')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-tojson','PerformanceElementTiming.toJson()')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/performanceelementtiming/url/index.html
+++ b/files/en-us/web/api/performanceelementtiming/url/index.html
@@ -46,8 +46,8 @@ observer.observe({ entryTypes: ["element"] });</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName('Element Timing','#dom-performanceelementtiming-url','PerformanceElementTiming.url')}}</td>
-    <td>{{Spec2('Element Timing')}}</td>
+    <td>{{SpecName('Element Timing API','#dom-performanceelementtiming-url','PerformanceElementTiming.url')}}</td>
+    <td>{{Spec2('Element Timing API')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/html/attributes/elementtiming/index.html
+++ b/files/en-us/web/html/attributes/elementtiming/index.html
@@ -46,8 +46,8 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <td>{{SpecName('Element Timing', 'forms.html#attr-label-for', 'for as used with label')}}</td>
-   <td>{{Spec2('Element Timing')}}</td>
+   <td>{{SpecName('Element Timing API', 'forms.html#attr-label-for', 'for as used with label')}}</td>
+   <td>{{Spec2('Element Timing API')}}</td>
    <td></td>
   </tr>
  </tbody>


### PR DESCRIPTION
Without this change, the spec name in the Specifications table in all PerformanceElementTiming articles renders as “Unknown”, with a broken link.