### PR TITLE
Add some docs for the box-shadow generator

### DIFF
--- a/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
@@ -2859,7 +2859,7 @@ var BoxShadow = (function BoxShadow() {
 
 <p>The box-shadow generator enables you to add one or more box shadows to an element.</p>
 
-<p>When you open the tool first, there's just an element shown as a rectangle in the top-right section of the tool. That's the element you're going to be applying shadows to. When this element is selected (as it is, when you first load the page) you can apply some basic styling to the element:</p>
+<p>On opening the tool, you'll find a rectangle in the top-right section of the tool. That's the element you're going to be applying shadows to. When this element is selected (as it is, when you first load the page) you can apply some basic styling to it:</p>
 <ul>
   <li>Set the element's {{cssxref("color")}} using the color picker tool.</li>
   <li>Give the element a {{cssxref("border")}} using the "border" checkbox.</li>

--- a/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
@@ -2874,7 +2874,7 @@ var BoxShadow = (function BoxShadow() {
   <li>Use the sliders to set the element's position, blur, and spread.</li>
 </ul>
 
-<p>To add another shadow, click "+" again. Now any values you set will apply to this new shadow. You can change the order in which these two shadows are applied using the ↑ and ↓ buttons at the top-left. You can select the first shadow again by clicking it in column on the left. If you want to update the element's own styles, you can select it by clicking the button labelled "element" along the top.</p>
+<p>To add another shadow, click "+" again. Now any values you set will apply to this new shadow. Change the order in which these two shadows are applied using the ↑ and ↓ buttons at the top-left. Select the first shadow again by clicking it in column on the left. To update the element's own styles, select it by clicking the button labelled "element" along the top.</p>
 
 <p>You can add {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements to the element, and give them box shadows as well. To switch between the element and its pseudo-elements, use the buttons along the top labeled "element", ":before", and ":after".</p>
 

--- a/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
@@ -2857,7 +2857,7 @@ var BoxShadow = (function BoxShadow() {
 
 <div>{{ EmbedLiveSample('box-shadow_generator', '100%', '1000px', '') }}</div>
 
-<p>The box-shadow generator enables you to add one or more box-shadows to an element.</p>
+<p>The box-shadow generator enables you to add one or more box shadows to an element.</p>
 
 <p>When you open the tool first, there's just an element shown as a rectangle in the top-right section of the tool. That's the element you're going to be applying shadows to. When this element is selected (as it is, when you first load the page) you can apply some basic styling to the element:</p>
 <ul>

--- a/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
+++ b/files/en-us/web/css/css_background_and_borders/box-shadow_generator/index.html
@@ -2855,4 +2855,27 @@ var BoxShadow = (function BoxShadow() {
 </pre>
 </div>
 
-<div>{{ EmbedLiveSample('box-shadow_generator', '100%', '1100px', '') }}</div>
+<div>{{ EmbedLiveSample('box-shadow_generator', '100%', '1000px', '') }}</div>
+
+<p>The box-shadow generator enables you to add one or more box-shadows to an element.</p>
+
+<p>When you open the tool first, there's just an element shown as a rectangle in the top-right section of the tool. That's the element you're going to be applying shadows to. When this element is selected (as it is, when you first load the page) you can apply some basic styling to the element:</p>
+<ul>
+  <li>Set the element's {{cssxref("color")}} using the color picker tool.</li>
+  <li>Give the element a {{cssxref("border")}} using the "border" checkbox.</li>
+  <li>Use the sliders to set the element's {{cssxref("top")}}, {{cssxref("left")}}, {{cssxref("width")}}, and {{cssxref("height")}} properties.</li>
+</ul>
+
+<p>To add a box shadow, click the "+" button at the top-left. This adds a shadow, and lists it in the column on the left. Now you can set the values of the new shadow:</p>
+
+<ul>
+  <li>Set the shadow's {{cssxref("color")}} using the color picker tool.</li>
+  <li>Set the shadow to be inset using the "inset" checkbox.</li>
+  <li>Use the sliders to set the element's position, blur, and spread.</li>
+</ul>
+
+<p>To add another shadow, click "+" again. Now any values you set will apply to this new shadow. You can change the order in which these two shadows are applied using the ↑ and ↓ buttons at the top-left. You can select the first shadow again by clicking it in column on the left. If you want to update the element's own styles, you can select it by clicking the button labelled "element" along the top.</p>
+
+<p>You can add {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements to the element, and give them box shadows as well. To switch between the element and its pseudo-elements, use the buttons along the top labeled "element", ":before", and ":after".</p>
+
+<p>The box at the bottom-right contains the CSS for the element and any <code>before::</code> or <code>::after</code> pseudo-elements.</p>


### PR DESCRIPTION
Fix for https://github.com/mdn/content/issues/4206 . 

I'm going to assume that people are filing bugs against this tool because the new CSS sidebar makes it slightly discoverable, which would be good, because I think it is a nice tool.

Having said that it is **wild** that it's implemented as a live sample. The least-effort way to improve this would be to port it to https://github.com/mdn/css-examples and embed it from a GitHub Pages page. A better option might be for the dev team to adopt it as a proper tool, that's not a content page at all. Ping @escattone and @peterbe about that, but it would be a long-term goal.

In the meantime, here's my attempt at some basic documentation.
