### PR TITLE
Fix broken dd elements in JS docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.html
@@ -30,22 +30,28 @@ copyWithin(target, start, end)
 
 <dl>
   <dt><code>target</code></dt>
-  <dd>Zero-based index at which to copy the sequence to. If negative, <code>target</code>
-    will be counted from the end.</dd>
-  <dd>If <code>target</code> is at or greater than <code>arr.length</code>, nothing will
+  <dd>
+    <p>Zero-based index at which to copy the sequence to. If negative, <code>target</code>
+    will be counted from the end.</p>
+    <p>If <code>target</code> is at or greater than <code>arr.length</code>, nothing will
     be copied. If <code>target</code> is positioned after <code>start</code>, the copied
-    sequence will be trimmed to fit <code>arr.length</code>.</dd>
+    sequence will be trimmed to fit <code>arr.length</code>.</p>
+  </dd>
   <dt><code>start</code> {{optional_inline}}</dt>
-  <dd>Zero-based index at which to start copying elements from. If negative,
-    <code>start</code> will be counted from the end.</dd>
-  <dd>If <code>start</code> is omitted, <code>copyWithin</code> will copy from index
-    <code>0</code>. </dd>
+  <dd>
+    <p>Zero-based index at which to start copying elements from. If negative,
+    <code>start</code> will be counted from the end.</p>
+    <p>If <code>start</code> is omitted, <code>copyWithin</code> will copy from index
+    <code>0</code>.</p>
+  </dd>
   <dt><code>end</code> {{optional_inline}}</dt>
-  <dd>Zero-based index at which to end copying elements from. <code>copyWithin</code>
+  <dd>
+    <p>Zero-based index at which to end copying elements from. <code>copyWithin</code>
     copies up to but not including <code>end</code>. If negative, <code>end</code> will be
-    counted from the end.</dd>
-  <dd>If <code>end</code> is omitted, <code>copyWithin</code> will copy until the last
-    index (default to <code>arr.length</code>).</dd>
+    counted from the end.</p>
+    <p>If <code>end</code> is omitted, <code>copyWithin</code> will copy until the last
+    index (default to <code>arr.length</code>).</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -40,9 +40,8 @@ forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 <dl>
   <dt><code><var>callback</var></code></dt>
-  <dd>Function to execute on each element. It accepts between one and three arguments:
-  </dd>
   <dd>
+    <p>Function to execute on each element. It accepts between one and three arguments:</p>
     <dl>
       <dt><code><var>currentValue</var></code></dt>
       <dd>The current element being processed in the array.</dd>

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -41,15 +41,17 @@ includes(valueToFind, fromIndex)
     </div>
   </dd>
   <dt><code><var>fromIndex</var></code> {{optional_inline}}</dt>
