### PR TITLE
Add EmbedInteractiveExample macro for font-stretch page

### DIFF
--- a/files/en-us/web/css/font-stretch/index.html
+++ b/files/en-us/web/css/font-stretch/index.html
@@ -12,6 +12,10 @@ tags:
 
 <p><span class="seoSummary">The <strong><code>font-stretch</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property selects a normal, condensed, or expanded face from a font.</span></p>
 
+<div>{{EmbedInteractiveExample("pages/css/font-stretch.html")}}</div>
+
+<h2 id="Syntax">Syntax</h2>
+
 <pre class="brush:css no-line-numbers">/* Keyword values */
 font-stretch: ultra-condensed;
 font-stretch: extra-condensed;
@@ -33,8 +37,6 @@ font-stretch: inherit;
 font-stretch: initial;
 font-stretch: unset;
 </pre>
-
-<h2 id="Syntax">Syntax</h2>
 
 <p>This property may be specified as a single keyword value or a single {{cssxref("&lt;percentage&gt;")}} value.</p>
 


### PR DESCRIPTION
Mentioned in [this comment](https://github.com/mdn/interactive-examples/pull/1799#issuecomment-829561015) that to finish the interactive example addition that the macro needed to be inserted to `font-stretch.html`.

URL changed: https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch

Associated Issue and PR: Completes [#573](https://github.com/mdn/interactive-examples/issues/573) from `mdn/interactive-examples`. Related PR [#799](https://github.com/mdn/interactive-examples/pull/1799)
