### PR TITLE
Remove Page macro in example sections - AudioListener

### DIFF
--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.html
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.html
@@ -33,7 +33,7 @@ myListener.dopplerFactor = 1;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.html
+++ b/files/en-us/web/api/audiolistener/forwardx/index.html
@@ -14,8 +14,9 @@ tags:
 
 <p>The <code>forwardX</code> read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x value of the direction vector defining the forward direction the listener is pointing in.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -23,7 +24,7 @@ tags:
 <pre class="brush: js">var audioCtx = new AudioContext();
 var myListener = audioCtx.listener;
 myListener.forwardX.value = 0;
-</pre>
+</pre> 
 
 <h3 id="Value">Value</h3>
 
@@ -31,7 +32,12 @@ myListener.forwardX.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<pre class="brush: js">let audioCtx = new AudioContext();
+let myListener = audioCtx.listener;
+myListener.forwardX.value = 0;
+</pre>
+
+<p>For more detailed example code see <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.html
+++ b/files/en-us/web/api/audiolistener/forwardx/index.html
@@ -32,12 +32,7 @@ myListener.forwardX.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js">let audioCtx = new AudioContext();
-let myListener = audioCtx.listener;
-myListener.forwardX.value = 0;
-</pre>
-
-<p>For more detailed example code see <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a>.</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardy/index.html
+++ b/files/en-us/web/api/audiolistener/forwardy/index.html
@@ -14,8 +14,9 @@ tags:
 
 <p>The <code>forwardY</code> read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y value of the direction vector defining the forward direction the listener is pointing in.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -31,7 +32,7 @@ myListener.forwardY.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example">BaseAudioContext.createPanner()</a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardz/index.html
+++ b/files/en-us/web/api/audiolistener/forwardz/index.html
@@ -14,8 +14,9 @@ tags:
 
 <p>The <code>forwardZ</code> read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z value of the direction vector defining the forward direction the listener is pointing in.</p>
 
-<div class="note">
-<p><strong>Note</strong>: The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The parameter is <em>a-rate</em> when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or <em>k-rate</em> otherwise.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>
@@ -31,7 +32,7 @@ myListener.forwardZ.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/index.html
+++ b/files/en-us/web/api/audiolistener/index.html
@@ -79,7 +79,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/positionx/index.html
+++ b/files/en-us/web/api/audiolistener/positionx/index.html
@@ -31,7 +31,7 @@ myListener.positionX.value = 1;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/positiony/index.html
+++ b/files/en-us/web/api/audiolistener/positiony/index.html
@@ -31,7 +31,7 @@ myListener.positionY.value = 1;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/positionz/index.html
+++ b/files/en-us/web/api/audiolistener/positionz/index.html
@@ -31,7 +31,7 @@ myListener.positionZ.value = 1;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/setorientation/index.html
+++ b/files/en-us/web/api/audiolistener/setorientation/index.html
@@ -36,7 +36,7 @@ myListener.setOrientation(0,0,-1,0,1,0);</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Parameters">Parameters</h2>
 

--- a/files/en-us/web/api/audiolistener/setposition/index.html
+++ b/files/en-us/web/api/audiolistener/setposition/index.html
@@ -32,7 +32,7 @@ myListener.setPosition(1,1,1);</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Parameters">Parameters</h2>
 

--- a/files/en-us/web/api/audiolistener/speedofsound/index.html
+++ b/files/en-us/web/api/audiolistener/speedofsound/index.html
@@ -39,7 +39,7 @@ var <em>myListener</em> = <em>audioCtx</em>.listener;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createPanner","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/audiolistener/upx/index.html
+++ b/files/en-us/web/api/audiolistener/upx/index.html
@@ -31,7 +31,7 @@ myListener.upX.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>For more detailed example code see <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/upy/index.html
+++ b/files/en-us/web/api/audiolistener/upy/index.html
@@ -30,7 +30,7 @@ myListener.upY.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audiolistener/upz/index.html
+++ b/files/en-us/web/api/audiolistener/upz/index.html
@@ -31,7 +31,7 @@ myListener.upZ.value = 0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioListener","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createPanner#example"><code>BaseAudioContext.createPanner()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -23,7 +23,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">baseAudioCtx.createPanner();</pre>
+<pre class="brush: js">createPanner();</pre>
 
 <h3 id="Returns">Returns</h3>
 
@@ -138,8 +138,9 @@ function positionPanner() {
   pannerData.textContent = `Panner data: X ${xPos} Y ${yPos} Z ${zPos}`;
 }</pre>
 
-<div class="note">
-  <p><strong>Note</strong>: In terms of working out what position values to apply to the
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>In terms of working out what position values to apply to the
     listener and panner, to make the sound appropriate to what the visuals are doing on
     screen, there is quite a bit of math involved, but you will soon get used to it with a
     bit of experimentation.</p>


### PR DESCRIPTION
`AudioListener` properties and methods had the page macro in the Examples section that imported the example from [BaseAudioContext/createPanner()](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createPanner#example) (this was also included in `AudioListener` itself).

IMO an example should generally not be reproduced, but instead referenced. So I have replaced the inclusion with text like this:
![image](https://user-images.githubusercontent.com/5368500/115819775-e7e0d380-a442-11eb-85fc-043a1f1e93ee.png)

@wbamberg @chrisdavidmills If you're OK with this approach I will roll it out to the similar cases.

This is part of addressing #3196