-  <dd>The position in this array at which to begin searching for
-    <code><var>valueToFind</var></code>.</dd>
-  <dd>The first element to be searched is found at <code><var>fromIndex</var></code> for
+  <dd>
+    <p>The position in this array at which to begin searching for
+    <code><var>valueToFind</var></code>.</p>
+    <p>The first element to be searched is found at <code><var>fromIndex</var></code> for
     positive values of <code><var>fromIndex</var></code>, or at
     <code><var>arr</var>.length + <var>fromIndex</var></code> for negative values of
     <code><var>fromIndex</var></code> (using the {{interwiki("wikipedia", "absolute
     value")}} of <code><var>fromIndex</var></code> as the number of elements from the end
-    of the array at which to start the search).</dd>
-  <dd>Defaults to <code>0</code>.</dd>
+    of the array at which to start the search).</p>
+    <p>Defaults to <code>0</code>.</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.html
@@ -30,26 +30,30 @@ slice(start, end)
 
 <dl>
   <dt><code><var>start</var></code> {{optional_inline}}</dt>
-  <dd>Zero-based index at which to start extraction.</dd>
-  <dd>A negative index can be used, indicating an offset from the end of the sequence.
-    <code>slice(-2)</code> extracts the last two elements in the sequence.</dd>
-  <dd>If <code><var>start</var></code> is undefined, <code>slice</code> starts from the
-    index <code>0</code>.</dd>
-  <dd>If <code><var>start</var></code> is greater than the index range of the sequence, an
-    empty array is returned.</dd>
+  <dd>
+    <p>Zero-based index at which to start extraction.</p>
+    <p>A negative index can be used, indicating an offset from the end of the sequence.
+    <code>slice(-2)</code> extracts the last two elements in the sequence.</p>
+    <p>If <code><var>start</var></code> is undefined, <code>slice</code> starts from the
+    index <code>0</code>.</p>
+    <p>If <code><var>start</var></code> is greater than the index range of the sequence, an
+    empty array is returned.</p>
+  </dd>
   <dt><code><var>end</var></code> {{optional_inline}}</dt>
-  <dd>Zero-based index <em>before</em> which to end extraction. <code>slice</code>
+  <dd>
+    <p>Zero-based index <em>before</em> which to end extraction. <code>slice</code>
     extracts up to but not including <code><var>end</var></code>. For example,
     <code>slice(1,4)</code> extracts the second element through the fourth element
-    (elements indexed 1, 2, and 3).</dd>
-  <dd>A negative index can be used, indicating an offset from the end of the sequence.
+    (elements indexed 1, 2, and 3).</p>
+    <p>A negative index can be used, indicating an offset from the end of the sequence.
     <code>slice(2,-1)</code> extracts the third element through the second-to-last element
-    in the sequence.</dd>
-  <dd>If <code><var>end</var></code> is omitted, <code>slice</code> extracts through the
-    end of the sequence (<code><var>arr</var>.length</code>).</dd>
-  <dd>If <code><var>end</var></code> is greater than the length of the sequence,
+    in the sequence.</p>
+    <p>If <code><var>end</var></code> is omitted, <code>slice</code> extracts through the
+    end of the sequence (<code><var>arr</var>.length</code>).</p>
+    <p>If <code><var>end</var></code> is greater than the length of the sequence,
     <code>slice</code> extracts through to the end of the sequence
-    (<code><var>arr</var>.length</code>).</dd>
+    (<code><var>arr</var>.length</code>).</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -34,32 +34,29 @@ splice(start, deleteCount, item1, item2, itemN)
 
 <dl>
   <dt><code><var>start</var></code></dt>
-  <dd>The index at which to start changing the array.</dd>
-  <dd>If greater than the length of the array, <code><var>start</var></code> will be set
+  <dd>
+    <p>The index at which to start changing the array.</p>
+    <p>If greater than the length of the array, <code><var>start</var></code> will be set
     to the length of the array. In this case, no element will be deleted but the method
-    will behave as an adding function, adding as many element as item[n*] provided.</dd>
-  <dd>If negative, it will begin that many elements from the end of the array. (In this
+    will behave as an adding function, adding as many element as item[n*] provided.</p>
+    <p>If negative, it will begin that many elements from the end of the array. (In this
     case, the origin <code>-1</code>, meaning <code>-<var>n</var></code> is the index of
     the <code><var>n</var></code><sup>th</sup> last element, and is therefore equivalent
     to the index of <code><var>array</var>.length - <var>n</var></code>.) If
     <code><var>array</var>.length + <var>start</var></code> is less than <code>0</code>,
-    it will begin from index <code>0</code>.</dd>
+    it will begin from index <code>0</code>.</p>
+  </dd>
   <dt><code><var>deleteCount</var></code> {{optional_inline}}</dt>
-  <dd>An integer indicating the number of elements in the array to remove from
-    <code><var>start</var></code>.</dd>
-  <dd>If <code><var>deleteCount</var></code> is omitted, or if its value is equal to or
+  <dd>
+    <p>An integer indicating the number of elements in the array to remove from
+    <code><var>start</var></code>.</p>
+    <p>If <code><var>deleteCount</var></code> is omitted, or if its value is equal to or
     larger than <code><var>array</var>.length - <var>start</var></code> (that is, if it is
     equal to or greater than the number of elements left in the array, starting at
     <code><var>start</var></code>), then all the elements from
-    <code><var>start</var></code> to the end of the array will be deleted.</dd>
-  <dd>
-    <div class="notecard note">
-      <p><strong>Note:</strong> In IE8, it won't delete all when
-        <code><var>deleteCount</var></code> is omitted.</p>
-    </div>
-  </dd>
-  <dd>If <code><var>deleteCount</var></code> is <code>0</code> or negative, no elements
-    are removed. In this case, you should specify at least one new element (see below).
+    <code><var>start</var></code> to the end of the array will be deleted.</p>
+    <p>If <code><var>deleteCount</var></code> is <code>0</code> or negative, no elements
+    are removed. In this case, you should specify at least one new element (see below).</p>
   </dd>
   <dt><code><var>item1</var>, <var>item2</var>, ...</code> {{optional_inline}}</dt>
   <dd>The elements to add to the array, beginning from <code><var>start</var></code>. If

--- a/files/en-us/web/javascript/reference/global_objects/generator/next/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/generator/next/index.html
@@ -26,11 +26,13 @@ browser-compat: javascript.builtins.Generator.next
 
 <dl>
   <dt><code><var>value</var></code></dt>
-  <dd>The value to send to the generator.</dd>
-  <dd>The value will be assigned as a result of a <code>yield</code> expression. For
+  <dd>
+    <p>The value to send to the generator.</p>
+    <p>The value will be assigned as a result of a <code>yield</code> expression. For
     example, in <code><var>variable</var> = yield <var>expression</var></code>, the value
     passed to the <code>.next()</code> function will be assigned to
-    <code><var>variable</var></code>.</dd>
+    <code><var>variable</var></code>.</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -39,12 +41,14 @@ browser-compat: javascript.builtins.Generator.next
 
 <dl>
   <dt><code>done</code> (boolean)</dt>
-  <dd>Has the value <code>true</code> if the iterator is past the end of the iterated
+  <dd>
+    <p>Has the value <code>true</code> if the iterator is past the end of the iterated
     sequence. In this case <code>value</code> optionally specifies the <em>return
-      value</em> of the iterator.</dd>
-  <dd>Has the value <code>false</code> if the iterator was able to produce the next value
+      value</em> of the iterator.</p>
+    <p>Has the value <code>false</code> if the iterator was able to produce the next value
     in the sequence. This is equivalent of not specifying the <code>done</code> property
-    altogether.</dd>
+    altogether.</p>
+  </dd>
   <dt><code>value</code></dt>
   <dd>Any JavaScript value returned by the iterator. Can be omitted when <code>done</code>
     is <code>true</code>.</dd>

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.html
@@ -84,16 +84,15 @@ new Intl.DateTimeFormat(locales, options)
 				</div>
 			</dd>
 			<dt><code>timeStyle</code></dt>
-			<dd>The time formatting style to use when calling <code>format()</code>.
-				Possible values include:
+			<dd>
+        <p>The time formatting style to use when calling <code>format()</code>.
+				Possible values include:</p>
 				<ul>
 					<li>"<code>full</code>"</li>
 					<li>"<code>long</code>"</li>
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.html
@@ -27,13 +27,12 @@ browser-compat: javascript.builtins.Object.defineProperties
   <dt><code><var>obj</var></code></dt>
   <dd>The object on which to define or modify properties.</dd>
   <dt><code><var>props</var></code></dt>
-  <dd>An object whose keys represent the names of properties to be defined or modified and
+  <dd>
+    <p>An object whose keys represent the names of properties to be defined or modified and
     whose values are objects describing those properties. Each value in <code>props</code>
     must be either a data descriptor or an accessor descriptor; it cannot be both (see
-    {{jsxref("Object.defineProperty()")}} for more details).</dd>
-  <dd>Data descriptors and accessor descriptors may optionally contain the following keys:
-  </dd>
-  <dd>
+    {{jsxref("Object.defineProperty()")}} for more details).</p>
+    <p>Data descriptors and accessor descriptors may optionally contain the following keys:</p>
     <dl>
       <dt><code>configurable</code></dt>
       <dd><code>true</code> if and only if the type of this property descriptor may be

--- a/files/en-us/web/javascript/reference/global_objects/parseint/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/parseint/index.html
@@ -33,12 +33,13 @@ parseInt(string, radix)
     abstract operation. Leading {{glossary("whitespace")}} in this argument is ignored.
   </dd>
   <dt><code><var>radix</var></code><var> {{optional_inline}}</var></dt>
-  <dd>An integer between <code>2</code> and <code>36</code> that represents the
+  <dd>
+    <p>An integer between <code>2</code> and <code>36</code> that represents the
     <em>radix</em> (the base in mathematical numeral systems) of the
     <code><var>string</var></code>. Be careful—this does <strong><em>not</em></strong>
     default to <code>10</code>! If the radix value is not of the <code>Number</code> type
-    it will be coerced to a <code>Number</code></dd>
-  <dd><div class="notecard warning">
+    it will be coerced to a <code>Number</code>.</p>
+    <div class="notecard warning">
     <p><strong>Warning:</strong> The <a href="#description">description below</a> explains
     in more detail what happens when <code><var>radix</var></code> is not provided.
     </p>

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.html
@@ -192,23 +192,31 @@ window.addEventListener("message", (event) =&gt; {
 
 <dl>
  <dt>{{JSxRef("Promise.all", "Promise.all(iterable)")}}</dt>
- <dd>Wait for all promises to be resolved, or for any to be rejected.</dd>
- <dd>If the returned promise resolves, it is resolved with an aggregating array of the values from the resolved promises, in the same order as defined in the iterable of multiple promises.</dd>
- <dd>If it rejects, it is rejected with the reason from the first promise in the iterable that was rejected.</dd>
+ <dd>
+   <p>Wait for all promises to be resolved, or for any to be rejected.</p>
+   <p>If the returned promise resolves, it is resolved with an aggregating array of the values from the resolved promises, in the same order as defined in the iterable of multiple promises.</p>
+   <p>If it rejects, it is rejected with the reason from the first promise in the iterable that was rejected.</p>
+ </dd>
  <dt>{{JSxRef("Promise.allSettled", "Promise.allSettled(iterable)")}}</dt>
- <dd>Wait until all promises have settled (each may resolve or reject).</dd>
- <dd>Returns a Promise that resolves after all of the given promises have either resolved or rejected, with an array of objects that each describe the outcome of each promise.</dd>
+ <dd>
+   <p>Wait until all promises have settled (each may resolve or reject).</p>
+   <p>Returns a Promise that resolves after all of the given promises have either resolved or rejected, with an array of objects that each describe the outcome of each promise.</p>
+ </dd>
  <dt>{{JSxRef("Promise.any", "Promise.any(iterable)")}}</dt>
  <dd>Takes an iterable of Promise objects and, as soon as one of the promises in the iterable fulfills, returns a single promise that resolves with the value from that promise.</dd>
  <dt>{{JSxRef("Promise.race", "Promise.race(iterable)")}}</dt>
- <dd>Wait until any of the promises is resolved or rejected.</dd>
- <dd>If the returned promise resolves, it is resolved with the value of the first promise in the iterable that resolved.</dd>
- <dd>If it rejects, it is rejected with the reason from the first promise that was rejected.</dd>
+ <dd>
+   <p>Wait until any of the promises is resolved or rejected.</p>
+   <p>If the returned promise resolves, it is resolved with the value of the first promise in the iterable that resolved.</p>
+   <p>If it rejects, it is rejected with the reason from the first promise that was rejected.</p>
+ </dd>
  <dt>{{JSxRef("Promise.reject", "Promise.reject(reason)")}}</dt>
  <dd>Returns a new <code>Promise</code> object that is rejected with the given reason.</dd>
  <dt>{{JSxRef("Promise.resolve", "Promise.resolve(value)")}}</dt>
- <dd>Returns a new <code>Promise</code> object that is resolved with the given value. If the value is a thenable (i.e. has a <code>then</code> method), the returned promise will "follow" that thenable, adopting its eventual state; otherwise, the returned promise will be fulfilled with the value.</dd>
- <dd>Generally, if you don't know if a value is a promise or not, {{JSxRef("Promise.resolve", "Promise.resolve(value)")}} it instead and work with the return value as a promise.</dd>
+ <dd>
+   <p>Returns a new <code>Promise</code> object that is resolved with the given value. If the value is a thenable (i.e. has a <code>then</code> method), the returned promise will "follow" that thenable, adopting its eventual state; otherwise, the returned promise will be fulfilled with the value.</p>
+   <p>Generally, if you don't know if a value is a promise or not, {{JSxRef("Promise.resolve", "Promise.resolve(value)")}} it instead and work with the return value as a promise.</p>
+ </dd>
 </dl>
 
 <h2 id="Instance_methods">Instance methods</h2>

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.html
@@ -34,11 +34,13 @@ RegExp(<var>pattern</var>[, <var>flags</var>])
 
 <dl>
   <dt><code><var>pattern</var></code></dt>
-  <dd>The text of the regular expression.</dd>
-  <dd>As of ES5, this can also be another <code>RegExp</code> object or literal (for the
+  <dd>
+    <p>The text of the regular expression.</p>
+    <p>As of ES5, this can also be another <code>RegExp</code> object or literal (for the
     two RegExp constructor notations only). Patterns may include <a
       href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters">special
-      characters</a> to match a wider range of values than would a literal string.</dd>
+      characters</a> to match a wider range of values than would a literal string.</p>
+  </dd>
   <dt><code><var>flags</var></code></dt>
   <dd>
     <p>If specified, <code><var>flags</var></code> is a string that contains the flags to

--- a/files/en-us/web/javascript/reference/global_objects/set/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/set/foreach/index.html
@@ -27,8 +27,8 @@ browser-compat: javascript.builtins.Set.forEach
 
 <dl>
   <dt><code><var>callback</var></code></dt>
-  <dd>Function to execute for each element, taking three arguments:</dd>
   <dd>
+    <p>Function to execute for each element, taking three arguments:</p>
     <dl>
       <dt><code><var>currentValue</var></code>, <code><var>currentKey</var></code></dt>
       <dd>The current element being processed in the <code>Set</code>. As there are no

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.html
@@ -32,21 +32,25 @@ browser-compat: javascript.builtins.SharedArrayBuffer.slice
 
 <dl>
   <dt><code><var>begin</var></code> {{optional_inline}}</dt>
-  <dd>Zero-based index at which to begin extraction.</dd>
-  <dd>A negative index can be used, indicating an offset from the end of the sequence.
-    <code>slice(-2)</code> extracts the last two elements in the sequence.</dd>
-  <dd>If <code><var>begin</var></code> is undefined, <code>slice</code> begins from index
-    <code>0</code>.</dd>
+  <dd>
+    <p>Zero-based index at which to begin extraction.</p>
+    <p>A negative index can be used, indicating an offset from the end of the sequence.
+    <code>slice(-2)</code> extracts the last two elements in the sequence.</p>
+    <p>If <code><var>begin</var></code> is undefined, <code>slice</code> begins from index
+    <code>0</code>.</p>
+  </dd>
   <dt><code><var>end</var></code> {{optional_inline}}</dt>
-  <dd>Zero-based index <em>before</em> which to end extraction. <code>slice</code>
-    extracts up to but not including <code><var>end</var></code>.</dd>
-  <dd>For example, <code>slice(1,4)</code> extracts the second element through the fourth
-    element (elements indexed 1, 2, and 3).</dd>
-  <dd>A negative index can be used, indicating an offset from the end of the sequence.
+  <dd>
+    <p>Zero-based index <em>before</em> which to end extraction. <code>slice</code>
+    extracts up to but not including <code><var>end</var></code>.</p>
+    <p>For example, <code>slice(1,4)</code> extracts the second element through the fourth
+    element (elements indexed 1, 2, and 3).</p>
+    <p>A negative index can be used, indicating an offset from the end of the sequence.
     <code>slice(2,-1)</code> extracts the third element through the second-to-last element
-    in the sequence.</dd>
-  <dd>If <code><var>end</var></code> is omitted, <code>slice</code> extracts through the
-    end of the sequence (<code>sab.byteLength</code>).</dd>
+    in the sequence.</p>
+    <p>If <code><var>end</var></code> is omitted, <code>slice</code> extracts through the
+    end of the sequence (<code>sab.byteLength</code>).</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/javascript/reference/global_objects/string/match/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/match/index.html
@@ -28,12 +28,14 @@ browser-compat: javascript.builtins.String.match
 
 <dl>
   <dt><code><var>regexp</var></code></dt>
-  <dd>A regular expression object.</dd>
-  <dd>If <code><var>regexp</var></code> is a non-<code>RegExp</code> object, it is
+  <dd>
+    <p>A regular expression object.</p>
+    <p>If <code><var>regexp</var></code> is a non-<code>RegExp</code> object, it is
     implicitly converted to a {{jsxref("RegExp")}} by using
-    <code>new RegExp(<var>regexp</var>)</code>.</dd>
-  <dd>If you don't give any parameter and use the <code>match()</code> method directly,
-    you will get an {{jsxref("Array")}} with an empty string: <code>[""]</code>.</dd>
+    <code>new RegExp(<var>regexp</var>)</code>.</p>
+    <p>If you don't give any parameter and use the <code>match()</code> method directly,
+    you will get an {{jsxref("Array")}} with an empty string: <code>[""]</code>.</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/javascript/reference/global_objects/string/search/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/search/index.html
@@ -26,10 +26,11 @@ browser-compat: javascript.builtins.String.search
 
 <dl>
   <dt><code><var>regexp</var></code></dt>
-  <dd>A <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">regular
-      expression</a> object.</dd>
-  <dd>If a non-RegExp object <code><var>regexp</var></code> is passed, it is implicitly
-    converted to a {{jsxref("RegExp")}} with <code>new RegExp(<var>regexp</var>)</code>.
+  <dd>
+    <p>A <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">regular
+      expression</a> object.</p>
+    <p>If a non-RegExp object <code><var>regexp</var></code> is passed, it is implicitly
+    converted to a {{jsxref("RegExp")}} with <code>new RegExp(<var>regexp</var>)</code>.</p>
   </dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.html
@@ -31,21 +31,25 @@ browser-compat: javascript.builtins.TypedArray.slice
 
 <dl>
   <dt><code><var>begin</var></code> {{optional_inline}}</dt>
-  <dd>Zero-based index at which to begin extraction.</dd>
-  <dd>A negative index can be used, indicating an offset from the end of the sequence.
-    <code>slice(-2)</code> extracts the last two elements in the sequence.</dd>
-  <dd>If <code><var>begin</var></code> is undefined, <code>slice</code> begins from index
-    <code>0</code>.</dd>
+  <dd>
+    <p>Zero-based index at which to begin extraction.</p>
+    <p>A negative index can be used, indicating an offset from the end of the sequence.
+    <code>slice(-2)</code> extracts the last two elements in the sequence.</p>
+    <p>If <code><var>begin</var></code> is undefined, <code>slice</code> begins from index
+    <code>0</code>.</p>
+  </dd>
   <dt><code><var>end</var></code> {{optional_inline}}</dt>
-  <dd>Zero-based index <em>before</em> which to end extraction. <code>slice</code>
-    extracts up to but not including <code><var>end</var></code>.</dd>
-  <dd>For example, <code>slice(1,4)</code> extracts the second element through the fourth
-    element (elements indexed 1, 2, and 3).</dd>
-  <dd>A negative index can be used, indicating an offset from the end of the sequence.
+  <dd>
+    <p>Zero-based index <em>before</em> which to end extraction. <code>slice</code>
+    extracts up to but not including <code><var>end</var></code>.</p>
+    <p>For example, <code>slice(1,4)</code> extracts the second element through the fourth
+    element (elements indexed 1, 2, and 3).</p>
+    <p>A negative index can be used, indicating an offset from the end of the sequence.
     <code>slice(2,-1)</code> extracts the third element through the second-to-last element
-    in the sequence.</dd>
-  <dd>If <code><var>end</var></code> is omitted, <code>slice</code> extracts through the
-    end of the sequence (<code>typedarray.length</code>).</dd>
+    in the sequence.</p>
+    <p>If <code><var>end</var></code> is omitted, <code>slice</code> extracts through the
+    end of the sequence (<code>typedarray.length</code>).</p>
+  </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/javascript/reference/statements/for/index.html
+++ b/files/en-us/web/javascript/reference/statements/for/index.html
@@ -28,13 +28,15 @@ browser-compat: javascript.statements.for
 
 <dl>
   <dt><code><var>initialization</var></code></dt>
-  <dd>An expression (including assignment expressions) or variable declaration evaluated
+  <dd>
+    <p>An expression (including assignment expressions) or variable declaration evaluated
     once before the loop begins. Typically used to initialize a counter variable. This
     expression may optionally declare new variables with <code>var</code> or
     <code>let</code> keywords. Variables declared with <code>var</code> are not local to
     the loop, i.e. they are in the same scope the <code>for</code> loop is in. Variables
-    declared with <code>let</code> are local to the statement.</dd>
-  <dd>The result of this expression is discarded.</dd>
+    declared with <code>let</code> are local to the statement.</p>
+    <p>The result of this expression is discarded.</p>
+  </dd>
   <dt><code><var>condition</var></code></dt>
   <dd>An expression to be evaluated before each loop iteration. If this expression
     evaluates to true, <code><var>statement</var></code> is executed. This conditional

--- a/files/en-us/web/javascript/the_performance_hazards_of_prototype_mutation/index.html
+++ b/files/en-us/web/javascript/the_performance_hazards_of_prototype_mutation/index.html
@@ -70,8 +70,7 @@ p.sum(); // Pair.prototype.sum</pre>
 
 <dl>
  <dt>The shape of the <em>ultimate</em> object containing the inherited can be checked.</dt>
- <dd>In this case, a shape match must imply that no intervening object's <code>[[Prototype]]</code> has been modified.  Therefore, when an object's <code>[[Prototype]]</code> is mutated, every object along its <code>[[Prototype]]</code> chain must also have its shape changed.</dd>
- <dd>
+ <dd><p>In this case, a shape match must imply that no intervening object's <code>[[Prototype]]</code> has been modified.  Therefore, when an object's <code>[[Prototype]]</code> is mutated, every object along its <code>[[Prototype]]</code> chain must also have its shape changed.</p>
  <pre class="brush: js">var obj1 = {};
 var obj2 = Object.create(obj1);
 var obj3 = Object.create(obj2);
@@ -80,8 +79,7 @@ var obj3 = Object.create(obj2);
 obj3.__proto__ = {};</pre>
  </dd>
  <dt>The shape of the object initially accessed can be checked.</dt>
- <dd>Every object that might inherit through a changed-<code>[[Prototype]]</code> object must change, reflecting the <code>[[Prototype]]</code> mutation having happened</dd>
- <dd>
+ <dd><p>Every object that might inherit through a changed-<code>[[Prototype]]</code> object must change, reflecting the <code>[[Prototype]]</code> mutation having happened</p>
  <pre class="brush: js">var obj1 = {};
 var obj2 = Object.create(obj1);
 var obj3 = Object.create(obj2);


### PR DESCRIPTION
This PR aims to fix all the places in the JS docs that are incorrectly using multiple `<dd>` elements when they want to include multiple block elements in a single `<dd>`, as noted in https://github.com/mdn/content/issues/4367#issuecomment-829617386.

I'm guessing this is coming from the WYSIWYG editor in the old Wiki, where IIRC it was easy to add new `<dd>` elements by mistake.

There are no places in the JS docs where the author really wanted to use multiple `<dd>` elements as far as I can see. So I think we might want to automate a mass-conversion of these across all our docs. It wasn't too bad doing it by hand, but it's easy to make mistakes.
