### PR TITLE
Documents the size-adjust descriptor

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -343,6 +343,46 @@ tags:
  </tbody>
 </table>
 
+<h3 id="Descriptor_size_adjust">Descriptor: size-adjust</h3>
+
+<p>The {{cssxref("#font-face/size-adjust")}} CSS descriptor is part of the {{SpecName("CSS5 Fonts")}} specification and defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size. (See {{bug(1698495)}} for more details.)</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Release channel</th>
+   <th scope="col" style="vertical-align: bottom;">Version added</th>
+   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>89</td>
+   <td>Yes</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>89</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>89</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>89</td>
+   <td>No</td>
+  </tr>
+  <tr>
+   <th scope="row">Preference name</th>
+   <th colspan="2"><code>layout.css.size-adjust.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
 <h3 id="Single_numbers_as_aspect_ratio_in_media_queries">Single numbers as aspect ratio in media queries</h3>
 
 <p>Support for using a single {{cssxref("number")}} as a {{cssxref("ratio")}} when specifying the aspect ratio for a <a href="/en-US/docs/Web/CSS/Media_Queries">media query</a>. (See {{bug(1565562)}} for more details.)</p>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -345,7 +345,7 @@ tags:
 
 <h3 id="Descriptor_size_adjust">Descriptor: size-adjust</h3>
 
-<p>The {{cssxref("#font-face/size-adjust")}} CSS descriptor is part of the {{SpecName("CSS5 Fonts")}} specification and defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size. (See {{bug(1698495)}} for more details.)</p>
+<p>The {{cssxref("@font-face/size-adjust")}} CSS descriptor is part of the {{SpecName("CSS5 Fonts")}} specification and defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size. (See {{bug(1698495)}} for more details.)</p>
 
 <table class="standard-table">
  <thead>

--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -31,11 +31,11 @@ tags:
  <dt>{{cssxref("@font-face/font-family", "font-family")}}</dt>
  <dd>Specifies a name that will be used as the font face value for font properties.</dd>
  <dt>{{cssxref("@font-face/font-stretch", "font-stretch")}}</dt>
- <dd>A {{cssxref("font-stretch")}} value. Since Firefox 61 (and in other modern browsers) this also accepts two values to specify a range that is supported by a font-face, for example <code>font-stretch: 50% 200%;</code></dd>
+ <dd>A {{cssxref("font-stretch")}} value. Accepts two values to specify a range that is supported by a font-face, for example <code>font-stretch: 50% 200%;</code></dd>
  <dt>{{cssxref("@font-face/font-style", "font-style")}}</dt>
- <dd>A {{cssxref("font-style")}} value. Since Firefox 61 (and in other modern browsers) this also accepts two values to specify a range that is supported by a font-face, for example <code>font-style: oblique 20deg 50deg;</code></dd>
+ <dd>A {{cssxref("font-style")}} value. Accepts two values to specify a range that is supported by a font-face, for example <code>font-style: oblique 20deg 50deg;</code></dd>
  <dt>{{cssxref("@font-face/font-weight", "font-weight")}}</dt>
- <dd>A {{cssxref("font-weight")}} value. Since Firefox 61 (and in other modern browsers) this also accepts two values to specify a range that is supported by a font-face, for example <code>font-weight: 100 400;</code></dd>
+ <dd>A {{cssxref("font-weight")}} value. Accepts two values to specify a range that is supported by a font-face, for example <code>font-weight: 100 400;</code></dd>
  <dt>{{cssxref("@font-face/font-variant", "font-variant")}}</dt>
  <dd>A {{cssxref("font-variant")}} value.</dd>
  <dt>{{cssxref("font-feature-settings", "font-feature-settings")}}</dt>
@@ -53,6 +53,8 @@ tags:
 
  <p>The available types are: <code>"woff"</code>, <code>"woff2"</code>, <code>"truetype"</code>, <code>"opentype"</code>, <code>"embedded-opentype"</code>, and <code>"svg"</code>.</p>
  </dd>
+ <dt>{{cssxref("@font-face/size-adjust", "size-adjust")}}{{experimental_inline}}</dt>
+ <dd>Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size.</dd>
  <dt>{{cssxref("@font-face/unicode-range", "unicode-range")}}</dt>
  <dd>The range of Unicode code points to be used from the font.</dd>
 </dl>
@@ -169,6 +171,16 @@ tags:
   </tr>
  </thead>
  <tbody>
