### PR TITLE
Fix video/audio code bad links and anchors

### DIFF
--- a/files/en-us/web/media/formats/audio_codecs/index.html
+++ b/files/en-us/web/media/formats/audio_codecs/index.html
@@ -45,37 +45,37 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="#AAC">AAC</a></th>
+   <th scope="row"><a href="#aac_advanced_audio_coding">AAC</a></th>
    <td>Advanced Audio Coding</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#ALAC">ALAC</a></th>
+   <th scope="row"><a href="#alac_apple_lossless_audio_codec">ALAC</a></th>
    <td>Apple Lossless Audio Codec</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a> (MOV)</td>
   </tr>
   <tr>
-   <th scope="row"><a href="#AMR">AMR</a></th>
+   <th scope="row"><a href="#amr_adaptive_multi-rate">AMR</a></th>
    <td>Adaptive Multi-Rate</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#FLAC">FLAC</a></th>
+   <th scope="row"><a href="#flac_free_lossless_audio_codec">FLAC</a></th>
    <td>Free Lossless Audio Codec</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#flac">FLAC</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#G.711">G.711</a></th>
+   <th scope="row"><a href="#g.711_pulse_code_modulation_of_voice_frequencies">G.711</a></th>
    <td>Pulse Code Modulation (PCM) of Voice Frequencies</td>
    <td>{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#G.722">G.722</a></th>
+   <th scope="row"><a href="#g.722_64_kbps_7_khz_audio_coding">G.722</a></th>
    <td>7 kHz Audio Coding Within 64 kbps (for telephony/{{Glossary("VoIP")}})</td>
    <td>{{Glossary("RTP")}} / <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#MP3">MP3</a></th>
+   <th scope="row"><a href="#mp3_mpeg-1_audio_layer_iii">MP3</a></th>
    <td>MPEG-1 Audio Layer III</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#adts">ADTS</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpeg">MPEG</a><sup><a href="#in-brief-footnote1">1</a></sup>, <a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
@@ -196,7 +196,7 @@ tags:
 
 <h4 id="Lossless_versus_lossy_codecs">Lossless versus lossy codecs</h4>
 
-<p>There are two basic categories of audio compression. <strong>Lossless</strong> compression algorithms reduce the size of the audio without compromising the quality or fidelity of the sound. Upon decoding audio compressed with a lossless codec such as <a href="#FLAC">FLAC</a> or <a href="#ALAC">ALAC</a>, the result is identical in every way to the original sound, down to the bit.</p>
+<p>There are two basic categories of audio compression. <strong>Lossless</strong> compression algorithms reduce the size of the audio without compromising the quality or fidelity of the sound. Upon decoding audio compressed with a lossless codec such as <a href="#flac_free_lossless_audio_codec">FLAC</a> or <a href="#alac_apple_lossless_audio_codec">ALAC</a>, the result is identical in every way to the original sound, down to the bit.</p>
 
 <p><strong>Lossy</strong> codecs, on the other hand, take advantage of the fact that the human ear is not a perfect interpreter of audio, and of the fact that the human brain can pluck the important information out of imperfect or noisy audio. They strip away audio frequencies that aren't used much, tolerate loss of precision in the decoded output, and use other methods to lose audio content, quality, and fidelity to produce smaller encoded media. Upon decoding, the output is, to varying degrees, still understandable. The specific codec used—and the compression configuration selected—determine how close to the original, uncompressed audio signal the output seems to be when heard by the human ear.</p>
 
@@ -224,7 +224,8 @@ tags:
 
 <p>Below we take a brief look at each of these codecs, looking at their basic capabilities and their primary use cases.</p>
 
-<h3 id="AAC_Advanced_Audio_Coding"><a id="AAC">AAC</a> (Advanced Audio Coding)</h3>
+<a id="AAC"></a>
+<h3 id="aac_advanced_audio_coding">AAC (Advanced Audio Coding)</h3>
 
 <p>The <strong>Advanced Audio Coding</strong> (<strong>AAC</strong>) codec is defined as part of the MPEG-4 (H.264) standard; specifically, as part of <a href="https://www.iso.org/standard/53943.html">MPEG-4 Part 3</a> and <a href="https://www.iso.org/standard/43345.html">MPEG-2 Part 7</a>. Designed to be able to provide more compression with higher audio fidelity than MP3, AAC has become a popular choice, and is the standard format for audio in many types of media, including Blu-Ray discs and HDTV, as well as being the format used for songs purchased from online vendors including iTunes.</p>
 
@@ -346,7 +347,8 @@ tags:
 
 <p><a id="aac-foot-2">[2]</a> Chrome supports AAC only in MP4 containers, and only supports AAC's Main Profile. In addition, AAC is not available in Chromium builds.</p>
 
-<h3 id="ALAC_Apple_Lossless_Audio_Codec"><a id="ALAC">ALAC</a> (Apple Lossless Audio Codec)</h3>
+<a id="alac"></a>
+<h3 id="alac_apple_lossless_audio_codec">ALAC (Apple Lossless Audio Codec)</h3>
 
 <p>The <strong>Apple Lossless Audio Codec</strong> (<strong>ALAC</strong> or <strong>Apple Lossless</strong>) is a lossless codec developed by Apple. After initially being a closed format, Apple opened it up under an Apache license.</p>
 
@@ -434,7 +436,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="AMR_Adaptive_Multi-Rate"><a id="AMR">AMR</a> (Adaptive Multi-Rate)</h3>
+<a id="AMR"></a>
+<h3 id="AMR_Adaptive_Multi-Rate">AMR (Adaptive Multi-Rate)</h3>
 
 <p>The <strong><a href="http://www.voiceage.com/AMR-NB.AMR.html">Adaptive Multi-Rate audio codec</a></strong> is optimized for encoding human speech efficiently. It was standardized in 1999 as part of the 3GPP audio standard used for both {{interwiki("wikipedia", "GSM")}} and {{interwiki("wikipedia", "UMTS")}} cellular telephony, and uses a multi-rate narrowband algorithm to encode audio frequencies at a telephony-grade quality level at around 7.4 kbps. In addition to being used for real-time telephony, AMR audio may be used for voicemail and other short audio recordings.</p>
 
@@ -529,7 +532,8 @@ tags:
 
 <p><a id="amr-foot-2">[2]</a> The Firefox browser doesn't support AMR; however, the Boot to Gecko platform does support both narrow and wideband AMR in 3GP containers.</p>
 
-<h3 id="FLAC_Free_Lossless_Audio_Codec"><a id="FLAC">FLAC</a> (Free Lossless Audio Codec)</h3>
+<a id="flac"></a>
+<h3 id="flac_free_lossless_audio_codec">FLAC (Free Lossless Audio Codec)</h3>
 
 <p><strong>FLAC </strong>(<strong>Free Lossless Audio Codec</strong>) is a lossless audio codec published by the <a href="https://xiph.org/">Xiph.org Foundation</a>. It provides good compression rates with no loss of audio fidelity; that is, the decompressed audio is identical to the original. Because the compression algorithm is specifically designed for audio, it gives better results than would be achieved using a general-purpose compression algorithm.</p>
 
@@ -616,7 +620,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="G.711_Pulse_Code_Modulation_of_Voice_Frequencies"><a id="G.711">G.711</a> (Pulse Code Modulation of Voice Frequencies)</h3>
+<a id="g.711"></a>
+<h3 id="g.711_pulse_code_modulation_of_voice_frequencies">G.711 (Pulse Code Modulation of Voice Frequencies)</h3>
 
 <p>The <strong>G.711</strong> specification, published by the International Telecommunications Union (ITU), was initially created in 1972 to define standards for encoding the voice frequencies on telephone lines into digital form. The audio is encoded using Pulse Code Modulation (PCM) with either {{interwiki("wikipedia", "M-law", "µ-law")}} or {{interwiki("wikipedia", "A-law")}} encoding.</p>
 
@@ -708,7 +713,8 @@ tags:
 
 <p><a id="g711-foot-1">[1]</a> G.711 is supported only for WebRTC connections.</p>
 
-<h3 id="G.722_64_kbps_7_kHz_audio_coding"><a id="G.722">G.722</a> (64 kbps (7 kHz) audio coding)</h3>
+<a id="G.722"></a>
+<h3 id="g.722_64_kbps_7_khz_audio_coding">G.722 (64 kbps (7 kHz) audio coding)</h3>
 
 <p>Published by the International Telecommunications Union (ITU), the <strong>G.722</strong> codec is designed specifically for voice compression. Its audio coding bandwidth is limited to the 50 Hz to 7,000 Hz range, which covers most of the frequency range of typical human vocalization. This makes it ill-suited for handling any audio that might range outside the human speech range, such as music.</p>
 
@@ -801,7 +807,8 @@ tags:
 
 <p><a id="g722-foot-1">[1]</a> WebRTC only.</p>
 
-<h3 id="MP3_MPEG-1_Audio_Layer_III"><a id="MP3">MP3</a> (MPEG-1 Audio Layer III)</h3>
+<a id="MP3"></a>
+<h3 id="mp3_mpeg-1_audio_layer_iii">MP3 (MPEG-1 Audio Layer III)</h3>
 
 <p>Of the audio formats specified by the MPEG/MPEG-2 standards, <strong>MPEG-1 Audio Layer III</strong>—otherwise known as <strong>{{interwiki("wikipedia", "MP3")}}</strong>—is by far the most widely used and best-known. The MP3 codec is defined by <a href="https://www.iso.org/standard/22412.html">MPEG-1 Part 3</a> and <a href="https://www.iso.org/standard/26797.html">MPEG-2 Part 3</a>, and was introduced in 1991 (and finalized in 1992).</p>
 
@@ -931,7 +938,7 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Opus">Opus</h3>
+<h3 id="opus">Opus</h3>
 
 <p>The {{interwiki("wikipedia", "Opus (audio format)", "Opus")}} audio format was created by the Xiph.org Foundation as a fully open audio format; it has been standardized by <a href="https://www.ietf.org/">IETF</a> as {{RFC(6716)}}. It's a good general-purpose audio codec that can efficiently handle both low-complexity audio such as speech as well as music and other high-complexity sounds.</p>
 
@@ -1087,7 +1094,7 @@ tags:
 
 <p><a id="opus-foot-3">[3]</a> Although the {{interwiki("wikipedia", "Nyquist–Shannon sampling theorem")}} shows that audio bandwidth can be as much as one half of the sampling rate, Opus doesn't allow encoding outside a maximum 20 kHz audio frequency band, since the human ear can't percieve anything above the 20 kHz point anyway. This saves some space in the encoded audio.</p>
 
-<h3 id="Vorbis">Vorbis</h3>
+<h3 id="vorbis">Vorbis</h3>
 
 <p><a href="https://www.xiph.org/vorbis/">Vorbis</a> is an open format from the <a href="https://xiph.org/">Xiph.org Foundation</a> which supports a wide range of channel combinations, including monaural, stereo, polyphonic, quadraphonic, 5.1 surround, ambisonic, or up to 255 discrete audio channels. Depending on the quality setting used during encoding, the resulting bit rate can vary from around 45 kbps to 500 kbps. Vorbis inherently uses variable bit rate encoding; the bit rate can vary from one sample to the next as needed during the compression process.</p>
 
@@ -1215,7 +1222,8 @@ tags:
 <p>If you need to minimize latency during music playback, you should strongly consider Opus, which has the lowest range of latencies of the general-purpose codecs (5 ms to 66.5 ms, compared to at least 100 ms for the others).</p>
 
 <div class="notecard note">
-<p><strong>Note:</strong> Compatibility information described here is generally correct as of the time this article was written; however, there may be caveats and exceptions. Be sure to refer to the compatibility tables before committing to a given media format.</p>
+  <h4>Note</h4>
+  <p>Compatibility information described here is generally correct as of the time this article was written; however, there may be caveats and exceptions. Be sure to refer to the compatibility tables before committing to a given media format.</p>
 </div>
 
 <p>Based on this, AAC is likely your best choice if you can only support one audio format. Of course, if you can provide multiple formats (for example, by using the {{HTMLElement("source")}} element within your {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements), you can avoid many or all of those exceptions.</p>
@@ -1234,7 +1242,7 @@ tags:
 
 <p>The voice-specific codecs are all inherently very lossy, however, and any sound with significant information in the frequency bands outside the vocal range captured will be entirely lost. This makes these codecs completely unsuitable for anything but spoken words. Even audio that contains only voices, but singing rather than speaking, will likely not be of acceptable quality in one of these formats.</p>
 
-<p>Voice recording and playback usually needs to be low-latency in order to synchronize with video tracks, or in order to avoid cross-talk or other problems. Fortunately, the characteristics that lead to speech codecs being so efficient storage space-wise also make them tend to be very low latency. If you're working with WebRTC, <a href="#G.722">G.722</a>, for example, has 4 ms latency (compared with over 100 ms for MP3), and <a href="#AMR">AMR</a>'s latency is around 25 ms.</p>
+<p>Voice recording and playback usually needs to be low-latency in order to synchronize with video tracks, or in order to avoid cross-talk or other problems. Fortunately, the characteristics that lead to speech codecs being so efficient storage space-wise also make them tend to be very low latency. If you're working with WebRTC, <a href="#g.722_64_kbps_7_khz_audio_coding">G.722</a>, for example, has 4 ms latency (compared with over 100 ms for MP3), and <a href="#amr_adaptive_multi-rate">AMR</a>'s latency is around 25 ms.</p>
 
 <div class="notecard note">
 <p><strong>Note:</strong> For more about WebRTC and the codecs it can use, see <a href="/en-US/docs/Web/Media/Formats/WebRTC_codecs">Codecs used by WebRTC</a>.</p>

--- a/files/en-us/web/media/formats/video_codecs/index.html
+++ b/files/en-us/web/media/formats/video_codecs/index.html
@@ -58,7 +58,7 @@ tags:
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_h.264">AVC (H.264)</a></th>
+   <th scope="row"><a href="#avc_h.264">AVC (H.264)</a></th>
    <td>Advanced Video Coding</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>
@@ -68,22 +68,22 @@ tags:
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="#hevc">HEVC (H.265)</a></th>
+   <th scope="row"><a href="#hevc_h.265">HEVC (H.265)</a></th>
    <td>High Efficiency Video Coding</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("MP4V-ES")}}</th>
