### PR TITLE
Remove dead link in OpenSearch Description Docs

### DIFF
--- a/files/en-us/web/opensearch/index.html
+++ b/files/en-us/web/opensearch/index.html
@@ -154,6 +154,5 @@ tags:
  <li><a href="https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/search-provider-discovery">Microsoft Edge Dev Guide: Search provider discovery</a></li>
  <li><a href="https://www.chromium.org/tab-to-search">The Chromium Projects: Tab to Search</a></li>
  <li>imdb.com has a <a class="external" href="https://m.media-amazon.com/images/G/01/imdb/images/imdbsearch-3349468880._CB470047351_.xml">working <code>osd.xml</code></a></li>
- <li><a class="external" href="http://www.7is7.com/software/firefox/opensearch.html">OpenSearch Plugin Generator</a></li>
  <li><a class="external" href="http://ready.to/search/en">Ready2Search</a> - create OpenSearch plugins. <a class="external" href="http://ready.to/search/make/en_make_plugin.htm">Customized Search through Ready2Search</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Dead link and website as a whole.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/OpenSearch

> Issue number (if there is an associated issue)

> Anything else that could help us review it
