### PR TITLE
fix: add example about difference with Promise.any

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
@@ -165,7 +165,7 @@ Promise.race([p5, p6])
 
 <h3 id="Comparison_with_Promise.any">Comparison with Promise.any</h3>
 
-<p><code>Promise.race</code> takes first settled {{jsxref("Promise")}}.</p>
+<p><code>Promise.race</code> takes the first settled {{jsxref("Promise")}}.</p>
 
 <pre class="brush: js">const promise1 = new Promise((resolve, reject) => {
   setTimeout(resolve, 500, 'one');

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
@@ -184,7 +184,7 @@ Promise.race([promise1, promise2]).then((value) => {
 // expected output: "failed with reason: two"
 </pre>
 
-<p>{{jsxref("Promise.any")}} takes first fulfilled {{jsxref("Promise")}}.</p>
+<p>{{jsxref("Promise.any")}} takes the first fulfilled {{jsxref("Promise")}}.</p>
 
 <pre class="brush: js">const promise1 = new Promise((resolve, reject) => {
   setTimeout(resolve, 500, 'one');

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
@@ -163,7 +163,7 @@ Promise.race([p5, p6])
 });
 </pre>
 
-<h3 id="The_difference_with_Promise.any">The difference with Promise.any</h3>
+<h3 id="Comparison_with_Promise.any">Comparison with Promise.any</h3>
 
 <p><code>Promise.race</code> takes first settled {{jsxref("Promise")}}.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.html
@@ -163,6 +163,46 @@ Promise.race([p5, p6])
 });
 </pre>
 
+<h3 id="The_difference_with_Promise.any">The difference with Promise.any</h3>
+
+<p><code>Promise.race</code> takes first settled {{jsxref("Promise")}}.</p>
+
+<pre class="brush: js">const promise1 = new Promise((resolve, reject) => {
+  setTimeout(resolve, 500, 'one');
+});
+
+const promise2 = new Promise((resolve, reject) => {
+  setTimeout(reject, 100, 'two');
+});
+
+Promise.race([promise1, promise2]).then((value) => {
+  console.log('succeeded with value:', value);
+}).catch((reason) => {
+  // Only promise1 is fulfilled, but promise2 is faster
+  console.log('failed with reason:', reason);
+});
+// expected output: "failed with reason: two"
+</pre>
+
+<p>{{jsxref("Promise.any")}} takes first fulfilled {{jsxref("Promise")}}.</p>
+
+<pre class="brush: js">const promise1 = new Promise((resolve, reject) => {
+  setTimeout(resolve, 500, 'one');
+});
+
+const promise2 = new Promise((resolve, reject) => {
+  setTimeout(reject, 100, 'two');
+});
+
+Promise.any([promise1, promise2]).then((value) => {
+  // Only promise1 is fulfilled, even though promise2 settled sooner
+  console.log('succeeded with value:', value);
+}).catch((reason) => {
+  console.log('failed with reason:', reason);
+});
+// expected output: "succeeded with value: one"
+</pre>
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I added an example about the difference with `Promise.any`.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/1667

> Anything else that could help us review it
