### PR TITLE
Remove use of page macro in release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/44/index.html
+++ b/files/en-us/mozilla/firefox/releases/44/index.html
@@ -13,7 +13,15 @@ tags:
 
 <h3 id="Developer_tools">Developer tools</h3>
 
-<p>{{page('/en-US/docs/Tools/Release_notes', 'Firefox_44')}}</p>
+<p>Highlights:
+<ul>
+  <li><a href="/en-US/docs/Tools/Memory">Memory tool</a></li>
+  <li><a href="/en-US/docs/Tools/Page_Inspector/How_to/Work_with_animations">Animation inspector improvements</a></li>
+  <li><a href="/en-US/docs/Tools/Performance/Waterfall#markers">New Waterfall markers: DomContentLoaded, load, worker messages</a></li>
+</ul>
+
+<a href="https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&classification=Client%20Software&chfieldto=2015-11-03&query_format=advanced&chfield=resolution&chfieldfrom=2015-09-19&chfieldvalue=FIXED&bug_status=RESOLVED&bug_status=VERIFIED&component=Developer%20Tools&component=Developer%20Tools%3A%203D%20View&component=Developer%20Tools%3A%20Canvas%20Debugger&component=Developer%20Tools%3A%20Console&component=Developer%20Tools%3A%20Debugger&component=Developer%20Tools%3A%20Framework&component=Developer%20Tools%3A%20Graphic%20Commandline%20and%20Toolbar&component=Developer%20Tools%3A%20Inspector&component=Developer%20Tools%3A%20Memory&component=Developer%20Tools%3A%20Netmonitor&component=Developer%20Tools%3A%20Object%20Inspector&component=Developer%20Tools%3A%20Performance%20Tools%20%28Profiler%2FTimeline%29&component=Developer%20Tools%3A%20Responsive%20Mode&component=Developer%20Tools%3A%20Scratchpad&component=Developer%20Tools%3A%20Source%20Editor&component=Developer%20Tools%3A%20Storage%20Inspector&component=Developer%20Tools%3A%20Style%20Editor&component=Developer%20Tools%3A%20User%20Stories&component=Developer%20Tools%3A%20Web%20Audio%20Editor&component=Developer%20Tools%3A%20WebGL%20Shader%20Editor&component=Developer%20Tools%3A%20WebIDE&product=Firefox&list_id=12582678">All devtools bugs fixed between Firefox 43 and Firefox 44.</a>
+</p>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/mozilla/firefox/releases/45/index.html
+++ b/files/en-us/mozilla/firefox/releases/45/index.html
@@ -11,7 +11,17 @@ tags:
 
 <h3 id="Developer_Tools">Developer Tools</h3>
 
-<p>{{page('/en-US/docs/Tools/Release_notes', 'Firefox_45')}}</p>
+<p>Highlights:
+  <ul>
+    <li><a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#searching">Full-text search in the Page Inspector</a></li>
+    <li><a href="/en-US/docs/Tools/Memory/Basic_operations#comparing_snapshots">Heap snapshot diffing in the Memory tool</a></li>
+    <li><a href="/en-US/docs/Tools/Network_Monitor#timeline">DomContentLoaded and load events shown in the Network Monitor</a></li>
+    <li><a href="/en-US/docs/Tools/Page_Inspector/How_to/Work_with_animations">Animation inspector improvements</a></li>
+  </ul>
+  
+  <a href="https://bugzilla.mozilla.org/buglist.cgi?bug_status=RESOLVED&bug_status=VERIFIED&chfield=resolution&chfieldfrom=2015-10-29&chfieldto=2015-12-14&chfieldvalue=FIXED&classification=Client%20Software&component=Developer%20Tools&component=Developer%20Tools%3A%203D%20View&component=Developer%20Tools%3A%20about%3Adebugging&component=Developer%20Tools%3A%20Animation%20Inspector&component=Developer%20Tools%3A%20Canvas%20Debugger&component=Developer%20Tools%3A%20Computed%20Styles%20Inspector&component=Developer%20Tools%3A%20Console&component=Developer%20Tools%3A%20CSS%20Rules%20Inspector&component=Developer%20Tools%3A%20Debugger&component=Developer%20Tools%3A%20Font%20Inspector&component=Developer%20Tools%3A%20Framework&component=Developer%20Tools%3A%20Graphic%20Commandline%20and%20Toolbar&component=Developer%20Tools%3A%20Inspector&component=Developer%20Tools%3A%20JSON%20Viewer&component=Developer%20Tools%3A%20Memory&component=Developer%20Tools%3A%20Netmonitor&component=Developer%20Tools%3A%20Object%20Inspector&component=Developer%20Tools%3A%20Performance%20Tools%20%28Profiler%2FTimeline%29&component=Developer%20Tools%3A%20Responsive%20Mode&component=Developer%20Tools%3A%20Scratchpad&component=Developer%20Tools%3A%20Source%20Editor&component=Developer%20Tools%3A%20Storage%20Inspector&component=Developer%20Tools%3A%20Style%20Editor&component=Developer%20Tools%3A%20User%20Stories&component=Developer%20Tools%3A%20Web%20Audio%20Editor&component=Developer%20Tools%3A%20WebGL%20Shader%20Editor&component=Developer%20Tools%3A%20WebIDE&product=Firefox&resolution=FIXED&list_id=12753878">All devtools bugs fixed between Firefox 43 and Firefox 44.</a>
+  </p>
+
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/en-us/mozilla/firefox/releases/46/index.html
+++ b/files/en-us/mozilla/firefox/releases/46/index.html
@@ -13,7 +13,16 @@ tags:
 
 <h3 id="Developer_Tools">Developer Tools</h3>
 
