### PR TITLE
Pagemacro fix4

### DIFF
--- a/files/en-us/tools/web_console/helpers/index.html
+++ b/files/en-us/tools/web_console/helpers/index.html
@@ -9,8 +9,6 @@ tags:
 ---
 <p>{{ToolsSidebar}}</p>
 
-<h2 id="The_commands">The commands</h2>
-
 <p>The JavaScript command line provided by the Web Console offers a few built-in helper functions that make certain tasks easier.</p>
 
 <dl>

--- a/files/en-us/tools/web_console/the_command_line_interpreter/index.html
+++ b/files/en-us/tools/web_console/the_command_line_interpreter/index.html
@@ -108,7 +108,7 @@ tags:
 	<li>In multi-line mode, use the  <strong>⋀</strong> and <strong>⋁</strong> icons in the editing panel's toolbar.</li>
 </ul>
 
-<p>The expression history is persisted across sessions. To clear the history, use the <code>clearHistory()</code> <a href="/en-US/docs/Tools/Web_Console/The_command_line_interpreter#helper_commands">helper function</a>.</p>
+<p>The expression history is persisted across sessions. To clear the history, use the <code>clearHistory()</code> <a href="#helper_commands">helper function</a>.</p>
 
 <p>You can initiate a reverse search through the expression history, much like you can in bash on Linux and Mac or PowerShell on Windows. On Windows and Linux press <kbd>F9</kbd>. On Mac press <kbd>Ctrl</kbd>+<kbd>R</kbd> (<strong>note:</strong> not <kbd>Cmd</kbd>+<kbd>R</kbd>!) to initiate the reverse search.</p>
 
@@ -128,4 +128,5 @@ tags:
 
 <h2 id="Helper_commands">Helper commands</h2>
 
-<p>{{ page("en-US/docs/Tools/Web_Console/Helpers", "The commands") }}</p>
+<p>The JavaScript command line provided by the Web Console offers a few built-in helper functions that make certain tasks easier.
+  For more information see <a href="/en-US/docs/Tools/Web_Console/Helpers">Web Console Helpers</a>.</p>

--- a/files/en-us/web/api/window/ondeviceorientation/index.html
+++ b/files/en-us/web/api/window/ondeviceorientation/index.html
@@ -2,11 +2,11 @@
 title: Window.ondeviceorientation
 slug: Web/API/Window/ondeviceorientation
 tags:
-- API
-- Device Orientation
-- Mobile
-- Orientation
-- Property
+  - API
+  - Device Orientation
+  - Mobile
+  - Orientation
+  - Property
 ---
 <p>{{ ApiRef() }}</p>
 
@@ -42,13 +42,13 @@ window.addEventListener('deviceorientation', function(event) { ... });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{ page("/en-US/docs/Web/API/DeviceOrientationEvent","Browser_compatibility") }}</p>
+<p>{{Compat("api.Window.ondeviceorientation")}}</p>
 
 <h2 id="See_also">See also</h2>
 
 <ul>
   <li>{{ event("deviceorientation") }}</li>
   <li>{{ domxref("DeviceOrientationEvent") }}</li>
-  <li><a href="/en-US/docs/Detecting_device_orientation"
+  <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation"
       title="Detecting device orientation">Detecting device orientation</a></li>
 </ul>

--- a/files/en-us/web/svg/attribute/class/index.html
+++ b/files/en-us/web/svg/attribute/class/index.html
@@ -42,22 +42,6 @@ tags:
 	</tbody>
 </table>
 
