### PR TITLE
Correct the example in Node.p.previousSibling doc

### DIFF
--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -31,6 +31,9 @@ console.log(document.getElementById("b2").previousSibling.id); // "b1"
 <p>In this example, we put the img elements next to each other, so that there's no white space between them. 
   See the next example and the Notes below for more detail.</p>
 <h3>Second example</h3>
+
+<p>In this example, there are whitespace text nodes (line breaks) between the <code>img</code> elements.</p>
+
 <pre class="brush: html">
 &lt;img id="b0"&gt;
 &lt;img id="b1"&gt;

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -44,7 +44,6 @@ console.log(document.getElementById("b2").previousSibling.id); // "b1"
     console.log(document.getElementById("b2").previousSibling); // #text
     console.log(document.getElementById("b2").previousSibling.id); // undefined
 </pre>
-<p>In this example, there are text nodes between the img elements.</p>
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -23,6 +23,9 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 <h3>First example</h3>
+
+<p>In this example, we have a series of <code>img</code> elements directly adjacent to each other, with no whitespace between them.</p>
+
 <pre class="brush: html">&lt;img id="b0"&gt;&lt;img id="b1"&gt;&lt;img id="b2"&gt;</pre>
 
 <pre class="brush:js">

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -22,6 +22,9 @@ tags:
 </pre>
 
 <h2 id="Examples">Examples</h2>
+
+<p>The following examples demonstrate how <code>previousSibling</code> works with and without text nodes mixed in with elements.</p>
+
 <h3>First example</h3>
 
 <p>In this example, we have a series of <code>img</code> elements directly adjacent to each other, with no whitespace between them.</p>

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -25,8 +25,9 @@ tags:
 <h3>First example</h3>
 <pre class="brush: html">&lt;img id="b0"&gt;&lt;img id="b1"&gt;&lt;img id="b2"&gt;</pre>
 
-<pre class="brush:js">console.log(document.getElementById("b1").previousSibling); // &lt;img id="b0"&gt;
-console.log(document.getElementById("b2").previousSibling.id); // "b1"
+<pre class="brush:js">
+document.getElementById("b1").previousSibling;    // &lt;img id="b0"&gt;
+document.getElementById("b2").previousSibling.id; // "b1"
 </pre>
 <h3>Second example</h3>
 

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -56,10 +56,7 @@ console.log(document.getElementById("b2").previousSibling.id); // "b1"
     or <a href="/en-US/docs/Web/API/Node/previousSibling"
       title="The Node.previousSibling read-only property returns the node immediately preceding the specified one in its parent's childNodes list, or null if the specified node is the first in that list."><code>Node.previousSibling</code></a>
     may refer to a whitespace text node rather than the actual element the author intended
-    to get. One could use <a
-    href="/en-US/docs/Web/API/Element/previousElementSibling"><code><strong>Element.previousElementSibling</strong></code></a> to get an element node.
-  
-  </p>
+    to get. You can use <code><a href="/en-US/docs/Web/API/Element/previousElementSibling">previousElementSibling</a></code> to get the previous element node (skipping text nodes and any other non-element nodes).</p>
 
   <p>See <a href="/en-US/docs/Web/Guide/DOM/Whitespace_in_the_DOM">Whitespace in the
       DOM</a> and <a href="https://www.w3.org/DOM/faq.html#emptytext"

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -38,11 +38,11 @@ console.log(document.getElementById("b2").previousSibling.id); // "b1"
 </pre>
 
 <pre class="brush:js">
-    console.log(document.getElementById("b1").previousSibling); // #text
-    console.log(document.getElementById("b1").previousSibling.previousSibling); // &lt;img id="b0"&gt;
-    console.log(document.getElementById("b2").previousSibling.previousSibling); // &lt;img id="b1"&gt;
-    console.log(document.getElementById("b2").previousSibling); // #text
-    console.log(document.getElementById("b2").previousSibling.id); // undefined
+document.getElementById("b1").previousSibling;                 // #text
+document.getElementById("b1").previousSibling.previousSibling; // &lt;img id="b0"&gt;
+document.getElementById("b2").previousSibling.previousSibling; // &lt;img id="b1"&gt;
+document.getElementById("b2").previousSibling;                 // #text
+document.getElementById("b2").previousSibling.id;              // undefined
 </pre>
 
 <h2 id="Notes">Notes</h2>

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -32,9 +32,9 @@ console.log(document.getElementById("b2").previousSibling.id); // "b1"
   See the next example and the Notes below for more detail.</p>
 <h3>Second example</h3>
 <pre class="brush: html">
