### PR TITLE
outline border.radius changes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -223,46 +223,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="outline_property">outline property to follow border-radius shape</h3>
-
-<p>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property will be removed. (See {{bug(315209)}} and {{bug(1694146)}} for more details.)</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>87</td>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>87</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>87</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>87</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference name</th>
-   <th colspan="2"><code>layout.css.outline-follows-border-radius.enabled</code></th>
-  </tr>
- </tbody>
-</table>
-
 <h3 id="Property_initial-letter">Property: initial-letter</h3>
 
 <p>The {{cssxref("initial-letter")}} CSS property is part of the {{SpecName("CSS3 Inline")}} specification and allows you to specify how dropped, raised, and sunken initial letters are displayed. (See {{bug(1223880)}} for more details.)</p>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -224,6 +224,7 @@ tags:
 </table>
 
 <h3 id="Property_initial-letter">Property: initial-letter</h3>
+<<<<<<< HEAD
 
 <p>The {{cssxref("initial-letter")}} CSS property is part of the {{SpecName("CSS3 Inline")}} specification and allows you to specify how dropped, raised, and sunken initial letters are displayed. (See {{bug(1223880)}} for more details.)</p>
 
@@ -264,6 +265,8 @@ tags:
 </table>
 
 <h3 id="Property_aspect-ratio">Property: aspect-ratio</h3>
+=======
+>>>>>>> f3b4cff85 (outline border.radius changes)
 
 <p>The {{cssxref("aspect-ratio")}} CSS property is part of the {{SpecName("CSS4 Sizing")}} specification and allows you to create boxes which conform to an aspect ratio. (See {{bug(1639963)}} and {{bug(1646096)}} for more details.)</p>
 

--- a/files/en-us/web/css/outline/index.html
+++ b/files/en-us/web/css/outline/index.html
@@ -17,6 +17,11 @@ tags:
 
 <div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
+
+<div class="note">
+  <p><strong>Note:</strong> The outline CSS property has been updated to follow the outline created by border-radius by using the <strong>layout.css.outline-follows-border-radius.enabled</strong> preference. This is set to <strong>True</strong> by default starting with Nightly 88. (See {{bug(315209)}} and {{bug(1694146)}} for more details.).</p>
+  </div>  
+
 <h2 id="Constituent_properties">Constituent properties</h2>
 
 <p>This property is a shorthand for the following CSS properties:</p>

--- a/files/en-us/web/css/outline/index.html
+++ b/files/en-us/web/css/outline/index.html
@@ -17,11 +17,6 @@ tags:
 
 <div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
-
-<div class="note">
-  <p><strong>Note:</strong> The outline CSS property has been updated to follow the outline created by border-radius by using the <strong>layout.css.outline-follows-border-radius.enabled</strong> preference. This is set to <strong>True</strong> by default starting with Nightly 88. (See {{bug(315209)}} and {{bug(1694146)}} for more details.).</p>
-  </div>  
-
 <h2 id="Constituent_properties">Constituent properties</h2>
 
 <p>This property is a shorthand for the following CSS properties:</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
- Removed outline property notes and table from experimental features page as it is already enabled by default in all release channels. 
- Added Note under demo https://developer.mozilla.org/en-US/docs/Web/CSS/outline about the layout.css.outline-follows-border-radius.enabled pref being enabled by default. 


> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features#outline_property
https://developer.mozilla.org/en-US/docs/Web/CSS/outline

> Issue number (if there is an associated issue)
#3453