+   <th scope="row"><a href="#mp4v-es">MP4V-ES</a></th>
    <td>MPEG-4 Video Elemental Stream</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("MPEG-1")}}</th>
+   <th scope="row"><a href="#mpeg-1_part_2_video">MPEG-1</a></th>
    <td>MPEG-1 Part 2 Visual</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a></td>
   </tr>
   <tr>
-   <th scope="row">{{anch("MPEG-2")}}</th>
+   <th scope="row"><a href="#mpeg-2_part_2_video">MPEG-2</a></th> 
    <td>MPEG-2 Part 2 Visual</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a></td>
   </tr>
@@ -134,7 +134,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Frame rate</th>
-   <td>Primarily affects the perceived smoothness of the motion in the image. To a point, the higher the frame rate, the smoother and more realistic the motion will appear. Eventually the point of diminishing returns is reached. See {{anch("Frame rate")}} below for details.</td>
+   <td>Primarily affects the perceived smoothness of the motion in the image. To a point, the higher the frame rate, the smoother and more realistic the motion will appear. Eventually the point of diminishing returns is reached. See <a href="#reduced_frame_rate">Frame rate</a> below for details.</td>
    <td>Assuming the frame rate is not reduced during encoding, higher frame rates cause larger compressed video sizes.</td>
   </tr>
   <tr>
