### PR TITLE
Adds TransformStreamDefaultController

### DIFF
--- a/files/en-us/web/api/streams_api/index.html
+++ b/files/en-us/web/api/streams_api/index.html
@@ -9,7 +9,7 @@ tags:
   - Reference
   - Streams
 ---
-<div>{{SeeCompatTable}}{{DefaultAPISidebar("Streams")}}</div>
+<div>{{DefaultAPISidebar("Streams")}}</div>
 
 <p>The Streams API allows JavaScript to programmatically access streams of data received over the network and process them as desired by the developer.</p>
 
@@ -59,6 +59,15 @@ tags:
  <dd>Represents a default writable stream writer that can be used to write chunks of data to a writable stream.</dd>
  <dt>{{domxref("WritableStreamDefaultController")}}</dt>
  <dd>Represents a controller allowing control of a {{domxref("WritableStream")}}'s state. When constructing a <code>WritableStream</code>, the underlying sink is given a corresponding <code>WritableStreamDefaultController</code> instance to manipulate.</dd>
+</dl>
+
+<h3 id="Transform_Streams">Transform Streams</h3>
+
+<dl>
+  <dt>{{domxref("TransformStream")}}</dt>
+  <dd>Represents a set of transformable data.</dd>
+  <dt>{{domxref("TransformStreamDefaultController")}}</dt>
+  <dd>Provides methods to manipulate the {{domxref("ReadableStream")}} and {{domxref("WritableStream")}} associated with a transform stream.</dd>
 </dl>
 
 <h3 id="Related_stream_APIs_and_operations">Related stream APIs and operations</h3>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
@@ -14,6 +14,8 @@ tags:
 
 <p>The internal queue of a <code>ReadableStream</code> contains chunks that have been enqueued, but not yet read. The browser determines the <strong>desired size</strong> to fill the stream, and it is this value returned by the <code>desiredSize</code> property.</p>
 
