### PR TITLE
Removes dead links from PWA "Tools" documentation

### DIFF
--- a/files/en-us/web/progressive_web_apps/index.html
+++ b/files/en-us/web/progressive_web_apps/index.html
@@ -89,11 +89,9 @@ tags:
  <li><a href="https://developers.google.com/web/progressive-web-apps/checklist">Progressive Web Apps Check List</a>.</li>
  <li><a href="https://developers.google.com/web/tools/lighthouse">The Lighthouse Tool</a> by Google.</li>
  <li><a href="https://github.com/angular/mobile-toolkit">Tools for building progressive web apps with Angular</a>.</li>
- <li><a href="https://github.com/codebusking/react-pwa-guide-kit">React PWA Guide Kit</a>.</li>
  <li><a href="https://pokedex.org/">Offline-capable Pokédex web site</a>.</li>
  <li><a href="https://hnpwa.com/">Hacker News readers as Progressive Web Apps</a>.</li>
  <li><a href="https://goingmeta.io/progressive-web-app/">Progressive Web App: Advantages in a nutshell</a></li>
- <li><a href="https://ymedialabs.com/progressive-web-apps">Why Progressive Web Apps Are The Future of Mobile Web (2019 Research)</a>.</li>
  <li><a href="https://www.csschopper.com/blog/progressive-web-apps-everything-you-need-to-know/">Progressive Web Apps: Everything You Need To Know</a></li>
  <li><a href="https://pwafire.org">Collection of resources, codelabs and tools you need to build PWAs by the team at pwafire.org</a></li>
  <li><a href="https://github.com/pwafire/pwadev-tips">Setting up your Progressive Web App Development environment</a></li>

--- a/files/en-us/web/progressive_web_apps/index.html
+++ b/files/en-us/web/progressive_web_apps/index.html
@@ -91,7 +91,6 @@ tags:
  <li><a href="https://github.com/angular/mobile-toolkit">Tools for building progressive web apps with Angular</a>.</li>
  <li><a href="https://pokedex.org/">Offline-capable Pokédex web site</a>.</li>
  <li><a href="https://hnpwa.com/">Hacker News readers as Progressive Web Apps</a>.</li>
- <li><a href="https://goingmeta.io/progressive-web-app/">Progressive Web App: Advantages in a nutshell</a></li>
  <li><a href="https://www.csschopper.com/blog/progressive-web-apps-everything-you-need-to-know/">Progressive Web Apps: Everything You Need To Know</a></li>
  <li><a href="https://pwafire.org">Collection of resources, codelabs and tools you need to build PWAs by the team at pwafire.org</a></li>
  <li><a href="https://github.com/pwafire/pwadev-tips">Setting up your Progressive Web App Development environment</a></li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A handful of links listed in the documentation for Progressive Web Apps under the Tools section are no longer valid for various reasons

- _React PWA Guide Kit_: returns 404
- _Progressive Web App: Advantages in a nutshell_: Host not resolved
- _Why Progressive Web Apps Are The Future of Mobile Web (2019 Research)_: Article deleted

> MDN URL of main page changed

[Progressive Web Apps](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps#tools)
 
> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

No apparent copy is available elsewhere for any of the links removed in this PR