### PR TITLE
lowercase anchor

### DIFF
--- a/files/en-us/web/svg/attribute/letter-spacing/index.html
+++ b/files/en-us/web/svg/attribute/letter-spacing/index.html
@@ -51,7 +51,7 @@ tags:
  </tbody>
 </table>
 
-<p>For a description of the values, please refer to the <a href="/en-US/docs/Web/CSS/letter-spacing#Values">CSS <code>letter-spacing</code></a> property.</p>
+<p>For a description of the values, please refer to the <a href="/en-US/docs/Web/CSS/letter-spacing#values">CSS <code>letter-spacing</code></a> property.</p>
 
 <p class="note">Prior to Firefox 72 Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=371787">ignored <code>letter-spacing</code></a> and renders text without.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

Reported by https://github.com/mdn/content/pull/4664#issuecomment-831067522

> What was wrong/why is this fix needed? (quick summary only)

The upper case anchor broke the link.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/letter-spacing (below the Usage box)

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

N/A