### PR TITLE
Remove obsolete macros and deprecated versions

### DIFF
--- a/files/en-us/glossary/document_directive/index.html
+++ b/files/en-us/glossary/document_directive/index.html
@@ -31,7 +31,7 @@ tags:
    <li><a href="https://www.w3.org/TR/CSP/#directives-document">https://www.w3.org/TR/CSP/#directives-document</a></li>
    <li>{{HTTPHeader("Content-Security-Policy/upgrade-insecure-requests", "upgrade-insecure-requests")}}</li>
    <li>{{HTTPHeader("Content-Security-Policy/block-all-mixed-content", "block-all-mixed-content")}}</li>
-   <li>{{HTTPHeader("Content-Security-Policy/require-sri-for", "require-sri-for")}} {{obsolete_inline}}</li>
+   <li>{{HTTPHeader("Content-Security-Policy/require-sri-for", "require-sri-for")}} {{Deprecated_Inline}}</li>
    <li>{{HTTPHeader("Content-Security-Policy")}}</li>
   </ol>
  </li>

--- a/files/en-us/glossary/fetch_directive/index.html
+++ b/files/en-us/glossary/fetch_directive/index.html
@@ -28,7 +28,7 @@ tags:
    <li><a href="https://www.w3.org/TR/CSP/#directives-fetch">https://www.w3.org/TR/CSP/#directives-fetch</a></li>
    <li>{{HTTPHeader("Content-Security-Policy/upgrade-insecure-requests", "upgrade-insecure-requests")}}</li>
    <li>{{HTTPHeader("Content-Security-Policy/block-all-mixed-content", "block-all-mixed-content")}}</li>
-   <li>{{HTTPHeader("Content-Security-Policy/require-sri-for", "require-sri-for")}} {{obsolete_inline}}</li>
+   <li>{{HTTPHeader("Content-Security-Policy/require-sri-for", "require-sri-for")}} {{Deprecated_Inline}}</li>
    <li>{{HTTPHeader("Content-Security-Policy")}}</li>
   </ol>
  </li>

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -147,24 +147,20 @@ tags:
 
 <h3 id="Inline_indicators_that_support_specifying_the_technology">Inline indicators that support specifying the technology</h3>
 
-<p>In these macros the parameter (when specified) should be one of the strings "html", "js", "css", or "gecko", followed by the version number.</p>
-
 <h4 id="Deprecated">Deprecated</h4>
 
-<p><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/deprecated_inline.ejs">deprecated_inline</a></code> inserts an in-line deprecated mark to discourage the use of an API that is officially deprecated. <strong>Note:</strong> "Deprecated" means that the item should no longer be used, but still functions. If you mean that it no longer works at all, use the term "obsolete."</p>
-
-<p>Don't use the parameter in any browser-agnostic area (HTML, APIs, JS, CSS, …).</p>
+<p><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/deprecated_inline.ejs">deprecated_inline</a></code> inserts an in-line deprecated mark ({{Deprecated_Inline}}) to discourage the use of an API that is officially deprecated (or has been removed).</p>
 
 <h5 id="Syntax_3">Syntax</h5>
 
-<p><code>\{{Deprecated_Inline}}</code> or<code> \{{Deprecated_Inline("gecko5")}}</code></p>
+<p><code>\{{Deprecated_Inline}}</code></p>
 
 <h5 id="Examples_3">Examples</h5>
 
 <ul>
  <li>Icon: {{Deprecated_Inline}}</li>
- <li>Badge:{{Deprecated_Inline("gecko5")}}</li>
 </ul>
+
 
 <h3 id="Page_or_section_header_indicators">Page or section header indicators</h3>
 
@@ -174,7 +170,7 @@ tags:
  <li>{{TemplateLink("non-standard_header")}}: <code>\{{Non-standard_Header}}</code> {{Non-standard_Header}}</li>
  <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/SeeCompatTable.ejs">SeeCompatTable</a></code> should be used on pages that document <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental features</a>. Example: <code>\{{SeeCompatTable}}</code> {{SeeCompatTable}}</li>
  <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/deprecated_header.ejs">deprecated_header</a></code>: <code>\{{Deprecated_Header}}</code> {{Deprecated_Header}}</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/deprecated_header.ejs">deprecated_header</a></code> with parameter: <code>\{{Deprecated_Header("gecko5")}}</code> {{Deprecated_Header("gecko5")}} Don't use the parameter in any browser-agnostic area (HTML, APIs, JS, CSS, …).</li>
