### PR TITLE
remove all demos from Web/CSS/appearance

### DIFF
--- a/files/en-us/web/css/appearance/index.html
+++ b/files/en-us/web/css/appearance/index.html
@@ -62,73 +62,26 @@ appearance: progress-bar;
 	<tbody>
 		<tr>
 			<th>Value</th>
-			<th>Demo</th>
 			<th>Browser</th>
 			<th>Description</th>
 		</tr>
 		<tr>
 			<td><code>none</code></td>
-			<td>
-			<div class="hidden" id="sampleNone">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance:none;
--webkit-appearance:none;
-appearance:none; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleNone",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td>No special styling is applied. This is the default.</td>
 		</tr>
 		<tr>
 			<td><code>auto</code></td>
-			<td>
-			<div class="hidden" id="sampleAuto">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: auto;
--webkit-appearance: auto;
-appearance:auto; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleAuto",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome</td>
 			<td>The user agent selects the appropriate special styling based on the element. Acts as <code>none</code> on elements with no special styling.</td>
 		</tr>
 		<tr>
 			<td><code>menulist-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMenuListButton">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: menulist-button;
--webkit-appearance: menulist-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMenuListButton",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td>The element is styled as a button that would indicate a menulist can be opened.</td>
 		</tr>
 		<tr>
 			<td><code>textfield</code></td>
