### PR TITLE
Add a page for WebHID API

### DIFF
--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -15,19 +15,19 @@ tags:
 
 <dl>
     <dt>{{domxref("HID")}}</dt>
-    <dd>provides methods for connecting to HID devices, listing attached HID devices and event handlers for connected HID devices.</dd>
+    <dd>Provides methods for connecting to HID devices, listing attached HID devices and event handlers for connected HID devices.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDDevice")}}</dt>
-    <dd>represents an HID device. It's possible for a single physical device to be represented by multiple `HIDDevice` obects.</dd>
+    <dd>Represents an HID device. It's possible for a single physical device to be represented by multiple `HIDDevice` obects.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDInputReportEvent")}}</dt>
-    <dd>passed to {{domxref("HIDDevice.oninputreport")}} when an input report is received from the any associated HID device.</dd>
+    <dd>Passed to {{domxref("HIDDevice.oninputreport")}} when an input report is received from any associated HID device.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDConnectionEvent")}}</dt>
-    <dd>passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when a device is connected or disconnected.</dd>
+    <dd>Passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when a device is connected or disconnected.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>You can connect to a device with {{domxref("HID.requestDevices")}}. In this case, we gonna select from all the available devices.</p>
+<p>You can connect to a device with {{domxref("HID.requestDevices")}}. In this case, we select from all the available devices.</p>
 
 <pre class="brush: js">
 const device = await navigator.hid.requestDevice({filters: []})

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -35,47 +35,47 @@ tags:
 <p>You can connect to a device with {{domxref("HID.requestDevices")}}. In this case, we gonna select from all the available devices.</p>
 
 <pre class="brush: js">
-    const device = await navigator.hid.requestDevice({filters: []})
-    // A popup titled `... wants to connect to a HID Device` with `Cancel` and `Connect` buttons will show up with a device list to select from.
-    // Select one and click on `Connect` button. Then the device will be an array with the selected device in it.
+const device = await navigator.hid.requestDevice({filters: []})
+// A popup titled `... wants to connect to a HID Device` with `Cancel` and `Connect` buttons will show up with a device list to select from.
+// Select one and click on `Connect` button. Then the device will be an array with the selected device in it.
 </pre>
 
 <p>We can retrieve all the connected devices and log the device names to the console.</p>
 
 <pre class="brush: js">
-    let devices = await navigator.hid.getDevices();
-    devices.forEach(device => {
-        console.log(`HID: ${device.productName}`);
-    });
+let devices = await navigator.hid.getDevices();
+devices.forEach(device => {
+    console.log(`HID: ${device.productName}`);
+});
 </pre>
 
 <p>We can register event listeners for disconnection of any HID devices.</p>
 
 <pre class="brush: js">
-    navigator.hid.addEventListener('disconnect', (event) => {
-        console.log(`HID disconnected: ${event.device.productName}`);
-        console.dir(event)
-    });
-    // For example, when my connected keyboard gets disconnected, the log in the console will show:
-    // HID disconnected: USB USB Keyboard
-    // {
-    //    bubbles: false
-    //    cancelBubble: false
-    //    cancelable: false
-    //    composed: false
-    //    currentTarget: HID {onconnect: null, ondisconnect: null}
-    //    defaultPrevented: false
-    //    device: HIDDevice {oninputreport: null, opened: false, vendorId: 6700, productId: 11555, productName: "USB USB Keyboard", …}
-    //    eventPhase: 0
-    //    isTrusted: true
-    //    path: []
-    //    returnValue: true
-    //    srcElement: HID {onconnect: null, ondisconnect: null}
-    //    target: HID {onconnect: null, ondisconnect: null}
-    //    timeStamp: 18176.600000023842
-    //    type: "disconnect"
-    // }
-    // The event is an instance of the HIDConnectionEvent interface.
+navigator.hid.addEventListener('disconnect', (event) => {
+    console.log(`HID disconnected: ${event.device.productName}`);
+    console.dir(event)
+});
+// For example, when my connected keyboard gets disconnected, the log in the console will show:
+// HID disconnected: USB USB Keyboard
+// {
+//    bubbles: false
+//    cancelBubble: false
+//    cancelable: false
+//    composed: false
+//    currentTarget: HID {onconnect: null, ondisconnect: null}
+//    defaultPrevented: false
+//    device: HIDDevice {oninputreport: null, opened: false, vendorId: 6700, productId: 11555, productName: "USB USB Keyboard", …}
+//    eventPhase: 0
+//    isTrusted: true
+//    path: []
+//    returnValue: true
+//    srcElement: HID {onconnect: null, ondisconnect: null}
+//    target: HID {onconnect: null, ondisconnect: null}
+//    timeStamp: 18176.600000023842
+//    type: "disconnect"
+// }
+// The event is an instance of the HIDConnectionEvent interface.
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -7,7 +7,7 @@ tags:
   - WebHID
   - WebHID API
 ---