+<p>If the <code>desiredSize</code> is <code>0</code> then the queue is full. Therefore you can use this information to <a href="/en-US/docs/Web/API/Streams_API/Concepts#backpressure">manually apply backpressure</a> to manage the queue.</p>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">let desiredSize = TransformStreamDefaultController.desiredSize;</pre>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.html
@@ -1,0 +1,51 @@
+---
+title: TransformStreamDefaultController.desiredSize
+slug: Web/API/TransformStreamDefaultController/desiredSize
+tags:
+  - API
+  - Property
+  - Reference
+  - desiredSize
+  - TransformStreamDefaultController
+---
+<div>{{DefaultAPISidebar("Streams API")}}</div>
+
+<p class="summary">The <strong><code>desiredSize</code></strong> read-only property of the {{domxref("TransformStreamDefaultController")}} interface returns the desired size to fill the queue of the associated {{domxref("ReadableStream")}}.</p>
+
+<p>The internal queue of a <code>ReadableStream</code> contains chunks that have been enqueued, but not yet read. The browser determines the <strong>desired size</strong> to fill the stream, and it is this value returned by the <code>desiredSize</code> property.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let desiredSize = TransformStreamDefaultController.desiredSize;</pre>
+
+<h3>Value</h3>
+<p>The desired size.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the next example the <code>desiredSize</code> is logged to the console.</p>
+
+<pre class="brush: js">console.log(controller.desiredSize);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Streams','#ts-default-controller-desired-size','TransformStreamDefaultController.desiredSize')}}</td>
+    <td>{{Spec2('Streams')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TransformStreamDefaultController.desiredSize")}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example an endoded string is passed to the queue using the <code>enqueue()</code> method.</p>
+<p>In this example an encoded string is passed to the queue using the <code>enqueue()</code> method.</p>
 
 <pre class="brush: js">controller.enqueue(this.textencoder.encode(String(chunk)))</pre>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
@@ -27,9 +27,16 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In this example an encoded string is passed to the queue using the <code>enqueue()</code> method.</p>
+<p>In this example an encoded chunk is passed to the queue using the <code>enqueue()</code> method.</p>
 
-<pre class="brush: js">controller.enqueue(this.textencoder.encode(String(chunk)))</pre>
+<pre class="brush: js">const textEncoderStream = new TransformStream({
+  transform(chunk, controller) {
+    controller.enqueue(new TextEncoder().encode(chunk));
+  },
+  flush(controller) {
+    controller.terminate();
+  },
+});</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.html
@@ -1,0 +1,55 @@
+---
+title: TransformStreamDefaultController.enqueue()
+slug: Web/API/TransformStreamDefaultController/enqueue
+tags:
+  - API
+  - Method
+  - Reference
+  - enqueue
+  - TransformStreamDefaultController
+---
+<div>{{DefaultAPISidebar("Streams API")}}</div>
+
+<p class="summary">The <strong><code>enqueue()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface enqueues the given chunk in the readable side of the stream.</p>
+
+<p>For more information on readable streams and chunks see <a href="/en-US/docs/Web/API/Streams_API/Using_readable_streams">Using Readable Streams</a>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">TransformStreamDefaultController.enqueue(chunk);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>chunk</code></dt>
+  <dd>The chunk being queued. A chunk is a single piece of data. It can be any type of data, and a stream can contain chunks of different types.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example an endoded string is passed to the queue using the <code>enqueue()</code> method.</p>
+
+<pre class="brush: js">controller.enqueue(this.textencoder.encode(String(chunk)))</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Streams','#ts-default-controller-enqueue','TransformStreamDefaultController.enqueue()')}}</td>
+    <td>{{Spec2('Streams')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TransformStreamDefaultController.enqueue")}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
@@ -14,7 +14,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">TransformStreamDefaultController.error(e);</pre>
+<pre class="syntaxbox">TransformStreamDefaultController.error(reason);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
@@ -19,7 +19,7 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code>e</code></dt>
+  <dt><code>reason</code></dt>
   <dd>A string containing the error message to be returned on any further interaction with the stream.</dd>
 </dl>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.html
@@ -1,0 +1,55 @@
+---
+title: TransformStreamDefaultController.error()
+slug: Web/API/TransformStreamDefaultController/error
+tags:
+  - API
+  - Method
+  - Reference
+  - error
+  - TransformStreamDefaultController
+---
+<div>{{DefaultAPISidebar("Streams API")}}</div>
+
+<p class="summary">The <strong><code>error()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface errors both sides of the stream. Any further interactions with it will fail with the given error message, and any chunks in the queue will be discarded.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">TransformStreamDefaultController.error(e);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>e</code></dt>
+  <dd>A string containing the error message to be returned on any further interaction with the stream.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example the <code>error()</code> method is used when a chunk contains a symbol.</p>
+
+<pre class="brush:js">case 'symbol':
+  controller.error("Cannot send a symbol as a chunk part")
+  break</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Streams','#ts-default-controller-error','TransformStreamDefaultController.error()')}}</td>
+    <td>{{Spec2('Streams')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TransformStreamDefaultController.error")}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/index.html
@@ -1,0 +1,95 @@
+---
+title: TransformStreamDefaultController
+slug: Web/API/TransformStreamDefaultController
+tags:
+  - API
+  - Interface
+  - Reference
+  - TransformStreamDefaultController
+---
+<div>{{DefaultAPISidebar("Streams API")}}</div>
+
+<p class="summary">The <strong><code>TransformStreamDefaultController</code></strong> interface of the {{domxref('Streams API','','',' ')}} provides methods to manipulate the associated {{domxref("ReadableStream")}} and {{domxref("WritableStream")}}.</p>
+
+<p>When constructing a {{domxref("TransformStream")}}, the <code>TransformStreamDefaultController</code> is created. It therefore has no constructor.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+  <dt>{{domxref("TransformStreamDefaultController.desiredSize")}}{{readonlyinline}}</dt>
+  <dd>Returns the desired size to fill the readable side of the stream's internal queue.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("TransformStreamDefaultController.enqueue()")}}</dt>
+  <dd>Enqueues a chunk (single piece of data) in the readable side of the stream.</dd>
+  <dt>{{domxref("TransformStreamDefaultController.error()")}}</dt>
+  <dd>Errors both the readable and writable side of the transform stream.</dd>
+  <dt>{{domxref("TransformStreamDefaultController.terminate()")}}</dt>
+  <dd>Closes the readable side and errors the writable side of the stream.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example, a transform stream passes through all chunks it receives as {{jsxref("Uint8Array")}} values, using the {{domxref("TransformStreamDefaultController.error()","error()")}} and {{domxref("TransformStreamDefaultController.enqueue()","enqueue()")}} methods.</p>
+
+<pre class="brush: js">const transformContent = {
+  start() {}, // required.
+  async transform(chunk, controller) {
+    chunk = await chunk
+    switch (typeof chunk) {
+      case 'object':
+        // just say the stream is done I guess
+        if (chunk === null) controller.terminate()
+        else if (ArrayBuffer.isView(chunk))
+          controller.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+        else if (Array.isArray(chunk) &amp;&amp; chunk.every(value =&gt; typeof value === 'number'))
+          controller.enqueue(new Uint8Array(chunk))
+        else if ('function' === typeof chunk.valueOf &amp;&amp; chunk.valueOf() !== chunk)
+          this.transform(chunk.valueOf(), controller) // hack
+        else if ('toJSON' in chunk) this.transform(JSON.stringify(chunk), controller)
+        break
+      case 'symbol':
+        controller.error("Cannot send a symbol as a chunk part")
+        break
+      case 'undefined':
+        controller.error("Cannot send undefined as a chunk part")
+        break
+      default:
+        controller.enqueue(this.textencoder.encode(String(chunk)))
+        break
+  },
+  flush() { /* do any destructor work here */ }
+}
+
+class AnyToU8Stream extends TransformStream {
+  constructor() {
+    super({...transformContent, textencoder: new TextEncoder()})
+  }
+}
+</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('Streams','#ts-default-controller-class','TransformStreamDefaultController')}}</td>
+   <td>{{Spec2('Streams')}}</td>
+   <td>Initial definition</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TransformStreamDefaultController")}}</p>

--- a/files/en-us/web/api/transformstreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p class="summary">The <strong><code>TransformStreamDefaultController</code></strong> interface of the {{domxref('Streams API','','',' ')}} provides methods to manipulate the associated {{domxref("ReadableStream")}} and {{domxref("WritableStream")}}.</p>
 
-<p>When constructing a {{domxref("TransformStream")}}, the <code>TransformStreamDefaultController</code> is created. It therefore has no constructor.</p>
+<p>When constructing a {{domxref("TransformStream")}}, the <code>TransformStreamDefaultController</code> is created. It therefore has no constructor. The way to get an instance of <code>TransformStreamDefaultController</code> is via the callback methods of {{domxref("TransformStream.TransformStream()")}}.</p>
 
 <h2 id="Properties">Properties</h2>
 

--- a/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.html
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.html
@@ -1,0 +1,50 @@
+---
+title: TransformStreamDefaultController.terminate()
+slug: Web/API/TransformStreamDefaultController/terminate
+tags:
+  - API
+  - Method
+  - Reference
+  - terminate
+  - TransformStreamDefaultController
+---
+<div>{{DefaultAPISidebar("Streams API")}}</div>
+
+<p class="summary">The <strong><code>terminate()</code></strong> method of the {{domxref("TransformStreamDefaultController")}} interface Closes the readable side and errors the writable side of the stream.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">TransformStreamDefaultController.terminate();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the below example the <code>terminate()</code> method is called on a {{domxref("TransformStreamDefaultController")}}.</p>
+
+<pre class="brush: js">controller.terminate()</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Streams','#ts-default-controller-terminate','TransformStreamDefaultController.terminate()')}}</td>
+    <td>{{Spec2('Streams')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.TransformStreamDefaultController.terminate")}}</p>


### PR DESCRIPTION
Documenting the `TransformStreamDefaultController` interface.

I also updated the main Streams API overview to link to this interface, and TransformStream. In working on this I saw that TransformStream is missing a bunch of pages: https://developer.mozilla.org/en-US/docs/Web/API/TransformStream

Reviewer: @jpmedley 