### PR TITLE
fixing the masking examples

### DIFF
--- a/files/en-us/web/css/mask-border/index.html
+++ b/files/en-us/web/css/mask-border/index.html
@@ -5,12 +5,10 @@ tags:
   - CSS
   - CSS Masking
   - CSS Property
-  - Experimental
-  - NeedsCompatTable
   - Reference
   - recipe:css-shorthand-property
 ---
-<div>{{CSSRef}}{{SeeCompatTable}}</div>
+<div>{{CSSRef}}</div>
 
 <p>The <strong><code>mask-border</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> lets you create a mask along the edge of an element's border.</p>
 
@@ -75,48 +73,9 @@ mask-border: url('border-mask.png') 25 / 35px / 12px space alpha;
 
 <p><img alt="" src="mask-border-diamonds.png"></p>
 
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="bitmap"&gt;This element is surrounded by a bitmap-based mask border! Pretty neat, isn't it?&lt;/div&gt;</pre>
-
-<h4 id="CSS">CSS</h4>
-
 <p>To match the size of a single diamond, we will use a value of 90 divided by 3, or <code>30</code>, for slicing the image into corner and edge regions. A repeat value of <code>round</code> will make the mask slices fit evenly, i.e., without clipping or gaps.</p>
 
-<pre class="brush: css">div {
-  width: 200px;
-  background-color: lavender;
-  border: 18px solid salmon;
-  padding: 10px;
-
-  /* Prefixed longhand properties currently supported in Chromium
-    -webkit-mask-box-image-source: url(https://mdn.mozillademos.org/files/15836/mask-border-diamonds.png);
-    -webkit-mask-box-image-slice: 30 fill;
-    -webkit-mask-box-image-width: 20px;
-    -webkit-mask-box-image-repeat: round;
-    -webkit-mask-box-image-outset: 1px;
-  */
-
-  /* Prefixed shorthand property currently supported in Chromium */
-  -webkit-mask-box-image: url("https://mdn.mozillademos.org/files/15836/mask-border-diamonds.png") /* source */
-  30 fill /          /* slice */
-  20px /             /* width */
-  1px                /* outset */
-  round;             /* repeat */
-
-  /* Updated standard shorthand property, not supported anywhere yet */
-  mask-border:
-    url("https://mdn.mozillademos.org/files/15836/mask-border-diamonds.png")  /* source */
-    30 fill /        /* slice */
-    20px /           /* width */
-    1px              /* outset */
-    round;           /* repeat */
-}
-</pre>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Setting_a_bitmap-based_mask_border")}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-border.html", '100%', 800)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/mask-composite/index.html
+++ b/files/en-us/web/css/mask-composite/index.html
@@ -56,44 +56,7 @@ mask-composite: unset;
 
 <h3 id="Compositing_mask_layers_with_addition">Compositing mask layers with addition</h3>
 
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css; highlight[7]">#masked {
-  width: 100px;
-  height: 100px;
-  background-color: #8cffa0;
-  mask-image: url(https://mdn.mozillademos.org/files/12668/MDN.svg),
-              url(https://mdn.mozillademos.org/files/12676/star.svg);
-  mask-size: 100% 100%;
-  mask-composite: add; /* Can be changed in the live sample */
-}
-</pre>
-
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="masked"&gt;
-&lt;/div&gt;
-&lt;select id="compositeMode"&gt;
-  &lt;option value="add"&gt;add&lt;/option&gt;
-  &lt;option value="subtract"&gt;subtract&lt;/option&gt;
-  &lt;option value="intersect"&gt;intersect&lt;/option&gt;
-  &lt;option value="exclude"&gt;exclude&lt;/option&gt;
-&lt;/select&gt;
-</pre>
-
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var clipBox = document.getElementById("compositeMode");
-clipBox.addEventListener("change", function (evt) {
-  document.getElementById("masked").style.maskComposite = evt.target.value;
-});
-</pre>
-</div>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Compositing_mask_layers_with_addition", "100px", "130px")}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-composite.html", '100%', 550)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/mask-origin/index.html
+++ b/files/en-us/web/css/mask-origin/index.html
@@ -80,48 +80,9 @@ mask-origin: unset;
 
 <h3 id="Setting_mask_origin_to_border-box">Setting mask origin to border-box</h3>
 
-<h4 id="CSS">CSS</h4>
+<p>Try some of the other possible values by updating the CSS in the box below.</p>
 
