### PR TITLE
FF89 large ArrayBuffers

### DIFF
--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -27,6 +27,10 @@ tags:
 
 <h3 id="JavaScript">JavaScript</h3>
 
+<ul>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> can be created with a length greater than 2GB-1 (up to 8GB) on 64-bit systems ({{bug(1703505)}}).</li>
+</ul>
+
 <h4 id="removals_js">Removals</h4>
 
 <h3 id="HTTP">HTTP</h3>

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -28,7 +28,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
-  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> can be created with a length greater than 2GB-1 (up to 8GB) on 64-bit systems ({{bug(1703505)}}).</li>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a>s can now be created with a length greater than 2GB-1 (up to 8GB) on 64-bit systems ({{bug(1703505)}}).</li>
 </ul>
 
 <h4 id="removals_js">Removals</h4>

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>The JavaScript exception "Invalid array length" occurs when specifying an array length that is either negative or exceeds the maximum supported by the platform (i.e when creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}}, or when setting the {{jsxref("Array.length")}} property).</p>
 
-<p>The maximum allowed array length depends on the platform and browser version. For {{jsxref("Array")}} the maximum length is 2GB-1 (2^32-1). For {{jsxref("ArrayBuffer")}} the maximum is 8GB on 64-bit systems (2^33) and 2GB-1 on 32-bit systems (2^32-1). Prior to Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} was also 2GB-1 on 64-bit systems.</p>
+<p>The maximum allowed array length depends on the platform, browser and browser version. For {{jsxref("Array")}} the maximum length is 2GB-1 (2^32-1). For {{jsxref("ArrayBuffer")}} the maximum is 2GB-1 on 32-bit systems (2^32-1). From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 8GB on 64-bit systems (2^33).</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> <code>Array</code> and <code>ArrayBuffer</code> are independent data structures (the implementation of one does not affect the other)..</p>

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
@@ -17,8 +17,7 @@ tags:
 
 <h2 id="Message">Message</h2>
 
-<pre class="brush: js">// Negative array buffer length
-RangeError: invalid array length (Firefox)
+<pre class="brush: js">RangeError: invalid array length (Firefox)
 RangeError: Invalid array length (Chrome)
 RangeError: Invalid array buffer length (Chrome)
 RangeError: Array buffer allocation failed (Chrome)

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
@@ -9,19 +9,21 @@ tags:
 ---
 <div>{{jsSidebar("Errors")}}</div>
 
-<p>The JavaScript exception "Invalid array length" occurs when creating
-  an {{jsxref("Array")}} or an {{jsxref("ArrayBuffer")}} which has a length which is
-  either negative or larger or equal to 2<sup>32</sup>, or when setting the
-  {{jsxref("Array.length")}} property to a value which is either negative or larger or
-  equal to 2<sup>32</sup>.</p>
+<p>The JavaScript exception "Invalid array length" occurs when specifying an array length that is either negative or exceeds the maximum supported by the platform (i.e when creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}}, or when setting the {{jsxref("Array.length")}} property).</p>
+
+<p>The maximum allowed array length depends on the platform and browser version. For {{jsxref("Array")}} the maximum length is 2GB-1 (2^32-1). For {{jsxref("ArrayBuffer")}} the maximum is 8GB on 64-bit systems (2^33) and 2GB-1 on 32-bit systems (2^32-1). Prior to Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} was also 2GB-1 on 64-bit systems.</p>
+
+<div class="notecard note">
+  <p><strong>Note:</strong> <code>Array</code> and <code>ArrayBuffer</code> are independent data structures (the implementation of one does not affect the other)..</p>
+</div>
 
 <h2 id="Message">Message</h2>
 
 <pre class="brush: js">RangeError: invalid array length (Firefox)
-RangeError: Invalid array length (Chrome)
-RangeError: Invalid array buffer length (Chrome)
-RangeError: Array buffer allocation failed (Chrome)
+RangeError: Invalid array length (Chromium-based)
+RangeError: Array buffer allocation failed (Chromium-based)
 </pre>
+
 
 <h2 id="Error_type">Error type</h2>
 
@@ -32,16 +34,11 @@ RangeError: Array buffer allocation failed (Chrome)
 <p>An invalid array length might appear in these situations:</p>
 
 <ul>
