### PR TITLE
Update Web/JavaScript/Reference/Functions

### DIFF
--- a/files/en-us/web/javascript/reference/functions/index.html
+++ b/files/en-us/web/javascript/reference/functions/index.html
@@ -2,12 +2,12 @@
 title: Functions
 slug: Web/JavaScript/Reference/Functions
 tags:
-- Function
-- Functions
-- Guide
-- JavaScript
-- Parameter
-- parameters
+  - Function
+  - Functions
+  - Guide
+  - JavaScript
+  - Parameter
+  - parameters
 ---
 <div>{{jsSidebar("Functions")}}</div>
 
@@ -20,7 +20,7 @@ tags:
 <p>In JavaScript, functions are first-class objects, because they can have properties and
    methods just like any other object. What distinguishes them from other objects is that
    functions can be called. In brief, they are
-   <code><a href="/en-US/docs/JavaScript/Reference/Global_Objects/Function">Function</a></code>
+   <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">Function</a></code>
    objects.</p>
 
 <p>For more examples and explanations, see also the <a
@@ -94,18 +94,18 @@ console.log(mycar.brand);
       href="/en-US/docs/Web/JavaScript/Reference/Statements/function">function
       statement</a> for details):</p>
 
-<pre class="brush: js">function <em>name</em>([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function <var>name</var>([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
-   <dt><code>name</code></dt>
-   <dd>The function name.</dd>
-   <dt><code>param</code></dt>
-   <dd>The name of an argument to be passed to the function.</dd>
-   <dt><code>statements</code></dt>
-   <dd>The statements comprising the body of the function.</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>The function name.</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>The name of an argument to be passed to the function.</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>The statements comprising the body of the function.</dd>
 </dl>
 
 <h3 id="The_function_expression_function_expression">The function expression
@@ -119,19 +119,19 @@ console.log(mycar.brand);
    expressions. Function expressions are not <em>hoisted</em> onto the beginning of the
    scope, therefore they cannot be used before they appear in the code.</p>
 
-<pre class="brush: js">function [<em>name</em>]([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function [<var>name</var>]([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
-   <dt><code>name</code></dt>
-   <dd>The function name. Can be omitted, in which case the function becomes known as an
-      anonymous function.</dd>
-   <dt><code>param</code></dt>
-   <dd>The name of an argument to be passed to the function.</dd>
-   <dt><code>statements</code></dt>
-   <dd>The statements comprising the body of the function.</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>The function name. Can be omitted, in which case the function becomes known as an
+    anonymous function.</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>The name of an argument to be passed to the function.</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>The statements comprising the body of the function.</dd>
 </dl>
 
 <p>Here is an example of an <strong>anonymous</strong> function expression (the
@@ -173,18 +173,18 @@ console.log(mycar.brand);
 <p>There is a special syntax for generator function declarations (see
    {{jsxref('Statements/function*', 'function* statement')}} for details):</p>
 
-<pre class="brush: js">function* <em>name</em>([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function* <var>name</var>([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
-   <dt><code>name</code></dt>
-   <dd>The function name.</dd>
-   <dt><code>param</code></dt>
-   <dd>The name of an argument to be passed to the function.</dd>
-   <dt><code>statements</code></dt>
-   <dd>The statements comprising the body of the function.</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>The function name.</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>The name of an argument to be passed to the function.</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>The statements comprising the body of the function.</dd>
 </dl>
 
 <h3 id="The_generator_function_expression_function*_expression">The generator function
@@ -194,19 +194,19 @@ console.log(mycar.brand);
    function declaration (see {{jsxref('Operators/function*', 'function* expression')}} for
    details):</p>
 
-<pre class="brush: js">function* [<em>name</em>]([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function* [<var>name</var>]([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
-   <dt><code>name</code></dt>
-   <dd>The function name. Can be omitted, in which case the function becomes known as an
-      anonymous function.</dd>
-   <dt><code>param</code></dt>
-   <dd>The name of an argument to be passed to the function.</dd>
-   <dt><code>statements</code></dt>
-   <dd>The statements comprising the body of the function.</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>The function name. Can be omitted, in which case the function becomes known as an
+    anonymous function.</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>The name of an argument to be passed to the function.</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>The statements comprising the body of the function.</dd>
 </dl>
 
 <h3 id="The_arrow_function_expression_>">The arrow function expression (=&gt;)</h3>
@@ -224,13 +224,13 @@ param =&gt; expression
 </pre>
 
 <dl>
-   <dt><code>param</code></dt>
-   <dd>The name of an argument. Zero arguments need to be indicated with <code>()</code>. 
-      For only one argument, the parentheses are not required.
-      (like <code>foo =&gt; 1</code>)</dd>
-   <dt><code>statements or expression</code></dt>
-   <dd>Multiple statements need to be enclosed in brackets. A single expression requires
-      no brackets. The expression is also the implicit return value of the function.</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>The name of an argument. Zero arguments need to be indicated with <code>()</code>. 
+    For only one argument, the parentheses are not required.
+    (like <code>foo =&gt; 1</code>)</dd>
+  <dt><code><var>statements</var></code> or <code><var>expression</var></code></dt>
+  <dd>Multiple statements need to be enclosed in brackets. A single expression requires
+    no brackets. The expression is also the implicit return value of the function.</dd>
 </dl>
 
 <h3 id="The_Function_constructor">The <code>Function</code> constructor</h3>
@@ -244,14 +244,14 @@ param =&gt; expression
 <p>As all other objects, {{jsxref("Function")}} objects can be created using the
    <code>new</code> operator:</p>
 
-<pre class="brush: js">new Function (<em>arg1</em>, <em>arg2</em>, ... <em>argN</em>, <em>functionBody</em>)
+<pre class="brush: js">new Function (<var>arg1</var>, <var>arg2</var>, ... <var>argN</var>, <var>functionBody</var>)
 </pre>
 
 <dl>
-   <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
-   <dd>Zero or more names to be used by the function as formal parameters. Each must be a
-      proper JavaScript identifier.</dd>
-   <dt><code>functionBody</code></dt>
+  <dt><code><var>arg1</var>, <var>arg2</var>, ... <var>argN</var></code></dt>
+  <dd>Zero or more names to be used by the function as formal parameters. Each must be a
+    proper JavaScript identifier.</dd>
+  <dt><code><var>functionBody</var></code></dt>
    <dd>A string containing the JavaScript statements comprising the function body.</dd>
 </dl>
 
@@ -277,18 +277,18 @@ param =&gt; expression
 <p>As all other objects, {{jsxref("GeneratorFunction")}} objects can be created using the
    <code>new</code> operator:</p>
 
-<pre class="brush: js">new GeneratorFunction (<em>arg1</em>, <em>arg2</em>, ... <em>argN</em>, <em>functionBody</em>)
+<pre class="brush: js">new GeneratorFunction (<var>arg1</var>, <var>arg2</var>, ... <var>argN</var>, <var>functionBody</var>)
 </pre>
 
 <dl>
-   <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
-   <dd>Zero or more names to be used by the function as formal argument names. Each must
-      be a string that conforms to the rules for a valid JavaScript identifier or a list
-      of such strings separated with a comma; for example "<code>x</code>",
-      "<code>theValue</code>", or "<code>a,b</code>".</dd>
-   <dt><code>functionBody</code></dt>
-   <dd>A string containing the JavaScript statements comprising the function definition.
-   </dd>
+  <dt><code><var>arg1</var>, <var>arg2</var>, ... <var>argN</var></code></dt>
+  <dd>Zero or more names to be used by the function as formal argument names. Each must
+    be a string that conforms to the rules for a valid JavaScript identifier or a list
+    of such strings separated with a comma; for example "<code>x</code>",
+    "<code>theValue</code>", or "<code>a,b</code>".</dd>
+  <dt><code><var>functionBody</var></code></dt>
+  <dd>A string containing the JavaScript statements comprising the function definition.
+  </dd>
 </dl>
 
 <p>Invoking the <code>GeneratorFunction</code> constructor as a function (without using
@@ -317,19 +317,19 @@ param =&gt; expression
       href="/en-US/docs/Web/JavaScript/Reference/Functions/arguments">arguments</a>.</p>
 
 <ul>
-   <li>
-      <code><a href="/en-US/docs/JavaScript/Reference/Functions_and_function_scope/arguments">arguments</a></code>:
-      An array-like object containing the arguments passed to the currently executing
-      function.</li>
-   <li>
-      <code><a href="/en-US/docs/JavaScript/Reference/Functions_and_function_scope/arguments/callee">arguments.callee</a></code>
-      : The currently executing function.</li>
-   <li>
-      <code><a href="/en-US/docs/JavaScript/Reference/Functions_and_function_scope/arguments/caller">arguments.caller</a></code>
-      : The function that invoked the currently executing function.</li>
-   <li>
-      <code><a href="/en-US/docs/JavaScript/Reference/Functions_and_function_scope/arguments/length">arguments.length</a></code>:
-      The number of arguments passed to the function.</li>
+  <li>
+    <code><a href="/en-US/docs/Web/JavaScript/Reference/Functions/arguments">arguments</a></code>:
+    An array-like object containing the arguments passed to the currently executing
+    function.</li>
+  <li>
+    <code><a href="/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee">arguments.callee</a></code>
+    : The currently executing function.</li>
+  <li>
+    <code><a href="/en-US/docs/JavaScript/Reference/Functions_and_function_scope/arguments/caller">arguments.caller</a></code>
+    : The function that invoked the currently executing function.</li>
+  <li>
+    <code><a href="/en-US/docs/Web/JavaScript/Reference/Functions/arguments/length">arguments.length</a></code>:
+    The number of arguments passed to the function.</li>
 </ul>
 
 <h2 id="Defining_method_functions">Defining method functions</h2>
@@ -341,14 +341,12 @@ param =&gt; expression
    The syntax for defining getters and setters uses the object literal syntax.</p>
 
 <dl>
-   <dt><a href="/en-US/docs/Web/JavaScript/Reference/Functions/get">get</a></dt>
-   <dd>
-      <p>Binds an object property to a function that will be called when that property is
-         looked up.</p>
-   </dd>
-   <dt><a href="/en-US/docs/Web/JavaScript/Reference/Functions/set">set</a></dt>
-   <dd>Binds an object property to a function to be called when there is an attempt to set
-      that property.</dd>
+  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Functions/get">get</a></dt>
+  <dd>Binds an object property to a function that will be called when that property is
+        looked up.</dd>
+  <dt><a href="/en-US/docs/Web/JavaScript/Reference/Functions/set">set</a></dt>
+  <dd>Binds an object property to a function to be called when there is an attempt to set
+    that property.</dd>
 </dl>
 
 <h3 id="Method_definition_syntax">Method definition syntax</h3>
@@ -369,7 +367,7 @@ param =&gt; expression
 <p>Compare the following:</p>
 
 <p>A function defined with the <code>Function</code> <em>constructor</em> assigned to the
-   variable <code>multiply:</code></p>
+   variable <code>multiply</code>:</p>
 
 <pre class="brush: js">var multiply = new Function('x', 'y', 'return x * y');</pre>
 
@@ -381,7 +379,7 @@ param =&gt; expression
 </pre>
 
 <p>A <em>function expression</em> of an anonymous function assigned to the variable
-   <code>multiply:</code></p>
+   <code>multiply</code>:</p>
 
 <pre class="brush: js">var multiply = function(x, y) {
    return x * y;
@@ -389,7 +387,7 @@ param =&gt; expression
 </pre>
 
 <p>A <em>function expression</em> of a function named <code>func_name</code> assigned to
-   the variable <code>multiply:</code></p>
+   the variable <code>multiply</code>:</p>
 
 <pre class="brush: js">var multiply = function func_name(x, y) {
    return x * y;
@@ -663,15 +661,17 @@ result = padZeros(5,4);  // returns "0005"
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">
-   <tbody>
-      <tr>
-         <th scope="col">Specification</th>
-      </tr>
-      <tr>
-         <td>{{SpecName('ESDraft', '#sec-function-definitions', 'Function definitions')}}
-         </td>
-      </tr>
-   </tbody>
+  <thead>
+    <tr>
+      <th scope="col">Specification</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('ESDraft', '#sec-function-definitions', 'Function definitions')}}
+      </td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
@@ -681,19 +681,19 @@ result = padZeros(5,4);  // returns "0005"
 <h2 id="See_also">See also</h2>
 
 <ul>
-   <li>{{jsxref("Statements/function", "function statement")}}</li>
-   <li>{{jsxref("Operators/function", "function expression")}}</li>
-   <li>{{jsxref("Statements/function*", "function* statement")}}</li>
-   <li>{{jsxref("Operators/function*", "function* expression")}}</li>
-   <li>{{jsxref("Function")}}</li>
-   <li>{{jsxref("GeneratorFunction")}}</li>
-   <li>{{jsxref("Functions/Arrow_functions", "Arrow functions")}}</li>
-   <li>{{jsxref("Functions/Default_parameters", "Default parameters")}}</li>
-   <li>{{jsxref("Functions/rest_parameters", "Rest parameters")}}</li>
-   <li>{{jsxref("Functions/arguments", "Arguments object")}}</li>
-   <li>{{jsxref("Functions/get", "getter")}}</li>
-   <li>{{jsxref("Functions/set", "setter")}}</li>
-   <li>{{jsxref("Functions/Method_definitions", "Method definitions")}}</li>
-   <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope">Functions
-         and function scope</a></li>
+  <li>{{jsxref("Statements/function", "function statement")}}</li>
+  <li>{{jsxref("Operators/function", "function expression")}}</li>
+  <li>{{jsxref("Statements/function*", "function* statement")}}</li>
+  <li>{{jsxref("Operators/function*", "function* expression")}}</li>
+  <li>{{jsxref("Function")}}</li>
+  <li>{{jsxref("GeneratorFunction")}}</li>
+  <li>{{jsxref("Functions/Arrow_functions", "Arrow functions")}}</li>
+  <li>{{jsxref("Functions/Default_parameters", "Default parameters")}}</li>
+  <li>{{jsxref("Functions/rest_parameters", "Rest parameters")}}</li>
+  <li>{{jsxref("Functions/arguments", "Arguments object")}}</li>
+  <li>{{jsxref("Functions/get", "getter")}}</li>
+  <li>{{jsxref("Functions/set", "setter")}}</li>
+  <li>{{jsxref("Functions/Method_definitions", "Method definitions")}}</li>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions">Functions
+        and function scope</a></li>
 </ul>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There are some link flaws and inconsist usage of elements.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions

> Issue number (if there is an associated issue)

> Anything else that could help us review it
