### PR TITLE
fix(html select element): change link to dropdown content

### DIFF
--- a/files/en-us/web/html/element/select/index.html
+++ b/files/en-us/web/html/element/select/index.html
@@ -25,7 +25,7 @@ tags:
 
 <p>You can further nest <code>&lt;option&gt;</code> elements inside {{htmlelement("optgroup")}} elements to create separate groups of options inside the dropdown.</p>
 
-<p>For further examples, see <a href="/en-US/docs/Learn/Forms/Basic_native_form_controls#drop-down_content">The native form widgets: Drop-down content</a>.</p>
+<p>For further examples, see <a href="/en-US/docs/Learn/Forms/Other_form_controls#drop-down_controls">The native form widgets: Drop-down content</a>.</p>
 
 <h2 id="Attributes">Attributes</h2>
 


### PR DESCRIPTION
Closes #4349

> What was wrong/why is this fix needed? (quick summary only)
The link behind "You can further nest <option> elements inside <optgroup> elements to create separate groups of options inside the dropdown.
For further examples, see The native form widgets: Drop-down content." was wrong.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select

> Issue number (if there is an associated issue)
#4349