-  <li>When creating an {{jsxref("Array")}} or an {{jsxref("ArrayBuffer")}} which has a
-    length which is either negative or larger or equal to 2<sup>32</sup>, or</li>
-  <li>when setting the {{jsxref("Array.length")}} property to a value which is either
-    negative or larger or equal to 2<sup>32</sup>.</li>
+  <li>Creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}} with a negative length, or setting a negative value for the {{jsxref("Array.length")}} property.</li>
+  <li>Creating an {{jsxref("Array")}} or setting the {{jsxref("Array.length")}} property greater than 2GB-1 (2^32-1).</li>
+  <li>Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GB-1 (2^32-1) on a 32-bit system or 8GB (2^33) on a 64-bit system.</li>
+  <li>Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2GB-1 (2^32-1).</li>
 </ul>
-
-<p>Why are <code>Array</code> and <code>ArrayBuffer</code> length limited? The
-  <code>length</code> property of an <code>Array</code> or an <code>ArrayBuffer</code> is
-  represented with an unsigned 32-bit integer, that can only store values which are in the
-  range from 0 to 2<sup>32</sup>-1.</p>
 
 <p>If you are creating an <code>Array</code>, using the constructor, you probably want to
   use the literal notation instead, as the first argument is interpreted as the length of
@@ -56,7 +53,7 @@ RangeError: Array buffer allocation failed (Chrome)
 
 <pre class="brush: js example-bad">new Array(Math.pow(2, 40))
 new Array(-1)
-new ArrayBuffer(Math.pow(2, 32))
+new ArrayBuffer(Math.pow(2, 32)) //32-bit system
 new ArrayBuffer(-1)
 
 let a = [];
@@ -71,6 +68,7 @@ b.length = b.length + 1;         // set 2^32 to the length property
 <pre class="brush: js example-good">[ Math.pow(2, 40) ]                     // [ 1099511627776 ]
 [ -1 ]                                  // [ -1 ]
 new ArrayBuffer(Math.pow(2, 32) - 1)
+new ArrayBuffer(Math.pow(2, 33))  // 64-bit systems after Firefox 89
 new ArrayBuffer(0)
 
 let a = [];

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.html
@@ -17,10 +17,11 @@ tags:
 
 <h2 id="Message">Message</h2>
 
-<pre class="brush: js">RangeError: Array length must be a finite positive integer (Edge)
+<pre class="brush: js">// Negative array buffer length
 RangeError: invalid array length (Firefox)
 RangeError: Invalid array length (Chrome)
 RangeError: Invalid array buffer length (Chrome)
+RangeError: Array buffer allocation failed (Chrome)
 </pre>
 
 <h2 id="Error_type">Error type</h2>

--- a/files/en-us/web/javascript/reference/global_objects/array/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>Arrays are list-like objects whose prototype has methods to perform traversal and mutation operations. Neither the length of a JavaScript array nor the types of its elements are fixed. Since an array's length can change at any time, and data can be stored at non-contiguous locations in the array, JavaScript arrays are not guaranteed to be dense; this depends on how the programmer chooses to use them. In general, these are convenient characteristics; but if these features are not desirable for your particular use, you might consider using typed arrays.</p>
 
-<p>Arrays cannot use strings as element indexes (as in an <a href="https://en.wikipedia.org/wiki/Associative_array">associative array</a>) but must use integers. Setting or accessing via non-integers using <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Objects_and_properties">bracket notation</a> (or <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors">dot notation</a>) will not set or retrieve an element from the array list itself, but will set or access a variable associated with that array's <a href="/en-US/docs/Web/JavaScript/Data_structures#Properties">object property collection</a>. The array's object properties and list of array elements are separate, and the array's <a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Array_methods">traversal and mutation operations</a> cannot be applied to these named properties.</p>
+<p>Arrays cannot use strings as element indexes (as in an <a href="https://en.wikipedia.org/wiki/Associative_array">associative array</a>) but must use integers. Setting or accessing via non-integers using <a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#objects_and_properties">bracket notation</a> (or <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors">dot notation</a>) will not set or retrieve an element from the array list itself, but will set or access a variable associated with that array's <a href="/en-US/docs/Web/JavaScript/Data_structures#properties">object property collection</a>. The array's object properties and list of array elements are separate, and the array's <a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#array_methods">traversal and mutation operations</a> cannot be applied to these named properties.</p>
 
 <h3 id="Common_operations">Common operations</h3>
 
