### PR TITLE
Cross referencing events docs

### DIFF
--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.html
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.html
@@ -82,7 +82,7 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Guide/Events/Using_device_orientation_with_3D_transforms" title="Using Deviceorientation with 3D Transforms">Using device orientation with 3D Transforms</a></li>
+ <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms" title="Using Deviceorientation with 3D Transforms">Using device orientation with 3D Transforms</a></li>
  <li><a href="https://desandro.github.com/3dtransforms/">Intro to CSS 3D transforms</a> (Blog post by David DeSandro)</li>
  <li><a href="https://css-transform.moro.es/">CSS Transform Playground</a> (Online tool to visualize CSS Transform functions)</li>
 </ul>

--- a/files/en-us/web/events/creating_and_triggering_events/index.html
+++ b/files/en-us/web/events/creating_and_triggering_events/index.html
@@ -138,3 +138,11 @@ textarea.addEventListener('input', function() {
  <li>{{domxref("EventTarget.dispatchEvent()")}}</li>
  <li>{{domxref("EventTarget.addEventListener()")}}</li>
 </ul>
+
+<section id="Quick_links">
+  <ul>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
+    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
+  </ul>
+</section>

--- a/files/en-us/web/events/detecting_device_orientation/index.html
+++ b/files/en-us/web/events/detecting_device_orientation/index.html
@@ -22,8 +22,9 @@ tags:
 
 <p>All you need to do in order to begin receiving orientation change is to listen to the {{event("deviceorientation")}} event:</p>
 
-<div class="note">
-<p><strong>Note</strong>: <a href="https://github.com/wagerfield/parallax">parallax</a> is a polyfill for normalizing the accelerometer and gyroscope data on mobile devices. This is useful for overcoming some of the differences in device support for device orientation.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p><a href="https://github.com/wagerfield/parallax">parallax</a> is a polyfill for normalizing the accelerometer and gyroscope data on mobile devices. This is useful for overcoming some of the differences in device support for device orientation.</p>
 </div>
 
 <pre class="brush: js">window.addEventListener("deviceorientation", handleOrientation, true);
@@ -54,7 +55,7 @@ tags:
 
 <h3 id="Orientation_values_explained">Orientation values explained</h3>
 
-<p>The value reported for each axis indicates the amount of rotation around a given axis in reference to a standard coordinate frame. These are described in greater detail in the <a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a> article which is summarized below.</p>
+<p>The value reported for each axis indicates the amount of rotation around a given axis in reference to a standard coordinate frame. These are described in greater detail in the <a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a> article which is summarized below.</p>
 
 <ul>
  <li>The {{domxref("DeviceOrientationEvent.alpha")}} value represents the motion of the device around the z axis, represented in degrees with values ranging from 0 (inclusive) to 360 (exclusive).</li>
@@ -154,7 +155,7 @@ window.addEventListener('deviceorientation', handleOrientation);
 
 <h3 id="Motion_values_explained">Motion values explained</h3>
 
-<p>The {{domxref("DeviceMotionEvent")}} objects provide web developers with information about the speed of changes for the device's position and orientation. The changes are provided along three axis (see <a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a> for details).</p>
+<p>The {{domxref("DeviceMotionEvent")}} objects provide web developers with information about the speed of changes for the device's position and orientation. The changes are provided along three axis (see <a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a> for details).</p>
 
 <p>For {{domxref("DeviceMotionEvent.acceleration","acceleration")}} and {{domxref("DeviceMotionEvent.accelerationIncludingGravity","accelerationIncludingGravity")}}, those axes correspond to the following:</p>
 
@@ -211,7 +212,17 @@ window.addEventListener('deviceorientation', handleOrientation);
  <li>{{domxref("DeviceOrientationEvent")}}</li>
  <li>{{domxref("DeviceMotionEvent")}}</li>
  <li>The legacy <code><a href="/en-US/docs/Web/Events/MozOrientation">MozOrientation</a></code> event.</li>
- <li><a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a></li>
- <li><a href="/en-US/docs/Web/Guide/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D Transforms</a></li>
+ <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a></li>
+ <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D Transforms</a></li>
  <li><a href="/en-US/docs/Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation">Cyber Orb: 2D maze game with device orientation</a></li>
 </ul>
+
+<section id="Quick_links">
+  <ul>
+    <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a></li>
+    <li>{{domxref("DeviceOrientationEvent")}}</li>
+    <li>{{domxref("DeviceMotionEvent")}}</li>
+    <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D Transforms</a></li>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+  </ul>
+</section>

--- a/files/en-us/web/events/mouse_gesture_events/index.html
+++ b/files/en-us/web/events/mouse_gesture_events/index.html
@@ -93,3 +93,10 @@ tags:
  <li>Other <a href="/en-US/docs/Web/Events">DOM Events</a></li>
  <li>{{interface("nsIDOMSimpleGestureEvent")}}</li>
 </ul>
+
+<section id="Quick_links">
+  <ul>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+    <li><a href="/en-US/docs/Web/API/Touch_eventss">Touch events</a></li>
+  </ul>
+</section>

--- a/files/en-us/web/events/orientation_and_motion_data_explained/index.html
+++ b/files/en-us/web/events/orientation_and_motion_data_explained/index.html
@@ -71,3 +71,14 @@ tags:
 <p><img class="default internal" src="gamma.png"></p>
 
 <p>The gamma angle is 0° when the device's left and right sides are the same distance from the surface of the Earth, and increases toward 90° as the device is tipped toward the right, and toward -90° as the device is tipped toward the left.</p>
+
+
+<section id="Quick_links">
+  <ul>
+    <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
+    <li>{{domxref("DeviceOrientationEvent")}}</li>
+    <li>{{domxref("DeviceMotionEvent")}}</li>
+    <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D Transforms</a></li>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+  </ul>
+</section>

--- a/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.html
+++ b/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>The easiest way to convert <a href="/en-US/docs/Web/API/Window/deviceorientation_event">orientation data</a> to a <a href="/en-US/docs/Web/CSS/transform" title="CSS Reference Project">3D transform</a> is basically to use the alpha, gamma, and beta values as <code>rotateZ</code>, <code>rotateX</code> and <code>rotateY</code> values.</p>
 
-<p>It is important to keep in mind, however, that the <a href="/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained">Device Orientation coordinate system</a> is different from the <a href="/en-US/docs/Web/CSS/CSSOM_View/Coordinate_systems">CSS coordinate system</a>. Namely, the former is {{interwiki("wikipedia", "Right-hand_rule", "right-handed")}} and its Y axis is positive upwards, while the latter is a left-handed coordinate system whose Y axis is positive to the bottom. Furthermore, the Device Orientation angle rotations should always be done in a Z - X' - Y'' order that does not match the order of some <a href="/en-US/docs/Web/CSS/CSS_Transforms">CSS Transforms</a>. These are some of the practical consequences of these differences:</p>
+<p>It is important to keep in mind, however, that the <a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Device Orientation coordinate system</a> is different from the <a href="/en-US/docs/Web/CSS/CSSOM_View/Coordinate_systems">CSS coordinate system</a>. Namely, the former is {{interwiki("wikipedia", "Right-hand_rule", "right-handed")}} and its Y axis is positive upwards, while the latter is a left-handed coordinate system whose Y axis is positive to the bottom. Furthermore, the Device Orientation angle rotations should always be done in a Z - X' - Y'' order that does not match the order of some <a href="/en-US/docs/Web/CSS/CSS_Transforms">CSS Transforms</a>. These are some of the practical consequences of these differences:</p>
 
 <ul>
 	<li>The order of angle rotations matters, so make sure the alpha, beta and gamma rotations are applied in this order.</li>
@@ -82,7 +82,7 @@ function orient( aa ) {
 
 <ul>
 	<li><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></li>
-	<li><a href="/en-US/docs/Web/API/Detecting_device_orientation">Detecting device orientation</a></li>
+	<li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
 </ul>
 
 

--- a/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.html
+++ b/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.html
@@ -84,3 +84,13 @@ function orient( aa ) {
 	<li><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></li>
 	<li><a href="/en-US/docs/Web/API/Detecting_device_orientation">Detecting device orientation</a></li>
 </ul>
+
+
+<section id="Quick_links">
+    <ul>
+      <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
+      <li><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></li>
+      <li>{{domxref("DeviceOrientationEvent")}}</li>
+      <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+    </ul>
+</section>


### PR DESCRIPTION
This creates sidebar "Related topic" links for the events topics to ensure they are better cross linked.