### PR TITLE
Removing dead link

### DIFF
--- a/files/en-us/glossary/javascript/index.html
+++ b/files/en-us/glossary/javascript/index.html
@@ -37,7 +37,6 @@ tags:
  <li>The {{Link("/en-US/docs/Web/JavaScript/Guide")}} on MDN</li>
  <li><a href="https://nodeschool.io/#workshoppers">The "javascripting" workshop on NodeSchool</a></li>
  <li><a href="https://www.codecademy.com/tracks/javascript" rel="external">The JavaScript course on codecademy.com</a></li>
- <li><a href="http://ejohn.org/apps/learn/" rel="external">John Resig's <em>Learning Advanced JavaScript</em></a></li>
 </ul>
 
 <h3 id="Technical_reference">Technical reference</h3>

--- a/files/en-us/glossary/javascript/index.html
+++ b/files/en-us/glossary/javascript/index.html
@@ -21,7 +21,7 @@ tags:
 
 <p>In November 1996, Netscape began working with ECMA International to make JavaScript an industry standard. Since then, the standardized JavaScript is called ECMAScript and specified under ECMA-262, whose latest (eleventh, ES2020) edition is available as of June 2020.</p>
 
-<p>Recently, JavaScript's popularity has expanded even further through the successful <a href="https://nodejs.org/" rel="external">Node.js</a> platform—the most popular cross-platform JavaScript runtime environment outside the browser. Node.js - built using <a href="https://en.wikipedia.org/wiki/V8_(JavaScript_engine)">Chrome's V8 JavaScript Engine</a> - allows developers to use JavaScript as a scripting language to automate things on a computer and build fully functional {{Glossary("HTTP")}} and {{Glossary("Web Sockets")}} servers.</p>
+<p>Recently, JavaScript's popularity has expanded even further through the successful <a href="https://nodejs.org/" rel="external">Node.js</a> platform—the most popular cross-platform JavaScript runtime environment outside the browser. Node.js - built using <a href="https://en.wikipedia.org/wiki/V8_(JavaScript_engine)">Chrome's V8 JavaScript Engine</a> - allows developers to use JavaScript as a scripting language to automate things on a computer and build fully functional {{Glossary("HTTP")}} and {{Glossary("WebSockets")}} servers.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

Learn area points to a dead domain. Its owner is not reacting on GitHub.

> What was wrong/why is this fix needed? (quick summary only)

The domain ejohn.org is dead since a few years.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Glossary/JavaScript

> Issue number (if there is an associated issue)

Fixes #4567 

> Anything else that could help us review it

Reach out to John and ask, whether he ported the content or whether it is link rotten now? :)