@@ -453,9 +453,10 @@ console.table(values)</pre>
 <ul>
  <li>From the JavaScript Guide:
   <ul>
-   <li><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#Indexing_object_properties">“Indexing object properties”</a></li>
-   <li><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#Array_object">“Indexed collections: <code>Array</code> object”</a></li>
+   <li><a href="/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#indexing_object_properties">“Indexing object properties”</a></li>
+   <li><a href="/en-US/docs/Web/JavaScript/Guide/Indexed_collections#array_object">“Indexed collections: <code>Array</code> object”</a></li>
   </ul>
  </li>
- <li><a href="/en-US/docs/JavaScript_typed_arrays">Typed Arrays</a></li>
+ <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays">Typed Arrays</a></li>
+ <li><a href="/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length">RangeError: invalid array length</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.html
@@ -46,7 +46,7 @@ arr.forEach(element =&gt; console.log(element));
 // 2
 </pre>
 
-<p>As you can see, the <code>length</code> property does not necessarily indicate the number of defined values in the array. See also <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Relationship_between_length_and_numerical_properties" title="Relationship between length and numerical properties">Relationship between <code>length</code> and numerical properties</a>.</p>
+<p>As you can see, the <code>length</code> property does not necessarily indicate the number of defined values in the array. See also <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#relationship_between_length_and_numerical_properties" title="Relationship between length and numerical properties">Relationship between <code>length</code> and numerical properties</a>.</p>
 
 <p>{{js_property_attributes(1, 0, 0)}}</p>
 
@@ -115,4 +115,5 @@ console.log(numbers); // [undefined, undefined, undefined]
 
 <ul>
  <li>{{jsxref("Array")}}</li>
+ <li><a href="/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length">RangeError: invalid array length</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.html
@@ -14,7 +14,7 @@ tags:
 
 <p>It is an array of bytes, often referred to in other languages as a "byte array".You cannot directly manipulate the contents of an <code>ArrayBuffer</code>; instead, you create one of the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray">typed array objects</a> or a {{jsxref("DataView")}} object which represents the buffer in a specific format, and use that to read and write the contents of the buffer.</p>
 
-<p>The <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer">ArrayBuffer()</a></code> constructor creates a new <code>ArrayBuffer</code> of the given length in bytes. You can also get an array buffer from existing data, for example <a href="/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#Appendix_to_Solution_1_Decode_a_Base64_string_to_Uint8Array_or_ArrayBuffer">from a Base64 string</a> or <a href="/en-US/docs/Web/API/FileReader/readAsArrayBuffer">from a local file</a>.</p>
+<p>The <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer">ArrayBuffer()</a></code> constructor creates a new <code>ArrayBuffer</code> of the given length in bytes. You can also get an array buffer from existing data, for example <a href="/en-US/docs/Glossary/Base64#appendix_to_solution_1_decode_a_base64_string_to_uint8array_or_arraybuffer">from a Base64 string</a> or <a href="/en-US/docs/Web/API/FileReader/readAsArrayBuffer">from a local file</a>.</p>
 
 <h2 id="Constructor">Constructor</h2>
 
@@ -84,4 +84,5 @@ const view = new Int32Array(buffer);</pre>
 <ul>
  <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays">JavaScript typed arrays</a></li>
  <li>{{jsxref("SharedArrayBuffer")}}</li>
+ <li><a href="/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length">RangeError: invalid array length</a></li>
 </ul>


### PR DESCRIPTION
This is partial fix for #4314.

- [x] [Reference/Errors/Invalid_array_length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length) - clarify max allowed length
- [x] Cross link the ArrayBuffer and Array docs to the invalid array length
- [x] Add FF release notes

This is in draft because still [clarifying the inconsistency](https://bugzilla.mozilla.org/show_bug.cgi?id=1703505#c4) in the invalid array length docs.