### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -14,7 +14,7 @@ tags:
 <div>{{JSRef}}</div>
 
 <p>The <code><strong>reduce()</strong></code> method executes a <strong>reducer</strong>
-  function (that you provide) on each element of the array, resulting in single output
+  function (that you provide) on each element of the array, resulting in a single output
   value.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-reduce.html")}}</div>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The word "a" is missing from the line "... resulting in single output value."

> MDN URL of main page changed

[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce](url)

> Issue number (if there is an associated issue)

Not sure if there is one
