### PR TITLE
Specify Markdown note syntax

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -115,7 +115,7 @@ const greeting = "I'm a good example";
 
 <h3>Notes, warnings, and callouts</h3>
 
-<p>Sometimes writers want to call special attention to some piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts:</p>
+<p>Sometimes writers want to call special attention to some piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts.</p>
 
 <h4>Notes</h4>
 

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -177,7 +177,7 @@ const greeting = "I'm a good example";
 <pre>
 &gt; **Callout:** **This is how you write a callout**.
 &gt;
-&gt; It can have multiple lines.
+&gt; It can have multiple paragaphs.
 </pre>
 
 <p>This will produce the following HTML:</p>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -113,7 +113,108 @@ const greeting = "I'm a good example";
 ```
 </pre>
 
-<h3>Notes and warnings</h3>
+<h3>Notes, warnings, and callouts</h3>
+
+<p>Sometimes writers want to call special attention to some piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts:</p>
+
+<h4>Notes</h4>
+
+<p>To write a note, an author creates a GFM blockquote whose first paragraph starts with "**Note:**":</p>
+
+<pre>
+&gt; **Note:** This is how you write a note.
+&gt;
+&gt; It can have multiple lines.
+</pre>
+
+<p>This will produce the following HTML:</p>
+
+<pre class="brush: html">
+&lt;div class="notecard note"&gt;
+  &lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; This is how you write a note.&lt;/p&gt;
+  &lt;p&gt;It can have multiple paragraphs.&lt;/p&gt;
+&lt;/div&gt;
+</pre>
+
+<p>This HTML will be rendered as a highlighted box, like:</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This is how you write a note.</p>
+  <p>It can have multiple paragraphs.</p>
+</div>
+
+<h4>Warnings</h4>
+
+<p>To write a warning, an author creates a GFM blockquote whose first paragraph starts with "**Warning:**":</p>
+
+<pre>
+&gt; **Warning: This is how you write a warning.
+&gt;
+&gt; It can have multiple lines.
+</pre>
+
+<p>This will produce the following HTML:</p>
+
+<pre class="brush: html">
+&lt;div class="notecard warning"&gt;
+  &lt;p&gt;&lt;strong&gt;Warning:&lt;/strong&gt; This is how you write a warning.&lt;/p&gt;
+  &lt;p&gt;It can have multiple paragraphs.&lt;/p&gt;
+&lt;/div&gt;
+</pre>
+
+<p>This HTML will be rendered as a highlighted box, like:</p>
+
+<div class="notecard warning">
+  <p><strong>Warning:</strong> This is how you write a warning.</p>
+  <p>It can have multiple paragraphs.</p>
+</div>
+
+
+<h4>Callouts</h4>
+
+<p>To write a callout, an author creates a GFM blockquote whose first paragraph starts with "**Callout:**":</p>
+
+<pre>
+&gt; **Callout:** **This is how you write a callout**.
+&gt;
+&gt; It can have multiple lines.
+</pre>
+
+<p>This will produce the following HTML:</p>
+
+<pre class="brush: html">
+&lt;div class="callout"&gt;
+  &lt;p&gt;&lt;strong&gt;This is how you write a callout.&lt;/strong&gt;&lt;/p&gt;
+  &lt;p&gt;It can have multiple paragraphs.&lt;/p&gt;
+&lt;/div&gt;
+</pre>
+
+<p>This HTML will be rendered as a highlighted box, like:</p>
+
+<div class="callout">
+  <p><strong>This is how you write a callout.</strong></p>
+  <p>It can have multiple paragraphs.</p>
+</div>
+
+<p>Note that while notes and warnings keep the magic word in the output, callouts don't. This means that they are a good choice when an author wants to use a custom title.</p>
+
+<h4>Notes, warnings, and translations</h4>
+
+<p>Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations. In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.</p>
+
+<p>For example, if we want to use "Warnung" for "Warning" in German, then in German pages we would write:</p>
+
+<pre>
+&gt; Warnung: So schreibt man eine Warnung.
+</pre>
+
+<p>...and this will produce:</p>
+
+<pre class="brush: html">
+&lt;div class="notecard warning"&gt;
+  &lt;p&gt;&lt;strong&gt;Warnung:&lt;/strong&gt; So schreibt man eine Warnung.&lt;/p&gt;
+&lt;/div&gt;
+</pre>
 
 <h3>Definition lists</h3>
 

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -117,9 +117,25 @@ const greeting = "I'm a good example";
 
 <p>Sometimes writers want to call special attention to some piece of content. To do this, they will use a GFM blockquote with a special first paragraph. There are three types of these: notes, warnings, and callouts.</p>
 
-<h4>Notes</h4>
+<ul>
+  <li>To add a note, create a GFM blockquote whose first paragraph starts with <code>**Note:**</code>.</li>
+  <li>To add a warning, create a GFM blockquote whose first paragraph starts with <code>**Warning:**</code>.</li>
+  <li>To add a callout, create a GFM blockquote whose first paragraph starts with <code>**Callout:**</code>.</li>
+</ul>
 
-<p>To write a note, an author creates a GFM blockquote whose first paragraph starts with "**Note:**".</p>
+<p>Notes and warnings will render the <strong>Note:</strong> or <strong>Warning:</strong> text in the output, while callouts will not. This makes callouts a good choice when an author wants to provide a custom title.</p>
+
+<p>Processing of the markup works on the AST it produces, not on the exact characters provided. This means that providing <code>&lt;strong&gt;Note:&lt;/strong&gt;</code> will also generate a note. However, the Markdown syntax is required as a matter of style.</p>
+
+<p>Multiple lines are produced by an empty block quote line in the same way as normal paragraphs. Further, multiple lines without a space are also treated like normal markdown lines, and concatenated.</p>
+
+<p>The blockquote can contain code blocks or other block elements.</p>
+
+<p>Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations. In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.</p>
+
+<h4>Examples</h4>
+
+<h5>Note</h5>
 
 <pre>
 &gt; **Note:** This is how you write a note.
@@ -143,9 +159,7 @@ const greeting = "I'm a good example";
   <p>It can have multiple paragraphs.</p>
 </div>
 
-<h4>Warnings</h4>
-
-<p>To write a warning, an author creates a GFM blockquote whose first paragraph starts with "**Warning:**":</p>
+<h5>Warnings</h5>
 
 <pre>
 &gt; **Warning: This is how you write a warning.
@@ -169,10 +183,7 @@ const greeting = "I'm a good example";
   <p>It can have multiple paragraphs.</p>
 </div>
 
-
-<h4>Callouts</h4>
-
-<p>To write a callout, an author creates a GFM blockquote whose first paragraph starts with "**Callout:**":</p>
+<h5>Callouts</h5>
 
 <pre>
 &gt; **Callout:** **This is how you write a callout**.
@@ -196,11 +207,7 @@ const greeting = "I'm a good example";
   <p>It can have multiple paragraphs.</p>
 </div>
 
-<p>Note that while notes and warnings keep the magic word in the output, callouts don't. This means that they are a good choice when an author wants to use a custom title.</p>
-
-<h4>Notes, warnings, and translations</h4>
-
-<p>Because the text "Note:" or "Warning:" also appears in the rendered output, it has to be sensitive to translations. In practice this means that every locale supported by MDN must supply its own translation of these strings, and the platform must recognize them as indicating that the construct needs special treatment.</p>
+<h5>Translated warning</h5>
 
 <p>For example, if we want to use "Warnung" for "Warning" in German, then in German pages we would write:</p>
 
@@ -215,6 +222,41 @@ const greeting = "I'm a good example";
   &lt;p&gt;&lt;strong&gt;Warnung:&lt;/strong&gt; So schreibt man eine Warnung.&lt;/p&gt;
 &lt;/div&gt;
 </pre>
+
+<h5>Note containing a code block</h5>
+
+<p>This example contains a code block.</p>
+
+<pre>
+&gt; **Note:** This is how you write a note.
+&gt;
+&gt; It can contain code blocks.
+&gt;
+&gt; ```js
+&gt; const s = "I'm in a code block";
+&gt; ```
+&gt; Like that.
+</pre>
+
+<p>This will produce the following HTML:</p>
+
+<pre class="brush: html">
+&lt;div class="notecard note"&gt;
+  &lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; This is how you write a note.&lt;/p&gt;
+  &lt;p&gt;It can contain code blocks.&lt;/p&gt;
+  &lt;pre class="brush: js"&gt;const s = "I'm in a code block";&lt;/pre&gt;
+  &lt;p&gt;Like that.&lt;/p&gt;
+&lt;/div&gt;
+</pre>
+
+<p>This HTML will be rendered as with a code block, like:</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> This is how you write a note.</p>
+  <p>It can contain code blocks.</p>
+  <pre class="brush: js">const s = "I'm in a code block";</pre>
+  <p>Like that.</p>
+</div>
 
 <h3>Definition lists</h3>
 

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -119,7 +119,7 @@ const greeting = "I'm a good example";
 
 <h4>Notes</h4>
 
-<p>To write a note, an author creates a GFM blockquote whose first paragraph starts with "**Note:**":</p>
+<p>To write a note, an author creates a GFM blockquote whose first paragraph starts with "**Note:**".</p>
 
 <pre>
 &gt; **Note:** This is how you write a note.

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -132,7 +132,7 @@ const greeting = "I'm a good example";
 <pre class="brush: html">
 &lt;div class="notecard note"&gt;
   &lt;p&gt;&lt;strong&gt;Note:&lt;/strong&gt; This is how you write a note.&lt;/p&gt;
-  &lt;p&gt;It can have multiple paragraphs.&lt;/p&gt;
+  &lt;p&gt;It can have multiple lines.&lt;/p&gt;
 &lt;/div&gt;
 </pre>
 

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -140,7 +140,7 @@ const greeting = "I'm a good example";
 
 <div class="notecard note">
   <p><strong>Note:</strong> This is how you write a note.</p>
-  <p>It can have multiple paragraphs.</p>
+  <p>It can have multiple lines.</p>
 </div>
 
 <h4>Warnings</h4>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -150,7 +150,7 @@ const greeting = "I'm a good example";
 <pre>
 &gt; **Warning: This is how you write a warning.
 &gt;
-&gt; It can have multiple lines.
+&gt; It can have multiple paragraphs.
 </pre>
 
 <p>This will produce the following HTML:</p>


### PR DESCRIPTION
This PR updates the "MDN Markdown" spec to talk about representing notes, warnings, and what I'm awkwardly calling "callouts", based on conversations in https://github.com/mdn/content/issues/3483 and https://github.com/mdn/content/issues/3927.

I'm choosing option 2 from https://github.com/mdn/content/issues/3483 as the authoring format, where you use a blockquote and a magic word at the start of the content, and asking this to be converted to the `<div class="thing">` syntax in the output (and I think in the internal representation, although I haven't specified that here, and perhaps I should).
