### PR TITLE
Adding note for deprecation of moz-outline-radius property

### DIFF
--- a/files/en-us/web/css/-moz-outline-radius-bottomleft/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-bottomleft/index.html
@@ -12,10 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<div class="notecard warning">
-  <h4>Scheduled for removal</h4>
-  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
-</div>
+<div>{{deprecated_header}}</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-bottomleft</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the bottom-left corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-bottomright/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-bottomright/index.html
@@ -12,10 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<div class="notecard warning">
-  <h4>Scheduled for removal</h4>
-  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
-</div>
+<div>{{deprecated_header}}</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-bottomright</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the bottom-right corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-topleft/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-topleft/index.html
@@ -12,10 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<div class="notecard warning">
-  <h4>Scheduled for removal</h4>
-  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
-</div>
+<div>{{deprecated_header}}</div>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-topleft</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the top-left corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius-topright/index.html
+++ b/files/en-us/web/css/-moz-outline-radius-topright/index.html
@@ -12,10 +12,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<div class="notecard warning">
-  <h4>Scheduled for removal</h4>
-  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
-</div>
+<div>{{deprecated_header}}</div>>
 
 <p>In Mozilla applications, the <strong><code>-moz-outline-radius-topright</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property can be used to round the top-right corner of an element's {{cssxref("outline")}}.</p>
 

--- a/files/en-us/web/css/-moz-outline-radius/index.html
+++ b/files/en-us/web/css/-moz-outline-radius/index.html
@@ -11,10 +11,7 @@ tags:
 ---
 <div>{{CSSRef}}</div>
 
-<div class="notecard warning">
-  <h4>Scheduled for removal</h4>
-  <p>From Firefox 88 onwards, the standard {{cssxref("outline")}} property will follow the shape of {{cssxref("border-radius")}}, making <code>-moz-outline-radius</code> properties redundant. As such, this property will be removed.</p>
-</div>
+<div>{{deprecated_header}}</div>
 
 <p>In Mozilla applications like Firefox, the <strong><code>-moz-outline-radius</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> can be used to give an element's {{cssxref("outline")}} rounded corners.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

moz-outline-radius was deprecated starting with FF88 and the changes made are:

 - removal of the "scheduled removal in FF88" note 
 -  adding standard Deprecated note 

> Issue number (if there is an associated issue)

Follow up for https://github.com/mdn/content/issues/3453#event-4643780227

Complimentary BCD changes in https://github.com/mdn/browser-compat-data/pull/10127 and https://github.com/mdn/browser-compat-data/pull/10151