-<p>{{page('/en-US/docs/Tools/Release_notes', 'Firefox_46')}}</p>
+<p>Highlights:
+  <ul>
+    <li><a href="/en-US/docs/Tools/Memory/Dominators_view">Dominators view in the Memory tool</a></li>
+    <li><a href="/en-US/docs/Tools/Performance/Allocations">Allocations view in the Performance tool</a></li>
+    <li><a href="/en-US/docs/Tools/Style_Editor#the_media_sidebar">One click to apply @media rule conditions in the Style Editor</a></li>
+  </ul>
+  
+  <a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=13263754&resolution=FIXED&classification=Client%20Software&chfieldto=2016-01-25&query_format=advanced&chfield=resolution&chfieldfrom=2015-12-14&chfieldvalue=FIXED&bug_status=RESOLVED&bug_status=VERIFIED&component=Developer%20Tools&component=Developer%20Tools%3A%20about%3Adebugging&component=Developer%20Tools%3A%20Animation%20Inspector&component=Developer%20Tools%3A%20Canvas%20Debugger&component=Developer%20Tools%3A%20Computed%20Styles%20Inspector&component=Developer%20Tools%3A%20Console&component=Developer%20Tools%3A%20CSS%20Rules%20Inspector&component=Developer%20Tools%3A%20Debugger&component=Developer%20Tools%3A%20DOM&component=Developer%20Tools%3A%20Font%20Inspector&component=Developer%20Tools%3A%20Framework&component=Developer%20Tools%3A%20Graphic%20Commandline%20and%20Toolbar&component=Developer%20Tools%3A%20Inspector&component=Developer%20Tools%3A%20JSON%20Viewer&component=Developer%20Tools%3A%20Memory&component=Developer%20Tools%3A%20Netmonitor&component=Developer%20Tools%3A%20Object%20Inspector&component=Developer%20Tools%3A%20Performance%20Tools%20%28Profiler%2FTimeline%29&component=Developer%20Tools%3A%20Responsive%20Design%20Mode&component=Developer%20Tools%3A%20Scratchpad&component=Developer%20Tools%3A%20Shared%20Components&component=Developer%20Tools%3A%20Source%20Editor&component=Developer%20Tools%3A%20Storage%20Inspector&component=Developer%20Tools%3A%20Style%20Editor&component=Developer%20Tools%3A%20User%20Stories&component=Developer%20Tools%3A%20Web%20Audio%20Editor&component=Developer%20Tools%3A%20WebGL%20Shader%20Editor&component=Developer%20Tools%3A%20WebIDE&product=Firefox">All devtools bugs fixed between Firefox 45 and Firefox 46.</a>
+  </p>
+
 
 <h3 id="HTML">HTML</h3>
 


### PR DESCRIPTION
This is part of fixing #3196 (removing the page macro).

This replaces the developer tools inclusion from FF44, 45, 46, which has not worked as far as I can tell since 2017.

Information came from the wayback machine in the last good record:
- https://web.archive.org/web/20170820162331/https://developer.mozilla.org/en-US/Firefox/Releases/44
- https://web.archive.org/web/20170819040958/https://developer.mozilla.org/en-US/Firefox/Releases/45
- https://web.archive.org/web/20170621163618/https://developer.mozilla.org/en-US/Firefox/Releases/46

The links all worked except for one - which I have traced and fixed.
