### PR TITLE
Remove duplicate double-quote from aria-haspopup

### DIFF
--- a/files/en-us/web/api/element/ariahaspopup/index.html
+++ b/files/en-us/web/api/element/ariahaspopup/index.html
@@ -45,7 +45,7 @@ tags:
 
 <pre class="brush: html">&lt;div class="animals-combobox"&gt;
   &lt;label for="animal"&gt;Animal&lt;/label&gt;
-  &lt;input id="animal" type="text" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true""&gt;
+  &lt;input id="animal" type="text" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true"&gt;
   &lt;button id="animals-button" tabindex="-1" aria-label="Open"&gt;&#9661;&lt;/button&gt;
   &lt;ul id="animals-listbox" role="listbox" aria-label="Animals"&gt;
     &lt;li id="animal-cat" role="option">Cat&lt;/li&gt;


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Small typo, extra double-quote after the attribute value of `aria-haspopup` in Example 1.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaHasPopup

Specifically Example 1 (scroll the code box all the way to the right): https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaHasPopup#examples

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

No.
Thanks for the great docs! I use them often :smile_cat:.