-<div>{{DefaultAPISidebar("WebHID API")}}</div>
+<div>{{DefaultAPISidebar("WebHID API")}}{{SeeCompatTable}}</div>
 
 <p>A Human Interface Device (HID) is a type of device that takes input from or provides output to humans. It also refers to the HID protocol, a standard for bi-directional communication between a host and a device that is designed to simplify the installation procedure. The HID protocol was originally developed for USB devices but has since been implemented over many other protocols, including Bluetooth.</p>
 

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -75,7 +75,8 @@ navigator.hid.addEventListener('disconnect', (event) => {
 //    timeStamp: 18176.600000023842
 //    type: "disconnect"
 // }
-// The event is an instance of the HIDConnectionEvent interface.
+
+// The event above is an instance of the HIDConnectionEvent interface.
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -1,0 +1,75 @@
+---
+title: WebHID API
+slug: Web/API/WebHID_API
+tags:
+  - API
+  - Advanced
+  - WebHID
+  - WebHID API
+---
+<div>{{DefaultAPISidebar("WebHID API")}}</div>
+
+<p>A HID (Human Interface Device) is a type of device that takes input from or provides output to humans. It also refers to the HID protocol, a standard for bi-directional communication between a host and a device that is designed to simplify the installation procedure. The HID protocol was originally developed for USB devices but has since been implemented over many other protocols, including Bluetooth.</p>
+
+<h2 id="Interfaces">Interfaces</h2>
+
+<dl>
+    <dt>{{domxref("HID")}}</dt>
+    <dd>The global HID interface.</dd>
+</dl>
+<dl>
+    <dt>{{domxref("HIDDevice")}}</dt>
+    <dd>Filter the device. Valid if filter.productId, filter.vendorId, filter.invalid and filter.usage exist.</dd>
+</dl>
+<dl>
+    <dt>{{domxref("HIDInputReportEvent")}}</dt>
+    <dd>The Event about HID Input Report.</dd>
+</dl>
+<dl>
+    <dt>{{domxref("HIDConnectionEvent")}}</dt>
+    <dd>The Event about HID Connection.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>Retrieve devices and log the device names to the console.</p>
+
+<pre class="brush: js">document.addEventListener('DOMContentLoaded', async () => {
+    let devices = await navigator.hid.getDevices();
+    devices.forEach(device => {
+        console.log(`HID: ${device.productName}`);
+    });
+});</pre>
+
+<p>Register event listeners for connection and disconnection of HID devices.</p>
+
+<pre class="brush: js">navigator.hid.addEventListener('connect', ({device}) => {
+    console.log(`HID connected: ${device.productName}`);
+    });
+
+    navigator.hid.addEventListener('disconnect', ({device}) => {
+    console.log(`HID disconnected: ${device.productName}`);
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+    <td>{{SpecName('WebHID API')}}</td>
+    <td>{{Spec2('WebHID API')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.HID")}}</p>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -19,7 +19,7 @@ tags:
 </dl>
 <dl>
     <dt>{{domxref("HIDDevice")}}</dt>
-    <dd>Filter the device. Valid if filter.productId, filter.vendorId, filter.invalid and filter.usage exist.</dd>
+    <dd>An object representing a physical device. It's possible for a single physical device to be represented by multiple `HIDDevice` obects.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDInputReportEvent")}}</dt>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -15,7 +15,7 @@ tags:
 
 <dl>
     <dt>{{domxref("HID")}}</dt>
-    <dd>The global HID interface.</dd>
+    <dd>provides methods for listing and retrieving attached devices and event callbacks triggered when devices are added or removed.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDDevice")}}</dt>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -15,41 +15,68 @@ tags:
 
 <dl>
     <dt>{{domxref("HID")}}</dt>
-    <dd>provides methods for listing and retrieving attached devices and event callbacks triggered when devices are added or removed.</dd>
+    <dd>provides methods for connecting to HID devices, listing attached HID devices and event handlers for connected HID devices.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDDevice")}}</dt>
-    <dd>An object representing a physical device. It's possible for a single physical device to be represented by multiple `HIDDevice` obects.</dd>
+    <dd>represents an HID device. It's possible for a single physical device to be represented by multiple `HIDDevice` obects.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDInputReportEvent")}}</dt>
-    <dd>Passed to {{domxref("HIDDevice. oninputreport")}} when a user interacts with the specified device.</dd>
+    <dd>passed to {{domxref("HIDDevice.oninputreport")}} when an input report is received from the any associated HID device.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDConnectionEvent")}}</dt>
-    <dd>Passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when a device is connected or disconnected.</dd>
+    <dd>passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when a device is connected or disconnected.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>
 
-<p>Retrieve devices and log the device names to the console.</p>
+<p>You can connect to a device with {{domxref("HID.requestDevices")}}. In this case, we gonna select from all the available devices.</p>
 
-<pre class="brush: js">document.addEventListener('DOMContentLoaded', async () => {
+<pre class="brush: js">
+    const device = await navigator.hid.requestDevice({filters: []})
+    // A popup titled `... wants to connect to a HID Device` with `Cancel` and `Connect` buttons will show up with a device list to select from.
+    // Select one and click on `Connect` button. Then the device will be an array with the selected device in it.
+</pre>
+
+<p>We can retrieve all the connected devices and log the device names to the console.</p>
+
+<pre class="brush: js">
     let devices = await navigator.hid.getDevices();
     devices.forEach(device => {
         console.log(`HID: ${device.productName}`);
     });
-});</pre>
+</pre>
 
-<p>Register event listeners for connection and disconnection of HID devices.</p>
+<p>We can register event listeners for disconnection of any HID devices.</p>
 
-<pre class="brush: js">navigator.hid.addEventListener('connect', ({device}) => {
-    console.log(`HID connected: ${device.productName}`);
+<pre class="brush: js">
+    navigator.hid.addEventListener('disconnect', (event) => {
+        console.log(`HID disconnected: ${event.device.productName}`);
+        console.dir(event)
     });
-
-    navigator.hid.addEventListener('disconnect', ({device}) => {
-    console.log(`HID disconnected: ${device.productName}`);
-});</pre>
+    // For example, when my connected keyboard gets disconnected, the log in the console will show:
+    // HID disconnected: USB USB Keyboard
+    // {
+    //    bubbles: false
+    //    cancelBubble: false
+    //    cancelable: false
+    //    composed: false
+    //    currentTarget: HID {onconnect: null, ondisconnect: null}
+    //    defaultPrevented: false
+    //    device: HIDDevice {oninputreport: null, opened: false, vendorId: 6700, productId: 11555, productName: "USB USB Keyboard", …}
+    //    eventPhase: 0
+    //    isTrusted: true
+    //    path: []
+    //    returnValue: true
+    //    srcElement: HID {onconnect: null, ondisconnect: null}
+    //    target: HID {onconnect: null, ondisconnect: null}
+    //    timeStamp: 18176.600000023842
+    //    type: "disconnect"
+    // }
+    // The event is an instance of the HIDConnectionEvent interface.
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{DefaultAPISidebar("WebHID API")}}</div>
 
-<p>A HID (Human Interface Device) is a type of device that takes input from or provides output to humans. It also refers to the HID protocol, a standard for bi-directional communication between a host and a device that is designed to simplify the installation procedure. The HID protocol was originally developed for USB devices but has since been implemented over many other protocols, including Bluetooth.</p>
+<p>A Human Interface Device (HID) is a type of device that takes input from or provides output to humans. It also refers to the HID protocol, a standard for bi-directional communication between a host and a device that is designed to simplify the installation procedure. The HID protocol was originally developed for USB devices but has since been implemented over many other protocols, including Bluetooth.</p>
 
 <h2 id="Interfaces">Interfaces</h2>
 

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -91,8 +91,8 @@ navigator.hid.addEventListener('disconnect', (event) => {
  </thead>
  <tbody>
   <tr>
-    <td>{{SpecName('WebHID API')}}</td>
-    <td>{{Spec2('WebHID API')}}</td>
+    <td>{{SpecName('WebHID')}}</td>
+    <td>{{Spec2('WebHID')}}</td>
    <td>Initial definition.</td>
   </tr>
  </tbody>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -23,7 +23,7 @@ tags:
 </dl>
 <dl>
     <dt>{{domxref("HIDInputReportEvent")}}</dt>
-    <dd>The Event about HID Input Report.</dd>
+    <dd>Passed to {{domxref("HIDDevice. oninputreport")}} when a user interacts with the specified device.</dd>
 </dl>
 <dl>
     <dt>{{domxref("HIDConnectionEvent")}}</dt>

--- a/files/en-us/web/api/webhid_api/index.html
+++ b/files/en-us/web/api/webhid_api/index.html
@@ -27,7 +27,7 @@ tags:
 </dl>
 <dl>
     <dt>{{domxref("HIDConnectionEvent")}}</dt>
-    <dd>The Event about HID Connection.</dd>
+    <dd>Passed to {{domxref("HID.onconnect")}} and {{domxref("HID.ondisconnect")}} when a device is connected or disconnected.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
Add a page for WebHID API. Later I will add pull requests one by one for the global interfaces `HID`, `HIDConnectionEvent`, `HIDInputReportEvent`, `HIDDevice`.

As for compat data, already added a pull request: https://github.com/mdn/browser-compat-data/pull/9910

And it seems the backend didn't recognize the correct specification url, it should be: https://wicg.github.io/webhid/ . So maybe ur backend developers should work to fix that recognization problem?

**To-do list about associated pages:** (I think maybe I'll do them one by one in future PRs, it's not recommended to make a substantial PR)
- [x] `navigator.hid` - https://github.com/mdn/content/pull/4345
- [ ] interface pages
  - [x] `HID` - https://github.com/mdn/content/pull/4368
  - [ ] `HIDConnectionEvent`
  - [ ] `HIDInputReportEvent`
  - [ ] `HIDConnectionEvent`