### PR TITLE
Downgrade requestPostAnimationFrame rule to a suggestion

### DIFF
--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.html
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.html
@@ -685,7 +685,7 @@ async function readPixelsAsync(gl, x, y, w, h, format, type, dest) {
 }
 </pre>
 
-<h2 id="Use_requestPostAnimationFrame_not_requestAnimationFrame">Use <code>requestPostAnimationFrame</code> not <code>requestAnimationFrame</code></h2>
+<h3 id="Consider_requestPostAnimationFrame_not_requestAnimationFrame">Consider <code>requestPostAnimationFrame</code> not <code>requestAnimationFrame</code></h3>
 
 <p>While it's well-known that apps should use <code>requestAnimationFrame</code> ("RAF") instead of <code>setTimeout</code> (et al) to redraw on-demand, what's less well-known is that non-trivial WebGL apps should often <em>not</em> render within a RAF callback.</p>
 
@@ -695,7 +695,9 @@ async function readPixelsAsync(gl, x, y, w, h, format, type, dest) {
 
 <p>This allows as much time as possible for rendering each frame.</p>
 
-<h2 id="devicePixelRatio_and_high-dpi_rendering"><code>devicePixelRatio</code> and high-dpi rendering</h2>
+<p><em>Note</em> that <code>requestPostAnimationFrame</code> is still under development as of this writing. Polyfills of this API do <a href="http://crbug.com/1199005">not yet have</a> the desired performance characteristics. It's currently recommended to use <code>requestPostAnimationFrame</code> in Firefox, but in Chrome, to continue to use <code>requestAnimationFrame</code>.
+
+<h3 id="devicePixelRatio_and_high-dpi_rendering"><code>devicePixelRatio</code> and high-dpi rendering</h3>
 
 <p>Handling <code>devicePixelRatio != 1.0</code> is tricky. While the common approach is to set <code>canvas.width = width * devicePixelRatio</code>, this will cause moire artifacts with non-integer values of <code>devicePixelRatio</code>, as is common with UI scaling on Windows, as well as zooming on all platforms.</p>
 

--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.html
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.html
@@ -695,7 +695,7 @@ async function readPixelsAsync(gl, x, y, w, h, format, type, dest) {
 
 <p>This allows as much time as possible for rendering each frame.</p>
 
-<p><em>Note</em> that <code>requestPostAnimationFrame</code> is still under development as of this writing. Polyfills of this API do <a href="http://crbug.com/1199005">not yet have</a> the desired performance characteristics. It's currently recommended to use <code>requestPostAnimationFrame</code> in Firefox, but in Chrome, to continue to use <code>requestAnimationFrame</code>.
+<p><em>Note</em> that <code>requestPostAnimationFrame</code> is still under development as of this writing. Polyfills of this API do <a href="https://crbug.com/1199005">not yet have</a> the desired performance characteristics. It's currently recommended to use <code>requestPostAnimationFrame</code> in Firefox, but in Chrome, to continue to use <code>requestAnimationFrame</code>.
 
 <h3 id="devicePixelRatio_and_high-dpi_rendering"><code>devicePixelRatio</code> and high-dpi rendering</h3>
 

--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.html
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.html
@@ -695,7 +695,18 @@ async function readPixelsAsync(gl, x, y, w, h, format, type, dest) {
 
 <p>This allows as much time as possible for rendering each frame.</p>
 
-<p><em>Note</em> that <code>requestPostAnimationFrame</code> is still under development as of this writing. Polyfills of this API do <a href="https://crbug.com/1199005">not yet have</a> the desired performance characteristics. It's currently recommended to use <code>requestPostAnimationFrame</code> in Firefox, but in Chrome, to continue to use <code>requestAnimationFrame</code>.
+<p><em>Note</em> that <code>requestPostAnimationFrame</code> is still under development as of this writing. Polyfills of this API are recommended in Firefox, but not in Chrome, due to <a href="https://crbug.com/1199005">undesirable performance characteristics</a>. Here is one possible polyfill:
+
+<pre>
+if (!window.requestPostAnimationFrame) {
+   window.requestPostAnimationFrame = function(task) {
+      requestAnimationFrame(() => {
+         setTimeout(task, 0);
+      });
+   }
+}
+</pre>
+</p>
 
 <h3 id="devicePixelRatio_and_high-dpi_rendering"><code>devicePixelRatio</code> and high-dpi rendering</h3>
 


### PR DESCRIPTION
Users attempting to put requestPostAnimationFrame into production
using polyfills are running into performance problems. Turn this best
practice into a suggestion and add a cautionary note about it.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Users are encountering performance problems on some browsers when using this best practice.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it
