### PR TITLE
Replace Content-Type with Accept in fetch GET examples

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/fetch/index.html
@@ -187,7 +187,7 @@ fetch(myRequest)
 <pre class="brush: js">const myImage = document.querySelector('img');
 
 let myHeaders = new Headers();
-myHeaders.append('Content-Type', 'image/jpeg');
+myHeaders.append('Accept', 'image/jpeg');
 
 const myInit = {
   method: 'GET',
@@ -214,7 +214,7 @@ fetch(myRequest, myInit).then(function(response) {
 <pre class="brush: js">const myInit = {
   method: 'GET',
   headers: {
-    'Content-Type': 'image/jpeg'
+    'Accept': 'image/jpeg'
   },
   mode: 'cors',
   cache: 'default'


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

`Content-Type` doesn't make sense for requests without bodies. `Accept` is likely what the author intended.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch

> Issue number (if there is an associated issue)

> Anything else that could help us review it

I have seen this error being made twice in production code and it's possible MDN was the cause. Setting the Content-Type header for a GET request can also lead to an unnecessary CORS preflight request.