### PR TITLE
Fix problem with num_visits count in Django Tutorial doc example

### DIFF
--- a/files/en-us/learn/server-side/django/sessions/index.html
+++ b/files/en-us/learn/server-side/django/sessions/index.html
@@ -126,7 +126,7 @@ request.session.modified = True
     num_authors = Author.objects.count()  # The 'all()' is implied by default.
 
     # Number of visits to this view, as counted in the session variable.
-    num_visits = request.session.get('num_visits', 1)
+    num_visits = request.session.get('num_visits', 0)
     request.session['num_visits'] = num_visits + 1
 
     context = {
@@ -141,7 +141,7 @@ request.session.modified = True
     return render(request, 'index.html', context=context)</pre>
 
 
-<p>Here we first get the value of the <code>'num_visits'</code> session key, setting the value to 1 if it has not previously been set. Each time a request is received, we then increment the value and store it back in the session (for the next time the user visits the page). The <code>num_visits</code> variable is then passed to the template in our context variable.</p>
+<p>Here we first get the value of the <code>'num_visits'</code> session key, setting the value to 0 if it has not previously been set. Each time a request is received, we then increment the value and store it back in the session (for the next time the user visits the page). The <code>num_visits</code> variable is then passed to the template in our context variable.</p>
 
 <div class="notecard note">
     <h4>Note</h4>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The num_visits already has a +1 on the next line. Therefore, the default for the first visit (when the key does not exist) should be 0 as the next line will make the num_visits = 1.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Sessions

> Issue number (if there is an associated issue)
N/A

> Anything else that could help us review it
The document demonstrates how to show the users the number of visits on the page. When the num_visits key exists in the session, the value is extracted and saved in a variable. However, when the num_visits key does not exist (potentially user's first visit), the value returned to the user is 2 instead of 1 as the default value extracted is 1 and 1 more is added on the next line.