### PR TITLE
fix live sample in Web/Accessibility/ARIA/ARIA_Live_Regions

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.html
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.html
@@ -96,7 +96,7 @@ renderPlanetInfoButton.addEventListener('click', event =&gt; {
 });
 </pre>
 
-<p>{{EmbedLiveSample('Dropdown_box_updates_useful_onscreen_information', '', 350)}}</p>
+<p>{{EmbedLiveSample('Basic_example_Dropdown_box_updates_useful_onscreen_information', '', 350)}}</p>
 
 <p>As the user selects a new planet, the information in the live region will be announced. Because the live region has <code>aria-live="polite"</code>, the screen reader will wait until the user pauses before announcing the update. Thus, moving down in the list and selecting another planet will not announce updates in the live region. Updates in the live region will only be announced for the planet finally chosen.</p>
 


### PR DESCRIPTION
See first live sample on https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#basic_example_dropdown_box_updates_useful_onscreen_information

> What was wrong/why is this fix needed? (quick summary only)

live sample

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions

> Issue number (if there is an associated issue)

sorry

> Anything else that could help us review it
