### PR TITLE
Opacity: fix content overflow in example

### DIFF
--- a/files/en-us/web/css/opacity/index.html
+++ b/files/en-us/web/css/opacity/index.html
@@ -102,7 +102,7 @@ tags:
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample('Setting_background_opacity', '640', '64')}}</p>
+<p>{{EmbedLiveSample('Setting_background_opacity', '640', '85')}}</p>
 
 <h3 id="Setting_opacity_on_hover">Setting opacity on hover</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The CSS `opacity` page has a helpful example that's cut off, so you can't see the 100% opacity example.

![image](https://user-images.githubusercontent.com/310323/115333935-5c6bf780-a14f-11eb-8256-25cefc2c6261.png)

![image](https://user-images.githubusercontent.com/310323/115334131-ab199180-a14f-11eb-8d11-5861c87b464a.png)


<img width="963" alt="opacity_-_CSS__Cascading_Style_Sheets___MDN" src="https://user-images.githubusercontent.com/310323/115333799-22025a80-a14f-11eb-851f-6d97909f1546.png">


> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/opacity

> Issue number (if there is an associated issue)
N/A

> Anything else that could help us review it

Thanks - let me know if there's anything else I can provide for this PR