### PR TITLE
Fix browser compatibility link in noopener

### DIFF
--- a/files/en-us/web/html/link_types/noopener/index.html
+++ b/files/en-us/web/html/link_types/noopener/index.html
@@ -39,4 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.link.a.noopener")}}</p>
+<p>{{Compat("html.elements.a.rel.noopener")}}</p>

--- a/files/en-us/web/html/link_types/noopener/index.html
+++ b/files/en-us/web/html/link_types/noopener/index.html
@@ -40,3 +40,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("html.elements.a.rel.noopener")}}</p>
+<p>{{Compat("html.elements.area.rel.noopener")}}</p>


### PR DESCRIPTION
Fix this page https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener  

The link in the diagram showing the browser compatibility was incorrect, so I corrected it.

You probably had a problem when it was changed in this issue.
https://github.com/mdn/browser-compat-data/pull/5978