### PR TITLE
fixing some links

### DIFF
--- a/files/en-us/web/html/element/input/date/index.html
+++ b/files/en-us/web/html/element/input/date/index.html
@@ -72,7 +72,7 @@ tags:
 <p><strong>The displayed date format will differ from the actual <code>value</code></strong> — the displayed date is formatted <em>based on the locale of the user's browser</em>, but the parsed <code>value</code> is always formatted <code>yyyy-mm-dd</code>.</p>
 </div>
 
-<p>You can get and set the date value in JavaScript with the input element's {{domxref("HTMLInputElement.value", "value")}} and {{domxref("HTMLInputElement.valueAsNumber", "valueAsNumber")}} properties. For example:</p>
+<p>You can get and set the date value in JavaScript with the {{domxref("HTMLInputElement")}} <code>value</code> and <code>valueAsNumber</code> properties. For example:</p>
 
 <pre class="brush: js">var dateControl = document.querySelector('input[type="date"]');
 dateControl.value = '2017-06-01';

--- a/files/en-us/web/html/element/input/datetime-local/index.html
+++ b/files/en-us/web/html/element/input/datetime-local/index.html
@@ -83,7 +83,7 @@ tags:
 <p><strong>Note:</strong> Also bear in mind that if such data is submitted via HTTP <code><a href="/en-US/docs/Web/HTTP/Methods/GET">GET</a></code>, the colon character will need to be escaped for inclusion in the URL parameters, e.g. <code>partydate=2017-06-01T08%3A30</code>. See {{jsxref("Global_Objects/encodeURI", "encodeURI()")}} for one way to do this.</p>
 </div>
 
-<p>You can also get and set the date value in JavaScript using the {{domxref("HTMLInputElement.value")}} property, for example:</p>
+<p>You can also get and set the date value in JavaScript using the {{domxref("HTMLInputElement")}} <code>value</code> property, for example:</p>
 
 <pre class="brush: js">var dateControl = document.querySelector('input[type="datetime-local"]');
 dateControl.value = '2017-06-01T08:30';</pre>

--- a/files/en-us/web/html/element/input/text/index.html
+++ b/files/en-us/web/html/element/input/text/index.html
@@ -46,7 +46,7 @@ tags:
 
 <h2 id="Value">Value</h2>
 
-<p>The {{htmlattrxref("value", "input")}} attribute is a {{domxref("DOMString")}} that contains the current value of the text entered into the text field. You can retrieve this using the {{domxref("HTMLInputElement.value", "value")}} property in JavaScript.</p>
+<p>The {{htmlattrxref("value", "input")}} attribute is a {{domxref("DOMString")}} that contains the current value of the text entered into the text field. You can retrieve this using the {{domxref("HTMLInputElement")}} <code>value</code> property in JavaScript.</p>
 
 <pre class="brush: js">let theText = myTextInput.value;
 </pre>
@@ -142,7 +142,7 @@ tags:
 
 <h3 id="htmlattrdefreadonly">{{htmlattrdef("readonly")}}</h3>
 
-<p>A Boolean attribute which, if present, means this field cannot be edited by the user. Its <code>value</code> can, however, still be changed by JavaScript code directly setting the {{domxref("HTMLInputElement.value")}} property.</p>
+<p>A Boolean attribute which, if present, means this field cannot be edited by the user. Its <code>value</code> can, however, still be changed by JavaScript code directly setting the {{domxref("HTMLInputElement")}} <code>value</code> property.</p>
 
 <div class="note">
 <p><strong>Note:</strong> Because a read-only field cannot have a value, <code>required</code> does not have any effect on inputs with the <code>readonly</code> attribute also specified.</p>

--- a/files/en-us/web/html/element/input/time/index.html
+++ b/files/en-us/web/html/element/input/time/index.html
@@ -86,7 +86,7 @@ tags:
 
 <p>{{ EmbedLiveSample('value-sample1', 600, 60) }}</p>
 
-<p>You can also get and set the date value in JavaScript using the {{domxref("HTMLInputElement.value")}} property, for example:</p>
+<p>You can also get and set the date value in JavaScript using the {{domxref("HTMLInputElement")}} <code>value</code> property, for example:</p>
 
 <pre class="brush: js">var timeControl = document.querySelector('input[type="time"]');
 timeControl.value = '15:30';</pre>


### PR DESCRIPTION
Noticed that there were a number of links using the macro to HTMLInputElement.value which doesn't exist so they were broken. The value property is listed on the HTMLInputElement page in the table, so I have adjusted these to to link to that page.