### PR TITLE
fix: element.onerror example

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onerror/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.html
@@ -59,7 +59,7 @@ tags:
 
 <p>A good example for this is when you are using an image tag, and need to specify a backup image in case the one you need is not available on the server for any reason.</p>
 
-<pre class="brush: html">&lt;img src=&quot;imagenotfound.gif&quot; onerror=&quot;this.onerror=null;this.src='imagefound.gif';&quot; /&gt;
+<pre class="brush: html">&lt;img src=&quot;imagefound.gif&quot; onerror=&quot;this.onerror=null;this.src='imagenotfound.gif';&quot; /&gt;
 </pre>
 
 <p>The reason we have the <code>this.onerror=null</code> in the function is that the browser will be stuck in an endless loop if the onerror image itself generates an error.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
In the <img> code block example, switch the src instances of "imagefound.gif" and fallback "imagenotfound.gif" onerror so they are in the correct order.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror

> Issue number (if there is an associated issue)
n/a

> Anything else that could help us review it
just a wee change (-_^ )