### PR TITLE
fix flaws in Web/JavaScript/Reference/Global_Objects/Array

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.html
@@ -1,20 +1,20 @@
 ---
-title: 'Array.prototype[@@iterator]()'
+title: Array.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Array/@@iterator
 tags:
-- Array
-- Beginner
-- ECMAScript 2015
-- Iterator
-- JavaScript
-- Method
-- Prototype
-- Reference
+  - Array
+  - Beginner
+  - ECMAScript 2015
+  - Iterator
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p>The <code><strong>@@iterator</strong></code> method is part of <a
-    href="/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterable_protocol">The
+    href="/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol">The
     iterable protocol</a>, that defines how to synchronously iterate over a sequence of
   values.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.html
@@ -2,10 +2,10 @@
 title: Array() constructor
 slug: Web/JavaScript/Reference/Global_Objects/Array/Array
 tags:
-- Array
-- Constructor
-- JavaScript
-- Reference
+  - Array
+  - Constructor
+  - JavaScript
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
@@ -47,7 +47,7 @@ new Array(arrayLength)</pre>
 <h3 id="Array_literal_notation">Array literal notation</h3>
 
 <p>Arrays can be created using the <a
-    href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Array_literals">literal</a>
+    href="/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#array_literals">literal</a>
   notation:</p>
 
 <pre class="brush: js">let fruits = ['Apple', 'Banana'];

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -2,12 +2,12 @@
 title: Array.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/Array/forEach
 tags:
-- Array
-- ECMAScript 5
-- JavaScript
-- Method
-- Prototype
-- Reference
+  - Array
+  - ECMAScript 5
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
@@ -65,7 +65,7 @@ forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
 <p><code>forEach()</code> calls a provided <code><var>callback</var></code> function once
   for each element in an array in ascending index order. It is not invoked for index properties
   that have been deleted or are uninitialized. (For sparse arrays, <a
-    href="#sparseArray">see example below</a>.)</p>
+    href="#sparsearray">see example below</a>.)</p>
 
 <p><code><var>callback</var></code> is invoked with three arguments:</p>
 
@@ -91,7 +91,7 @@ forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
   visited are not visited. If elements that are already visited are removed (e.g. using
   {{jsxref("Array.prototype.shift()", "shift()")}}) during the iteration, later elements
   will be skipped. (<a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Modifying_the_array_during_iteration">See
+    href="#Modifying_the_array_during_iteration">See
     this example, below</a>.)</p>
 
 <p><code>forEach()</code> executes the <code><var>callback</var></code> function once for

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.html
@@ -2,12 +2,12 @@
 title: Array.from()
 slug: Web/JavaScript/Reference/Global_Objects/Array/from
 tags:
-- Array
-- ECMAScript 2015
-- JavaScript
-- Method
-- Reference
-- polyfill
+  - Array
+  - ECMAScript 2015
+  - JavaScript
+  - Method
+  - Reference
+  - polyfill
 ---
 <div>{{JSRef}}</div>
 
