### PR TITLE
correct the description of <input> value attribute

### DIFF
--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -397,7 +397,7 @@ tags:
   <tr>
    <td>{{anch('htmlattrdefvalue', 'value')}}</td>
    <td>all</td>
-   <td>At first, the initial value if specified explicitly in HTML. More generally, the current value of the form control. Submitted with the form as part of a name/value pair.</td>
+   <td>The default value. Not to be confuse with the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement">HTMLInputElement.value</a> property - which gets/sets the <code>&lt;input&gt;</code>'s current value.</td>
   </tr>
   <tr>
    <td>{{anch('htmlattrdefwidth', 'width')}}</td>

--- a/files/en-us/web/html/element/input/index.html
+++ b/files/en-us/web/html/element/input/index.html
@@ -397,7 +397,7 @@ tags:
   <tr>
    <td>{{anch('htmlattrdefvalue', 'value')}}</td>
    <td>all</td>
-   <td>The default value. Not to be confuse with the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement">HTMLInputElement.value</a> property - which gets/sets the <code>&lt;input&gt;</code>'s current value.</td>
+   <td>The initial value of the control.</td>
   </tr>
   <tr>
    <td>{{anch('htmlattrdefwidth', 'width')}}</td>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Existing description had confused the [HTMLInputElement.value](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) property (live value), with the \<input> 'value' attribute (default value).

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefvalue

> Issue number (if there is an associated issue)

> Anything else that could help us review it
