### PR TITLE
Fix small typo

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for-await...of/index.html
+++ b/files/en-us/web/javascript/reference/statements/for-await...of/index.html
@@ -169,7 +169,7 @@ for (let numOrPromise of generator()) {
   <p><strong>Note</strong>: be aware of yielding rejected promises from sync generator. In
     such case <code>for await...of</code> throws when consuming rejected promise and
     DOESN'T CALL <code>finally</code> blocks within that generator. This can be
-    undesireable if you need to free some allocated resources with
+    undesirable if you need to free some allocated resources with
     <code>try/finally</code>.</p>
 </div>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Just a small typo: s/undesireable/undesirable/

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

The word is ["undesirable"](https://www.dictionary.com/browse/undesirable) in the dictionary.
