### PR TITLE
Use JS exponentiation operator in Number doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.html
@@ -120,8 +120,8 @@ const notANum        = Number.NaN
 
 <p>The following example shows the minimum and maximum integer values that can be represented as <code>Number</code> object. (More details on this are described in the ECMAScript standard, chapter <em><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">6.1.6 The Number Type</a>.</em>)</p>
 
-<pre class="brush: js">const biggestInt  = Number.MAX_SAFE_INTEGER  //  (2^53 - 1) =&gt;  9007199254740991
-const smallestInt = Number.MIN_SAFE_INTEGER  // -(2^53 - 1) =&gt; -9007199254740991</pre>
+<pre class="brush: js">const biggestInt  = Number.MAX_SAFE_INTEGER  //  (2**53 - 1) =&gt;  9007199254740991
+const smallestInt = Number.MIN_SAFE_INTEGER  // -(2**53 - 1) =&gt; -9007199254740991</pre>
 
 <p>When parsing data that has been serialized to JSON, integer values falling outside of this range can be expected to become corrupted when JSON parser coerces them to <code>Number</code> type.</p>
 


### PR DESCRIPTION
https://github.com/mdn/content/pull/858/files (27c69dc) changed some example code to use `2^53` for exponentiation. But since in JS, the caret doesn’t actually do exponentiation, if you enter `2^53` into the devtools console, it won’t work; it needs to instead be `2**53` — that is, to be runnable code, it needs to use the actual JS exponentiation operator: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation

--- 

https://github.com/mdn/content/pull/858#discussion_r550907589 is what introduced this mistake. Not sure now what I was thinking — other than I guess I didn’t realize then that this was intended to be showing runnable code (though in code comment).