### PR TITLE
Typo: remove extra "two"

### DIFF
--- a/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.html
+++ b/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.html
@@ -72,7 +72,7 @@ ints.filter(x =&gt; x &gt; 0)         // removes all elements
     .reduce((x, y) =&gt; x + y, 0) // the initial value is the neutral element of the addition
 </pre>
 
-<p>Another way would be two to handle the empty case, either before calling
+<p>Another way would be to handle the empty case, either before calling
   <code>reduce</code>, or in the callback after adding an unexpected dummy initial value.
 </p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

## What was wrong/why is this fix needed? (quick summary only)

Very small typo in this sentence:

> Another way would be **two to** handle the empty case, either before calling reduce, or in the callback after adding an unexpected dummy initial value.

## MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value#valid_cases

## Anything else that could help us review it

Just wanted to say I love the Mozilla docs 😃 