### PR TITLE
Add deprecated icon to regex.prototype.compile()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.html
@@ -94,7 +94,7 @@ let re = new RegExp('\\w+')
 <h2 id="Instance_methods">Instance methods</h2>
 
 <dl>
- <dt>{{JSxRef("RegExp.prototype.compile()")}}</dt>
+ <dt>{{JSxRef("RegExp.prototype.compile()")}} {{deprecated_inline}}</dt>
  <dd>(Re-)compiles a regular expression during execution of a script.</dd>
  <dt>{{JSxRef("RegExp.prototype.exec()")}}</dt>
  <dd>Executes a search for a match in its string parameter.</dd>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The icon for deprecated is missing on the link to the `regex.prototype.compile()` method.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
> Issue number (if there is an associated issue)

> Anything else that could help us review it

If you follow the link, the page for that method describes it as deprecated: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile
