### PR TITLE
Hint for the trick with a css variable

### DIFF
--- a/files/en-us/web/css/line-height/index.html
+++ b/files/en-us/web/css/line-height/index.html
@@ -140,6 +140,17 @@ h1 {
 
 <p>{{EmbedLiveSample('Prefer_unitless_numbers_for_line-height_values', 600, 200)}}</p>
 
+<p>One way to fix the bad inheritance behaviour would be to use a css variable:</p>
+
+<pre class="brush: css">* {
+  line-height:var(--line-height);
+}
+html {
+  --line-height: calc(0.8em + 0.5rem);
+}
+</pre>
+
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Line-heights has a poor inheritance behavior.
You can get around this with CSS variables.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/line-height

