### PR TITLE
Improve US spelling guidance

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.html
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.html
@@ -532,9 +532,9 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
 
 <h3 id="Spelling">Spelling</h3>
 
-<p>For words with variant spellings, always use their American English spelling.</p>
+<p>Use American-English spelling.</p>
 
-<p>In general, use the first entry at <a href="http://www.dictionary.com/">Dictionary.com</a>, unless that entry is listed as a variant spelling or as being primarily used in a non-American form of English. For example, if you <a href="http://www.dictionary.com/browse/behavior">look up "behavior"</a>, you find the phrase "Chiefly British" followed by a link to the American standard form, "<a href="http://dictionary.reference.com/browse/behavior">behavior</a>". Do not use variant spellings.</p>
+<p><a href="http://www.dictionary.com/">Dictionary.com</a> can be used to identify non-American variants and determine the correct American-English version. For example, if you look up <a href="https://www.dictionary.com/browse/behaviour">"behaviour"</a>, you find the phrase "Chiefly British" followed by a link to the American standard form (<a href="http://dictionary.reference.com/browse/behavior">behavior</a>).</p>
 
 <ul>
  <li><span class="correct"><strong>Correct</strong></span>: localize, behavior</li>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

As per #4462 the spelling guidelines use an invalid example on dictionary.com (they point to US version of word when they should point to the non-English version). This adds the correct link and makes the instructions clear.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Writing_style_guide

> Issue number (if there is an associated issue)

Fixes #4462

> Anything else that could help us review it
