### PR TITLE
mention extension scheme for url matching

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
@@ -38,7 +38,7 @@ tags:
    <td>Only "http" and "https" and in some browsers also <a href="/en-US/docs/Web/API/WebSockets_API">"ws" and "wss"</a>.</td>
   </tr>
   <tr>
-   <td>One of <code>http</code>, <code>https</code>, <code>ws</code>, <code>wss</code>, <code>ftp</code>, <code>ftps</code>, <code>data</code> or <code>file</code>.</td>
+   <td>One of <code>http</code>, <code>https</code>, <code>ws</code>, <code>wss</code>, <code>ftp</code>, <code>ftps</code>, <code>data</code>, <code>file</code>, or <code>(chrome-)extension</code>.</td>
    <td>Only the given scheme.</td>
   </tr>
  </tbody>


### PR DESCRIPTION
[MDN URL](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#scheme).

`(chrome-)extension` schemes are not matched by `*` either. This commits mentions the existence of this scheme as option for specific matching for completeness sake (since the list ending with `or` lets it sound like the complete set of possible options).