-<pre class="brush: css; highlight[9]">#masked {
-  width: 100px;
-  height: 100px;
-  margin: 10px;
-  border: 10px solid blue;
-  background-color: #8cffa0;
-  padding: 10px;
-  mask-image: url(https://mdn.mozillademos.org/files/12676/star.svg);
-  mask-origin: border-box; /* Can be changed in the live sample */
-}
-</pre>
-
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="masked"&gt;
-&lt;/div&gt;
-&lt;select id="origin"&gt;
-  &lt;option value="content-box"&gt;content-box&lt;/option&gt;
-  &lt;option value="padding-box"&gt;padding-box&lt;/option&gt;
-  &lt;option value="border-box" selected&gt;border-box&lt;/option&gt;
-  &lt;option value="margin-box"&gt;margin-box&lt;/option&gt;
-  &lt;option value="fill-box"&gt;fill-box&lt;/option&gt;
-  &lt;option value="stroke-box"&gt;stroke-box&lt;/option&gt;
-  &lt;option value="view-box"&gt;view-box&lt;/option&gt;
-&lt;/select&gt;
-</pre>
-
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var origin = document.getElementById("origin");
-origin.addEventListener("change", function (evt) {
-  document.getElementById("masked").style.maskOrigin = evt.target.value;
-});
-</pre>
-</div>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Setting_mask_origin_to_border-box", 160, 200)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-origin.html", '100%', 600)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/mask-repeat/index.html
+++ b/files/en-us/web/css/mask-repeat/index.html
@@ -117,45 +117,7 @@ mask-repeat: unset;
 
 <h3 id="Setting_repeat_for_a_single_mask">Setting repeat for a single mask</h3>
 
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css; highlight[6]">#masked {
-  width: 250px;
-  height: 250px;
-  background: blue linear-gradient(red, blue);
-  mask-image: url(https://mdn.mozillademos.org/files/12676/star.svg);
-  mask-repeat: repeat; /* Can be changed in the live sample */
-  margin-bottom: 10px;
-}
-</pre>
-
-<div class="hidden">
-<h4 id="HTML_Content">HTML Content</h4>
-
-<pre class="brush: html">&lt;div id="masked"&gt;
-&lt;/div&gt;
-&lt;select id="repetition"&gt;
-  &lt;option value="repeat-x"&gt;repeat-x&lt;/option&gt;
-  &lt;option value="repeat-y"&gt;repeat-y&lt;/option&gt;
-  &lt;option value="repeat" selected&gt;repeat&lt;/option&gt;
-  &lt;option value="space"&gt;space&lt;/option&gt;
-  &lt;option value="round"&gt;round&lt;/option&gt;
-  &lt;option value="no-repeat"&gt;no-repeat&lt;/option&gt;
-&lt;/select&gt;
-</pre>
-
-<h4 id="JavaScript_Content">JavaScript Content</h4>
-
-<pre class="brush: js">var repetition = document.getElementById("repetition");
-repetition.addEventListener("change", function (evt) {
-  document.getElementById("masked").style.maskRepeat = evt.target.value;
-});
-</pre>
-</div>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Setting_repeat_for_a_single_mask", "290px", "290px")}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-repeat.html", '100%', 700)}}</p>
 
 <h3 id="Multiple_mask_image_support">Multiple mask image support</h3>
 

--- a/files/en-us/web/css/mask-size/index.html
+++ b/files/en-us/web/css/mask-size/index.html
@@ -107,47 +107,7 @@ mask-size: unset;
 
 <h3 id="Setting_mask_size_as_a_percentage">Setting mask size as a percentage</h3>
 
-<h4 id="CSS">CSS</h4>
-
-<pre class="brush: css; highlight[6]">#masked {
-  width: 200px;
-  height: 200px;
-  background: blue linear-gradient(red, blue);
-  -webkit-mask-image: url(https://mdn.mozillademos.org/files/12668/MDN.svg);
-  mask-image: url(https://mdn.mozillademos.org/files/12668/MDN.svg);
-  -webkit-mask-size: 50%;
-  mask-size: 50%; /* Can be changed in the live sample */
-  margin-bottom: 10px;
-}
-</pre>
-
-<div class="hidden">
-<h4 id="HTML">HTML</h4>
-
-<pre class="brush: html">&lt;div id="masked"&gt;
-&lt;/div&gt;
-&lt;select id="maskSize"&gt;
-  &lt;option value="auto"&gt;auto&lt;/option&gt;
-  &lt;option value="40% 80%"&gt;40% 80%&lt;/option&gt;
-  &lt;option value="50%" selected&gt;50%&lt;/option&gt;
-  &lt;option value="200px 100px"&gt;200px 100px&lt;/option&gt;
-  &lt;option value="cover"&gt;cover&lt;/option&gt;
-  &lt;option value="contain"&gt;contain&lt;/option&gt;
-&lt;/select&gt;
-</pre>
-
-<h4 id="JavaScript">JavaScript</h4>
-
-<pre class="brush: js">var maskSize = document.getElementById("maskSize");
-maskSize.addEventListener("change", function (evt) {
-  document.getElementById("masked").style.maskSize = evt.target.value;
-});
-</pre>
-</div>
-
-<h4 id="Result">Result</h4>
-
-<p>{{EmbedLiveSample("Setting_mask_size_as_a_percentage", 210, 240)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/masking/mask-size.html", '100%', 700)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Fixes: #4203 

Also ref: #4203 

Fixes a bunch of CSS masking examples by moving them to the css-examples repo.
