### PR TITLE
Fixed a typo in the HTMLElement.inert documentation

### DIFF
--- a/files/en-us/web/api/htmlelement/inert/index.html
+++ b/files/en-us/web/api/htmlelement/inert/index.html
@@ -25,7 +25,7 @@ slug: Web/API/HTMLElement/inert
   &lt;button id="button1"&gt;I am not inert&lt;/button&gt;
 &lt;/div&gt;
 &lt;div inert&gt;
-  &lt;label for="button2"&gt;Button 1&lt;/label&gt;
+  &lt;label for="button2"&gt;Button 2&lt;/label&gt;
   &lt;button id="button2"&gt;I am inert&lt;/button&gt;
 &lt;/div&gt;</pre>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Button 2 was labeled as button 1

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert

> Issue number (if there is an associated issue)

> Anything else that could help us review it
