### PR TITLE
Fix information for fullscreenchange event

### DIFF
--- a/files/en-us/web/api/fullscreen_api/index.html
+++ b/files/en-us/web/api/fullscreen_api/index.html
@@ -101,9 +101,9 @@ tags:
 
 <dl>
  <dt>{{Event("fullscreenchange")}}</dt>
- <dd>Sent to a {{DOMxRef("Element")}} when it transitions into or out of full-screen mode.</dd>
+ <dd>Sent to an {{DOMxRef("Element")}} when it transitions into or out of full-screen mode.</dd>
  <dt>{{Event("fullscreenerror")}}</dt>
- <dd>Sent to a <code>Element</code> if an error occurs while attempting to switch it into or out of full-screen mode.</dd>
+ <dd>Sent to an <code>Element</code> if an error occurs while attempting to switch it into or out of full-screen mode.</dd>
 </dl>
 
 <h2 id="Dictionaries">Dictionaries</h2>

--- a/files/en-us/web/api/fullscreen_api/index.html
+++ b/files/en-us/web/api/fullscreen_api/index.html
@@ -72,9 +72,9 @@ tags:
 
 <dl>
  <dt>{{DOMxRef("Document.onfullscreenchange")}}</dt>
- <dd>An event handler for the {{Event("fullscreenchange")}} event that's sent to a {{DOMxRef("Document")}} when that document is placed into full-screen mode, or when that document exits full-screen mode. This handler is called only when the entire document is presented in full-screen mode.</dd>
+ <dd>An event handler for the {{Event("fullscreenchange")}} event that's bubbled up to the {{DOMxRef("Document")}} when any {{DOMxRef("Element")}} in that document is placed into full-screen mode, or exits full-screen mode.</dd>
  <dt>{{DOMxRef("Document.onfullscreenerror")}}</dt>
- <dd>An event handler for the {{Event("fullscreenerror")}} event that gets sent to a {{DOMxRef("Document")}} when an error occurs while trying to enable or disable full-screen mode for the entire document.</dd>
+ <dd>An event handler for the {{Event("fullscreenerror")}} event that gets bubbled up to the {{DOMxRef("Document")}} when an error occurs while trying to enable or disable full-screen mode for any {{DOMxRef("Element")}} in that document.</dd>
 </dl>
 
 <h4 id="Event_handlers_on_elements">Event handlers on elements</h4>
@@ -101,9 +101,9 @@ tags:
 
 <dl>
  <dt>{{Event("fullscreenchange")}}</dt>
- <dd>Sent to a {{DOMxRef("Document")}} or {{DOMxRef("Element")}} when it transitions into or out of full-screen mode.</dd>
+ <dd>Sent to a {{DOMxRef("Element")}} when it transitions into or out of full-screen mode.</dd>
  <dt>{{Event("fullscreenerror")}}</dt>
- <dd>Sent to a <code>Document</code> or <code>Element</code> if an error occurs while attempting to switch it into or out of full-screen mode.</dd>
+ <dd>Sent to a <code>Element</code> if an error occurs while attempting to switch it into or out of full-screen mode.</dd>
 </dl>
 
 <h2 id="Dictionaries">Dictionaries</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Fixing wrong statement stating that the that "fullscreenchange" event is sent to the Document object when entire document is entered/exited fullscreen mode. But in real, this event never gets sent directly to document, instead when any Element in the document raises fullscreenchange event, it gets bubbled up to the Document object.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/4590

> Anything else that could help us review it

Read above github issue for tested prove
