### PR TITLE
updating release notes post-88 release

### DIFF
--- a/files/en-us/mozilla/firefox/releases/88/index.html
+++ b/files/en-us/mozilla/firefox/releases/88/index.html
@@ -9,7 +9,12 @@ tags:
 ---
 <p>{{FirefoxSidebar}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 88 that will affect developers. Firefox 88 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">April 19, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 88 that will affect developers. Firefox 88 was released on April 19, 2021.</p>
+
+<div class="note notecard">
+  <h4>Note</h4>
+  <p>See also <a href="https://hacks.mozilla.org/2021/04/never-too-late-for-firefox-88/">Never too late for Firefox 88</a> on Mozilla Hacks.</p>
+</div>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/90/index.html
+++ b/files/en-us/mozilla/firefox/releases/90/index.html
@@ -1,15 +1,15 @@
 ---
-title: Firefox 89 for developers
-slug: Mozilla/Firefox/Releases/89
+title: Firefox 90 for developers
+slug: Mozilla/Firefox/Releases/90
 tags:
-  - '89'
+  - '90'
   - Firefox
   - Mozilla
   - Release
 ---
 <p>{{FirefoxSidebar}}{{draft}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 89 that will affect developers. Firefox 89 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">June 1, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 90 that will affect developers. Firefox 90 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">June 29, 2021</a>.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 
@@ -59,4 +59,4 @@ tags:
 
 <h2 id="Older_versions">Older versions</h2>
 
-<p>{{Firefox_for_developers(88)}}</p>
+<p>{{Firefox_for_developers(89)}}</p>


### PR DESCRIPTION
This includes:

* Adding a new page for Firefox 90 release notes
* Updating the 88/89/90 release notes so they correctly refer to the status of each version (release/beta/nightly).
* Adding a link to the hacks blog post for 88 to the 88 rel notes.