### PR TITLE
fix flaws in "Getting started with Svelte" docs

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.html
@@ -116,21 +116,22 @@ npm run dev</pre>
 <p>The starter template comes with the following structure:</p>
 
 <pre>moz-todo-svelte
-├── readme.md
+├── README.md
 ├── package.json
 ├── package-lock.json
 ├── rollup.config.js
 ├── .gitignore
 ├── node_modules
 ├── public
-│   ├── favicon.ico
+│   ├── favicon.png
 │   ├── index.html
 │   ├── global.css
 │   └── build
 │       ├── bundle.css
-│       ├── bundle.css.map
 │       ├── bundle.js
 │       └── bundle.js.map
+├── scripts
+│   └── setupTypeScript.js
 └── src
     ├── App.svelte
     └── main.js</pre>
@@ -142,7 +143,11 @@ npm run dev</pre>
  <li><code>node_modules</code>: This is where node saves the project dependencies. These dependencies won't be sent to production, they are just used for development purposes.</li>
  <li><code>.gitignore</code>: Tells git which files or folder to ignore from the project — useful if you decide to include your app in a git repo.</li>
  <li><code>rollup.config.js</code>: Svelte uses <a href="https://rollupjs.org/">rollup.js</a> as a module bundler. This configuration file tells rollup how to compile and build your app. If you prefer <a href="https://webpack.js.org/">webpack</a> you can create your starter project with <code>npx degit sveltejs/template-webpack svelte-app</code> instead.</li>
- <li>scripts: Contains setup scripts as required. Currently should only contain <code>setupTypeScript.js</code>, a script that sets up TypeScript support in Svelte. We'll talk about this more in the last article.</li>
+ <li><code>scripts</code>: Contains setup scripts as required. Currently should only contain <code>setupTypeScript.js</code>.
+  <ul>
+    <li><code>setupTypeScript.js</code>: This script that sets up TypeScript support in Svelte. We'll talk about this more in the last article.</li>
+  </ul>
+ </li>
  <li><code>src</code>: This directory is where the source code for your application lives — where you'll be creating the code for your app.
   <ul>
    <li><code>App.svelte</code>: This is the top-level component of your app. So far it just renders the 'Hello World!' message.</li>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

starter template  structure like missing "scripts" description...

so, i fix two things
1. fix starter template  structure in real situation ( after running create starter app commands )
2. fix "scripts" content description and add setupTypeScript.js description

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A