### PR TITLE
remove outline property to follow border-radius shape

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -223,45 +223,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="outline_property">outline property to follow border-radius shape</h3>
-
-<p>The {{cssxref("outline")}} CSS property has been updated to follow the outline created by {{cssxref("border-radius")}}. As part of this work the non-standard {{cssxref("-moz-outline-radius")}} property will be removed. (See {{bug(315209)}} and {{bug(1694146)}} for more details.)</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>87</td>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>87</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>87</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>87</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Preference name</th>
-   <th colspan="2"><code>layout.css.outline-follows-border-radius.enabled</code></th>
-  </tr>
- </tbody>
-</table>
 
 <h3 id="Property_initial-letter">Property: initial-letter</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Removed outline property notes and table from experimental features page as it is already enabled by default in all release channels.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features#outline_property

> Issue number (if there is an associated issue)
Second try for https://github.com/mdn/content/pull/4300
Fixes https://github.com/mdn/content/issues/3453
