### PR TITLE
Fix openOrCloseShadowRoot example

### DIFF
--- a/files/en-us/web/api/element/openorclosedshadowroot/index.html
+++ b/files/en-us/web/api/element/openorclosedshadowroot/index.html
@@ -28,7 +28,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>shadowroot = element</em>.shadowRoot;
+<pre class="brush: js">var <em>shadowroot = element</em>.openOrCloseShadowRoot;
 </pre>
 
 <h3 id="Value">Value</h3>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The example shows accessing `shadowRoot` despite the page documenting `openOrCloseShadowRoot`. This seems to be a copy-paste issue perhaps?

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Element/openOrClosedShadowRoot

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A