### PR TITLE
new font-face descriptors

### DIFF
--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -25,7 +25,7 @@ tags:
 
 <ul>
   <li>The {{cssxref("@media/forced-colors","forced-colors")}} media feature has been implemented ({{bug(1659511)}}).</li>
-  <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} have been implemented ({{bug(1681691)}}).</li>
+  <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} have been implemented ({{bug(1681691)}}) and ({{bug(1704494)}}).</li>
 </ul>
 
 <h4 id="removals_css">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -25,7 +25,7 @@ tags:
 
 <ul>
   <li>The {{cssxref("@media/forced-colors","forced-colors")}} media feature has been implemented ({{bug(1659511)}}).</li>
-  <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} have been implemented ({{bug(1681691)}}) and ({{bug(1704494)}}).</li>
+  <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} <code>@font-face</code> descriptors have been implemented ({{bug(1681691)}}) and ({{bug(1704494)}}).</li>
 </ul>
 
 <h4 id="removals_css">Removals</h4>

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -25,6 +25,7 @@ tags:
 
 <ul>
   <li>The {{cssxref("@media/forced-colors","forced-colors")}} media feature has been implemented ({{bug(1659511)}}).</li>
+  <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} have been implemented ({{bug(1681691)}}).</li>
 </ul>
 
 <h4 id="removals_css">Removals</h4>

