### PR TITLE
Fixed broken link

### DIFF
--- a/files/en-us/webassembly/understanding_the_text_format/index.html
+++ b/files/en-us/webassembly/understanding_the_text_format/index.html
@@ -69,7 +69,7 @@ tags:
  <li>
   The absence of a <code>(result)</code> means the function doesn’t return anything.
  </li>
- <li>In the current iteration, there can be at most 1 return type, but <a href="https://webassembly.org/docs/future-features#multiple-return">later this will be relaxed</a> to any number.</li>
+ <li>In the current iteration, there can be at most 1 return type, but <a href="https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md">later this will be relaxed</a> to any number.</li>
 </ul>
 
 <p>Each parameter has a type explicitly declared; wasm currently has four available number types (plus reference types; see the {{anch("Reference types")}}) section below):</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
Fixed broken link 

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format

> Issue number (if there is an associated issue)
Resolves #755

> Anything else that could help us review it
--
