### PR TITLE
removing nullbyte from code snippet so it can be flaw fixed

### DIFF
--- a/files/en-us/learn/css/building_blocks/organizing/index.html
+++ b/files/en-us/learn/css/building_blocks/organizing/index.html
@@ -308,9 +308,9 @@ blockquote { ... }
 
 <p>Once compiled to CSS, you would end up with the following CSS in the final stylesheet.</p>
 
-<pre class="brush: css"><code>.alert {
-  border: 1px solid #c6538c;
-}</code></pre>
+<pre class="brush: css">.alert {
+  border: 1px solid #c6538c;
+}</pre>
 
 <h4 id="Compiling_component_stylesheets">Compiling component stylesheets</h4>
 


### PR DESCRIPTION
Part of https://github.com/mdn/yari/issues/3564

The Yari flaw fixer couldn't even find the code in the original document because it contained a nullbyte character. I manually removed the nullbyte character with my IDE, then the "Fix fixable flaws" button could do its thing. 