### PR TITLE
kitchensink shouldn't use any http:// links

### DIFF
--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -342,7 +342,7 @@ rect2.bind("EnterFrame", function () {
   <li>{{DOMxRef("XMLHttpRequest")}}</li>
   <li>{{DOMxRef("Fetch API")}}</li>
   <li><a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch">Using Fetch API</a></li>
-  <li><a href="http://peoplesofttutorial.com/difference-between-synchronous-and-asynchronous-messaging/">Synchronous vs. Asynchronous Communications</a></li>
+  <li><a href="https://peoplesofttutorial.com/difference-between-synchronous-and-asynchronous-messaging/">Synchronous vs. Asynchronous Communications</a></li>
 </ul>
 
 <ul>


### PR DESCRIPTION
We need the kitchensink page to flawless for https://github.com/mdn/yari/pull/3619 to work. 