-<dl>
-	<dt><a href="/en-US/docs/Web/SVG/Content_type#list-of-ts">&lt;list-of-<var>T</var>s&gt;</a></dt>
-	<dd>
-	<p>(Where <var>T</var> is some type.) A list consists of a separated sequence of values. Unless explicitly described differently, lists within SVG's XML attributes can be either comma-separated (with optional white space before or after the comma), or white space-separated.</p>
-
-	<p>White space in lists is defined as one or more of the following consecutive characters: "space" (<code>U+0020</code>), "tab" (<code>U+0009</code>), "line feed" (<code>U+000A</code>), "carriage return" (<code>U+000D</code>), and "form-feed" (<code>U+000C</code>).</p>
-
-	<p>The following is a template for an EBNF grammar describing the &lt;list-of-<var>T</var>s&gt; syntax:</p>
-
-	<pre>list-of-<var>T</var>s ::= <var>T</var>
-               | <var>T</var>, list-of-<var>T</var>s</pre>
-
-	<p>Within the SVG DOM, values of a &lt;list-of-<var>T</var>s&gt; type are represented by an interface specific for the particular type <var>T</var>. For example, a &lt;list-of-lengths&gt; is represented in the SVG DOM using an {{domxref("SVGLengthList")}} or {{domxref("SVGAnimatedLengthList")}} object.</p>
-	</dd>
-</dl>
-
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/svg/attribute/class/index.html
+++ b/files/en-us/web/svg/attribute/class/index.html
@@ -42,8 +42,21 @@ tags:
 	</tbody>
 </table>
 
+<dl>
+	<dt><a href="/en-US/docs/Web/SVG/Content_type#list-of-ts">&lt;list-of-<var>T</var>s&gt;</a></dt>
+	<dd>
+	<p>(Where <var>T</var> is some type.) A list consists of a separated sequence of values. Unless explicitly described differently, lists within SVG's XML attributes can be either comma-separated (with optional white space before or after the comma), or white space-separated.</p>
 
-<p>{{ page("Web/SVG/Content_type","List-of-Ts") }}</p>
+	<p>White space in lists is defined as one or more of the following consecutive characters: "space" (<code>U+0020</code>), "tab" (<code>U+0009</code>), "line feed" (<code>U+000A</code>), "carriage return" (<code>U+000D</code>), and "form-feed" (<code>U+000C</code>).</p>
+
+	<p>The following is a template for an EBNF grammar describing the &lt;list-of-<var>T</var>s&gt; syntax:</p>
+
+	<pre>list-of-<var>T</var>s ::= <var>T</var>
+               | <var>T</var>, list-of-<var>T</var>s</pre>
+
+	<p>Within the SVG DOM, values of a &lt;list-of-<var>T</var>s&gt; type are represented by an interface specific for the particular type <var>T</var>. For example, a &lt;list-of-lengths&gt; is represented in the SVG DOM using an {{domxref("SVGLengthList")}} or {{domxref("SVGAnimatedLengthList")}} object.</p>
+	</dd>
+</dl>
 
 
 <h2 id="Example">Example</h2>

--- a/files/en-us/web/svg/attribute/class/index.html
+++ b/files/en-us/web/svg/attribute/class/index.html
@@ -6,7 +6,7 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<p>« <a href="/en-US/docs/SVG/Attribute">SVG Attribute reference home</a></p>
+<p>« <a href="/en-US/docs/Web/SVG/Attribute">SVG Attribute reference home</a></p>
 
 <p>Assigns a class name or set of class names to an element. You may assign the same class name or names to any number of elements, however, multiple class names must be separated by whitespace characters.</p>
 
@@ -29,7 +29,7 @@ tags:
 		</tr>
 		<tr>
 			<th scope="row">Value</th>
-			<td><a href="/en-US/docs/SVG/Content_type#List-of-Ts">&lt;list-of-class-names&gt;</a></td>
+			<td><a href="/en-US/docs/Web/SVG/Content_type#list-of-ts">&lt;list-of-class-names&gt;</a></td>
 		</tr>
 		<tr>
 			<th scope="row">Animatable</th>
@@ -42,7 +42,9 @@ tags:
 	</tbody>
 </table>
 