@@ -59,7 +59,7 @@ Array.from(arrayLike, function mapFn(currentValue, index, array) { ... }, thisAr
 <ul>
     <li>array-like objects (objects with a <code>length</code> property and indexed
         elements); or</li>
-    <li><a href="/en-US/docs/Web/JavaScript/Guide/iterable">iterable objects</a> (objects
+    <li><a href="/en-US/docs/Web/JavaScript/Reference/Iteration_protocols">iterable objects</a> (objects
         such as {{jsxref("Map")}} and {{jsxref("Set")}}).</li>
 </ul>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -2,14 +2,14 @@
 title: Array.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/Array/includes
 tags:
-- Array
-- JavaScript
-- Method
-- Prototype
-- Reference
-- inArray
-- in_array
-- polyfill
+  - Array
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
+  - inArray
+  - in_array
+  - polyfill
 ---
 <div>{{JSRef}}</div>
 
@@ -63,7 +63,7 @@ includes(valueToFind, fromIndex)
 
 <div class="note">
   <p><strong>Note:</strong> Technically speaking, <code>includes()</code> uses the
-    <code><a href="/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Same-value-zero_equality">sameValueZero</a></code>
+    <code><a href="/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#same-value-zero_equality">sameValueZero</a></code>
     algorithm to determine whether the given element is found.</p>
 </div>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>Arrays are list-like objects whose prototype has methods to perform traversal and mutation operations. Neither the length of a JavaScript array nor the types of its elements are fixed. Since an array's length can change at any time, and data can be stored at non-contiguous locations in the array, JavaScript arrays are not guaranteed to be dense; this depends on how the programmer chooses to use them. In general, these are convenient characteristics; but if these features are not desirable for your particular use, you might consider using typed arrays.</p>
 
-<p>Arrays cannot use strings as element indexes (as in an <a href="https://en.wikipedia.org/wiki/Associative_array">associative array</a>) but must use integers. Setting or accessing via non-integers using <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Objects_and_properties">bracket notation</a> (or <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors">dot notation</a>) will not set or retrieve an element from the array list itself, but will set or access a variable associated with that array's <a href="/en-US/docs/Web/JavaScript/Data_structures#Properties">object property collection</a>. The array's object properties and list of array elements are separate, and the array's <a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Array_methods">traversal and mutation operations</a> cannot be applied to these named properties.</p>
+<p>Arrays cannot use strings as element indexes (as in an <a href="https://en.wikipedia.org/wiki/Associative_array">associative array</a>) but must use integers. Setting or accessing via non-integers using <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#objects_and_properties">bracket notation</a> (or <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors">dot notation</a>) will not set or retrieve an element from the array list itself, but will set or access a variable associated with that array's <a href="/en-US/docs/Web/JavaScript/Data_structures#properties">object property collection</a>. The array's object properties and list of array elements are separate, and the array's <a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#array_methods">traversal and mutation operations</a> cannot be applied to these named properties.</p>
 
 <h3 id="Common_operations">Common operations</h3>
 
@@ -453,9 +453,9 @@ console.table(values)</pre>
 <ul>
  <li>From the JavaScript Guide:
   <ul>
-   <li><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Indexing_object_properties">“Indexing object properties”</a></li>
-   <li><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Array_object">“Indexed collections: <code>Array</code> object”</a></li>
+   <li><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#indexing_object_properties">“Indexing object properties”</a></li>
+   <li><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#array_object">“Indexed collections: <code>Array</code> object”</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/JavaScript_typed_arrays">Typed Arrays</a></li>
+ <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays">Typed Arrays</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/array/join/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/join/index.html
@@ -2,17 +2,17 @@
 title: Array.prototype.join()
 slug: Web/JavaScript/Reference/Global_Objects/Array/join
 tags:
-- Array
-- JavaScript
-- Method
-- Prototype
-- Reference
+  - Array
+  - JavaScript
+  - Method
+  - Prototype
+  - Reference
 ---
 <div>{{JSRef}}</div>
 
 <p><span class="seoSummary">The <code><strong>join()</strong></code> method creates and
     returns a new string by concatenating all of the elements in an array (or an <a
-      href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Working_with_array-like_objects">array-like
+      href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects">array-like
       object</a>), separated by commas or a specified separator string. If the array has
     only one item, then that item will be returned without using the separator.</span></p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/lastindexof/index.html
@@ -2,12 +2,12 @@
 title: Array.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
 tags:
-- Array
-- ECMAScript 5
-- JavaScript
-- Method
-- Prototype
-- polyfill
+  - Array
+  - ECMAScript 5
+  - JavaScript
+  - Method
+  - Prototype
+  - polyfill
 ---
 <div>{{JSRef}}</div>
 
@@ -47,7 +47,7 @@ lastIndexOf(searchElement, fromIndex)
 
 <p><code>lastIndexOf</code> compares <code>searchElement</code> to elements of the Array
   using <a
-    href="/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Using_the_Equality_Operators">strict
+    href="/en-US/docs/Web/JavaScript/Reference/Operators#using_the_equality_operators">strict
     equality</a> (the same method used by the ===, or triple-equals, operator).</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.html
@@ -46,7 +46,7 @@ arr.forEach(element =&gt; console.log(element));
 // 2
 </pre>
 
-<p>As you can see, the <code>length</code> property does not necessarily indicate the number of defined values in the array. See also <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Relationship_between_length_and_numerical_properties" title="Relationship between length and numerical properties">Relationship between <code>length</code> and numerical properties</a>.</p>
+<p>As you can see, the <code>length</code> property does not necessarily indicate the number of defined values in the array. See also <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#relationship_between_length_and_numerical_properties" title="Relationship between length and numerical properties">Relationship between <code>length</code> and numerical properties</a>.</p>
 
 <p>{{js_property_attributes(1, 0, 0)}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/tolocalestring/index.html
@@ -2,11 +2,11 @@
 title: Array.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toLocaleString
 tags:
-- Array
-- Internationalization
-- JavaScript
-- Method
-- Prototype
+  - Array
+  - Internationalization
+  - JavaScript
+  - Method
+  - Prototype
 ---
 <div>{{JSRef}}</div>
 
@@ -154,8 +154,8 @@ prices.toLocaleString('ja-JP', { style: 'currency', currency: 'JPY' });
 // "￥7,￥500,￥8,123,￥12"
 </pre>
 
-<p>For more examples, see also the {{jsxref("Intl")}}, {{jsxref("NumberFormat")}}, and
-  {{jsxref("DateTimeFormat")}} pages.</p>
+<p>For more examples, see also the {{jsxref("Intl")}}, {{jsxref("Intl/NumberFormat")}}, and
+  {{jsxref("Intl/DateTimeFormat")}} pages.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>It is an array of bytes, often referred to in other languages as a "byte array".You cannot directly manipulate the contents of an <code>ArrayBuffer</code>; instead, you create one of the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray">typed array objects</a> or a {{jsxref("DataView")}} object which represents the buffer in a specific format, and use that to read and write the contents of the buffer.</p>
 
-<p>The <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer">ArrayBuffer()</a></code> constructor creates a new <code>ArrayBuffer</code> of the given length in bytes. You can also get an array buffer from existing data, for example <a href="/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Appendix_to_Solution_1_Decode_a_Base64_string_to_Uint8Array_or_ArrayBuffer">from a Base64 string</a> or <a href="/en-US/docs/Web/API/FileReader/readAsArrayBuffer">from a local file</a>.</p>
+<p>The <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer">ArrayBuffer()</a></code> constructor creates a new <code>ArrayBuffer</code> of the given length in bytes. You can also get an array buffer from existing data, for example <a href="/en-US/docs/Glossary/Base64#appendix_to_solution_1_decode_a_base64_string_to_uint8array_or_arraybuffer">from a Base64 string</a> or <a href="/en-US/docs/Web/API/FileReader/readAsArrayBuffer">from a local file</a>.</p>
 
 <h2 id="Constructor">Constructor</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

These are all the docs with fixable flaws in the Web/JavaScript/Reference/Global_Objects/Array tree

> MDN URL of main page changed

See review companion. 

> Anything else that could help us review it

Testing out https://github.com/mdn/yari/pull/3602 to more quickly find fixable flaws. 