@@ -253,7 +253,7 @@ tags:
 
 <p><a href="https://mdn.mozillademos.org/files/16684/Ringing-effects.png"><img alt="Example of the ringing effect" src="ringing-effects.png"></a></p>
 
-<p>Note the blue and pink fringes around the edges of the star above (as well as the stepping and other significant compression artifacts). Those fringes are the ringing effect. Ringing is similar in some respects to {{anch("Mosquito noise", "mosquito noise")}}, except that while the ringing effect is more or less steady and unchanging, mosquito noise shimmers and moves.</p>
+<p>Note the blue and pink fringes around the edges of the star above (as well as the stepping and other significant compression artifacts). Those fringes are the ringing effect. Ringing is similar in some respects to <a href="#mosquito_noise">mosquito noise</a>, except that while the ringing effect is more or less steady and unchanging, mosquito noise shimmers and moves.</p>
 
 <p>RInging is another type of artifact that can make it particularly difficult to read text contained in your images.</p>
 
@@ -273,9 +273,9 @@ tags:
 
 <p>In the example image above, note how the sky has bands of different shades of blue, instead of being a consistent gradient as the sky color changes toward the horizon. This is the contouring effect.</p>
 
-<h3 id="Mosquito_noise">Mosquito noise</h3>
+<h3 id="mosquito_noise">Mosquito noise</h3>
 
