### PR TITLE
Documents type() for image-set()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -26,6 +26,7 @@ tags:
 <ul>
   <li>The {{cssxref("@media/forced-colors","forced-colors")}} media feature has been implemented ({{bug(1659511)}}).</li>
   <li>The {{cssxref("@font-face/ascent-override", "ascent-override")}}, {{cssxref("@font-face/descent-override", "descent-override")}}, and {{cssxref("@font-face/line-gap-override", "line-gap-override")}} <code>@font-face</code> descriptors have been implemented ({{bug(1681691)}}) and ({{bug(1704494)}}).</li>
+  <li>The <code>type()</code> function for {{cssxref("image-set()","image-set()")}} has been implemented ({{bug(1695404)}}).</li>
 </ul>
 
 <h4 id="removals_css">Removals</h4>

--- a/files/en-us/web/css/image-set()/index.html
+++ b/files/en-us/web/css/image-set()/index.html
@@ -26,17 +26,30 @@ where &lt;image-set-option&gt; = [ &lt;image&gt; | &lt;string&gt; ] &lt;resoluti
 
 <h3 id="Values">Values</h3>
 
-<p>Most commonly you'll see an <code>url()</code> <code>&lt;string&gt;</code> value, but the <code><a href="/en-US/docs/Web/CSS/image">&lt;image&gt;</a></code> can be any image type except for an image set. The <code>image-set()</code> function can not be nested inside another <code>image-set()</code> function.</p>
-
-<p><code><a href="/en-US/docs/Web/CSS/resolution">&lt;resolution&gt;</a></code> units include <code>x</code> or <code>dppx</code>, for dots per pixel unit, <code>dpi</code>, for dots per inch, and <code>dpcm</code> for dots per centimeter. Every image within an <code>image-set()</code> must have a unique resolution.</p>
+<dl>
+  <dt><code>&lt;image&gt;</code></dt>
+  <dd>The <code><a href="/en-US/docs/Web/CSS/image">&lt;image&gt;</a></code> can be any image type except for an image set. The <code>image-set()</code> function may not be nested inside another <code>image-set()</code> function.</dd>
+  <dt><code>&lt;string&gt;</code></dt>
+  <dd>A <code>url()</code> to an image.</dd>
+  <dt><code>&lt;resolution&gt;</code>{{optional_inline}}</dt>
+  <dd><code><a href="/en-US/docs/Web/CSS/resolution">&lt;resolution&gt;</a></code> units include <code>x</code> or <code>dppx</code>, for dots per pixel unit, <code>dpi</code>, for dots per inch, and <code>dpcm</code> for dots per centimeter. Every image within an <code>image-set()</code> must have a unique resolution.</dd>
+  <dt><code>type(&lt;string&gt;)</code>{{optional_inline}}</dt>
+  <dd>A valid MIME type string, for example "image/jpeg".</dd>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 
 <h3 id="Using_image-set_to_provide_alternative_background-image_options">Using image-set() to provide alternative background-image options</h3>
 
+<p>This example shows how to use <code><a class="css" href="https://drafts.csswg.org/css-images-4/#funcdef-image-set" id="ref-for-funcdef-image-set⑨">image-set()</a></code> to provide two alternative {{cssxref("background-image")}} options, chosen depending on the resolution needed: a normal version and a high-resolution version.</p>
+
 <p>{{EmbedGHLiveSample("css-examples/images/image-set.html", '100%', 600)}}</p>
 
-<p>This example shows how to use <code><a class="css" href="https://drafts.csswg.org/css-images-4/#funcdef-image-set" id="ref-for-funcdef-image-set⑨">image-set()</a></code> to provide two alternative {{cssxref("background-image")}} options, chosen depending on the resolution needed: a normal version and a high-resolution version.</p>
+<h3 id="Using_image-set_to_provide_alternative_formats">Using image-set() to provide alternative image formats</h3>
+
+<p>In the next example the <code>type()</code> function is used to serve the image in avif and jpeg formats. If the browser supports avif, it will choose that version. Otherwise it will use the jpeg version.</p>
+
+<p>{{EmbedGHLiveSample("css-examples/images/image-set-type.html", '100%', 600)}}</p>
 
 <h2 id="Accessibility_concerns">Accessibility concerns</h2>
 

--- a/files/en-us/web/css/image-set()/index.html
+++ b/files/en-us/web/css/image-set()/index.html
@@ -47,7 +47,7 @@ where &lt;image-set-option&gt; = [ &lt;image&gt; | &lt;string&gt; ] &lt;resoluti
 
 <h3 id="Using_image-set_to_provide_alternative_formats">Using image-set() to provide alternative image formats</h3>
 
-<p>In the next example the <code>type()</code> function is used to serve the image in avif and jpeg formats. If the browser supports avif, it will choose that version. Otherwise it will use the jpeg version.</p>
+<p>In the next example the <code>type()</code> function is used to serve the image in AVIF and JPEG formats. If the browser supports avif, it will choose that version. Otherwise it will use the jpeg version.</p>
 
 <p>{{EmbedGHLiveSample("css-examples/images/image-set-type.html", '100%', 600)}}</p>
 


### PR DESCRIPTION
Working on #4306 

Fixes: #4175 

Documented the `type()` functionality, adds an example, adds to release notes. 

I need to update the data for the syntax, and also BCD.