### PR TITLE
Scroll to not Scroll down

### DIFF
--- a/files/en-us/web/api/window/scroll/index.html
+++ b/files/en-us/web/api/window/scroll/index.html
@@ -38,7 +38,7 @@ window.scroll(<em>options</em>)
 
 <pre class="brush:html;htmlScript:true;">&lt;!-- put the 100th vertical pixel at the top of the window --&gt;
 
-&lt;button onclick="scroll(0, 100);"&gt;click to scroll down 100 pixels&lt;/button&gt;
+&lt;button onclick="scroll(0, 100);"&gt;click to scroll to the 100th pixel&lt;/button&gt;
 </pre>
 
 <p>Using <code>options</code>:</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The page says "click to scroll down 100 pixels" when it should really say "click to scroll to the 100th pixels
> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll
> Anything else that could help us review it
