### PR TITLE
Add Safari support for <input> w/ type=time, type=datetime-local

### DIFF
--- a/files/en-us/web/html/element/input/datetime-local/index.html
+++ b/files/en-us/web/html/element/input/datetime-local/index.html
@@ -23,7 +23,7 @@ tags:
 
 <div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
-<p>The control's UI varies in general from browser to browser; at the moment support is patchy, with only Chrome/Opera and Edge on desktop and most modern versions of mobile browsers having usable implementations. In other browsers, these degrade gracefully to simple <code><a href="/en-US/docs/Web/HTML/Element/input/text">&lt;input type="text"&gt;</a></code> controls.</p>
+<p>The control's UI varies in general from browser to browser; at the moment support is patchy, with Chrome/Opera/Edge and Safari 14.1 on desktop and most modern versions of mobile browsers having usable implementations. In other browsers, these degrade gracefully to simple <code><a href="/en-US/docs/Web/HTML/Element/input/text">&lt;input type="text"&gt;</a></code> controls.</p>
 
 <p>The control is intended to represent <em>a local date and time</em>, not necessarily <em>the user's local date and time</em>. In other words, an implementation should allow any valid combination of year, month, day, hour, and minute - even if such a combination is invalid in the user's local time zone (such as times within a daylight saving time spring-forward transition gap). Some mobile browsers (particularly on iOS) do not currently implement this correctly.</p>
 
@@ -264,7 +264,7 @@ input:valid+span:after {
 
 <h2 id="Handling_browser_support">Handling browser support</h2>
 
-<p>As mentioned above, the major problem with using date inputs at the time of writing is browser support — only Chrome/Opera and Edge support it on desktop, and most modern browsers on mobile. As an example, the <code>datetime-local</code> picker on Firefox for Android looks like this:</p>
+<p>As mentioned above, the major problem with using datetime-local inputs at the time of writing is browser support — Chrome/Opera/Edge and Safari support it on desktop, and most modern browsers on mobile. As an example, the <code>datetime-local</code> picker on Firefox for Android looks like this:</p>
 
 <p><img alt="" src="datetime-local-fxa.png" style="display: block; margin: 0px auto;"></p>
 

--- a/files/en-us/web/html/element/input/time/index.html
+++ b/files/en-us/web/html/element/input/time/index.html
@@ -18,7 +18,7 @@ tags:
 
 <p><span class="seoSummary">{{htmlelement("input")}} elements of type <strong><code>time</code></strong> create input fields designed to let the user easily enter a time (hours and minutes, and optionally seconds).</span></p>
 
-<p>The control's user interface will vary from browser to browser. Support is good in modern browsers, with Safari being the sole major browser not yet implementing it; in Safari, and any other browsers that don't support <code>&lt;time&gt;</code>, it degrades gracefully to <code><a href="/en-US/docs/Web/HTML/Element/input/text">&lt;input type="text"&gt;</a></code>.</p>
+<p>The control's user interface varies from browser to browser; see {{anch("Browser compatibility")}} for further details. In unsupported browsers, the control degrades gracefully to <code><a href="/en-US/docs/Web/HTML/Element/input/text">&lt;input type="text"&gt;</a></code>.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/input-time.html", "tabbed-standard")}}</div>
 
@@ -184,10 +184,6 @@ startTime.addEventListener("input", function() {
 
 <h2 id="Using_time_inputs">Using time inputs</h2>
 
-<p>Although among the date and time input types <code>time</code> has the widest browser support, it is not yet approaching universal, so it is likely that you'll need to provide an alternative method for entering the date and time, so that Safari users (and users of other non-supporting browsers) can still easily enter time values.</p>
-
-<p>We'll look at basic and more complex uses of <code>&lt;input type="time"&gt;</code>, then offer advice on mitigating the browser support issue later on (see {{anch("Handling browser support")}}).</p>
-
 <h3 id="Basic_uses_of_time">Basic uses of time</h3>
 
 <p>The simplest use of <code>&lt;input type="time"&gt;</code> involves a basic <code>&lt;input&gt;</code> and {{htmlelement("label")}} element combination, as seen below:</p>
@@ -283,7 +279,7 @@ input:valid+span:after {
 
 <h4 id="Making_min_and_max_cross_midnight">Making min and max cross midnight</h4>
 
-<p>By setting a {{htmlattrxref("min", "input")}} attribute greater than the {{htmlattrxref("max", "input")}} attribute, the valid time range will wrap around midnight to produce a valid time range which crosses midnight. This functionality is not supported by any other input types. While this feature is <a href="https://html.spec.whatwg.org/C/#has-a-reversed-range">in the HTML spec</a>, it is not yet universally supported. Chrome-based browsers support it starting in version 82 and Firefox added it in version 76. No information is yet available about when or if Safari will add it. Be prepared for this situation to arise:</p>
+<p>By setting a {{htmlattrxref("min", "input")}} attribute greater than the {{htmlattrxref("max", "input")}} attribute, the valid time range will wrap around midnight to produce a valid time range which crosses midnight. This functionality is not supported by any other input types. While this feature is <a href="https://html.spec.whatwg.org/C/#has-a-reversed-range">in the HTML spec</a>, it is not yet universally supported. Chrome-based browsers support it starting in version 82 and Firefox added it in version 76. Safari as of version 14.1 does not support this. Be prepared for this situation to arise:</p>
 
 <pre class="brush: js">const input = document.createElement('input');
 input.type = 'time';
@@ -330,7 +326,7 @@ if (input.validity.valid &amp;&amp; input.type === 'time') {
 
 <h2 id="Handling_browser_support">Handling browser support</h2>
 
-<p>As mentioned above, Safari and a few other, less common, browsers don't yet support time inputs natively. In general, otherwise, support is good — especially on mobile platforms, which tend to have very nice user interfaces for specifying a time value. For example, the <code>time</code> picker on Chrome for Android looks like this:</p>
+<p>As mentioned, older versions of Safari and a few other, less common, browsers don't support time inputs natively. In general, otherwise, support is good — especially on mobile platforms, which tend to have very nice user interfaces for specifying a time value. For example, the <code>time</code> picker on Chrome for Android looks like this:</p>
 
 <p><img alt="" src="chrome-android-time.png" style="display: block; margin: 0 auto;"></p>
 


### PR DESCRIPTION
Changed browser support notices to mention Safari support.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Safari 14.1 recently added support for input type date, time and datetime-local, this PR fixes some notices about browser support.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local

and

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time
