### PR TITLE
Add optional chaining

### DIFF
--- a/files/en-us/web/javascript/reference/index.html
+++ b/files/en-us/web/javascript/reference/index.html
@@ -248,6 +248,7 @@ tags:
 
 <ul>
  <li>{{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}</li>
+ <li>{{JSxRef("Operators/Optional_chaining", "Optional_chaining", "", 1)}}</li>
  <li>{{JSxRef("Operators/new", "new")}}</li>
  <li>{{JSxRef("Operators/new%2Etarget", "new.target")}}</li>
  <li>{{JSxRef("Statements/import%2Emeta", "import.meta")}}</li>

--- a/files/en-us/web/javascript/reference/index.html
+++ b/files/en-us/web/javascript/reference/index.html
@@ -248,7 +248,7 @@ tags:
 
 <ul>
  <li>{{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}</li>
- <li>{{JSxRef("Operators/Optional_chaining", "Optional_chaining", "", 1)}}</li>
+ <li>{{JSxRef("Operators/Optional_chaining", "Optional chaining", "", 1)}}</li>
  <li>{{JSxRef("Operators/new", "new")}}</li>
  <li>{{JSxRef("Operators/new%2Etarget", "new.target")}}</li>
  <li>{{JSxRef("Statements/import%2Emeta", "import.meta")}}</li>


### PR DESCRIPTION
Make it easier to find optional chaining on the reference page.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Optional chaining wasn't on the reference page

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference

> Issue number (if there is an associated issue)
https://github.com/mdn/content/issues/4355 
idk if this counts, I had created this issue.

> Anything else that could help us review it
this might not be the best place for it. Technically its a property accessor, but it seems unique enough to give its own line.
