### PR TITLE
Remove Page macro from glossary

### DIFF
--- a/files/en-us/glossary/denial_of_service/index.html
+++ b/files/en-us/glossary/denial_of_service/index.html
@@ -8,4 +8,6 @@ tags:
   - Intro
   - Security
 ---
-<p>{{page("/en-US/docs/Glossary/DOS_attack")}}</p>
+<p id="Summary">DoS (Denial of Service) is a category of network attack that consumes available server resources, typically by flooding the server with requests. The server is then sluggish or unavailable for legitimate users.</p>
+
+<p>See <a href="/en-US/docs/Glossary/DOS_attack">DoS attack</a> for more information.</p>

--- a/files/en-us/glossary/second-level_domain/index.html
+++ b/files/en-us/glossary/second-level_domain/index.html
@@ -5,4 +5,30 @@ tags:
   - Glossary
   - Infrastructure
 ---
-<p>{{page("/en-US/docs/Glossary/SLD")}}</p>
+
+<p>A Second Level Domain ({{Glossary("SLD")}}) is the part of the domain name that is located right before a Top Level Domain ({{Glossary("TLD")}}).</p>
+
+<p>For example, in <code>mozilla.org</code> the SLD is <code>mozilla</code> and the TLD is <code>org</code>.</p>
+
+<p>A domain name is not limited to a TLD and an SLD. Additional subdomains can be created in order to provide additional information about various functions of a server or to delimit areas under the same domain. For example, <code>www</code> is a commonly used subdomain to indicate the domain points to a web server.</p>
+
+<p>As another example, in <code>developer.mozilla.org</code>, the <code>developer</code> subdomain is used to specify that the subdomain contains the developer section of the Mozilla website.</p>
+
+<section id="Quick_links">
+<ol>
+ <li>Wikipedia articles
+  <ol>
+   <li>{{Interwiki("wikipedia", "Second-level domain", "SLD")}}</li>
+  </ol>
+ </li>
+ <li><a href="/en-US/docs/Glossary">Glossary</a>
+  <ol>
+   <li>{{Glossary("DNS")}}</li>
+   <li>{{Glossary("Domain")}}</li>
+   <li>{{Glossary("Domain name")}}</li>
+   <li>{{Glossary("TLD")}}</li>
+  </ol>
+ </li>
+</ol>
+</section>
+

--- a/files/en-us/glossary/sld/index.html
+++ b/files/en-us/glossary/sld/index.html
@@ -5,28 +5,7 @@ tags:
   - Glossary
   - Infrastructure
 ---
-<p>An SLD (Second Level Domain) is the domain name that is located right before a {{Glossary("TLD")}}.</p>
 
-<p>For example, in <code>mozilla.org</code>, <code>mozilla</code> is the second-level domain of the <code>.org</code> TLD.</p>
+<p>An SLD (<a href="/en-US/docs/Glossary/Second-level_Domain">Second Level Domain</a>) is the part of the domain name that is located right before a <em>Top Level Domain</em> ({{Glossary("TLD")}}). For example, in <code>mozilla.org</code> the SLD is <code>mozilla</code> and the TLD is <code>org</code>.</p>
 
-<p>A domain name is not limited to a TLD and an SLD. Additional subdomains can be created in order to provide additional information about various functions of a server or to delimit areas under the same domain. For example, <code>www</code> is a commonly used subdomain to indicate the domain points to a web server.</p>
-
-<p>As another example, in <code>developer.mozilla.org</code>, the <code>developer</code> subdomain is used to specify that the subdomain contains the developer section of the Mozilla website.</p>
-
-<section id="Quick_links">
-<ol>
- <li>Wikipedia articles
-  <ol>
-   <li>{{Interwiki("wikipedia", "Second-level domain", "SLD")}}</li>
-  </ol>
- </li>
- <li><a href="/en-US/docs/Glossary">Glossary</a>
-  <ol>
-   <li>{{Glossary("DNS")}}</li>
-   <li>{{Glossary("Domain")}}</li>
-   <li>{{Glossary("Domain name")}}</li>
-   <li>{{Glossary("TLD")}}</li>
-  </ol>
- </li>
-</ol>
-</section>
+<p>See <a href="/en-US/docs/Glossary/Second-level_Domain">Second Level Domain</a> for more information.</p>


### PR DESCRIPTION
As per #3196 we are removing the Page macro (transclusion).

This removes the two usages from the Glossary. In both cases transclusion was used to expand an acronym or close variant of a term (e.g. Denial of Service and DoS Attack). What I did was replace the page call with the first sentence of the transcluded article and a "See XXX for more information".

I also chose to swap the content from Second Level Domain and SDL topics - IMO the master document is the one that is most commonly used, and/or least ambiguous. So in this case I see SDL as ambiguous.
