### PR TITLE
Fix typo in assessment

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/marking_up_a_letter/index.html
+++ b/files/en-us/learn/html/introduction_to_html/marking_up_a_letter/index.html
@@ -54,7 +54,7 @@ tags:
 
 <ul>
  <li>The names of the sender and receiver (and <em>Tel</em> and <em>Email</em>) should be marked up with strong importance.</li>
- <li>The four dates in the document should be have appropriate elements containing machine-readable dates.</li>
+ <li>The four dates in the document should have appropriate elements containing machine-readable dates.</li>
  <li>The first address and first date in the letter should have a class attribute value of <em>sender-column</em>. The CSS you'll add later will cause these to be right aligned, as it should be in the case in a classic letter layout.</li>
  <li>Mark up the following five acronyms/abbreviations in the main text of the letter — "PhD," "HTML," "CSS," "BC," and "Esq." — to provide expansions of each one.</li>
  <li>The six sub/superscripts should be marked up appropriately — in the chemical formulae,  and the numbers 103 and 104 (they should be 10 to the power of 3 and 4, respectively).</li>


### PR DESCRIPTION
Fix typo

> What was wrong/why is this fix needed? (quick summary only)
Typo on the 2nd bullet point of the Inline Semantics section

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter

> Issue number (if there is an associated issue)

> Anything else that could help us review it
