### PR TITLE
Update Web/HTML/Element/hgroup

### DIFF
--- a/files/en-us/web/html/element/hgroup/index.html
+++ b/files/en-us/web/html/element/hgroup/index.html
@@ -12,8 +12,6 @@ tags:
 ---
 <div>{{HTMLRef}}{{deprecated_header}}</div>
 
-<div>{{HTMLRef}}</div>
-
 <p>The <strong>HTML <code>&lt;hgroup&gt;</code> element</strong> represents a multi-level heading for a section of a document. It groups a set of <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> elements.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/hgroup.html", "tabbed-standard")}}</div>
@@ -143,5 +141,5 @@ tags:
 
 <ul>
  <li>Others section-related elements: {{HTMLElement("body")}}, {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("nav")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}};</li>
- <li><a class="deki-ns current" href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines" title="Sections and Outlines of an HTML5 document">Sections and outlines of an HTML5 document</a>.</li>
+ <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines">Sections and outlines of an HTML5 document</a>.</li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There is still an unnecessary macro and attributes.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup

> Issue number (if there is an associated issue)

> Anything else that could help us review it
