### PR TITLE
Clarify HTMLElement.p.labels is null for type=hidden controls

### DIFF
--- a/files/en-us/web/api/htmlinputelement/labels/index.html
+++ b/files/en-us/web/api/htmlinputelement/labels/index.html
@@ -12,7 +12,8 @@ tags:
 
 <p>The <code><strong>HTMLInputElement.labels</strong></code> read-only property returns a
   {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
-  {{HTMLElement("input")}} element.</p>
+  {{HTMLElement("input")}} element, if the element is not hidden. If the element has the
+  type <code>hidden</code>, the property returns <code>null</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 


### PR DESCRIPTION
Without the addition, the text implies that hidden input elements, like other input elements, have label properties of type NodeList, but they do not. This addition corrects that implication.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