-<p><strong>Mosquito noise</strong> is a temporal artifact which presents as noise or <strong>edge busyness</strong> that appears as a flickering haziness or shimmering that roughly follows outside the edges of objects with hard edges or sharp transitions between foreground objects and the background. The effect can be similar in appearance to {{anch("Ringing", "ringing")}}.</p>
+<p><strong>Mosquito noise</strong> is a temporal artifact which presents as noise or <strong>edge busyness</strong> that appears as a flickering haziness or shimmering that roughly follows outside the edges of objects with hard edges or sharp transitions between foreground objects and the background. The effect can be similar in appearance to <a href="#ringing">ringing</a> .</p>
 
 <p><img alt="" src="mosquito-effect-sm.png"></p>
 
@@ -334,7 +334,7 @@ tags:
 
 <h3 id="AV1">AV1</h3>
 
-<p>The <strong>AOMedia Video 1</strong> (<strong>AV1</strong>) codec is an open format designed by the <a href="https://aomedia.org/">Alliance for Open Media</a> specifically for internet video. It achieves higher data compression rates than {{anch("VP9")}} and {{anch("HEVC", "H.265/HEVC")}}, and as much as 50% higher rates than <a href="/en-US/docs/Web/Media/Formats/Video_codecs#avc_(h.264)">AVC</a>. AV1 is fully royalty-free and is designed for use by both the {{HTMLElement("video")}} element and by <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a>.</p>
+<p>The <strong>AOMedia Video 1</strong> (<strong>AV1</strong>) codec is an open format designed by the <a href="https://aomedia.org/">Alliance for Open Media</a> specifically for internet video. It achieves higher data compression rates than <a href="#VP9">VP9</a> and <a href="#hevc_h.265">H.265/HEVC</a>, and as much as 50% higher rates than <a href="#avc_h.264">AVC</a>. AV1 is fully royalty-free and is designed for use by both the {{HTMLElement("video")}} element and by <a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a>.</p>
 
 <p>AV1 currently offers three profiles: <strong>main</strong>, <strong>high</strong>, and <strong>professional</strong> with increasing support for color depths and chroma subsampling. In addition, a series of <strong>levels</strong> are specified, each defining limits on a range of attributes of the video. These attributes include frame dimensions, image area in pixels, display and decode rates, average and maximum bit rates, and limits on the number of tiles and tile columns used in the encoding/decoding process.</p>
 
