### PR TITLE
remove duplicated library names

### DIFF
--- a/files/en-us/web/api/indexeddb_api/index.html
+++ b/files/en-us/web/api/indexeddb_api/index.html
@@ -17,7 +17,7 @@ tags:
 <p>{{AvailableInWorkers}}</p>
 
 <div class="note">
-<p><strong>Note</strong>: IndexedDB API is powerful, but may seem too complicated for simple cases. If you'd prefer a simple API, try libraries such as <a href="https://localforage.github.io/localForage/">localForage</a>, <a href="https://dexie.org/">dexie.js</a>, <a href="https://github.com/erikolson186/zangodb">ZangoDB</a>, <a href="https://pouchdb.com/">PouchDB</a>, <a href="https://www.npmjs.com/package/idb">idb</a>, <a href="https://www.npmjs.com/package/idb-keyval">idb-keyval</a>, <a href="https://jsstore.net/">JsStore</a> and <a href="https://github.com/google/lovefield">lovefield</a> that make IndexedDB more programmer-friendly.</p>
+<p><strong>Note</strong>: IndexedDB API is powerful, but may seem too complicated for simple cases. If you'd prefer a simple API, try libraries in <a href="#see_also">See also</a> section that make IndexedDB more programmer-friendly.</p>
 </div>
 
 <h2 id="Key_concepts_and_usage">Key concepts and usage</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There is very little introduction to the library in the note and duplicates the one in see also .
> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API

> Issue number (if there is an associated issue)

> Anything else that could help us review it
