### PR TITLE
Correct the ariaExpanded boolean description, which was backwards

### DIFF
--- a/files/en-us/web/api/element/ariaexpanded/index.html
+++ b/files/en-us/web/api/element/ariaexpanded/index.html
@@ -24,9 +24,9 @@ tags:
 
 <dl>
   <dt><code>"true"</code></dt>
-  <dd>The grouping element this element owns or controls is collapsed.</dd>
-  <dt><code>"false"</code></dt>
   <dd>The grouping element this element owns or controls is expanded.</dd>
+  <dt><code>"false"</code></dt>
+  <dd>The grouping element this element owns or controls is collapsed.</dd>
   <dt><code>"undefined"</code></dt>
   <dd>The element does not own or control a grouping element that is expandable.</dd>
 </dl>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The boolean logic in the explanation was reversed.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaExpanded

> Issue number (if there is an associated issue)

> Anything else that could help us review it

Here's what W3 says:

https://www.w3.org/TR/wai-aria-1.1/#aria-expanded

<img width="848" alt="Screen Shot 2021-04-21 at 2 26 36 PM" src="https://user-images.githubusercontent.com/16627268/115603039-acf96700-a2ad-11eb-94d3-91f9ca557fbf.png">

Here's what is live on MDN right now:

<img width="721" alt="Screen Shot 2021-04-21 at 2 36 20 PM" src="https://user-images.githubusercontent.com/16627268/115604102-fc8c6280-a2ae-11eb-9b8c-03dc29545c89.png">


