### PR TITLE
fix: minor grammar error

### DIFF
--- a/files/en-us/webassembly/rust_to_wasm/index.html
+++ b/files/en-us/webassembly/rust_to_wasm/index.html
@@ -182,7 +182,7 @@ wasm-bindgen = "0.2"</pre>
  <li>Copies your <code>README.md</code> (if you have one) into the package.</li>
 </ol>
 
-<p>The end result? You have an package inside of the <code>pkg</code> directory.</p>
+<p>The end result? You have a package inside of the <code>pkg</code> directory.</p>
 
 <h4 id="A_digression_about_code_size">A digression about code size</h4>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There's a minor grammar error, it should be 'a package' rather than 'an package'.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/WebAssembly/Rust_to_wasm

> Issue number (if there is an associated issue)

> Anything else that could help us review it
