### PR TITLE
Add version to unbreak link to WAI-ARIA spec. Fixes #4320

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.html
@@ -57,7 +57,7 @@ function triggerAlert() {
    <td>{{Spec2('ARIA')}}</td>
   </tr>
   <tr>
-   <td>{{SpecName("ARIA Authoring Practices","#alert","Alert")}}</td>
+   <td>{{SpecName("ARIA Authoring Practices 1.1","#alert","Alert")}}</td>
    <td>{{Spec2('ARIA Authoring Practices')}}</td>
   </tr>
  </tbody>
@@ -77,4 +77,4 @@ function triggerAlert() {
    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
   </ol>
 </section>
-  
+


### PR DESCRIPTION
Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The link to WAI-ARIA spec was not recognised.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role

> Issue number (if there is an associated issue)

#4320 

> Anything else that could help us review it

This site contains flaws. They are kept track off in #4281. Since WAI-ARIA 1.2 is a working draft (to be published later this year IIRC), I went with v1.1. The status is shown as „Unknown” locally.