### PR TITLE
add icon size

### DIFF
--- a/files/en-us/web/manifest/shortcuts/index.html
+++ b/files/en-us/web/manifest/shortcuts/index.html
@@ -53,7 +53,7 @@ tags:
   </tr>
   <tr>
    <td><code>icons</code></td>
-   <td>A set of icons that represent the shortcut. They can be used, e.g., in the context menu.</td>
+   <td>A set of icons that represent the shortcut. They can be used, e.g., in the context menu. When used must include a 96x96 pixel icon.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/web/manifest/shortcuts/index.html
+++ b/files/en-us/web/manifest/shortcuts/index.html
@@ -53,7 +53,7 @@ tags:
   </tr>
   <tr>
    <td><code>icons</code></td>
-   <td>A set of icons that represent the shortcut. They can be used, e.g., in the context menu. When used must include a 96x96 pixel icon.</td>
+   <td>A set of icons that represent the shortcut. They can be used, e.g., in the context menu. When included, the icon set must include a 96x96 pixel icon.</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
- Docs do not specify an icon size
- https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts
- Screenshot from the application tab in chrome dev tools
![image](https://user-images.githubusercontent.com/6934044/115288853-3d229980-a152-11eb-82fa-8eb23bed3310.png)
