### PR TITLE
fix link to RegExp flags

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>flags</code></strong> property returns a string consisting of the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags">flags</a> of the current regular expression object.</p>
+<p>The <strong><code>flags</code></strong> property returns a string consisting of the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags">flags</a> of the current regular expression object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-flags.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{JSRef}}</div>
 
-<p>The <strong><code>flags</code></strong> property returns a string consisting of the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2">flags</a> of the current regular expression object.</p>
+<p>The <strong><code>flags</code></strong> property returns a string consisting of the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags">flags</a> of the current regular expression object.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-flags.html")}}</div>
 


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

On the RegExp/flags page, in a link back to the Regular Expressions page, there was an extraneous `_2` at the end of a fragment which didn't match an `id`/`name` on the Regular Expressions page.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

Link before, does not jump to flags list: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2

Link after, jumps to flags list: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags