### PR TITLE
Remove BCD from guide pages

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.html
@@ -9,7 +9,6 @@ tags:
   - RegExp
   - Regular Expressions
   - regex
-browser-compat: javascript.builtins.RegExp
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}</div>
 
@@ -442,22 +441,5 @@ function testInfo(phoneInput) {
  <dt><a href="https://extendsclass.com/regex-tester.html" rel="noopener">Regex visualizer</a></dt>
  <dd>An online visual regex tester.</dd>
 </dl>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-regexp-regular-expression-objects', 'RegExp')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat}}</p>
 
 <div>{{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}</div>

--- a/files/en-us/web/javascript/typed_arrays/index.html
+++ b/files/en-us/web/javascript/typed_arrays/index.html
@@ -4,7 +4,6 @@ slug: Web/JavaScript/Typed_arrays
 tags:
   - Guide
   - JavaScript
-browser-compat: javascript.builtins.Int8Array
 ---
 <div>{{JsSidebar("Advanced")}}</div>
 
@@ -245,25 +244,6 @@ const normalArray = [...typedArray];</pre>
 
 <pre class="brush:js">const typedArray = new Uint8Array([1, 2, 3, 4]);
 const normalArray = Array.prototype.slice.call(typedArray);</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-typedarray-objects', 'TypedArray Objects')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
See https://github.com/mdn/content/issues/4574#issuecomment-828805013

I think these guide pages talk about a variety of features and the compat data included isn't very suitable there. The relevant reference pages are linked heavily and that's where the reader typically finds compat / spec information.