### PR TITLE
Fix: Async function return behavior inaccuracy

### DIFF
--- a/files/en-us/web/javascript/reference/statements/async_function/index.html
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.html
@@ -80,7 +80,7 @@ tags:
 <div class="notecard note">
     <h4 id="checking_equality_with_promise_resolve_vs_async_return">Checking equality with <code>Promise.resolve</code> vs <code>async</code> return</h4>
     <p>Even though the return value of an async function behaves as if it's wrapped in a <code>Promise.resolve</code>, they are not equivalent.</p>
-    <p>An async function will return a different <i>reference</i>, whereas <code>Promise.resolve</code> returns the same reference if the given value is a promise.</p>
+    <p>An async function will return a different <em>reference</em>, whereas <code>Promise.resolve</code> returns the same reference if the given value is a promise.</p>
     <p>It can be a problem when you want to check the equality of a promise and a return value of an async function.</p>
     <pre class="brush: js">const p = new Promise((res, rej) => {
   res(1);

--- a/files/en-us/web/javascript/reference/statements/async_function/index.html
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.html
@@ -70,12 +70,33 @@ tags:
 }
 </pre>
 
-<p>...is equivalent to:</p>
+<p>...is similar to:</p>
 
 <pre class="brush: js">function <var>foo</var>() {
    <var>return Promise.resolve(1)</var>
 }
 </pre>
+
+<div class="notecard note">
+    <h4>Checking equality with <code>Promise.resolve</code> vs <code>async</code> return</h4>
+    <p>Even though the return value of an async function behaves as if it's wrapped in a <code>Promise.resolve</code>, they are not equivalent.</p>
+    <p>An async function will return a different <i>reference</i>, whereas <code>Promise.resolve</code> returns the same reference if the given value is a promise.</p>
+    <p>It can be a problem when you want to check the equality of a promise and a return value of an async function.</p>
+    <pre class="brush: js">const p = new Promise((res, rej) => {
+  res(1);
+})
+
+async function asyncReturn() {
+  return p;
+}
+
+function basicReturn() {
+  return Promise.resolve(p);
+}
+
+console.log(p === basicReturn()); // true
+console.log(p === asyncReturn()); // false</pre>
+</div>
 
 <p>The body of an async function can be thought of as being split by zero or more await
   expressions. Top-level code, up to and including the first await expression (if there is

--- a/files/en-us/web/javascript/reference/statements/async_function/index.html
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.html
@@ -78,7 +78,7 @@ tags:
 </pre>
 
 <div class="notecard note">
-    <h4>Checking equality with <code>Promise.resolve</code> vs <code>async</code> return</h4>
+    <h4 id="checking_equality_with_promise_resolve_vs_async_return">Checking equality with <code>Promise.resolve</code> vs <code>async</code> return</h4>
     <p>Even though the return value of an async function behaves as if it's wrapped in a <code>Promise.resolve</code>, they are not equivalent.</p>
     <p>An async function will return a different <i>reference</i>, whereas <code>Promise.resolve</code> returns the same reference if the given value is a promise.</p>
     <p>It can be a problem when you want to check the equality of a promise and a return value of an async function.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Recently, I implemented a feature that involves storing Promises as key in a Map. However, when I try to check if a key is present in the map, it always returns false. I found out the reason is because `async` function returns a different reference vs a `Promise.resolve` where it will return the same promise. Here's a brief snippet of the code I wrote:
``` javascript
const wm = new WeakMap();
async function createRequestAsync() {
  const p = fetchData();
  wm.set(p, 'value');
  return await p; // or just 'return p' here, it still won't work
}

// This is just to demonstrate async function return value doesn't behave 100% like Promise.resolve
function createRequestSync() {
  const p = fetchData();
  wm.set(p, 'value');
  return Promise.resolve(p);
}

const requestAsync = createRequestAsync();
const requestSync = createRequestSync();
console.log(wm.has(requestAsync)); // false
console.log(wm.has(requestSync)); // true
```

I have added a simple example in the .html file.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

I wonder if this is too niche of an example to be included in the page? Regardless, I think saying async function return value is equivalent to returning a `Promise.resolve(value)` is not 100% correct, however they do behave very similarly.


Also, please feel free to correct any grammatical mistake or any copy-edit type suggestions.