+  <tr>
+    <td>{{SpecName('CSS5 Fonts', '#font-face-rule', '@font-face')}}</td>
+    <td>{{Spec2('CSS5 Fonts')}}</td>
+    <td>Adds the <code>size-adjust</code> descriptor.</td>
+   </tr>
+  <tr>
+    <td>{{SpecName('CSS4 Fonts', '#font-face-rule', '@font-face')}}</td>
+    <td>{{Spec2('CSS4 Fonts')}}</td>
+    <td>Definition in this version of the specification.</td>
+   </tr>
   <tr>
    <td>{{SpecName('WOFF2.0', '', 'WOFF2 font format')}}</td>
    <td>{{Spec2('WOFF2.0')}}</td>

--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -54,7 +54,7 @@ tags:
  <p>The available types are: <code>"woff"</code>, <code>"woff2"</code>, <code>"truetype"</code>, <code>"opentype"</code>, <code>"embedded-opentype"</code>, and <code>"svg"</code>.</p>
  </dd>
  <dt>{{cssxref("@font-face/size-adjust", "size-adjust")}}{{experimental_inline}}</dt>
- <dd>Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size.</dd>
+ <dd>Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.</dd>
  <dt>{{cssxref("@font-face/unicode-range", "unicode-range")}}</dt>
  <dd>The range of Unicode code points to be used from the font.</dd>
 </dl>

--- a/files/en-us/web/css/@font-face/size-adjust/index.html
+++ b/files/en-us/web/css/@font-face/size-adjust/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{CSSRef}}</p>
 
-<p>The <strong><code>size-adjust</code></strong> CSS descriptor defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size.</p>
+<p>The <strong><code>size-adjust</code></strong> CSS descriptor defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.</p>
 
 <p>The <code>size-adjust</code> descriptor behaves in a similar fashion to the {{cssxref("font-size-adjust")}} property. It calculates an adjustment per font by matching ex heights.</p>
 

--- a/files/en-us/web/css/@font-face/size-adjust/index.html
+++ b/files/en-us/web/css/@font-face/size-adjust/index.html
@@ -1,0 +1,92 @@
+---
+title: size-adjust
+slug: Web/CSS/@font-face/size-adjust
+tags:
+  - '@font-face'
+  - At-rule descriptor
+  - CSS
+  - Reference
+  - descriptor
+  - size-adjust
+---
+<p>{{CSSRef}}</p>
+
+<p>The <strong><code>size-adjust</code></strong> CSS descriptor defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font-size.</p>
+
+<p>The <code>size-adjust</code> descriptor behaves in a similar fashion to the {{cssxref("font-size-adjust")}} property. It calculates an adjustment per font by matching ex heights.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css">size-adjust: 90%;</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+ <dt><code>&lt;percentage&gt;</code></dt>
+ <dd>A {{cssxref("&lt;percentage&gt;")}} value with an initial value of 100%.</dd>
+</dl>
+
+<p>All metrics associated with this font are scaled by the given percentage. This includes glyph advances, baseline tables, and overrides provided by {{cssxref("@font-face")}} descriptors.</p>
+
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Formal syntax</h2>
+
+{{csssyntax}}
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Overriding metrics">Overriding metrics of a fallback font</h3>
+
+<p>The <code>size-adjust</code> property can help when overriding the metrics of a fallback font to better match those of a primary web font.</p>
+
+<pre class="brush: css">@font-face {
+  font-family: web-font;
+  src: url("https://example.com/font.woff");
+}
+
+@font-face {
+  font-family: local-font;
+  src: local(Local Font);
+  size-adjust: 90%;
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS5 Fonts', '#size-adjust-desc', 'size-adjust')}}</td>
+   <td>{{Spec2('CSS5 Fonts')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.at-rules.font-face.size-adjust")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{cssxref("@font-face/font-display", "font-display")}}</li>
+ <li>{{cssxref("@font-face/font-family", "font-family")}}</li>
+ <li>{{cssxref("@font-face/font-weight", "font-weight")}}</li>
+ <li>{{cssxref("@font-face/font-style", "font-style")}}</li>
+ <li>{{cssxref("@font-face/font-stretch", "font-stretch")}}</li>
+ <li>{{cssxref("@font-face/font-variant", "font-variant")}}</li>
+ <li>{{cssxref("font-feature-settings", "font-feature-settings")}}</li>
+ <li>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</li>
+ <li>{{cssxref("@font-face/src", "src")}}</li>
+ <li>{{cssxref("@font-face/unicode-range", "unicode-range descriptor")}}</li>
+</ul>


### PR DESCRIPTION
Part of #4298 

- Adds details to experimental features
- Creates a page for `size-adjust`
- Adds a link to the new page from `@font-face`
- Also removes some old browser-specific info from the `@font-face` page, given I was in there.

There will be a few macro errors due to the bits of this that need merging, syntax, spec, BCD etc.