### PR TITLE
Adding a short description to the 'infinite iterator' example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.html
@@ -45,6 +45,8 @@ console.log(generator().next().value); // 1</pre>
 
 <h3 id="An_infinite_iterator">An infinite iterator</h3>
 
+<p>With a generator function, values are not evaluated until it is needed. Therefore it allows us to define a potentially infinite data structure.</p>
+
 <pre class="brush: js;">function* infinite() {
     let index = 0;
 

--- a/files/en-us/web/javascript/reference/global_objects/generator/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.html
@@ -45,7 +45,7 @@ console.log(generator().next().value); // 1</pre>
 
 <h3 id="An_infinite_iterator">An infinite iterator</h3>
 
-<p>With a generator function, values are not evaluated until it is needed. Therefore it allows us to define a potentially infinite data structure.</p>
+<p>With a generator function, values are not evaluated until they are needed. Therefore a generator allows us to define a potentially infinite data structure.</p>
 
 <pre class="brush: js;">function* infinite() {
     let index = 0;


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

I believe lazy evaluation is also a primary benefit of Generator / generator functions, which can be demonstrated by the existing 'infinite iterator', but it's not immediately clear that the example is demonstrating this benefit. Therefore I am adding a short description to the 'infinite iterator' example.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator#an_infinite_iterator

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A