@@ -455,7 +455,8 @@ tags:
 
 <p><a name="av1-foot-2">[2]</a> See the AV1 specification's <a href="https://aomediacodec.github.io/av1-spec/#levels">tables of levels</a>, which describe the maximum resolutions and rates at each level.</p>
 
-<h3 id="AVC_H.264"><a name="AVC">AVC</a> (H.264)</h3>
+<a name="AVC"></a>
+<h3 id="avc_h.264">AVC (H.264)</h3>
 
 <p>The MPEG-4 specification suite's <strong>Advanced Video Coding</strong> (<strong>AVC</strong>) standard is specified by the identical ITU H.264 specification and the MPEG-4 Part 10 specification. It's a motion compensation based codec that is widely used today for all sorts of media, including broadcast television, {{Glossary("RTP")}} videoconferencing, and as the video codec for Blu-Ray discs.</p>
 
@@ -705,9 +706,10 @@ tags:
 
 <p><a id="h263-foot-2">[2]</a> Version 1 of H.263 specifies a set of picture sizes which are supported. Later versions may support additional resolutions.</p>
 
-<h3 id="HEVC_H.265"><a id="HEVC">HEVC</a> (H.265)</h3>
+<a id="hevc"></a>
+<h3 id="hevc_h.265">HEVC (H.265)</h3>
 
-<p>The <strong><a href="http://hevc.info/">High Efficiency Video Coding</a></strong> (<strong>HVEC</strong>) codec is defined by ITU's <strong>H.265</strong> as well as by MPEG-H Part 2 (the still in-development follow-up to MPEG-4). HEVC was designed to support efficient encoding and decoding of video in sizes including very high resolutions (including 8K video), with a structure specifically designed to let software take advantage of modern processors. Theoretically, HEVC can achieve compressed file sizes half that of {{anch("AVC")}} but with comparable image quality.</p>
+<p>The <strong><a href="http://hevc.info/">High Efficiency Video Coding</a></strong> (<strong>HVEC</strong>) codec is defined by ITU's <strong>H.265</strong> as well as by MPEG-H Part 2 (the still in-development follow-up to MPEG-4). HEVC was designed to support efficient encoding and decoding of video in sizes including very high resolutions (including 8K video), with a structure specifically designed to let software take advantage of modern processors. Theoretically, HEVC can achieve compressed file sizes half that of <a href="#avc_h.264">AVC</a> but with comparable image quality.</p>
 
 <p>For example, each coding tree unit (CTU)—similar to the macroblock used in previous codecs—consists of a tree of luma values for each sample as well as a tree of chroma values for each chroma sample used in the same coding tree unit, as well as any required syntax elements. This structure supports easy processing by multiple cores.</p>
 
