### PR TITLE
Un-deprecate ShadowRoot.p.delegatesFocus

### DIFF
--- a/files/en-us/web/api/shadowroot/delegatesfocus/index.html
+++ b/files/en-us/web/api/shadowroot/delegatesfocus/index.html
@@ -3,7 +3,6 @@ title: ShadowRoot.delegatesFocus
 slug: Web/API/ShadowRoot/delegatesFocus
 tags:
 - API
-- Non-standard
 - Property
 - Reference
 - ShadowRoot
@@ -11,7 +10,7 @@ tags:
 - delegatesFocus
 - shadow dom
 ---
-<div>{{APIRef("Shadow DOM")}}{{Deprecated_Header}}</div>
+<div>{{APIRef("Shadow DOM")}}</div>
 
 <p>The <strong><code>delegatesFocus</code></strong> read-only property of the
   {{domxref("ShadowRoot")}} interface returns a boolean that indicates whether
@@ -50,10 +49,10 @@ let hostElem = shadow.delegatesFocus;</pre>
   </thead>
   <tbody>
     <tr>
-      <td>{{SpecName('HTML WHATWG',
-        '#shadowroot-delegates-focus', 'delegatesFocus')}}
+      <td>{{SpecName('DOM WHATWG',
+        '#dom-shadowroot-delegatesfocus', 'delegatesFocus')}}
       </td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
+      <td>{{Spec2('DOM WHATWG')}}</td>
       <td></td>
     </tr>
   </tbody>


### PR DESCRIPTION
https://github.com/whatwg/dom/pull/974 added ShadowRoot.prototype.delegatesFocus to the DOM spec (see https://github.com/whatwg/dom/commit/f346858). And per https://github.com/whatwg/dom/issues/931#issuecomment-827075191 (https://trac.webkit.org/r276585) it’s been implemented in WebKit.

So given that it’s now part of the DOM standard, and implemented in multiple browsers, this change drops the Deprecated_Header macro from the source — as well as fixing the spec URL.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10102
