### PR TITLE
Cite DOMMatrix, not SVGMatrix, in CanvasRenderingContext2D doc

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.html
@@ -200,11 +200,11 @@ ctx.stroke();
 
 <h3 id="Transformations">Transformations</h3>
 
-<p>Objects in the <code>CanvasRenderingContext2D</code> rendering context have a current transformation matrix and methods to manipulate it. The transformation matrix is applied when creating the current default path, painting text, shapes and {{domxref("Path2D")}} objects. The methods listed below remain for historical and compatibility reasons as {{domxref("SVGMatrix")}} objects are used in most parts of the API nowadays and will be used in the future instead.</p>
+<p>Objects in the <code>CanvasRenderingContext2D</code> rendering context have a current transformation matrix and methods to manipulate it. The transformation matrix is applied when creating the current default path, painting text, shapes and {{domxref("Path2D")}} objects. The methods listed below remain for historical and compatibility reasons as {{domxref("DOMMatrix")}} objects are used in most parts of the API nowadays and will be used in the future instead.</p>
 
 <dl>
  <dt>{{domxref("CanvasRenderingContext2D.currentTransform")}} {{experimental_inline}}</dt>
- <dd>Current transformation matrix ({{domxref("SVGMatrix")}} object).</dd>
+ <dd>Current transformation matrix ({{domxref("DOMMatrix")}} object).</dd>
  <dt>{{domxref("CanvasRenderingContext2D.getTransform()")}}</dt>
  <dd>Retrieves the current transformation matrix being applied to the context.</dd>
  <dt>{{domxref("CanvasRenderingContext2D.rotate()")}}</dt>
@@ -340,7 +340,7 @@ ctx.stroke();
 
 <dl>
  <dt>{{non-standard_inline}} {{deprecated_inline}} <code>CanvasRenderingContext2D.webkitBackingStorePixelRatio</code></dt>
- <dd>The backing store size in relation to the canvas element. See <a href="http://www.html5rocks.com/en/tutorials/canvas/hidpi/">High DPI Canvas</a>.</dd>
+ <dd>The backing store size in relation to the canvas element. See <a href="https://www.html5rocks.com/en/tutorials/canvas/hidpi/">High DPI Canvas</a>.</dd>
  <dt>{{non-standard_inline}} {{deprecated_inline}} <code>CanvasRenderingContext2D.webkitGetImageDataHD</code></dt>
  <dd>Intended for HD backing stores, but removed from canvas specifications.</dd>
  <dt>{{non-standard_inline}} {{deprecated_inline}} <code>CanvasRenderingContext2D.webkitPutImageDataHD</code></dt>
@@ -383,7 +383,7 @@ ctx.stroke();
 
 <dl>
  <dt>{{non-standard_inline}} <code>CanvasRenderingContext2D.msFillRule</code></dt>
- <dd>The <a href="http://cairographics.org/manual/cairo-cairo-t.html#cairo-fill-rule-t">fill rule</a> to use. This must be one of <code>evenodd</code> or <code>nonzero</code> (default).</dd>
+ <dd>The <a href="https://cairographics.org/manual/cairo-cairo-t.html#cairo-fill-rule-t">fill rule</a> to use. This must be one of <code>evenodd</code> or <code>nonzero</code> (default).</dd>
 </dl>
 
 <h2 id="Specifications">Specifications</h2>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/4348