### PR TITLE
dump a build/DIFF file for review companion

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -110,6 +110,12 @@ jobs:
           # Save the PR number into the build
           echo ${{ github.event.number }} > build/NR
 
+          # Save the raw diff blob and store that inside the ./build/
+          # directory.
+          # The purpose of this is for the PR Review Companion to later
+          # be able to use this raw diff file for the benefit of analyzing.
+          git diff --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > build/DIFF
+
       - name: Merge static assets with built documents
         if: ${{ env.GIT_DIFF_CONTENT }}
         run: |


### PR DESCRIPTION
@escattone This is a precursor to being able to analyze the raw git diff in the Deployer pr_analyze.py code. 
Equipped with this file in the `build.zip` we can optionally pass it into the review companion to improve the listing of the external URLs.

I've tested it locally in my fork and downloading the `build.zip` and looking into the `DIFF` file is the same you get in a PR when you look at the diff from that perspective. 