### PR TITLE
Remove hidden paragraphs from JS docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.html
@@ -94,7 +94,6 @@ iterator.next().value;        //  "n"
   <p>if the values in the array changed the array iterator object values change too.</p>
 </div>
 
-<p class="hidden"><strong>TODO</strong>: please write about why we need it, use cases.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tolocalestring/index.html
@@ -130,10 +130,6 @@ console.log(bigint.toLocaleString('en-IN', { maximumSignificantDigits: 3 }));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.BigInt.toLocaleString")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.html
@@ -99,10 +99,6 @@ BigInt(-0).toString(); // '0'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.BigInt.toString")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/valueof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/valueof/index.html
@@ -48,10 +48,6 @@ typeof Object(1n).valueOf(); // bigint
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.BigInt.valueOf")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/gethours/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/gethours/index.html
@@ -56,10 +56,6 @@ console.log(hours); // 23
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.getHours")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/gettime/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettime/index.html
@@ -111,10 +111,6 @@ console.log('Operation took ' + (end.getTime() - start.getTime()) + ' msec');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.getTime")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/gettimezoneoffset/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettimezoneoffset/index.html
@@ -94,10 +94,6 @@ currentLocalDate.getTimezoneOffset() === laborDay2016at0324GMTminus2.getTimezone
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.getTimezoneOffset")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.html
@@ -81,10 +81,6 @@ Date.now();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.now")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/todatestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/todatestring/index.html
@@ -84,10 +84,6 @@ console.log(d.toDateString()); // logs Mon Jun 28 1993
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.toDateString")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocalestring/index.html
@@ -195,10 +195,6 @@ console.log(date.toLocaleString('en-US', { hour12: false }));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.toLocaleString")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/tosource/index.html
@@ -41,10 +41,6 @@ Date.toSource()</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.toSource")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/date/valueof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/date/valueof/index.html
@@ -60,10 +60,6 @@ var myVar = x.valueOf();      // assigns -424713600000 to myVar
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Date.valueOf")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.html
@@ -142,10 +142,6 @@ Math.ceil10(-59, 1);       // -50
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Math.ceil")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log1p/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/log1p/index.html
@@ -110,10 +110,6 @@ Math.log1p(-2); // NaN
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Math.log1p")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/random/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/random/index.html
@@ -115,10 +115,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Math.random")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/round/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/round/index.html
@@ -72,10 +72,6 @@ Math.round(-20.51); // -21</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Math.round")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sqrt/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/sqrt/index.html
@@ -119,10 +119,6 @@ Math.sqrt(-0); // -0
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Math.sqrt")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/math/tanh/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/math/tanh/index.html
@@ -150,10 +150,6 @@ Math.tanh(1);        // 0.7615941559557649
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Math.tanh")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.html
@@ -171,7 +171,6 @@ Number('-Infinity') //-Infinity</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Number")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.html
@@ -167,10 +167,6 @@ console.log(num.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFrac
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Number.toLocaleString")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/toprecision/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/toprecision/index.html
@@ -85,10 +85,6 @@ console.log((1234.5).toPrecision(2)) // logs '1.2e+3'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Number.toPrecision")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/number/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/tosource/index.html
@@ -46,10 +46,6 @@ Number.toSource()</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.Number.toSource")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.html
@@ -18,10 +18,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/promise-all.html")}}</div>
 
-<p class="hidden">The source for this interactive demo is stored in a GitHub repository.
-  If you'd like to contribute to the interactive demo project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -256,10 +252,6 @@ Promise.all([
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</p>
 
 <p>{{Compat("javascript.builtins.Promise.all")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/resolve/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/resolve/index.html
@@ -139,10 +139,6 @@ p3.then(function(v) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request
-  against this repository: <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.
-</p>
 
 <p>{{Compat("javascript.builtins.Promise.resolve")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/then/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/then/index.html
@@ -16,10 +16,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/js/promise-then.html")}}</div>
 
-<p class="hidden">The source for this interactive demo is stored in a GitHub repository.
-  If you'd like to contribute to the interactive demo project, please clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.</p>
 
 <div class="note">
   <p>If one or both arguments are omitted or are provided non-functions, then

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.html
@@ -153,10 +153,6 @@ String.fromCharCode(55356, 57091);   // Stars" == "\uD83C\uDF03"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.fromCodePoint")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/includes/index.html
@@ -100,10 +100,6 @@ console.log(str.includes(''))             // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.includes")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.html
@@ -112,10 +112,6 @@ console.log('The index of "new" from the end is ' + anyString.lastIndexOf('new')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.lastIndexOf")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/localecompare/index.html
@@ -184,10 +184,6 @@ console.log(<span class="message-body-wrapper"><span class="message-flex-body"><
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.localeCompare")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.html
@@ -155,10 +155,6 @@ array[1];
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.matchAll")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/normalize/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/normalize/index.html
@@ -250,10 +250,6 @@ str.normalize('NFKD'); // '\u0073\u0323\u0307'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.normalize")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.html
@@ -71,10 +71,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.padEnd")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.html
@@ -309,10 +309,6 @@ console.log(newstr);  // Smith, John
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.replace")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.html
@@ -192,10 +192,6 @@ TypeError: replaceAll must be called with a global RegExp
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.replaceAll")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.html
@@ -260,10 +260,6 @@ const strReverse = str.split(/(?:)/u).reverse().join('')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.split")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tolowercase/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/tolowercase/index.html
@@ -54,10 +54,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.toLowerCase")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/tosource/index.html
@@ -49,10 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.toSource")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/tostring/index.html
@@ -58,10 +58,6 @@ console.log(x.toString()); // logs 'Hello world'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.toString")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/trim/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/trim/index.html
@@ -69,10 +69,6 @@ console.log(orig.trim()); // 'foo'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.trim")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/string/valueof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/valueof/index.html
@@ -55,10 +55,6 @@ console.log(x.valueOf()); // Displays 'Hello world'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
 
 <p>{{Compat("javascript.builtins.String.valueOf")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.html
@@ -92,7 +92,6 @@ iterator.next().value;        //  "n"
   <p>if the values in the array changed the array iterator object values change too.</p>
 </div>
 
-<p class="hidden"><strong>TODO</strong>: please write about why we need it, use cases.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
@@ -36,14 +36,6 @@ tags:
 <div>{{EmbedInteractiveExample("pages/js/expressions-nullishcoalescingoperator.html")}}
 </div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub
-  repository. If you'd like to contribute to the interactive examples project, please
-  clone <a
-    href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>
-  and send us a pull request.<br>
-  See <a
-    href="https://github.com/mdn/interactive-examples/pull/1482#issuecomment-553841750">PR
-    #1482</a> regarding the addition of this example.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
I realise that https://github.com/mdn/content/pull/3755 only removed hidden text in `<div>` elements. This PR does the same thing for `<p>` elements. See https://github.com/mdn/content/issues/3694 for the rationale here.

