### PR TITLE
specify attribute support

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
@@ -57,11 +57,14 @@ tags:
 
 <h3 id="support">Elements supporting aria-label</h3>
 
-The <code>aria-label</code> attribute <a href="https://www.tpgi.com/short-note-on-aria-label-aria-labelledby-and-aria-describedby/">should only be used</a> on the following elements:
-- interactive elements
-- landmark elements
-- elements that have an explicit widget role
-- <code>iframe</code> and <code>img</code> elements
+<p>The <code>aria-label</code> attribute <a href="https://www.tpgi.com/short-note-on-aria-label-aria-labelledby-and-aria-describedby/">should only be used</a> on the following elements:</p>
+
+<ul>
+  <li>Interactive elements</li>
+  <li>Landmark elements</li>
+  <li>Elements that have an explicit widget role</li>
+  <li><code>iframe</code> and <code>img</code> elements</li>
+</ul>
 
 <h3 id="Compatibility">Compatibility</h3>
 

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
@@ -55,6 +55,14 @@ tags:
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute">Using the aria-labelledby attribute</a></li>
 </ul>
 
+<h3 id="support">Elements supporting aria-label</h3>
+The <code>aria-label</code> attribute should only be used on the following elements:
+- interactive elements
+- landmark elements
+- elements that have an explicit widget role
+- <code>iframe</code> and <code>img</code> elements
+<a href="https://www.tpgi.com/short-note-on-aria-label-aria-labelledby-and-aria-describedby/">source</a>
+
 <h3 id="Compatibility">Compatibility</h3>
 
 <p class="comment">TBD: Add support information for common UA and AT product combinations</p>
@@ -63,4 +71,5 @@ tags:
 
 <ul>
  <li><a href="https://www.w3.org/TR/wai-aria/#aria-label">WAI-ARIA specification for aria-label</a></li>
+  <li><a href="https://www.w3.org/TR/using-aria/#label-support">WAI-ARIA Notes on ARIA</li>
 </ul>

--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.html
@@ -56,12 +56,12 @@ tags:
 </ul>
 
 <h3 id="support">Elements supporting aria-label</h3>
-The <code>aria-label</code> attribute should only be used on the following elements:
+
+The <code>aria-label</code> attribute <a href="https://www.tpgi.com/short-note-on-aria-label-aria-labelledby-and-aria-describedby/">should only be used</a> on the following elements:
 - interactive elements
 - landmark elements
 - elements that have an explicit widget role
 - <code>iframe</code> and <code>img</code> elements
-<a href="https://www.tpgi.com/short-note-on-aria-label-aria-labelledby-and-aria-describedby/">source</a>
 
 <h3 id="Compatibility">Compatibility</h3>
 


### PR DESCRIPTION
The aria-element can only be used on certain elements.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Missing important information

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute

> Issue number (if there is an associated issue)

> Anything else that could help us review it
