### PR TITLE
Add information about ui.systemUsesDarkTheme

### DIFF
--- a/files/en-us/web/css/@media/prefers-color-scheme/index.html
+++ b/files/en-us/web/css/@media/prefers-color-scheme/index.html
@@ -94,7 +94,7 @@ tags:
  <li><a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#view_media_rules_for_prefers-color-scheme">Simulate prefers-color-scheme in Firefox</a> (Firefox Page Inspector > Examine and edit CSS)</li>
  <li><a href="https://www.youtube.com/watch?v=jmepqJ5UbuM">Video tutorial: Coding a Dark Mode for your Website</a></li>
  <li><a href="https://stuffandnonsense.co.uk/blog/redesigning-your-product-and-website-for-dark-mode">Redesigning your product and website for dark mode</a></li>
- <li>Changing color schemes in <a href="https://blogs.windows.com/windowsexperience/2019/04/01/windows-10-tip-dark-theme-in-file-explorer/">Windows</a>, <a href="https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/">macOS</a> and <a href="https://www.theverge.com/2019/5/7/18530599/google-android-q-features-hands-on-dark-mode-gestures-accessibility-io-2019">Android</a>.</li>
+ <li>Changing color schemes in <a href="https://blogs.windows.com/windowsexperience/2019/04/01/windows-10-tip-dark-theme-in-file-explorer/">Windows</a>, <a href="https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/">macOS</a>, <a href="https://www.theverge.com/2019/5/7/18530599/google-android-q-features-hands-on-dark-mode-gestures-accessibility-io-2019">Android</a>, or <a href="https://support.mozilla.org/en-US/questions/1271928">other platforms</a>.</li>
 </ul>
 
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/CSS/@media/")}}</div>


### PR DESCRIPTION
What was wrong/why is this fix needed? (quick summary only): Add link about `ui.systemUsesDarkTheme` for whoever needs it.

MDN URL of main page changed: <https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme>

Issue number (if there is an associated issue): None

Anything else that could help us review it:

MDN was mentioning `ui.systemUsesDarkTheme` until #2562. However, there is not only Windows, Android, or macOS platform. For Linux (and potentially other) platform user, they don't have a way to set global theme preference. That's when `ui.systemUsesDarkTheme` can be useful.

Also worth mentioning that mdn/browser-compat-data#9299 once attempted to take it back to BCD, but it does not belong there. (I also agree so, since this is actually more user-centric rather than developer-centric.)