### PR TITLE
Consistent string name for comparison

### DIFF
--- a/files/en-us/web/api/performance/measure/index.html
+++ b/files/en-us/web/api/performance/measure/index.html
@@ -87,7 +87,7 @@ setTimeout(function() {
     performance.measure("measure a to b", markerNameA, markerNameB);
     performance.measure("measure a to now", markerNameA);
     performance.measure("measure from navigation start to b", undefined, markerNameB);
-    performance.measure("measure from the start of navigation to now");
+    performance.measure("measure from navigation start to now");
 
     // Pull out all of the measurements.
     console.log(performance.getEntriesByType("measure"));


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

When reading each of the measurement marks, it helps to
have some continuity in the language so it's easy to recognize
what is different. This change makes the line match the line above

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure

> Issue number (if there is an associated issue)

> Anything else that could help us review it
