### PR TITLE
Fix: Broken link to `Accept-Type` in "HTTP Messages"

### DIFF
--- a/files/en-us/web/http/messages/index.html
+++ b/files/en-us/web/http/messages/index.html
@@ -65,7 +65,7 @@ tags:
 
 <ul>
  <li><em>General headers</em>, like {{HTTPHeader("Via")}}, apply to the message as a whole.</li>
- <li><em>Request headers</em>, like {{HTTPHeader("User-Agent")}}, {{HTTPHeader("Accept-Type")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).</li>
+ <li><em>Request headers</em>, like {{HTTPHeader("User-Agent")}}, {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).</li>
  <li><em>Representation metadata headers</em> (formerly <em>entity headers</em>), like {{HTTPHeader("Content-Length")}} that describe the encoding and format of the message body (only present if the message has a body).</li>
 </ul>
 

--- a/files/en-us/web/http/messages/index.html
+++ b/files/en-us/web/http/messages/index.html
@@ -65,7 +65,7 @@ tags:
 
 <ul>
  <li><em>General headers</em>, like {{HTTPHeader("Via")}}, apply to the message as a whole.</li>
- <li><em>Request headers</em>, like {{HTTPHeader("User-Agent")}}, {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).</li>
+ <li><em>Request headers</em>, like {{HTTPHeader("User-Agent")}} or {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).</li>
  <li><em>Representation metadata headers</em> (formerly <em>entity headers</em>), like {{HTTPHeader("Content-Length")}} that describe the encoding and format of the message body (only present if the message has a body).</li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I fixed link's label and href to `Accept` in "HTTP Message" page.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages

> Issue number (if there is an associated issue)

fix: #4429 

> Anything else that could help us review it