--- a/files/en-us/web/css/@font-face/ascent-override/index.html
+++ b/files/en-us/web/css/@font-face/ascent-override/index.html
@@ -1,0 +1,94 @@
+---
+title: ascent-override
+slug: Web/CSS/@font-face/ascent-override
+tags:
+  - '@font-face'
+  - At-rule descriptor
+  - CSS
+  - Reference
+  - descriptor
+  - ascent-override
+---
+<p>{{CSSRef}}</p>
+
+<p>The <strong><code>ascent-override</code></strong> CSS descriptor defines the ascent metric for the font. The ascent metric is the height above the baseline that CSS uses to lay out line boxes in an inline formatting context.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css">ascent-override: normal;
+ascent-override: 90%;</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+ <dt><code>normal</code></dt>
+ <dd>The default value. When used the metric value is obtained from the font file.</dd>
+ <dt><code>&lt;percentage&gt;</code></dt>
+ <dd>A {{cssxref("&lt;percentage&gt;")}} value.</dd>
+</dl>
+
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Formal syntax</h2>
+
+{{csssyntax}}
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Overriding_metrics_of_a_fallback_font">Overriding metrics of a fallback font</h3>
+
+<p>The <code>ascent-override</code> property can help when overriding the metrics of a fallback font to better match those of a primary web font.</p>
+
+<pre class="brush: css">@font-face {
+  font-family: web-font;
+  src: url("https://example.com/font.woff");
+}
+
+@font-face {
+  font-family: local-font;
+  src: local(Local Font);
+  ascent-override: 125%;
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS4 Fonts', '#descdef-font-face-ascent-override', 'ascent-override')}}</td>
+   <td>{{Spec2('CSS4 Fonts')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.at-rules.font-face.ascent-override")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{cssxref("@font-face/descent-override", "descent-override")}}</li>
+ <li>{{cssxref("@font-face/font-display", "font-display")}}</li>
+ <li>{{cssxref("@font-face/font-family", "font-family")}}</li>
+ <li>{{cssxref("@font-face/font-weight", "font-weight")}}</li>
+ <li>{{cssxref("@font-face/font-style", "font-style")}}</li>
+ <li>{{cssxref("@font-face/font-stretch", "font-stretch")}}</li>
+ <li>{{cssxref("@font-face/font-variant", "font-variant")}}</li>
+ <li>{{cssxref("font-feature-settings", "font-feature-settings")}}</li>
+ <li>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</li>
+ <li>{{cssxref("@font-face/line-gap-override", "line-gap-override")}}</li>
+ <li>{{cssxref("@font-face/src", "src")}}</li>
+ <li>{{cssxref("@font-face/size-adjust", "src")}}</li>
+ <li>{{cssxref("@font-face/unicode-range", "unicode-range descriptor")}}</li>
+</ul>

--- a/files/en-us/web/css/@font-face/descent-override/index.html
+++ b/files/en-us/web/css/@font-face/descent-override/index.html
@@ -1,0 +1,94 @@
+---
+title: descent-override
+slug: Web/CSS/@font-face/descent-override
+tags:
+  - '@font-face'
+  - At-rule descriptor
+  - CSS
+  - Reference
+  - descriptor
+  - descent-override
+---
+<p>{{CSSRef}}</p>
+
+<p>The <strong><code>descent-override</code></strong> CSS descriptor defines the descent metric for the font. The descent metric is the height below the baseline that CSS uses to lay out line boxes in an inline formatting context.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css">descent-override: normal;
+descent-override: 90%;</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+ <dt><code>normal</code></dt>
+ <dd>The default value. When used the metric value is obtained from the font file.</dd>
+ <dt><code>&lt;percentage&gt;</code></dt>
+ <dd>A {{cssxref("&lt;percentage&gt;")}} value.</dd>
+</dl>
+
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Formal syntax</h2>
+
+{{csssyntax}}
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Overriding_metrics_of_a_fallback_font">Overriding metrics of a fallback font</h3>
+
+<p>The <code>descent-override</code> property can help when overriding the metrics of a fallback font to better match those of a primary web font.</p>
+
+<pre class="brush: css">@font-face {
+  font-family: web-font;
+  src: url("https://example.com/font.woff");
+}
+
+@font-face {
+  font-family: local-font;
+  src: local(Local Font);
+  descent-override: 125%;
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS4 Fonts', '#descdef-font-face-descent-override', 'descent-override')}}</td>
+   <td>{{Spec2('CSS4 Fonts')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.at-rules.font-face.descent-override")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{cssxref("@font-face/ascent-override", "ascent-override")}}</li>
+ <li>{{cssxref("@font-face/font-display", "font-display")}}</li>
+ <li>{{cssxref("@font-face/font-family", "font-family")}}</li>
+ <li>{{cssxref("@font-face/font-weight", "font-weight")}}</li>
+ <li>{{cssxref("@font-face/font-style", "font-style")}}</li>
+ <li>{{cssxref("@font-face/font-stretch", "font-stretch")}}</li>
+ <li>{{cssxref("@font-face/font-variant", "font-variant")}}</li>
+ <li>{{cssxref("font-feature-settings", "font-feature-settings")}}</li>
+ <li>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</li>
+ <li>{{cssxref("@font-face/line-gap-override", "line-gap-override")}}</li>
+ <li>{{cssxref("@font-face/src", "src")}}</li>
+ <li>{{cssxref("@font-face/size-adjust", "src")}}</li>
+ <li>{{cssxref("@font-face/unicode-range", "unicode-range descriptor")}}</li>
+</ul>

--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -26,6 +26,10 @@ tags:
 <h3 id="Descriptors">Descriptors</h3>
 
 <dl>
+ <dt>{{cssxref("@font-face/ascent-override", "ascent-override")}}</dt>
+ <dd>Defines the ascent metric for the font.</dd>
+ <dt>{{cssxref("@font-face/descent-override", "descent-override")}}</dt>
+ <dd>Defines the descent metric for the font.</dd>
  <dt>{{cssxref("@font-face/font-display", "font-display")}}</dt>
  <dd>Determines how a font face is displayed based on whether and when it is downloaded and ready to use.</dd>
  <dt>{{cssxref("@font-face/font-family", "font-family")}}</dt>
@@ -42,6 +46,8 @@ tags:
  <dd>Allows control over advanced typographic features in OpenType fonts.</dd>
  <dt>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</dt>
  <dd>Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values.</dd>
+ <dt>{{cssxref("@font-face/line-gap-override", "line-gap-override")}}</dt>
+ <dd>Defines the line gap metric for the font.</dd>
  <dt>{{cssxref("@font-face/src", "src")}}</dt>
  <dd>
  <p>Specifies the resource containing the font data. This can be a URL to a remote font file location or the name of a font on the user's computer.</p>

--- a/files/en-us/web/css/@font-face/line-gap-override/index.html
+++ b/files/en-us/web/css/@font-face/line-gap-override/index.html
@@ -1,0 +1,94 @@
+---
+title: line-gap-override
+slug: Web/CSS/@font-face/line-gap-override
+tags:
+  - '@font-face'
+  - At-rule descriptor
+  - CSS
+  - Reference
+  - descriptor
+  - line-gap-override
+---
+<p>{{CSSRef}}</p>
+
+<p>The <strong><code>line-gap-override</code></strong> CSS descriptor defines the line-gap metric for the font. The line-gap metric is the font recommended line-gap or external leading.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: css">line-gap-override: normal;
+line-gap-override: 90%;</pre>
+
+<h3 id="Values">Values</h3>
+
+<dl>
+ <dt><code>normal</code></dt>
+ <dd>The default value. When used the metric value is obtained from the font file.</dd>
+ <dt><code>&lt;percentage&gt;</code></dt>
+ <dd>A {{cssxref("&lt;percentage&gt;")}} value.</dd>
+</dl>
+
+<h2 id="Formal_definition">Formal definition</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Formal syntax</h2>
+
+{{csssyntax}}
+
+<h2 id="Examples">Examples</h2>
+
+<h3 id="Overriding_metrics_of_a_fallback_font">Overriding metrics of a fallback font</h3>
+
+<p>The <code>line-gap-override</code> property can help when overriding the metrics of a fallback font to better match those of a primary web font.</p>
+
+<pre class="brush: css">@font-face {
+  font-family: web-font;
+  src: url("https://example.com/font.woff");
+}
+
+@font-face {
+  font-family: local-font;
+  src: local(Local Font);
+  line-gap-override: 125%;
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS4 Fonts', '#descdef-font-face-line-gap-override', 'line-gap-override')}}</td>
+   <td>{{Spec2('CSS4 Fonts')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("css.at-rules.font-face.line-gap-override")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{cssxref("@font-face/descent-override", "descent-override")}}</li>
+ <li>{{cssxref("@font-face/font-display", "font-display")}}</li>
+ <li>{{cssxref("@font-face/font-family", "font-family")}}</li>
+ <li>{{cssxref("@font-face/font-weight", "font-weight")}}</li>
+ <li>{{cssxref("@font-face/font-style", "font-style")}}</li>
+ <li>{{cssxref("@font-face/font-stretch", "font-stretch")}}</li>
+ <li>{{cssxref("@font-face/font-variant", "font-variant")}}</li>
+ <li>{{cssxref("font-feature-settings", "font-feature-settings")}}</li>
+ <li>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</li>
+ <li>{{cssxref("@font-face/line-gap-override", "line-gap-override")}}</li>
+ <li>{{cssxref("@font-face/src", "src")}}</li>
+ <li>{{cssxref("@font-face/size-adjust", "src")}}</li>
+ <li>{{cssxref("@font-face/unicode-range", "unicode-range descriptor")}}</li>
+</ul>


### PR DESCRIPTION
Working on #4299 this adds the three new pages for:

- `ascent-override`
- `descent-override`
- `line-gap-override`

Also updates the `@font-face` page, and the 89 release notes.