-<p>{{ page("/en/SVG/Content_type","List-of-Ts") }}</p>
+
+<p>{{ page("Web/SVG/Content_type","List-of-Ts") }}</p>
+
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/svg/attribute/cursor/index.html
+++ b/files/en-us/web/svg/attribute/cursor/index.html
@@ -5,11 +5,11 @@ tags:
   - SVG
   - SVG Attribute
 ---
-<p>« <a href="/en-US/docs/SVG/Attribute">SVG Attribute reference home</a></p>
+<p>« <a href="/en-US/docs/Web/SVG/Attribute">SVG Attribute reference home</a></p>
 
 <p>The <code>cursor</code> attribute specifies the mouse cursor displayed when the mouse pointer is over an element.</p>
 
-<p>This attribute behaves exactly like the {{ cssxref("cursor","CSS cursor") }} property except that if the browser supports the {{ SVGElement("cursor") }} element, you should be able to use it with the <a href="/en-US/docs/SVG/Content_type#FuncIRI">&lt;funciri&gt;</a> notation.</p>
+<p>This attribute behaves exactly like the {{ cssxref("cursor","CSS cursor") }} property except that if the browser supports the {{ SVGElement("cursor") }} element, you should be able to use it with the <a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;funciri&gt;</a> notation.</p>
 
 <p>As a presentation attribute, it also can be used as a property directly inside a CSS stylesheet, see {{ cssxref("cursor","CSS cursor") }} for further information.</p>
 
@@ -23,7 +23,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Value</th>
-   <td>[[<a href="/en-US/docs/SVG/Content_type#FuncIRI">&lt;funciri&gt;</a>,]* [ <strong>auto</strong> | crosshair | default | pointer | move | e-resize | ne-resize | nw-resize | n-resize | se-resize | sw-resize | s-resize | w-resize| text | wait | help ]] | inherit</td>
+   <td>[[<a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;funciri&gt;</a>,]* [ <strong>auto</strong> | crosshair | default | pointer | move | e-resize | ne-resize | nw-resize | n-resize | se-resize | sw-resize | s-resize | w-resize| text | wait | help ]] | inherit</td>
   </tr>
   <tr>
    <th scope="row">Animatable</th>
@@ -42,8 +42,8 @@ tags:
 <p>The following elements can use the <code>cursor</code> attribute</p>
 
 <ul>
- <li><a href="/en-US/docs/SVG/Element#Container_elements">Container elements</a> »</li>
- <li><a href="/en-US/docs/SVG/Element#Graphics_elements">Graphics elements</a> »</li>
+ <li><a href="/en-US/docs/Web/SVG/Element#container_elements">Container elements</a> »</li>
+ <li><a href="/en-US/docs/Web/SVG/Element#graphics_elements">Graphics elements</a> »</li>
 </ul>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/svg/attribute/cursor/index.html
+++ b/files/en-us/web/svg/attribute/cursor/index.html
@@ -36,7 +36,11 @@ tags:
  </tbody>
 </table>
 
-<p>{{ page("/en/SVG/Content_type","FuncIRI") }}</p>
+
+<dl>
+	<dt><a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a></dt>
+	<dd>Functional notation for a reference. The syntax for this reference is the same as the {{cssxref("url()", "CSS URI")}}.</dd>
+</dl>
 
 <h2 id="Elements">Elements</h2>
 

--- a/files/en-us/web/svg/attribute/cursor/index.html
+++ b/files/en-us/web/svg/attribute/cursor/index.html
@@ -37,11 +37,6 @@ tags:
 </table>
 
 
-<dl>
-	<dt><a href="/en-US/docs/Web/SVG/Content_type#funciri">&lt;FuncIRI&gt;</a></dt>
-	<dd>Functional notation for a reference. The syntax for this reference is the same as the {{cssxref("url()", "CSS URI")}}.</dd>
-</dl>
-
 <h2 id="Elements">Elements</h2>
 
 <p>The following elements can use the <code>cursor</code> attribute</p>


### PR DESCRIPTION
Part of fixing #3196. Mostly by linking to the original rather than transcluding. But also two case of simply removing the macro