### PR TITLE
Fix wording in lazy loading page

### DIFF
--- a/files/en-us/web/performance/lazy_loading/index.html
+++ b/files/en-us/web/performance/lazy_loading/index.html
@@ -41,7 +41,7 @@ tags:
 <h3 id="JavaScript">JavaScript</h3>
 
 <p><strong>Script type module</strong><br>
- Any script tag with <code>type="module"</code> is treated like a <a href="/en-US/docs/Web/JavaScript/Guide/Modules">JavaScript module</a> and is deferred by default.</p>
+ Any script tag with <code>type="module"</code> is treated as a <a href="/en-US/docs/Web/JavaScript/Guide/Modules">JavaScript module</a> and is deferred by default.</p>
 
 <h3 id="CSS">CSS</h3>
 


### PR DESCRIPTION
`<script type="module">` is treated *as* a JavaScript module, not just *like* a JavaScript module.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only) 

This fixes an incorrect word choice.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

> Issue number (if there is an associated issue)

> Anything else that could help us review it
