### PR TITLE
Adds a note to datetime

### DIFF
--- a/files/en-us/web/html/element/input/datetime/index.html
+++ b/files/en-us/web/html/element/input/datetime/index.html
@@ -20,6 +20,12 @@ tags:
 
 <p>The format of the date and time value used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid global date and time string")}}.</p>
 
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="notecard note">
+<p>This feature has no current browser implementations.</p>
+</div>
+
 <h2 id="See_also">See also</h2>
 
 <ul>


### PR DESCRIPTION
Fixes mdn/content#4431 

Adds a note to `datetime` as we don't have BCD for this unimplemented feature. See also mdn/yari#6668 