### PR TITLE
Fixes an http link in domstring

### DIFF
--- a/files/en-us/web/api/domstring/index.html
+++ b/files/en-us/web/api/domstring/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{APIRef("DOM")}}</div>
 
-<p>A <strong><code>DOMString</code></strong> is a sequence of 16-bit unsigned integers, typically interpreted as UTF-16 <a href="http://www.unicode.org/glossary/#code_unit">code units</a>. This corresponds exactly to the JavaScript <a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">primitive String type</a>. When a <code>DOMString</code> is provided to JavaScript, it maps directly to the corresponding {{jsxref("String")}}.</p>
+<p>A <strong><code>DOMString</code></strong> is a sequence of 16-bit unsigned integers, typically interpreted as UTF-16 <a href="https://www.unicode.org/glossary/#code_unit">code units</a>. This corresponds exactly to the JavaScript <a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">primitive String type</a>. When a <code>DOMString</code> is provided to JavaScript, it maps directly to the corresponding {{jsxref("String")}}.</p>
 
 <p>When a Web API accepts a <code>DOMString</code>, the value provided will be stringified, using the <code><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></code> abstract operation. (For types other than Symbol, this has the same behavior as the {{jsxref("String/String", "String()")}} function.)</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Changes an http link to https on the DOMString page

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/DOMString


> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A