@@ -951,7 +953,8 @@ tags:
 
 <p><a name="mp4ves-foot-2">[2]</a> Chrome does not support MP4V-ES; however, Chrome OS does.</p>
 
-<h3 id="MPEG-1_Part_2_Video"><a id="MPEG-1">MPEG-1</a> Part 2 Video</h3>
+<a id="MPEG-1"></a>
+<h3 id="mpeg-1_part_2_video">MPEG-1 Part 2 Video</h3>
 
 <p><strong>MPEG-1 Part 2 Video</strong> was unveiled at the beginning of the 1990s. Unlike the later MPEG video standards, MPEG-1 was created solely by MPEG, without the {{Glossary("ITU", "ITU's")}} involvement.</p>
 
@@ -1037,7 +1040,8 @@ tags:
  </tbody>
 </table>
 
-<h3 id="MPEG-2_Part_2_Video"><a id="MPEG-2">MPEG-2</a> Part 2 Video</h3>
+<a id="MPEG-2"></a>
+<h3 id="mpeg-2_part_2_video">MPEG-2 Part 2 Video</h3>
 
 <p><span class="seoSummary"><strong><a href="https://en.wikipedia.org/wiki/H.262/MPEG-2_Part_2">MPEG-2 Part 2</a></strong> is the video format defined by the MPEG-2 specification, and is also occasionally referred to by its {{Glossary("ITU")}} designation, H.262.</span> It is very similar to MPEG-1 video—in fact, any MPEG-2 player can automatically handle MPEG-1 without any special work—except it has been expanded to support higher bit rates and enhanced encoding techniques.</p>
 
@@ -1286,7 +1290,7 @@ tags:
 
 <h3 id="VP8">VP8</h3>
 
-<p>The <strong>Video Processor 8</strong> (<strong>VP8</strong>) codec was initially created by On2 Technologies. Following their purchase of On2, Google released VP8 as an open and royalty-free video format under a promise not to enforce the relevant patents. In terms of quality and compression rate, VP8 is comparable to {{anch("AVC")}}.</p>
+<p>The <strong>Video Processor 8</strong> (<strong>VP8</strong>) codec was initially created by On2 Technologies. Following their purchase of On2, Google released VP8 as an open and royalty-free video format under a promise not to enforce the relevant patents. In terms of quality and compression rate, VP8 is comparable to <a href="#avc_h.264">AVC</a>.</p>
 
 <p>If supported by the browser, VP8 allows video with an alpha channel, allowing the video to play with the background able to be seen through the video to a degree specified by each pixel's alpha component.</p>
 
@@ -1393,7 +1397,7 @@ tags:
 
 <p>VP9's main profile supports only 8-bit color depth at 4:2:0 chroma subsampling levels, but its profiles include support for deeper color and the full range of chroma subsampling modes. It supports several HDR imiplementations, and offers substantial freedom in selecting frame rates, aspect ratios, and frame sizes.</p>
 
-<p>VP9 is widely supported by browsers, and hardware implementations of the codec are fairly common. VP9 is one of the two video codecs mandated by <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a> (the other being {{anch("VP8")}}). Of note, however, is that Safari supports neither WebM nor VP9, so if you choose to use VP9, be sure to offer a fallback format such as AVC or HEVC for iPhone, iPad, and Mac users.</p>
+<p>VP9 is widely supported by browsers, and hardware implementations of the codec are fairly common. VP9 is one of the two video codecs mandated by <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a> (the other being <a href="#vp8">VP8</a>). Of note, however, is that Safari supports neither WebM nor VP9, so if you choose to use VP9, be sure to offer a fallback format such as AVC or HEVC for iPhone, iPad, and Mac users.</p>
 
 <p>Aside from the lack of Safari support, VP9 is a good choice if you are able to use a WebM container and are able to provide a fallback video in a format such as AVC or HEVC for Safari users. This is especially true if you wish to use an open codec rather than a proprietary one. If you can't provide a fallback and aren't willing to sacrifice Safari compatibility, VP9 in WebM is a good option. Otherwise, you should probably consider a different codec.</p>
 
