### PR TITLE
Fix misplaced compat table

### DIFF
--- a/files/en-us/learn/css/building_blocks/debugging_css/index.html
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.html
@@ -151,9 +151,7 @@ tags:
 
 <p><img alt="Image of browser DevTools with the grid-template-columns: subgrid crossed out as the subgrid value is not supported." src="no-support.png"></p>
 
-<p>You can also take a look at the Browser compatibility tables at the bottom of each property page on MDN. These show you browser support for that property, often broken down if there is support for some usage of the property and not others. The below table shows the compat data for the {{cssxref("shape-outside")}} property.</p>
-
-<p>{{Compat("css.properties.shape-outside")}}</p>
+<p>You can also take a look at the Browser compatibility tables at the bottom of each property page on MDN. These show you browser support for that property, often broken down if there is support for some usage of the property and not others. <a href="/en-US/docs/Web/CSS/shape-outside#browser_compatibility">See the compatibility table for the <code>shape-outside</code> property</a>.</p>
 
 <h3 id="Is_something_else_overriding_your_CSS">Is something else overriding your CSS?</h3>
 


### PR DESCRIPTION
This is another attempt to fix https://github.com/mdn/content/issues/4000, this time by linking to the table in the reference page. For the details of why this problem is happening, see https://github.com/mdn/content/pull/4026.

@sideshowbarker , I'm sorry I didn't fully read your PR description before commenting, or I would have seen that you'd already considered and rejected the option of linking to the table. Still this seems like a more obvious option, although I agree that making people navigate to a different page is not ideal.