### PR TITLE
Fix typo in “JavaScript data types and data structures” doc

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.html
+++ b/files/en-us/web/javascript/data_structures/index.html
@@ -301,7 +301,7 @@ Infinity
 
 <h3 id="Indexed_collections_Arrays_and_typed_Arrays">Indexed collections: Arrays and typed Arrays</h3>
 
-<p><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Arrays</a> are regular objects for which there is a particular relationship between integer-key-ed properties and the <code>length</code> property.</p>
+<p><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Arrays</a> are regular objects for which there is a particular relationship between integer-keyed properties and the <code>length</code> property.</p>
 
 <p>Additionally, arrays inherit from <code>Array.prototype</code>, which provides to them a handful of convenient methods to manipulate arrays. For example, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf">indexOf</a></code> (searching a value in the array) or <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push">push</a></code> (adding an element to the array), and so on. This makes Arrays a perfect candidate to represent lists or sets.</p>
 


### PR DESCRIPTION
a typo.