-			<td>
-			<div class="hidden" id="sampleTextField">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: textfield;
--webkit-appearance: textfield; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleTextField",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
@@ -137,187 +90,61 @@ div { color: black;
 		</tr>
 		<tr>
 			<td><code>button</code></td>
-			<td>
-			<div class="hidden" id="sampleButton">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: button;
--webkit-appearance: button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleButton",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td>The element is drawn like a button.</td>
 		</tr>
 		<tr>
 			<td><code>checkbox</code></td>
-			<td>
-			<div class="hidden" id="sampleCheckbox">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: checkbox;
--webkit-appearance: checkbox; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleCheckbox",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td>The element is drawn like a checkbox, including only the actual "checkbox" portion.</td>
 		</tr>
 		<tr>
 			<td><code>listbox</code></td>
-			<td>
-			<div class="hidden" id="sampleListBox">
-			<pre class="brush: css">
-div { color: black; height:20px;
--moz-appearance: listbox;
--webkit-appearance: listbox; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleListBox",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>menulist</code></td>
-			<td>
-			<div class="hidden" id="sampleMenuList">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: menulist;
--webkit-appearance: menulist; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMenuList",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>meter</code></td>
-			<td>
-			<div class="hidden" id="sampleMeter">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: meter; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMeter",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>progress-bar</code></td>
-			<td>
-			<div class="hidden" id="sampleProgressBarWebkit">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: progress-bar; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleProgressBarWebkit",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>push-button</code></td>
-			<td>
-			<div class="hidden" id="samplePushButton">
-			<pre class="brush: css">
-div{ color: black; -webkit-appearance: push-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("samplePushButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>radio</code></td>
-			<td>
-			<div class="hidden" id="sampleRadio">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: radio;
--webkit-appearance: radio; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleRadio",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td>The element is drawn like a radio button, including only the actual "radio button" portion.</td>
 		</tr>
 		<tr>
 			<td><code>searchfield</code></td>
-			<td>
-			<div class="hidden" id="sampleSearchField">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: searchfield;
--webkit-appearance: searchfield; }</pre>
-
-			<pre class="bruh: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSearchField",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>slider-horizontal</code></td>
-			<td>
-			<div class="hidden" id="sampleSliderHorizontal">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: slider-horizontal; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSliderHorizontal",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>square-button</code></td>
-			<td>
-			<div class="hidden" id="sampleSquareButton">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: square-button;
--webkit-appearance: square-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSquareButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>textarea</code></td>
-			<td>
-			<div class="hidden" id="sampleTextArea">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: textarea; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleTextArea",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
@@ -332,1154 +159,373 @@ div{ color: black;
 	<tbody>
 		<tr>
 			<th>Value</th>
-			<th>Demo</th>
 			<th>Browser</th>
 			<th>Description</th>
 		</tr>
 		<tr>
 			<td><code>attachment</code></td>
-			<td>
-			<div class="hidden" id="sampleAttachment">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: attachment;
--webkit-appearance: attachment; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleAttachment",100,50,"","", "nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>borderless-attachment</code></td>
-			<td>
-			<div class="hidden" id="sample-borderless-attachment">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: borderless-attachment;
--webkit-appearance: borderless-attachment; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
 			</div>
-			{{EmbedLiveSample("sample-borderless-attachment",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>button-bevel</code></td>
-			<td>
-			<div class="hidden" id="sampleButtonBevel">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: button-bevel;
--webkit-appearance: button-bevel; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleButtonBevel",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>caps-lock-indicator</code></td>
-			<td>
-			<div class="hidden" id="sample-caps-lock-indicator">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: caps-lock-indicator;
--webkit-appearance: caps-lock-indicator; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-caps-lock-indicator",100,50,"","","nobutton")}}</td>
 			<td>Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>caret</code></td>
-			<td>
-			<div class="hidden" id="sampleCaret">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: caret;
--webkit-appearance: caret; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleCaret",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>checkbox-container</code></td>
-			<td>
-			<div class="hidden" id="sampleCheckboxContainer">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: checkbox-container;
--webkit-appearance: checkbox-container; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleCheckboxContainer",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td>The element is drawn like a container for a checkbox, which may include a prelighting background effect under certain platforms. Normally it would contain a label and a checkbox.</td>
 		</tr>
 		<tr>
 			<td><code>checkbox-label</code></td>
-			<td>
-			<div class="hidden" id="sampleCheckboxLabel">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: checkbox-label;
--webkit-appearance: checkbox-label; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
 			</div>
-			{{EmbedLiveSample("sampleCheckboxLabel",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>checkmenuitem</code></td>
-			<td>
-			<div class="hidden" id="sampleCheckmenuitem">
-			<pre class="brush: css">
-div { color: black; height: 20px;
--moz-appearance: checkmenuitem;
--webkit-appearance: checkmenuitem; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleCheckmenuitem",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>color-well</code></td>
-			<td>
-			<div class="hidden" id="sample-color-well">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: color-well;
--webkit-appearance: color-well; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-color-well",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td><code>input type=color</code></td>
 		</tr>
 		<tr>
 			<td><code>continuous-capacity-level-indicator</code></td>
-			<td>
-			<div class="hidden" id="sample-continuous-capacity-level-indicator">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: continuous-capacity-level-indicator;
--webkit-appearance: continuous-capacity-level-indicator; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-continuous-capacity-level-indicator",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>default-button</code></td>
-			<td>
-			<div class="hidden" id="sample-default-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: default-button;
--webkit-appearance: default-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-default-button",100,50,"","","nobutton")}}</td>
 			<td>Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>discrete-capacity-level-indicator</code></td>
-			<td>
-			<div class="hidden" id="sample-discrete-capacity-level-indicator">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: discrete-capacity-level-indicator;
--webkit-appearance: discrete-capacity-level-indicator; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-discrete-capacity-level-indicator",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>inner-spin-button</code></td>
-			<td>
-			<div class="hidden" id="sampleInnerSpinButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: inner-spin-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleInnerSpinButton",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>image-controls-button</code></td>
-			<td>
-			<div class="hidden" id="sample-image-controls-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: image-controls-button;
--webkit-appearance: image-controls-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-image-controls-button",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>list-button</code></td>
-			<td>
-			<div class="hidden" id="sample-list-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: list-button;
--webkit-appearance: list-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-list-button",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td>datalist</td>
 		</tr>
 		<tr>
 			<td><code>listitem</code></td>
-			<td>
-			<div class="hidden" id="sampleListItem">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: listitem;
--webkit-appearance: listitem; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleListItem",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-enter-fullscreen-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaEnterFullscreenButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-enter-fullscreen-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaEnterFullscreenButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-exit-fullscreen-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaExitFullscreenButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-exit-fullscreen-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaExitFullscreenButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-fullscreen-volume-slider</code></td>
-			<td>
-			<div class="hidden" id="sample-media-fullscreen-volume-slider">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-fullscreen-volume-slider;
--webkit-appearance: media-fullscreen-volume-slider; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-fullscreen-volume-slider",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-fullscreen-volume-slider-thumb</code></td>
-			<td>
-			<div class="hidden" id="sample-media-fullscreen-volume-slider-thumb">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-fullscreen-volume-slider-thumb;
--webkit-appearance: media-fullscreen-volume-slider-thumb; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-fullscreen-volume-slider-thumb",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-mute-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaMuteButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-mute-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaMuteButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-play-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaPlayButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-play-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaPlayButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-overlay-play-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaOverlayPlayButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-overlay-play-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaOverlayPlayButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-return-to-realtime-button</code></td>
-			<td>
-			<div class="hidden" id="sample-media-return-to-realtime-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-return-to-realtime-button;
--webkit-appearance: media-return-to-realtime-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-return-to-realtime-button",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-rewind-button</code></td>
-			<td>
-			<div class="hidden" id="sample-media-rewind-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-rewind-button;
--webkit-appearance: media-rewind-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-rewind-button",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-seek-back-button</code></td>
-			<td>
-			<div class="hidden" id="sample-media-seek-back-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-seek-back-button;
--webkit-appearance: media-seek-back-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-seek-back-button",100,50,"","","nobutton")}}</td>
 			<td>Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-seek-forward-button</code></td>
-			<td>
-			<div class="hidden" id="sample-media-seek-forward-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-seek-forward-button;
--webkit-appearance: media-seek-forward-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-seek-forward-button",100,50,"","","nobutton")}}</td>
 			<td>Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-toggle-closed-captions-button</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaToggleClosedCaptionsButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-toggle-closed-captions-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaToggleClosedCaptionsButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-slider</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaSlider">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-slider; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaSlider",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-sliderthumb</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaSliderThumb">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-sliderthumb; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaSliderThumb",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-volume-slider-container</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaVolumeSliderContainer">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-volume-slider-container; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaVolumeSliderContainer",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-volume-slider-mute-button</code></td>
-			<td>
-			<div class="hidden" id="sample-media-volume-slider-mute-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-volume-slider-mute-button;
--webkit-appearance: media-volume-slider-mute-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-volume-slider-mute-button",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-volume-slider</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaVolumeSlider">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-volume-slider; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaVolumeSlider",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-volume-sliderthumb</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaVolumeSliderThumb">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-volume-slider-thumb; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaVolumeSliderThumb",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-controls-background</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaControlsBackground">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-controls-background; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaControlsBackground",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-controls-dark-bar-background</code></td>
-			<td>
-			<div class="hidden" id="sample-media-controls-dark-bar-background">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-controls-dark-bar-background;
--webkit-appearance: media-controls-dark-bar-background; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-controls-dark-bar-background",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-controls-fullscreen-background</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaControlsFullscreenBackground">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-controls-fullscreen-background; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaControlsFullscreenBackground",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-controls-light-bar-background</code></td>
-			<td>
-			<div class="hidden" id="sample-media-controls-light-bar-background">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: media-controls-light-bar-background;
--webkit-appearance: media-controls-light-bar-background; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-media-controls-light-bar-background",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-current-time-display</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaCurrentTimeDisplay">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-current-time-display; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaCurrentTimeDisplay",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>media-time-remaining-display</code></td>
-			<td>
-			<div class="hidden" id="sampleMediaTimeRemainingDisplay">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: media-time-remaining-display; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMediaTimeRemainingDisplay",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>menulist-text</code></td>
-			<td>
-			<div class="hidden" id="sampleMenuListText">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: menulist-text;
--webkit-appearance: menulist-text; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMenuListText",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>menulist-textfield</code></td>
-			<td>
-			<div class="hidden" id="sampleMenuListTextfield">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: menulist-textfield;
--webkit-appearance: menulist-textfield; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMenuListTextfield",100,50,"","", "nobutton")}}</td>
 			<td>Firefox Chrome Safari Edge</td>
 			<td>The element is styled as the text field for a menulist. (Not implemented for the Windows platform)</td>
 		</tr>
 		<tr>
 			<td><code>meterbar</code> </td>
-			<td>
-			<div class="hidden" id="sampleMeterbar">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: meterbar;
--webkit-appearance: meterbar; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleMeterbar",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td>Use <code>meter</code> instead.</td>
 		</tr>
 		<tr>
 			<td><code>number-input</code></td>
-			<td>
-			<div class="hidden" id="sampleNumberInput">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: number-input;
--webkit-appearance: number-input; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleNumberInput",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>progress-bar-value</code></td>
-			<td>
-			<div class="hidden" id="sampleProgressBarValueWebkit">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: progress-bar-value; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleProgressBarValueWebkit",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>progressbar</code></td>
-			<td>
-			<div class="hidden" id="sampleProgressBar">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: progressbar;
--webkit-appearance: progressbar; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleProgressBar",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td>The element is styled like a progress bar. Use <code>progress-bar</code> instead</td>
 		</tr>
 		<tr>
 			<td><code>progressbar-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleProgressBarVertical">
-			<pre class="brush: css">
-div { color: transparent;
--moz-appearance: progressbar-vertical;
--webkit-appearance: progressbar-vertical; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleProgressBarVertical",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>range</code></td>
-			<td>
-			<div class="hidden" id="sampleRange">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: range;
--webkit-appearance: range; }</pre>
-			range
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleRange",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>range-thumb</code></td>
-			<td>
-			<div class="hidden" id="sampleRangeThumb">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: range-thumb;
--webkit-appearance: range-thumb; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleRangeThumb",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>rating-level-indicator</code></td>
-			<td>
-			<div class="hidden" id="sample-rating-level-indicator">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: rating-level-indicator;
--webkit-appearance: rating-level-indicator; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-rating-level-indicator",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>relevancy-level-indicator</code></td>
-			<td>
-			<div class="hidden" id="sample-relevancy-level-indicator">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: relevancy-level-indicator;
--webkit-appearance: relevancy-level-indicator; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-relevancy-level-indicator",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scale-horizontal</code></td>
-			<td>
-			<div class="hidden" id="sampleScaleHorizontal">
-			<pre class="brush: css">
-div { color: transparent;
--moz-appearance: scale-horizontal;
--webkit-appearance: scale-horizontal; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScaleHorizontal",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scalethumbend</code></td>
-			<td>
-			<div class="hidden" id="sampleThumbEnd">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scalethumbend;
--webkit-appearance: scalethumbend; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleThumbEnd",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scalethumb-horizontal</code></td>
-			<td>
-			<div class="hidden" id="sampleScaleThumbHorizontal">
-			<pre class="brush: css">
-div { color: transparent;
--moz-appearance: scalethumb-horizontal;
--webkit-appearance: scalethumb-horizontal; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScaleThumbHorizontal",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scalethumbstart</code></td>
-			<td>
-			<div class="hidden" id="sampleScaleThumbStart">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scalethumbstart;
--webkit-appearance: scalethumbstart; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScaleThumbStart",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scalethumbtick</code></td>
-			<td>
-			<div class="hidden" id="sampleScaleThumbTick">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scalethumbtick;
--webkit-appearance: scalethumbtick; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScaleThumbTick",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scalethumb-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleScaleThumbVertical">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scalethumb-vertical;
--webkit-appearance: scalethumb-vertical; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScaleThumbVertical",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scale-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleScaleVertical">
-			<pre class="brush: css">
-div { color: transparent;
--moz-appearance: scale-vertical;
--webkit-appearance: scale-vertical; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScaleVertical",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scrollbarthumb-horizontal</code></td>
-			<td>
-			<div class="hidden" id="sampleScrollbarThumbHorizontal">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scrollbarthumb-horizontal;
--webkit-appearance: scrollbarthumb-horizontal; }</pre>
-
-			<pre class="bruh: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScrollbarThumbHorizontal",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scrollbarthumb-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleScrollbarThumbVertical">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scrollbarthumb-vertical;
--webkit-appearance: scrollbarthumb-vertical; }</pre>
-
-			<pre class="bruh: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScrollbarThumbVertical",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scrollbartrack-horizontal</code></td>
-			<td>
-			<div class="hidden" id="sampleScrollbarTrackHorizontal">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scrollbartrack-horizontal;
--webkit-appearance: scrollbartrack-horizontal; }</pre>
-
-			<pre class="bruh: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScrollbarTrackHorizontal",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>scrollbartrack-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleScrollbarTrackVertical">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: scrollbartrack-vertical;
--webkit-appearance: scrollbartrack-vertical; }</pre>
-
-			<pre class="bruh: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleScrollbarTrackVertical",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>searchfield-decoration</code></td>
-			<td>
-			<div class="hidden" id="sample-searchfield-decoration">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: searchfield-decoration;
--webkit-appearance: searchfield-decoration; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-searchfield-decoration",100,50,"","","nobutton")}}</td>
 			<td>Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>searchfield-results-decoration</code></td>
-			<td>
-			<div class="hidden" id="sample-searchfield-results-decoration">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: searchfield-results-decoration;
--webkit-appearance: searchfield-results-decoration; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-searchfield-results-decoration",100,50,"","","nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td>(Works on Chrome 51 on Windows 7)</td>
 		</tr>
 		<tr>
 			<td><code>searchfield-results-button</code></td>
-			<td>
-			<div class="hidden" id="sample-searchfield-results-button">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: searchfield-results-button;
--webkit-appearance: searchfield-results-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-searchfield-results-button",100,50,"","","nobutton")}}</td>
 			<td>Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>searchfield-cancel-button</code></td>
-			<td>
-			<div class="hidden" id="sampleSearchFieldCancelButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: searchfield-cancel-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSearchFieldCancelButton",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>snapshotted-plugin-overlay</code></td>
-			<td>
-			<div class="hidden" id="sample-snapshotted-plugin-overlay">
-			<pre class="brush: css">
-div{ color: black;
--moz-appearance: snapshotted-plugin-overlay;
--webkit-appearance: snapshotted-plugin-overlay; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sample-snapshotted-plugin-overlay",100,50,"","","nobutton")}}</td>
 			<td>Safari</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>sheet</code></td>
-			<td>
-			<div class="hidden" id="sampleSheet">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: sheet;
--webkit-appearance: sheet; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSheet",100,50,"","", "nobutton")}}</td>
 			<td>None</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>slider-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleSliderVertical">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: slider-vertical; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSliderVertical",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>sliderthumb-horizontal</code></td>
-			<td>
-			<div class="hidden" id="sampleSliderThumbHorizontal">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: slider-thumb-horizontal; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSliderThumbHorizontal",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>sliderthumb-vertical</code></td>
-			<td>
-			<div class="hidden" id="sampleSliderThumbVertical">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: slider-thumb-vertical; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleSliderThumbVertical",100,50,"","", "nobutton")}}</td>
 			<td>Chrome Safari Edge</td>
 			<td></td>
 		</tr>
 		<tr>
 			<td><code>textfield-multiline</code></td>
-			<td>
-			<div class="hidden" id="sampleTextfieldMultiline">
-			<pre class="brush: css">
-div { color: black;
--moz-appearance: textfield-multiline;
--webkit-appearance: textfield-multiline; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleTextfieldMultiline",100,50,"","", "nobutton")}}</td>
 			<td>Firefox</td>
 			<td>Use <code>textarea</code> instead.</td>
 		</tr>
 		<tr>
 			<td><code>-apple-pay-button</code></td>
-			<td>
-			<div class="hidden" id="sampleApplePayButton">
-			<pre class="brush: css">
-div{ color: black;
--webkit-appearance: -apple-pay-button; }</pre>
-
-			<pre class="brush: html">
-&lt;div&gt;Lorem&lt;/div&gt;</pre>
-			</div>
-			{{EmbedLiveSample("sampleApplePayButton",100,50,"","", "nobutton")}}</td>
 			<td>Safari</td>
 			<td><strong>iOS and macOS only</strong>. Available on the web starting in iOS 10.1 and macOS 10.12.1</td>
 		</tr>
@@ -1494,445 +540,371 @@ div{ color: black;
 	<tbody>
 		<tr>
 			<th>Value</th>
-			<th></th>
 			<th>Browser</th>
 			<th>Description</th>
 		</tr>
 		<tr>
 			<td><code>button-arrow-down</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>button-arrow-next</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>button-arrow-previous</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>button-arrow-up</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>button-focus</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>dualbutton</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>groupbox</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menuarrow</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menubar</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menucheckbox</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menuimage</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menuitem</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>menuitemtext</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menupopup</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menuradio</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>menuseparator</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>meterchunk</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>progresschunk</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>progresschunk-vertical</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>radio-container</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>radio-label</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>radiomenuitem</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>resizer</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 63</td>
 		</tr>
 		<tr>
 			<td><code>resizerpanel</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 63.</td>
 		</tr>
 		<tr>
 			<td><code>scrollbarbutton-down</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 63.</td>
 		</tr>
 		<tr>
 			<td><code>scrollbarbutton-left</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 63.</td>
 		</tr>
 		<tr>
 			<td><code>scrollbarbutton-right</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 63.</td>
 		</tr>
 		<tr>
 			<td><code>scrollbarbutton-up</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 63.</td>
 		</tr>
 		<tr>
 			<td><code>separator</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>spinner</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>spinner-downbutton</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>spinner-textfield</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>spinner-upbutton</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>splitter</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>statusbar</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>statusbarpanel</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>tab</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>tabpanel</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>tabpanels</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64</td>
 		</tr>
 		<tr>
 			<td><code>tab-scroll-arrow-back</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>tab-scroll-arrow-forward</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>toolbar</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>toolbarbutton</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>toolbarbutton-dropdown</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>toolbargripper</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>toolbox</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>tooltip</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treeheader</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treeheadercell</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treeheadersortarrow</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treeitem</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treeline</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treetwisty</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treetwistyopen</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>treeview</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-borderless-glass</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-browsertabbar-toolbox</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-communicationstext</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-communications-toolbox</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-exclude-glass</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-glass</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-win-media-toolbox</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-button-box</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-button-box-maximized</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-button-close</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-button-maximize</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-button-minimize</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-button-restore</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-frame-bottom</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-frame-left</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-frame-right</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-titlebar</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>
 		<tr>
 			<td><code>-moz-window-titlebar-maximized</code></td>
-			<td></td>
 			<td>Firefox</td>
 			<td>Removed in Firefox 64.</td>
 		</tr>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

All the demos on https://developer.mozilla.org/en-US/docs/Web/CSS/appearance just don't seem to add any vaue

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/appearance

> Issue number (if there is an associated issue)

Discussed in weekly Editorial meeting

> Anything else that could help us review it

It'll render a heck of a lot faster now. :)