### PR TITLE
Fix dead-link in Web security doc

### DIFF
--- a/files/en-us/web/security/index.html
+++ b/files/en-us/web/security/index.html
@@ -25,7 +25,7 @@ tags:
  <dt>HTTPS</dt>
  <dd><strong>HTTPS</strong> (<strong><em>HyperText Transfer Protocol Secure</em></strong>) is an encrypted version of the {{Glossary("HTTP")}} protocol. It uses {{Glossary("SSL")}} or {{Glossary("TLS")}} to encrypt all communication between a client and a server. This secure connection allows clients to be sure that they are connected with the intended server, and to exchange sensitive data.</dd>
  <dt><a href="/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security">HTTP Strict-Transport-Security</a></dt>
- <dd>The <code>Strict-Transport-Security:</code> <a href="/en/HTTP">HTTP</a> header lets a website specify that it may only be accessed using HTTPS.</dd>
+ <dd>The <code>Strict-Transport-Security:</code> <a href="/en-US/docs/Web/HTTP">HTTP</a> header lets a website specify that it may only be accessed using HTTPS.</dd>
  <dt><a href="/en-US/docs/Web/Security/Certificate_Transparency">Certificate Transparency</a></dt>
  <dd><strong>Certificate Transparency</strong> is an open framework designed to protect against and monitor for certificate misissuances. Newly issued certificates are 'logged' to publicly run, often independent CT logs which maintain an append-only, cryptographically assured record of issued TLS certificates.</dd>
  <dt><a href="/en-US/docs/Web/Security/Mixed_content">Mixed content</a></dt>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Fix dead link.
"/en-US/HTTP" is not found.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/Security

> Issue number (if there is an associated issue)

none.

> Anything else that could help us review it