### PR TITLE
improve requestAnimationFrame description

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/timeouts_and_intervals/index.html
+++ b/files/en-us/learn/javascript/asynchronous/timeouts_and_intervals/index.html
@@ -242,9 +242,9 @@ alert('Hello');</pre>
 
 <h2 id="requestAnimationFrame">requestAnimationFrame()</h2>
 
-<p><code><a href="/en-US/docs/Web/API/window/requestAnimationFrame">requestAnimationFrame()</a></code> is a specialized looping function created for running animations efficiently in the browser. It is basically the modern version of <code>setInterval()</code> — it executes a specified block of code before the browser next repaints the display, allowing an animation to be run at a suitable frame rate regardless of the environment it is being run in.</p>
+<p><code><a href="/en-US/docs/Web/API/window/requestAnimationFrame">requestAnimationFrame()</a></code> is a specialized enqueueing function created for running animations efficiently in the browser. It runs a specified block of code before the browser next repaints the display, allowing the execution to be paired with the device's display frame rate.</p>
 
-<p>It was created in response to perceived problems with <code>setInterval()</code>, which for example doesn't run at a frame rate optimized for the device, sometimes drops frames, continues to run even if the tab is not the active tab or the animation is scrolled off the page, etc.</p>
+<p>It was created in response to perceived problems with previous async functions like <code>setInterval()</code>, which for example doesn't run at a frame rate optimized for the device, dropping frames in some cases. They also lacked some optimizations suited for animations, like stopping the execution if the tab isn't active or the animation is scrolled off the page, among other things.</p>
 
 <p>(<a href="http://creativejs.com/resources/requestanimationframe/index.html">Read more about this on CreativeJS</a>.)</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
The description wasn't precise, it told the reader that requestAnimationFrame was a looping function.
Aside from that, it referred to motivations based in setInterval alone, when it's actually related to all previous async functions.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Timeouts_and_intervals
