### PR TITLE
fixed typo

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.html
+++ b/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.html
@@ -71,7 +71,7 @@ tags:
 
 <p>Open the HTML index file. You'll see a number of features; the HTML is dominated by the video player and its controls:</p>
 
-<pre>&lt;div class="player"&gt;
+<pre class="brush: html">&lt;div class="player"&gt;
   &lt;video controls&gt;
     &lt;source src="video/sintel-short.mp4" type="video/mp4"&gt;
     &lt;source src="video/sintel-short.webm" type="video/webm"&gt;


### PR DESCRIPTION
The <pre> at line 74 did have a class of "brush: html" for styling the html code snippet

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
