### PR TITLE
Fix variable reference

### DIFF
--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.html
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-{{CSSSyntax}}
+{{csssyntax}}
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
Based on a couple of other documentation pages for reference:
- https://github.com/mdn/content/blob/main/files/en-us/web/css/flex-direction/index.html#L71
- https://github.com/mdn/content/blob/main/files/en-us/web/css/display/index.html#L223

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)


The [`::-webkit-scrollbar` documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) has a ~~display~~ template variable reference bug:

![Screen Shot 2021-04-28 at 11 04 33 AM](https://user-images.githubusercontent.com/24785158/116427848-627a6c00-a812-11eb-9ae9-6a33b2db62b1.png)

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar

> Issue number (if there is an associated issue)

> Anything else that could help us review it