-  &lt;img id="b0"&gt;
-  &lt;img id="b1"&gt;
-  &lt;img id="b2"&gt;
+&lt;img id="b0"&gt;
+&lt;img id="b1"&gt;
+&lt;img id="b2"&gt;
 </pre>
 
 <pre class="brush:js">

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -28,8 +28,6 @@ tags:
 <pre class="brush:js">console.log(document.getElementById("b1").previousSibling); // &lt;img id="b0"&gt;
 console.log(document.getElementById("b2").previousSibling.id); // "b1"
 </pre>
-<p>In this example, we put the img elements next to each other, so that there's no white space between them. 
-  See the next example and the Notes below for more detail.</p>
 <h3>Second example</h3>
 
 <p>In this example, there are whitespace text nodes (line breaks) between the <code>img</code> elements.</p>

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -21,15 +21,30 @@ tags:
 <pre class="brush: js"><var>previousNode</var> = <em>node</em>.previousSibling;
 </pre>
 
-<h2 id="Example">Example</h2>
-
-<pre class="brush: html">&lt;img id="b0"&gt;
-&lt;img id="b1"&gt;
-&lt;img id="b2"&gt;</pre>
+<h2 id="Examples">Examples</h2>
+<h3>First example</h3>
+<pre class="brush: html">&lt;img id="b0"&gt;&lt;img id="b1"&gt;&lt;img id="b2"&gt;</pre>
 
 <pre class="brush:js">console.log(document.getElementById("b1").previousSibling); // &lt;img id="b0"&gt;
 console.log(document.getElementById("b2").previousSibling.id); // "b1"
 </pre>
+<p>In this example, we put the img elements next to each other, so that there's no white space between them. 
+  See the next example and the Notes below for more detail.</p>
+<h3>Second example</h3>
+<pre class="brush: html">
+  &lt;img id="b0"&gt;
+  &lt;img id="b1"&gt;
+  &lt;img id="b2"&gt;
+</pre>
+
+<pre class="brush:js">
+    console.log(document.getElementById("b1").previousSibling); // #text
+    console.log(document.getElementById("b1").previousSibling.previousSibling); // &lt;img id="b0"&gt;
+    console.log(document.getElementById("b2").previousSibling.previousSibling); // &lt;img id="b1"&gt;
+    console.log(document.getElementById("b2").previousSibling); // #text
+    console.log(document.getElementById("b2").previousSibling.id); // undefined
+</pre>
+<p>In this example, there are text nodes between the img elements.</p>
 
 <h2 id="Notes">Notes</h2>
 
@@ -41,7 +56,10 @@ console.log(document.getElementById("b2").previousSibling.id); // "b1"
     or <a href="/en-US/docs/Web/API/Node/previousSibling"
       title="The Node.previousSibling read-only property returns the node immediately preceding the specified one in its parent's childNodes list, or null if the specified node is the first in that list."><code>Node.previousSibling</code></a>
     may refer to a whitespace text node rather than the actual element the author intended
-    to get.</p>
+    to get. One could use <a
+    href="/en-US/docs/Web/API/Element/previousElementSibling"><code><strong>Element.previousElementSibling</strong></code></a> to get an element node.
+  
+  </p>
 
   <p>See <a href="/en-US/docs/Web/Guide/DOM/Whitespace_in_the_DOM">Whitespace in the
       DOM</a> and <a href="https://www.w3.org/DOM/faq.html#emptytext"


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The img elements are on separate lines, so there are text nodes between them. The expected results from console.log are then wrong.
> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Node/previousSibling
> Issue number (if there is an associated issue)
Fixes #3377
> Anything else that could help us review it
I added the correct expected results for console.log of the previous example and another example where I put the three img elements next to each other.