### PR TITLE
Remove unpaired curly bracket in async/await example

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/async_await/index.html
+++ b/files/en-us/learn/javascript/asynchronous/async_await/index.html
@@ -130,7 +130,6 @@ hello().then(alert);</pre>
   let image = document.createElement('img');
   image.src = objectURL;
   document.body.appendChild(image);
-  }
 }
 
 myFetch()


### PR DESCRIPTION
Removes an errant curly bracket from the second example snippet under [this header](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await#rewriting_promise_code_with_asyncawait) on the "Making asynchronous programming easier with async and await" page: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await