### PR TITLE
Remove pagemacro from BiquadFilterNode

### DIFF
--- a/files/en-us/web/api/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/index.html
@@ -149,7 +149,8 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createBiquadFilter","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createBiquadFilter#example"><code>AudioContext.createBiquadFilter</code></a> for example code that shows how to use an <code>AudioContext</code> to create a Biquad filter node.</p>
+
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of addressing #3196 (removing pagemacro). More or less same approach as in #4401

Following this fix `BiquadFilterNode` links to example in `BaseAudioContext.createBiquadFilter()` rather than importing it.