@@ -1543,13 +1547,13 @@ tags:
 
 <ol>
  <li>
-  <p>A <strong><a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></strong> container using the <strong>{{anch("VP8")}}</strong> codec for video and the <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a></strong> codec for audio. These are all open, royalty-free formats which are generally well-supported, although only in quite recent browsers, which is why a fallback is a good idea.</p>
+  <p>A <strong><a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></strong> container using the <strong><a href="#vp8">VP8</a></strong> codec for video and the <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#opus">Opus</a></strong> codec for audio. These are all open, royalty-free formats which are generally well-supported, although only in quite recent browsers, which is why a fallback is a good idea.</p>
 
   <pre class="brush: js">&lt;video controls src="filename.webm"&gt;&lt;/video&gt;
 </pre>
  </li>
  <li>
-  <p>An <strong><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a></strong> container and the <strong>{{anch("AVC")}}</strong> (<strong>H.264</strong>) video codec, ideally with <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#AAC">AAC</a></strong> as your audio codec. This is because the MP4 container with AVC and AAC codecs within is a broadly-supported combination—by every major browser, in fact—and the quality is typically good for most use cases. Make sure you verify your compliance with the license requirements, however.</p>
+  <p>An <strong><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a></strong> container and the <strong><a href="#avc_h.264">AVC</a></strong> (<strong>H.264</strong>) video codec, ideally with <strong><a href="/en-US/docs/Web/Media/Formats/Audio_codecs#aac">AAC</a></strong> as your audio codec. This is because the MP4 container with AVC and AAC codecs within is a broadly-supported combination—by every major browser, in fact—and the quality is typically good for most use cases. Make sure you verify your compliance with the license requirements, however.</p>
 
   <pre class="brush: html">&lt;video controls&gt;
   &lt;source type="video/webm"
@@ -1577,7 +1581,7 @@ tags:
 </pre>
  </li>
  <li>
-  <p>An MP4 container using the {{anch("HEVC")}} codec using one of the advanced Main profiles, such as Main 4:2:2 with 10 or 12 bits of color depth, or even the Main 4:4:4 profile at up to 16 bits per component. At a high bit rate, this provides excellent graphics quality with remarkable color reproduction. In addition, you can optionally include HDR metadata to provide high dynamic range video. For audio, use the AAC codec at a high sample rate (at least 48 kHz but ideally 96kHz) and encoded with complex encoding rather than fast encoding.</p>
+  <p>An MP4 container using the <a href="#hevc_h.265">HEVC</a> codec using one of the advanced Main profiles, such as Main 4:2:2 with 10 or 12 bits of color depth, or even the Main 4:4:4 profile at up to 16 bits per component. At a high bit rate, this provides excellent graphics quality with remarkable color reproduction. In addition, you can optionally include HDR metadata to provide high dynamic range video. For audio, use the AAC codec at a high sample rate (at least 48 kHz but ideally 96kHz) and encoded with complex encoding rather than fast encoding.</p>
 
   <pre class="brush: html">&lt;video controls&gt;
   &lt;source type="video/webm"
@@ -1597,7 +1601,7 @@ tags:
 
 <h4 id="Preparing_video_externally">Preparing video externally</h4>
 
-<p>To prepare video for archival purposes from outside your web site or app, use a utility that performs compression on the original uncompressed video data. For example, the free <a href="https://www.videolan.org/developers/x264.html">x264</a> utility can be used to encode video in {{anch("AVC")}} format using a very high bit rate:</p>
+<p>To prepare video for archival purposes from outside your web site or app, use a utility that performs compression on the original uncompressed video data. For example, the free <a href="https://www.videolan.org/developers/x264.html">x264</a> utility can be used to encode video in <a href="#avc_h.264">AVC</a> format using a very high bit rate:</p>
 
 <pre class="brush: plain">x264 --crf 18 -preset ultrafast --output <em>outfilename.mp4</em> <em>infile</em></pre>
 
@@ -1605,7 +1609,7 @@ tags:
 
 <h4 id="Recording_video">Recording video</h4>
 
