### PR TITLE
Fix: Adding Modulo to the list of supported operators for BigInt

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.html
@@ -52,7 +52,7 @@ typeof BigInt('1') === 'bigint'  // true
 
 <p>The following operators may be used with BigInt values or object-wrapped BigInt values:</p>
 
-<pre>+ * - **</pre>
+<pre>+ * - % **</pre>
 
 <p><a href="/en-US/docs/Web/JavaScript/Reference/Operators">Bitwise operators</a> are supported as well, except <code>&gt;&gt;&gt;</code> (zero-fill right shift), as every BigInt value is signed.</p>
 


### PR DESCRIPTION
Adding Modulo to the list of supported operators for BigInt

> What was wrong/why is this fix needed? (quick summary only)

The examples showed using modulo operator with BigInt, but it's not listed in the 'Operators' section.

Did a quick test with the console with `console.log(BigInt(Number.MAX_SAFE_INTEGER) % 10n)`

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#operators

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/4440

> Anything else that could help us review it

The examples section already uses the modulo operator.
