### PR TITLE
Add missing 'are'

### DIFF
--- a/files/en-us/web/events/event_handlers/index.html
+++ b/files/en-us/web/events/event_handlers/index.html
@@ -12,7 +12,7 @@ tags:
 <p>This page provides a very brief "reminder" of how to work with events and event handlers. New developers should instead read <a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a>.</p>
 
 
-<h2 id="What_are_the_available_events">What the available events?</h2>
+<h2 id="What_are_the_available_events">What are the available events?</h2>
 
 <p>Events are documented in and/or below the pages for the JavaScript objects that emit them. For example, to find out events fired on the browser window or the current document see the events sections in <a href="/en-US/docs/Web/API/Window#events"><code>Window</code></a> and <a href="/en-US/docs/Web/API/Document#events"><code>Document</code></a>.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There was an **are** missing in the **h2**. Instead of "What **are** the available events" it was "What the available events"

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers

> Issue number (if there is an associated issue)
N/A

> Anything else that could help us review it
No
