### PR TITLE
example code tweak: use innerText, not innerHTML

### DIFF
--- a/files/en-us/web/api/mediastream_recording_api/index.html
+++ b/files/en-us/web/api/mediastream_recording_api/index.html
@@ -104,7 +104,7 @@ setTimeout(event =&gt; {
     let menu = document.getElementById("inputdevices");
     if (device.kind == "audioinput") {
       let item = document.createElement("option");
-      item.innerHTML = device.label;
+      item.innerText = device.label;
       item.value = device.deviceId;
       menu.appendChild(item);
     }


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

innerText should be safer for rendering user/browser-provided strings

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Recording_API

> Issue number (if there is an associated issue)

> Anything else that could help us review it
