### PR TITLE
Replace var with const

### DIFF
--- a/files/en-us/web/api/filereader/filereader/index.html
+++ b/files/en-us/web/api/filereader/filereader/index.html
@@ -13,7 +13,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var reader = new FileReader();</pre>
+<pre class="brush: js">const reader = new FileReader();</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
@@ -24,7 +24,7 @@ tags:
 <p>The following code snippet shows creation of a <code><a href="/en-US/docs/Web/API/FileReader">FileReader</a></code> object using the <code>FileReader()</code> constructor and subsequent usage of the object:</p>
 
 <pre class="brush: js">function printFile(file) {
-  var reader = new FileReader();
+  const reader = new FileReader();
   reader.onload = function(evt) {
     console.log(evt.target.result);
   };


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Variables were declared using `var`.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/FileReader/FileReader

> Issue number (if there is an associated issue)

I haven't looked for.

> Anything else that could help us review it

I'm fine, thanks.