### PR TITLE
FF89 ReleaseNotes: Add sensor removals

### DIFF
--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -50,6 +50,17 @@ tags:
 
 <h4 id="removals_media">Removals</h4>
 
+<ul>
+  <li>The following sensor events and their associated handlers have been removed (primarily for better compatibility with other major browser engines, and to address concerns related to privacy leaks):
+     <ul>
+       <li>{{domxref("DeviceProximityEvent")}} and its event handler <code>window.ondeviceproximity</code> ({{bug(1699707)}}).</li>
+       <li>{{domxref("UserProximityEvent")}} and its event handler <code>window.onuserproximity</code>) ({{bug(1699707)}})</li>
+       <li>{{domxref("DeviceLightEvent")}} and its event handler <code>window.ondevicelight</code> ({{bug(1701824)}}).</li>
+     </ul>
+  </li>
+ </ul>
+
+
 <h3 id="WebAssembly">WebAssembly</h3>
 
 <h4 id="removals_wasm">Removals</h4>


### PR DESCRIPTION
Release notes addition for the docs work in #4308

@chrisdavidmills Note that the light event and user event are still available in KaiOS (see https://bugzilla.mozilla.org/show_bug.cgi?id=1701824#c5). However I have not mentioned that, because we really don't want people to use this anymore, and in future it will disappear there too. 