### PR TITLE
Update Learn/Forms/HTML_forms_in_legacy_browsers

### DIFF
--- a/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
+++ b/files/en-us/learn/forms/html_forms_in_legacy_browsers/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h3 id="Graceful_degradation_is_web_developers_best_friend">Graceful degradation is web developer's best friend</h3>
 
-<p><a href="http://www.sitepoint.com/progressive-enhancement-graceful-degradation-choice/" rel="external">Graceful degradation and progressive enhancement</a> are development patterns that allow you to build great stuff by supporting a wide range of browsers at the same time. When you build something for a modern browser, and you want to be sure it will work, one way or another, on legacy browsers, you are performing graceful degradation.</p>
+<p><a href="https://www.sitepoint.com/progressive-enhancement-graceful-degradation-choice/" rel="external">Graceful degradation and progressive enhancement</a> are development patterns that allow you to build great stuff by supporting a wide range of browsers at the same time. When you build something for a modern browser, and you want to be sure it will work, one way or another, on legacy browsers, you are performing graceful degradation.</p>
 
 <p>Let's see some examples related to HTML forms.</p>
 
@@ -125,7 +125,7 @@ input[type="button"] {
 
 <p>It's generally a good idea to not alter the default appearance of form control because altering one CSS property value may alter some input types but not others. For example, if you declare <code>input { font-size: 2rem; }</code>, it will impact <code>number</code>, <code>date</code>, and <code>text</code>, but not <code>color</code> or <code>range</code>. If you alter a property, that may impact the appearance of the widget in unexpected ways. For example, <code>[value] { background-color: #ccc; }</code> may have been used to target every {{HTMLElement("input")}} with a <code>value</code> attribute, but changing the background-color or border radius on a {{HTMLElement("meter")}} will lead to likely unexpected results that differ across browsers. You can declare {{cssxref('appearance', 'appearance: none;')}} to remove the browser styles, but that generally defeats the purpose: as you lose all styling, removing the default look and feel your visitors are used to. </p>
 
-<p>To summarize, when it comes to styling form control widgets, the side effects of styling them with CSS can be unpredictable. So don't. As you can see from the complexity of the <a href="/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls">Property compatibility table for form widgets</a> article, it's very difficult. Even if it's still possible to do a few adjustments on text elements (such as sizing or font color), there are always side effects. The best approach remains to not style HTML Form widgets at all. But you can still apply styles to all the surrounding items. And, if you must alter the default styles of your form widgets, define a style guide to ensure consistency among all your form controls so user experience is not destroyed. You can also investigate some hard techniques such as <a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls">rebuilding widgets with JavaScript</a>. But in that case, do not hesitate to <a href="http://www.smashingmagazine.com/2011/11/03/but-the-client-wants-ie-6-support/" rel="external">charge your client for such foolishness</a>.</p>
+<p>To summarize, when it comes to styling form control widgets, the side effects of styling them with CSS can be unpredictable. So don't. As you can see from the complexity of the <a href="/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls">Property compatibility table for form widgets</a> article, it's very difficult. Even if it's still possible to do a few adjustments on text elements (such as sizing or font color), there are always side effects. The best approach remains to not style HTML Form widgets at all. But you can still apply styles to all the surrounding items. And, if you must alter the default styles of your form widgets, define a style guide to ensure consistency among all your form controls so user experience is not destroyed. You can also investigate some hard techniques such as <a href="/en-US/docs/Learn/Forms/How_to_build_custom_form_controls">rebuilding widgets with JavaScript</a>. But in that case, do not hesitate to <a href="https://www.smashingmagazine.com/2011/11/03/but-the-client-wants-ie-6-support/" rel="external">charge your client for such foolishness</a>.</p>
 
 <h2 id="Feature_detection_and_polyfills">Feature detection and polyfills</h2>
 
@@ -156,7 +156,7 @@ input[type="button"] {
 
 <h3 id="The_Modernizr_library">The Modernizr library</h3>
 
-<p>There are many cases where a good "polyfill" can help a lot by providing a missing API. A <a href="http://remysharp.com/2010/10/08/what-is-a-polyfill/" rel="external">polyfill</a> is a bit of JavaScript that "fills in the holes" in the functionality of legacy browsers. While they can be used to improve support for any functionality, using them for JavaScript is less risky than for CSS or HTML; there many cases where JavaScript can break (network issues, script conflicts, etc.). But for JavaScript, if you work with unobstructive JavaScript in mind, if polyfills are missing, it's no big deal.</p>
+<p>There are many cases where a good "polyfill" can help a lot by providing a missing API. A <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill/" rel="external">polyfill</a> is a bit of JavaScript that "fills in the holes" in the functionality of legacy browsers. While they can be used to improve support for any functionality, using them for JavaScript is less risky than for CSS or HTML; there many cases where JavaScript can break (network issues, script conflicts, etc.). But for JavaScript, if you work with unobstructive JavaScript in mind, if polyfills are missing, it's no big deal.</p>
 
 <p>The best way to polyfill missing API is by using the <a href="https://modernizr.com" rel="external">Modernizr</a> library and its spin-off project: <a href="https://yepnopejs.com" rel="external">YepNope</a>. Modernizr is a library that allows you to test the availability of functionality in order to act accordingly. YepNope is a conditional loading library.</p>
 
@@ -181,7 +181,7 @@ input[type="button"] {
 <p>The Modernizr team conveniently maintains <a href="https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills" rel="external">a list of great polyfills</a>. Just pick what you need.</p>
 
 <div class="note">
-<p><strong>Note:</strong> Modernizr has other awesome features to help you in dealing with unobstructive JavaScript and graceful degradation techniques. Please <a href="http://modernizr.com/docs/" rel="external">read the Modernizr documentation</a>.</p>
+<p><strong>Note:</strong> Modernizr has other awesome features to help you in dealing with unobstructive JavaScript and graceful degradation techniques. Please <a href="https://modernizr.com/docs/" rel="external">read the Modernizr documentation</a>.</p>
 </div>
 
 <h3 id="Pay_attention_to_performance">Pay attention to performance</h3>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Links should be https rather than http.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML_forms_in_legacy_browsers

> Issue number (if there is an associated issue)

> Anything else that could help us review it
