### PR TITLE
HID interface page

### DIFF
--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -33,7 +33,7 @@ tags:
  <dd>Returns a {{jsxref("Promise")}} that resolves to an array of connected {{domxref("HIDDevice")}}s.
  </dd>
  <dt>{{domxref("HID.requestDevices","requestDevice()")}}</dt>
- <dd>Returns a  that resolves to an array of connected {{domxref("HIDDevice")}}s from the HID device selected from popup.
+ <dd>Returns a {{jsxref("Promise")}} that resolves to an array of connected {{domxref("HIDDevice")}}s from the HID device selected from popup.
  <div class="note">You can only select one HID device from the popup at a time from this {{jsxref("Promise")}}, but the array might contain multiple {{domxref("HIDDevice")}}s.</div>
  </dd>
 </dl>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -33,7 +33,7 @@ tags:
  <dd>Returns a {{jsxref("Promise")}} that resolves with an array of connected {{domxref("HIDDevice")}} objects.
  </dd>
  <dt>{{domxref("HID.requestDevices","requestDevice()")}}</dt>
- <dd>Returns a {{jsxref("Promise")}} that resolves to an array of connected {{domxref("HIDDevice")}}s from the HID device selected from popup.
+ <dd>Returns a {{jsxref("Promise")}} that resolves with an array of connected {{domxref("HIDDevice")}} objects from the HID device selected from popup.
  <div class="note">You can only select one HID device from the popup at a time from this {{jsxref("Promise")}}, but the array might contain multiple {{domxref("HIDDevice")}}s.</div>
  </dd>
 </dl>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -50,7 +50,7 @@ tags:
   </thead>
   <tbody>
    <tr>
-     <td>{{SpecName('WebHID API', '#dom-hid', 'HID')}}</td>
+     <td>{{SpecName('WebHID', '#dom-hid', 'HID')}}</td>
      <td>{{Spec2('WebHID API')}}</td>
     <td>Initial definition.</td>
    </tr>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -30,7 +30,7 @@ tags:
 
 <dl>
  <dt>{{domxref("HID.getDevices","getDevices()")}}</dt>
- <dd>Returns a {{jsxref("Promise")}} that resolves to an array of connected {{domxref("HIDDevice")}}s.
+ <dd>Returns a {{jsxref("Promise")}} that resolves with an array of connected {{domxref("HIDDevice")}} objects.
  </dd>
  <dt>{{domxref("HID.requestDevices","requestDevice()")}}</dt>
  <dd>Returns a {{jsxref("Promise")}} that resolves to an array of connected {{domxref("HIDDevice")}}s from the HID device selected from popup.

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -19,7 +19,7 @@ tags:
 
 <dl>
  <dt>{{domxref("HID.onconnect")}}</dt>
- <dd>The event that's fired when an HID device is connected.</dd>
+ <dd>Fired when an HID device is connected.</dd>
  <dt>{{domxref("HID.ondisconnect")}}</dt>
  <dd>The event that's fired when an HID device is disconnected.</dd>
 </dl>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -13,7 +13,7 @@ tags:
 
 <h2 id="Properties">Properties</h2>
 
-<p><em>The <code>HID</code> interface doesn't inherit any property.</em></p>
+<p><em>This interface also inherits properties of its parent, {{domxref("EventTarget")}}.</em></p>
 
 <h3 id="Event_handlers">Event handlers</h3>
 
@@ -26,7 +26,7 @@ tags:
 
 <h2 id="Methods">Methods</h2>
 
-<p><em>The <code>HID</code></em> <em>interface doesn't inherit any methods.</em></p>
+<p><em>This interface also inherits methods of its parent, {{domxref("EventTarget")}}.</em></p>
 
 <dl>
  <dt>{{domxref("HID.getDevices","getDevices()")}}</dt>
@@ -51,7 +51,7 @@ tags:
   <tbody>
    <tr>
      <td>{{SpecName('WebHID', '#dom-hid', 'HID')}}</td>
-     <td>{{Spec2('WebHID API')}}</td>
+     <td>{{Spec2('WebHID')}}</td>
     <td>Initial definition.</td>
    </tr>
   </tbody>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -1,0 +1,70 @@
+---
+title: HID
+slug: Web/API/HID
+tags:
+  - API
+  - Advanced
+  - WebHID
+  - WebHID API
+---
+<div>{{ APIRef("WebHID API") }}{{SeeCompatTable}}</div>
+
+<p>The <strong><code>HID</code></strong> interface provides methods for connecting to <em>HID devices</em>, listing attached HID devices and event handlers for connected HID devices.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>The <code>HID</code> interface doesn't inherit any property.</em></p>
+
+<h3 id="Event_handlers">Event handlers</h3>
+
+<dl>
+ <dt>{{domxref("HID.onconnect")}}</dt>
+ <dd>The event that's fired when an HID device is connected.</dd>
+ <dt>{{domxref("HID.ondisconnect")}}</dt>
+ <dd>The event that's fired when an HID device is disconnected.</dd>
+ <dt>{{domxref("HID.oninputreport")}}</dt>
+ <dd>The event that's fired when an HID device sends an input report.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>The <code>HID</code></em> <em>interface doesn't inherit any methods.</em></p>
+
+<dl>
+ <dt>{{domxref("HID.getDevices","getDevices()")}}</dt>
+ <dd>Returns a {{jsxref("Promise")}} that resolves to an array of connected {{domxref("HIDDevice")}}s.
+ </dd>
+ <dt>{{domxref("HID.requestDevices","requestDevice()")}}</dt>
+ <dd>Returns a  that resolves to an array of connected {{domxref("HIDDevice")}}s from the HID device selected from popup.
+ <div class="note">You can only select one HID device from the popup at a time from this {{jsxref("Promise")}}, but the array might contain multiple {{domxref("HIDDevice")}}s.</div>
+ </dd>
+</dl>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <thead>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+     <td>{{SpecName('WebHID API', '#dom-hid', 'HID')}}</td>
+     <td>{{Spec2('WebHID API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.HID")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{domxref("WebHID API")}}</li>
+</ul>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -21,7 +21,7 @@ tags:
  <dt>{{domxref("HID.onconnect")}}</dt>
  <dd>Fired when an HID device is connected.</dd>
  <dt>{{domxref("HID.ondisconnect")}}</dt>
- <dd>The event that's fired when an HID device is disconnected.</dd>
+ <dd>Fired when an HID device is disconnected.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>

--- a/files/en-us/web/api/hid/index.html
+++ b/files/en-us/web/api/hid/index.html
@@ -22,8 +22,6 @@ tags:
  <dd>The event that's fired when an HID device is connected.</dd>
  <dt>{{domxref("HID.ondisconnect")}}</dt>
  <dd>The event that's fired when an HID device is disconnected.</dd>
- <dt>{{domxref("HID.oninputreport")}}</dt>
- <dd>The event that's fired when an HID device sends an input report.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>


### PR DESCRIPTION
Added a page about this interface. And this page is needed for https://github.com/mdn/content/pull/4234 .
Still, the same problem as the parent doc: it seems the backend didn't recognize the correct specification url, it should be: https://wicg.github.io/webhid/ . 