### PR TITLE
Include pointerup event in setpointercapture

### DIFF
--- a/files/en-us/web/api/element/setpointercapture/index.html
+++ b/files/en-us/web/api/element/setpointercapture/index.html
@@ -15,7 +15,8 @@ tags:
   {{domxref("Element")}} interface is used to designate a specific element as the
   <em>capture target</em> of future pointer events. Subsequent events for the pointer will
   be targeted at the capture element until capture is released (via
-  {{domxref("Element.releasePointerCapture()")}}).</p>
+  {{domxref("Element.releasePointerCapture()")}} or the
+  {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is fired).</p>
 
 <div class="note"><strong>Note:</strong> When pointer capture is set,
   {{domxref("HTMLElement/pointerover_event", "pointerover")}},


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Element.setPointerCapture() on mentions that pointer capture is released on Element.releasePointerCapture() but it is also released when the pointerup event fires.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

https://stackoverflow.com/questions/67073534/setpointercapture-only-works-whilst-pointer-depressed