+
  <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/secureContext_header.ejs">secureContext_header</a></code>: <code>\{{SecureContext_Header}}</code> {{SecureContext_Header}}</li>
 </ul>
 

--- a/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.html
+++ b/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.html
@@ -12,7 +12,7 @@ tags:
 
 <h3 id="Adding_a_feed_reader_from_a_web_application">Adding a feed reader from a web application</h3>
 
-<p>Support for adding feed readers from the web was removed from the HTML5 spec, and Firefox support is scheduled for removal in Firefox 62. {{obsolete_inline("62.0")}}</p>
+<p>Support for adding feed readers from the web was removed from the HTML5 spec, and Firefox support is scheduled for removal in Firefox 62. {{Deprecated_Inline}}</p>
 
 <p>In older versions, JavaScript code on the web can add a feed reader easily, using the {{domxref("window.navigator.registerContentHandler", "navigator.registerContentHandler()")}} function, like this:</p>
 

--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.html
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.html
@@ -49,7 +49,7 @@ tags:
 <h4 id="Deprecated_parameters">Deprecated parameters</h4>
 
 <dl>
-  <dt><code>context</code> {{obsolete_inline("")}}</dt>
+  <dt><code>context</code> {{Deprecated_Inline}}</dt>
   <dd>A reference to an {{domxref("AudioContext")}}. This parameter was removed from the
     spec.</dd>
 </dl>

--- a/files/en-us/web/api/document/all/index.html
+++ b/files/en-us/web/api/document/all/index.html
@@ -11,7 +11,7 @@ tags:
 - Reference
 - all
 ---
-<div>{{APIRef("DOM")}}{{Draft}}{{Deprecated_Header("HTML5")}}</div>
+<div>{{APIRef("DOM")}}{{Draft}}{{Deprecated_Header}}</div>
 
 <p>The {{DOMxRef("Document")}} interface's read-only <strong><code>all</code></strong>
   property returns an {{DOMxRef("HTMLAllCollection")}} rooted at the document node. In

--- a/files/en-us/web/api/document/anchors/index.html
+++ b/files/en-us/web/api/document/anchors/index.html
@@ -9,7 +9,7 @@ tags:
 - Property
 - Reference
 ---
-<div>{{APIRef("DOM")}} {{deprecated_header()}}</div>
+<div>{{APIRef("DOM")}} {{Deprecated_Header}}</div>
 
 <p>The <strong><code>anchors</code></strong> read-only property of the
   {{domxref("Document")}} interface returns a list of all of the anchors in the document.

--- a/files/en-us/web/api/documenttouch/index.html
+++ b/files/en-us/web/api/documenttouch/index.html
@@ -10,7 +10,7 @@ tags:
   - TouchList
   - touch
 ---
-<div>{{APIRef("DOM")}}{{deprecated_header("gecko25")}}</div>
+<div>{{APIRef("DOM")}}{{Deprecated_Header}}</div>
 
 <p><span class="seoSummary">The <code>DocumentTouch</code> interface used to provide convenience methods for creating {{DOMxRef("Touch")}} and {{DOMxRef("TouchList")}} objects, but <code>DocumentTouch</code> been removed from the standards. These two methods now live on the {{DOMxRef("Document")}} interface.</span></p>
 

--- a/files/en-us/web/api/file/filesize/index.html
+++ b/files/en-us/web/api/file/filesize/index.html
@@ -11,7 +11,7 @@ tags:
 - Property
 - Reference
 ---
-<p>{{APIRef("File API") }}{{non-standard_header}} {{deprecated_header(7.0)}}</p>
+<p>{{APIRef("File API") }}{{non-standard_header}} {{Deprecated_Header}}</p>
 
 <p>Returns the size of a file in bytes.</p>
 

--- a/files/en-us/web/api/htmlmenuitemelement/index.html
+++ b/files/en-us/web/api/htmlmenuitemelement/index.html
@@ -9,7 +9,7 @@ tags:
   - Interface
   - Reference
 ---
-<p>{{APIRef("HTML DOM")}}{{Draft}}{{Deprecated_Header("HTML5.2")}}</p>
+<p>{{APIRef("HTML DOM")}}{{Draft}}{{Deprecated_Header}}</p>
 
 <p class="summary">The <strong><code>HTMLMenuItemElement</code></strong> interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menuitem")}} elements.</p>
 

--- a/files/en-us/web/api/htmltableelement/align/index.html
+++ b/files/en-us/web/api/htmltableelement/align/index.html
@@ -11,7 +11,7 @@ tags:
 - Property
 - Reference
 ---
-<p>{{APIRef("HTML DOM")}}{{Deprecated_Header("HTML4")}}</p>
+<p>{{APIRef("HTML DOM")}}{{Deprecated_Header}}</p>
 
 <p>The <strong><code>HTMLTableElement.align</code></strong> property represents the
   alignment of the table.</p>

--- a/files/en-us/web/api/idbcursor/index.html
+++ b/files/en-us/web/api/idbcursor/index.html
@@ -59,7 +59,7 @@ tags:
 
 <h2 id="Constants">Constants</h2>
 
-<div>{{ deprecated_header(13) }}</div>
+<div>{{Deprecated_Header}}</div>
 
 <div class="warning">
 <p>These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ({{ bug(891944) }})</p>

--- a/files/en-us/web/api/window/releaseevents/index.html
+++ b/files/en-us/web/api/window/releaseevents/index.html
@@ -11,7 +11,7 @@ tags:
 - Window
 - releaseEvents
 ---
-<div>{{ ApiRef() }} {{deprecated_header(1.9)}} {{Non-standard_header}}</div>
+<div>{{ ApiRef() }} {{Deprecated_Header}} {{Non-standard_header}}</div>
 
 <p>Releases the window from trapping events of a specific type.</p>
 

--- a/files/en-us/web/css/-moz-user-input/index.html
+++ b/files/en-us/web/css/-moz-user-input/index.html
@@ -10,7 +10,7 @@ tags:
   - Reference
   - 'recipe:css-property'
 ---
-<div>{{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header(60)}}</div>
+<div>{{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}</div>
 
 <p>In Mozilla applications, <strong><code>-moz-user-input</code></strong> determines if an element will accept user input.</p>
 

--- a/files/en-us/web/html/element/menuitem/index.html
+++ b/files/en-us/web/html/element/menuitem/index.html
@@ -16,7 +16,7 @@ tags:
   - Web
   - menuitem
 ---
-<p>{{HTMLRef}}{{Deprecated_Header("HTML5.2")}}</p>
+<p>{{HTMLRef}}{{Deprecated_Header}}</p>
 
 <p>The <strong>HTML <code>&lt;menuitem&gt;</code> element</strong> represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button.</p>
 

--- a/files/en-us/web/svg/attribute/arabic-form/index.html
+++ b/files/en-us/web/svg/attribute/arabic-form/index.html
@@ -6,7 +6,7 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<div>{{SVGRef}}{{deprecated_header("SVG 2")}}</div>
+<div>{{SVGRef}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>arabic-form</code></strong> attribute indicates which of the four possible forms an Arabic glyph represents.</p>
 

--- a/files/en-us/web/svg/attribute/attributetype/index.html
+++ b/files/en-us/web/svg/attribute/attributetype/index.html
@@ -7,7 +7,7 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<div>{{SVGRef}}{{Deprecated_Header("SVG2")}}</div>
+<div>{{SVGRef}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>attributeType</code></strong> attribute specifies the namespace in which the target attribute and its associated values are defined.</p>
 

--- a/files/en-us/web/svg/attribute/baseprofile/index.html
+++ b/files/en-us/web/svg/attribute/baseprofile/index.html
@@ -6,7 +6,7 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<div>{{SVGRef}}{{deprecated_header("SVG 2")}}</div>
+<div>{{SVGRef}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>baseProfile</code></strong> attribute describes the minimum SVG language profile that the author believes is necessary to correctly render the content. The attribute does not specify any processing restrictions; It can be considered metadata.</p>
 

--- a/files/en-us/web/svg/attribute/cap-height/index.html
+++ b/files/en-us/web/svg/attribute/cap-height/index.html
@@ -6,7 +6,7 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<div>{{SVGRef}}{{deprecated_header("SVG2")}}</div>
+<div>{{SVGRef}}{{Deprecated_Header}}</div>
 
 <p>The <strong><code>cap-height</code></strong> attribute defines the height of uppercase glyphs of the font within the font coordinate system.</p>
 


### PR DESCRIPTION
According to @chrisdavidmills MDN does not used the argument in deprecated macro and should not use the obsolete macros (header or inline) - see https://github.com/mdn/content/pull/4226#issuecomment-825443083

What this does is remove mention of the version argument from deprecated, and mention of the obsolete macro. I have done a very small subset of the cases too. This gives people a chance to complain before I do a PR with all the remaining fixes.

FYI @chrisdavidmills @sideshowbarker @Elchi3 