### PR TITLE
Update "Customizing datalist styles"

### DIFF
--- a/files/en-us/web/html/element/datalist/index.html
+++ b/files/en-us/web/html/element/datalist/index.html
@@ -120,6 +120,10 @@ option {
   datalist.style.display = 'block';
 }
 
+input.onblur = function () {
+  datalist.style.display = 'none';
+}
+
 for (let option of datalist.options) {
   option.onclick = function () {
     input.value = this.value;


### PR DESCRIPTION
In order to replicate the behavior of an input with associated datalist, the datalist needs to disappear when the input loses focus. Without an onblur event, the datalist remains until one of the options is selected, triggering the onclick event.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The existing solution doesn't replicate the behavior that it intends to mimic. Having the datalist not disappear when the input loses focus is annoying.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
