### PR TITLE
Fix various problems in Array.p.find|findIndex

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -2,13 +2,12 @@
 title: Array.prototype.find()
 slug: Web/JavaScript/Reference/Global_Objects/Array/find
 tags:
-- Array
-- ECMAScript 2015
-- JavaScript
-- Method
-- Prototype
-- Reference
-- polyfill
+  - Array
+  - ECMAScript 2015
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
@@ -82,7 +81,7 @@ find(function callbackFn(element, index, array) { ... }, thisArg)
 
 <p>The <code>find</code> method executes the <code><var>callback</var></code> function
   once for each index of the array until the <code><var>callback</var></code> returns a <a
-    href="/en-US/docs/Glossary/truthy">truthy</a> value. If so, <code>find</code>
+    href="/en-US/docs/Glossary/Truthy">truthy</a> value. If so, <code>find</code>
   immediately returns the value of that element. Otherwise, <code>find</code> returns
   {{jsxref("undefined")}}.</p>
 
@@ -107,67 +106,8 @@ find(function callbackFn(element, index, array) { ... }, thisArg)
     <code><var>callback</var></code>, its value passed to the
     <code><var>callback</var></code> will be the value at the time <code>find</code>
     visits that element's index.</li>
-  <li>Elements that are {{jsxref("delete", "deleted")}} are still visited.</li>
+  <li>Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.</li>
 </ul>
-
-<h2 id="Polyfill">Polyfill</h2>
-
-<p>This method has been added to the ECMAScript 2015 specification and may not be
-  available in all JavaScript implementations yet. However, you can polyfill
-  <code>Array.prototype.find</code> with the following snippet:</p>
-
-<pre class="brush: js">// https://tc39.github.io/ecma262/#sec-array.prototype.find
-if (!Array.prototype.find) {
-  Object.defineProperty(Array.prototype, 'find', {
-    value: function(predicate) {
-      // 1. Let O be ? ToObject(this value).
-      if (this == null) {
-        throw TypeError('"this" is null or not defined');
-      }
-
-      var o = Object(this);
-
-      // 2. Let len be ? ToLength(? Get(O, "length")).
-      var len = o.length &gt;&gt;&gt; 0;
-
-      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-      if (typeof predicate !== 'function') {
-        throw TypeError('predicate must be a function');
-      }
-
-      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-      var thisArg = arguments[1];
-
-      // 5. Let k be 0.
-      var k = 0;
-
-      // 6. Repeat, while k &lt; len
-      while (k &lt; len) {
-        // a. Let Pk be ! ToString(k).
-        // b. Let kValue be ? Get(O, Pk).
-        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-        // d. If testResult is true, return kValue.
-        var kValue = o[k];
-        if (predicate.call(thisArg, kValue, k, o)) {
-          return kValue;
-        }
-        // e. Increase k by 1.
-        k++;
-      }
-
-      // 7. Return undefined.
-      return undefined;
-    },
-    configurable: true,
-    writable: true
-  });
-}
-</pre>
-
-<p>If you need to support truly obsolete JavaScript engines that don't support
-  <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty">Object.defineProperty</a></code>,
-  it is best not to polyfill <code>Array.prototype</code> at all, as you cannot make it
-  non-enumerable.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -74,8 +74,6 @@ find(function callbackFn(element, index, array) { ... }, thisArg)
 <p>The <strong>value</strong> of the <strong>first element</strong> in the array that
   satisfies the provided testing function. Otherwise, {{jsxref("undefined")}} is returned.
 </p>
-<p class="warning">Index <code>0</code> will be interpreted as a {{Glossary("Falsy")}}
-  value in conditional statements.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
@@ -8,7 +8,6 @@ tags:
 - Method
 - Prototype
 - Reference
-- polyfill
 ---
 <div>{{JSRef}}</div>
 
@@ -71,6 +70,8 @@ findIndex(function callbackFn(element, index, array) { ... }, thisArg)
 <p>The index of the first element in the array that passes the test. Otherwise,
   <code>-1</code>.</p>
 
+<p>Note: if the index of the first element in the array that passes the test is <code>0</code>, the return value of <code>findIndex</code> will be interpreted as {{Glossary("Falsy")}} in conditional statements.</p>
+
 <h2 id="Description">Description</h2>
 
 <p>The <code>findIndex()</code> method executes the <code><var>callback</var></code>
@@ -109,63 +110,7 @@ findIndex(function callbackFn(element, index, array) { ... }, thisArg)
   <code><var>callback</var></code> will be the value at the time <code>findIndex()</code>
   visits the element's index.</p>
 
-<p>Elements that are <a
-    href="/en-US/docs/Web/JavaScript/Reference/Operators/delete">deleted</a> are still
-  visited.</p>
-
-<h2 id="Polyfill">Polyfill</h2>
-
-<pre class="brush: js">// https://tc39.github.io/ecma262/#sec-array.prototype.findindex
-if (!Array.prototype.findIndex) {
-  Object.defineProperty(Array.prototype, 'findIndex', {
-    value: function(predicate) {
-     // 1. Let O be ? ToObject(this value).
-      if (this == null) {
-        throw new TypeError('"this" is null or not defined');
-      }
-
-      var o = Object(this);
-
-      // 2. Let len be ? ToLength(? Get(O, "length")).
-      var len = o.length &gt;&gt;&gt; 0;
-
-      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-      if (typeof predicate !== 'function') {
-        throw new TypeError('predicate must be a function');
-      }
-
-      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-      var thisArg = arguments[1];
-
-      // 5. Let k be 0.
-      var k = 0;
-
-      // 6. Repeat, while k &lt; len
-      while (k &lt; len) {
-        // a. Let Pk be ! ToString(k).
-        // b. Let kValue be ? Get(O, Pk).
-        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-        // d. If testResult is true, return k.
-        var kValue = o[k];
-        if (predicate.call(thisArg, kValue, k, o)) {
-          return k;
-        }
-        // e. Increase k by 1.
-        k++;
-      }
-
-      // 7. Return -1.
-      return -1;
-    },
-    configurable: true,
-    writable: true
-  });
-}
-</pre>
-
-<p>If you need to support truly obsolete JavaScript engines that do not support
-  {{jsxref("Object.defineProperty")}}, it is best not to polyfill
-  <code>Array.prototype</code> methods at all, as you cannot make them non-enumerable.</p>
+<p>Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
* Move statement about return value being falsy if array element found at index 0. Fixes https://github.com/mdn/content/issues/4239.

* Remove polyfills

* Fix fixable flaws