### PR TITLE
Fix: Incorrectly referenced JS object

### DIFF
--- a/files/en-us/web/api/rtcdatachannel/ordered/index.html
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.html
@@ -69,5 +69,5 @@ if (!dc.ordered) {
 <ul>
   <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a></li>
   <li>{{domxref("RTCDataChannel")}}</li>
-  <li>{{domxref("RTCDataChannel.createDataChannel()")}}</li>
+  <li>{{domxref("RTCPeerConnection.createDataChannel()")}}</li>
 </ul>


### PR DESCRIPTION
### What was wrong/why is this fix needed? (quick summary only)
`RTCDataChannel.createDataChannel()` should be [`RTCPeerConnection.createDataChannel()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel)
### MDN URL of main page changed
[`RTCDataChannel.ordered`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/ordered)