-<p>Given the constraints on how close to lossless you can get, you might consider using {{anch("AVC")}} or {{anch("AV1")}}. For example, if you're using the <a href="/en-US/docs/Web/API/MediaStream_Recording_API">MediaStream Recording API</a> to record video, you might use code like the following when creating your {{domxref("MediaRecorder")}} object:</p>
+<p>Given the constraints on how close to lossless you can get, you might consider using <a href="#avc_h.264">AVC</a> or <a href="#av1">AV1</a>. For example, if you're using the <a href="/en-US/docs/Web/API/MediaStream_Recording_API">MediaStream Recording API</a> to record video, you might use code like the following when creating your {{domxref("MediaRecorder")}} object:</p>
 
 <pre class="brush: js">const kbps = 1024;
 const Mbps = kbps*kbps;
@@ -1617,7 +1621,7 @@ const options = {
 
 let recorder = new MediaRecorder(sourceStream, options);</pre>
 
-<p>This example creates a <code>MediaRecorder</code> configured to record {{anch("AV1")}} video using BT.2100 HDR in 12-bit color with 4:4:4 chroma subsampling and <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#flac">FLAC</a> for lossless audio. The resulting file will use a bit rate of no more than 800 Mbps shared between the video and audio tracks. You will likely need to adjust these values depending on hardware performance, your requirements, and the specific codecs you choose to use. This bit rate is obviously not realistic for network transmission and would likely only be used locally.</p>
+<p>This example creates a <code>MediaRecorder</code> configured to record <a href="#av1">AV1</a> video using BT.2100 HDR in 12-bit color with 4:4:4 chroma subsampling and <a href="/en-US/docs/Web/Media/Formats/Audio_codecs#flac">FLAC</a> for lossless audio. The resulting file will use a bit rate of no more than 800 Mbps shared between the video and audio tracks. You will likely need to adjust these values depending on hardware performance, your requirements, and the specific codecs you choose to use. This bit rate is obviously not realistic for network transmission and would likely only be used locally.</p>
 
 <p>Breaking down the value of the <code>codecs</code> parameter into its dot-delineated properties, we see the following:</p>
 
@@ -1631,7 +1635,7 @@ let recorder = new MediaRecorder(sourceStream, options);</pre>
  <tbody>
   <tr>
    <td><code>av01</code></td>
-   <td>The four-character code (4CC) designation identifying the {{anch("AV1")}} codec.</td>
+   <td>The four-character code (4CC) designation identifying the <a href="#av1">AV1</a> codec.</td>
   </tr>
   <tr>
    <td><code>2</code></td>

--- a/files/en-us/web/media/formats/video_codecs/index.html
+++ b/files/en-us/web/media/formats/video_codecs/index.html
@@ -53,7 +53,7 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Video_codecs#av1">AV1</a></th>
+   <th scope="row"><a href="#av1">AV1</a></th>
    <td>AOMedia Video 1</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>
@@ -63,7 +63,7 @@ tags:
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Video_codecs#h.263">H.263</a></th>
+   <th scope="row"><a href="#h.263">H.263</a></th>
    <td>H.263 Video</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a></td>
   </tr>
@@ -88,17 +88,17 @@ tags:
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#mpegmpeg-2">MPEG</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#quicktime">QuickTime</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Video_codecs#theora">Theora</a></th>
+   <th scope="row"><a href="#theora">Theora</a></th>
    <td>Theora</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp8">VP8</a></th>
+   <th scope="row"><a href="#vp8">VP8</a></th>
    <td>Video Processor 8</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#3gp">3GP</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>
   <tr>
-   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Video_codecs#vp9">VP9</a></th>
+   <th scope="row"><a href="#vp9">VP9</a></th>
    <td>Video Processor 9</td>
    <td><a href="/en-US/docs/Web/Media/Formats/Containers#mp4">MP4</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a>, <a href="/en-US/docs/Web/Media/Formats/Containers#webm">WebM</a></td>
   </tr>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Links to various sections not working, and headings rendering poorly due to inline links. 
- Changed all the incorrectly used `{{anch}}` macro usage to be links 
- Removed all links from headings. 
   - These still exist but are declared before the heading as `<a id="whatever"></a>`. That means that the link will work.
   - Updated links to the heading to use the actual heading id. That ensures none of this falls apart when we move to markdown.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs

https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs

> Issue number (if there is an associated issue)

Fixes #4397

