### PR TITLE
Fix typo in common questions/what is web server

### DIFF
--- a/files/en-us/learn/common_questions/what_is_a_web_server/index.html
+++ b/files/en-us/learn/common_questions/what_is_a_web_server/index.html
@@ -60,7 +60,7 @@ tags:
 
 <ul>
  <li>A dedicated web server is typically more available. (up and running)</li>
- <li>Excusing downtime and systems troubles, a dedicated web server is always connected to the Internet.</li>
+ <li>Excluding downtime and systems troubles, a dedicated web server is always connected to the Internet.</li>
  <li>A dedicated web server can have the same IP address all the time. This is known as a <em>dedicated IP address</em>. (not all {{Glossary("ISP", "ISPs")}} provide a fixed IP address for home lines)</li>
  <li>A dedicated web server is typically maintained by a third-party.</li>
 </ul>
@@ -95,7 +95,7 @@ tags:
 <ol>
  <li>Upon receiving a request, an HTTP server first checks if the requested URL matches an existing file.</li>
  <li>If so, the web server sends the file content back to the browser. If not, an application server builds the necessary file.</li>
- <li>If neither process is possible, the web server returns an error message to the browser, most commonly {{HTTPStatus("404", "404 Not Found")}}. (The 404 error is so common that some web designers devote considerable time and effort to designing <a href="http://www.404notfound.fr/" rel="external">404 error pages</a>.)</li>
+ <li>If neither process is possible, the web server returns an error message to the browser, most commonly {{HTTPStatus("404", "404 Not Found")}}. The 404 error is so common that some web designers devote considerable time and effort to designing 404 error pages.</li>
 </ol>
 
 <h3 id="Static_vs._dynamic_content">Static vs. dynamic content</h3>


### PR DESCRIPTION
Fixes #4679

Changes "Excusing" where they mean "Excluding" and also removes a link flaw that is of no great benefit even if fixed.