### PR TITLE
Fix Array syntaxes/parameters

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.html
@@ -40,7 +40,7 @@ every(function callbackFn(element, index, array) { ... }, thisArg)
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>A function to test for each element, taking three arguments:
     <dl>
       <dt><code><var>element</var></code></dt>
@@ -52,23 +52,23 @@ every(function callbackFn(element, index, array) { ... }, thisArg)
     </dl>
   </dd>
   <dt><code><var>thisArg</var></code> {{Optional_inline}}</dt>
-  <dd>A value to use as <code>this</code> when executing <code><var>callback</var></code>.
+  <dd>A value to use as <code>this</code> when executing <code><var>callbackFn</var></code>.
   </dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
 
-<p><strong><code>true</code></strong> if the <code><var>callback</var></code> function
+<p><strong><code>true</code></strong> if the <code><var>callbackFn</var></code> function
   returns a {{Glossary("truthy")}} value for every array element. Otherwise,
   <strong><code>false</code></strong>.</p>
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>every</code> method executes the provided <code><var>callback</var></code>
+<p>The <code>every</code> method executes the provided <code><var>callbackFn</var></code>
   function once for each element present in the array until it finds the one where
-  <code><var>callback</var></code> returns a {{Glossary("falsy")}} value. If such an
+  <code><var>callbackFn</var></code> returns a {{Glossary("falsy")}} value. If such an
   element is found, the <code>every</code> method immediately returns <code>false</code>.
-  Otherwise, if <code><var>callback</var></code> returns a {{Glossary("truthy")}} value
+  Otherwise, if <code><var>callbackFn</var></code> returns a {{Glossary("truthy")}} value
   for all elements, <code>every</code> returns <code>true</code>.</p>
 
 <div class="notecard note">
@@ -76,11 +76,11 @@ every(function callbackFn(element, index, array) { ... }, thisArg)
     <code>true</code> for any condition!</p>
 </div>
 
-<p><code><var>callback</var></code> is invoked only for array indexes which have assigned
+<p><code><var>callbackFn</var></code> is invoked only for array indexes which have assigned
   values. It is not invoked for indexes which have been deleted, or which have never been
   assigned values.</p>
 
-<p><code><var>callback</var></code> is invoked with three arguments: the value of the
+<p><code><var>callbackFn</var></code> is invoked with three arguments: the value of the
   element, the index of the element, and the Array object being traversed.</p>
 
 <p>If a <code><var>thisArg</var></code> parameter is provided to <code>every</code>, it
@@ -94,10 +94,10 @@ every(function callbackFn(element, index, array) { ... }, thisArg)
 <p><code>every</code> does not mutate the array on which it is called.</p>
 
 <p>The range of elements processed by <code>every</code> is set before the first
-  invocation of <code><var>callback</var></code>. Therefore,
-  <code><var>callback</var></code> will not run on elements that are appended to the array
+  invocation of <code><var>callbackFn</var></code>. Therefore,
+  <code><var>callbackFn</var></code> will not run on elements that are appended to the array
   after the call to <code>every</code> begins. If existing elements of the array are
-  changed, their value as passed to <code><var>callback</var></code> will be the value at
+  changed, their value as passed to <code><var>callbackFn</var></code> will be the value at
   the time <code>every</code> visits them. Elements that are deleted are not visited.</p>
 
 <p><code>every</code> acts like the "for all" quantifier in mathematics. In particular,

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.html
@@ -22,32 +22,32 @@ browser-compat: javascript.builtins.Array.filter
 
 <pre class="brush: js">
 // Arrow function
-filter((currentValue) => { ... } )
-filter((currentValue, index) => { ... } )
-filter((currentValue, index, array) => { ... } )
+filter((element) => { ... } )
+filter((element, index) => { ... } )
+filter((element, index, array) => { ... } )
 
 // Callback function
 filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function callbackFn(currentValue) { ... })
-filter(function callbackFn(currentValue, index) { ... })
-filter(function callbackFn(currentValue, index, array){ ... })
-filter(function callbackFn(currentValue, index, array) { ... }, thisArg)
+filter(function callbackFn(element) { ... })
+filter(function callbackFn(element, index) { ... })
+filter(function callbackFn(element, index, array){ ... })
+filter(function callbackFn(element, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
- <dt><code><var>callback</var></code></dt>
+ <dt><code><var>callbackFn</var></code></dt>
  <dd>
  <p>Function is a predicate, to test each element of the array. Return a value that coerces to <code>true</code> to keep the element, or to <code>false</code> otherwise.</p>
 
  <p>It accepts three arguments:</p>
 
  <dl>
-  <dt><code><var>currentValue</var></code></dt>
+  <dt><code><var>element</var></code></dt>
   <dd>The current element being processed in the array.</dd>
   <dt><code><var>index</var></code>{{optional_inline}}</dt>
   <dd>The index of the current element being processed in the array.</dd>
@@ -56,7 +56,7 @@ filter(function callbackFn(currentValue, index, array) { ... }, thisArg)
  </dl>
  </dd>
  <dt><code><var>thisArg</var></code>{{optional_inline}}</dt>
- <dd>Value to use as <code>this</code> when executing <code><var>callback</var></code>.</dd>
+ <dd>Value to use as <code>this</code> when executing <code><var>callbackFn</var></code>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -65,9 +65,9 @@ filter(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 <h2 id="Description">Description</h2>
 
-<p><code>filter()</code> calls a provided <code><var>callback</var></code> function once for each element in an array, and constructs a new array of all the values for which <code><var>callback</var></code> returns <a href="/en-US/docs/Glossary/Truthy">a value that coerces to <code>true</code></a>. <code><var>callback</var></code> is invoked only for indexes of the array which have assigned values; it is not invoked for indexes which have been deleted or which have never been assigned values. Array elements which do not pass the <code><var>callback</var></code> test are skipped, and are not included in the new array.</p>
+<p><code>filter()</code> calls a provided <code><var>callbackFn</var></code> function once for each element in an array, and constructs a new array of all the values for which <code><var>callbackFn</var></code> returns <a href="/en-US/docs/Glossary/Truthy">a value that coerces to <code>true</code></a>. <code><var>callbackFn</var></code> is invoked only for indexes of the array which have assigned values; it is not invoked for indexes which have been deleted or which have never been assigned values. Array elements which do not pass the <code><var>callbackFn</var></code> test are skipped, and are not included in the new array.</p>
 
-<p><code><var>callback</var></code> is invoked with three arguments:</p>
+<p><code><var>callbackFn</var></code> is invoked with three arguments:</p>
 
 <ol>
  <li>the value of the element</li>
@@ -79,7 +79,7 @@ filter(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 <p><code>filter()</code> does not mutate the array on which it is called.</p>
 
-<p>The range of elements processed by <code>filter()</code> is set before the first invocation of <code><var>callback</var></code>. Elements which are appended to the array (from <code><var>callback</var></code>) after the call to <code>filter()</code> begins will not be visited by <code><var>callback</var></code>. If existing elements of the array are deleted in the same way they will not be visited.</p>
+<p>The range of elements processed by <code>filter()</code> is set before the first invocation of <code><var>callbackFn</var></code>. Elements which are appended to the array (from <code><var>callbackFn</var></code>) after the call to <code>filter()</code> begins will not be visited by <code><var>callbackFn</var></code>. If existing elements of the array are deleted in the same way they will not be visited.</p>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.html
@@ -54,7 +54,7 @@ find(function callbackFn(element, index, array) { ... }, thisArg)
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>Function to execute on each value in the array, taking 3 arguments:
     <dl>
       <dt><code><var>element</var></code></dt>
@@ -67,7 +67,7 @@ find(function callbackFn(element, index, array) { ... }, thisArg)
   </dd>
   <dt><code><var>thisArg</var></code> {{optional_inline}}</dt>
   <dd>Object to use as {{jsxref("Operators/this", "this")}} inside
-    <code><var>callback</var></code>.</dd>
+    <code><var>callbackFn</var></code>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -78,32 +78,32 @@ find(function callbackFn(element, index, array) { ... }, thisArg)
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>find</code> method executes the <code><var>callback</var></code> function
-  once for each index of the array until the <code><var>callback</var></code> returns a <a
+<p>The <code>find</code> method executes the <code><var>callbackFn</var></code> function
+  once for each index of the array until the <code><var>callbackFn</var></code> returns a <a
     href="/en-US/docs/Glossary/Truthy">truthy</a> value. If so, <code>find</code>
   immediately returns the value of that element. Otherwise, <code>find</code> returns
   {{jsxref("undefined")}}.</p>
 
-<p><code><var>callback</var></code> is invoked for <em>every</em> index of the array, not
+<p><code><var>callbackFn</var></code> is invoked for <em>every</em> index of the array, not
   just those with assigned values. This means it may be less efficient for sparse arrays,
   compared to methods that only visit assigned values.</p>
 
 <p>If a <code><var>thisArg</var></code> parameter is provided to <code>find</code>, it
   will be used as the <code>this</code> value inside each invocation of the
-  <code><var>callback</var></code>. If it is not provided, then {{jsxref("undefined")}} is
+  <code><var>callbackFn</var></code>. If it is not provided, then {{jsxref("undefined")}} is
   used.</p>
 
 <p>The <code>find</code> method does not mutate the array on which it is called, but the
-  function provided to <code><var>callback</var></code> can. If so, the elements processed
+  function provided to <code><var>callbackFn</var></code> can. If so, the elements processed
   by <code>find</code> are set <em>before</em> the first invocation of
-  <code><var>callback</var></code>. Therefore:</p>
+  <code><var>callbackFn</var></code>. Therefore:</p>
 
 <ul>
-  <li><code><var>callback</var></code> will not visit any elements added to the array
+  <li><code><var>callbackFn</var></code> will not visit any elements added to the array
     after the call to <code>find</code> begins.</li>
   <li>If an existing, yet-unvisited element of the array is changed by
-    <code><var>callback</var></code>, its value passed to the
-    <code><var>callback</var></code> will be the value at the time <code>find</code>
+    <code><var>callbackFn</var></code>, its value passed to the
+    <code><var>callbackFn</var></code> will be the value at the time <code>find</code>
     visits that element's index.</li>
   <li>Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.html
@@ -45,7 +45,7 @@ findIndex(function callbackFn(element, index, array) { ... }, thisArg)
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>
     <p>A function to execute on each value in the array until the function returns
       <code>true</code>, indicating that the satisfying element was found.</p>
@@ -63,7 +63,7 @@ findIndex(function callbackFn(element, index, array) { ... }, thisArg)
   </dd>
   <dt><code><var>thisArg</var></code> {{optional_inline}}</dt>
   <dd>Optional object to use as <code>this</code> when executing
-    <code><var>callback</var></code>.</dd>
+    <code><var>callbackFn</var></code>.</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>
@@ -75,22 +75,22 @@ findIndex(function callbackFn(element, index, array) { ... }, thisArg)
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>findIndex()</code> method executes the <code><var>callback</var></code>
+<p>The <code>findIndex()</code> method executes the <code><var>callbackFn</var></code>
   function once for every index in the array until it finds the one where
-  <code><var>callback</var></code> returns a {{Glossary("truthy")}} value.</p>
+  <code><var>callbackFn</var></code> returns a {{Glossary("truthy")}} value.</p>
 
 <p>If such an element is found, <code>findIndex()</code> immediately returns the element's
-  index. If <code><var>callback</var></code> never returns a truthy value (or the array's
+  index. If <code><var>callbackFn</var></code> never returns a truthy value (or the array's
   <code>length</code> is <code>0</code>), <code>findIndex()</code> returns
   <code>-1</code>.</p>
 
 <div class="notecard note">
   <p><strong>Note:</strong> Unlike other array methods such as
-    {{jsxref("Array.some()")}}, <code><var>callback</var></code> is run even for indexes
+    {{jsxref("Array.some()")}}, <code><var>callbackFn</var></code> is run even for indexes
     with unassigned values.</p>
 </div>
 
-<p><code><var>callback</var></code> is invoked with three arguments:</p>
+<p><code><var>callbackFn</var></code> is invoked with three arguments:</p>
 
 <ol>
   <li>The value of the element</li>
@@ -100,15 +100,15 @@ findIndex(function callbackFn(element, index, array) { ... }, thisArg)
 
 <p>If a <code><var>thisArg</var></code> parameter is passed to <code>findIndex()</code>,
   it will be used as the <code>this</code> inside each invocation of the
-  <code><var>callback</var></code>. If it is not provided, then {{jsxref("undefined")}} is
+  <code><var>callbackFn</var></code>. If it is not provided, then {{jsxref("undefined")}} is
   used.</p>
 
 <p>The range of elements processed by <code>findIndex()</code> is set before the first
-  invocation of <code><var>callback</var></code>. <code><var>callback</var></code> will
+  invocation of <code><var>callbackFn</var></code>. <code><var>callbackFn</var></code> will
   not process the elements appended to the array after the call to
   <code>findIndex()</code> begins. If an existing, unvisited element of the array is
-  changed by <code><var>callback</var></code>, its value passed to the
-  <code><var>callback</var></code> will be the value at the time <code>findIndex()</code>
+  changed by <code><var>callbackFn</var></code>, its value passed to the
+  <code><var>callbackFn</var></code> will be the value at the time <code>findIndex()</code>
   visits the element's index.</p>
 
 <p>Elements that are {{jsxref("Operators/delete", "deleted")}} are still visited.</p>

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.html
@@ -21,38 +21,38 @@ browser-compat: javascript.builtins.Array.forEach
 
 <pre class="brush: js">
 // Arrow function
-forEach((currentValue) => { ... } )
-forEach((currentValue, index) => { ... } )
-forEach((currentValue, index, array) => { ... } )
+forEach((element) => { ... } )
+forEach((element, index) => { ... } )
+forEach((element, index, array) => { ... } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function callbackFn(currentValue) { ... })
-forEach(function callbackFn(currentValue, index) { ... })
-forEach(function callbackFn(currentValue, index, array){ ... })
-forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
+forEach(function callbackFn(element) { ... })
+forEach(function callbackFn(element, index) { ... })
+forEach(function callbackFn(element, index, array){ ... })
+forEach(function callbackFn(element, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>
     <p>Function to execute on each element. It accepts between one and three arguments:</p>
     <dl>
-      <dt><code><var>currentValue</var></code></dt>
+      <dt><code><var>element</var></code></dt>
       <dd>The current element being processed in the array.</dd>
       <dt><code><var>index</var></code> {{optional_inline}}</dt>
-      <dd>The index of <code><var>currentValue</var></code> in the array.</dd>
+      <dd>The index of <code><var>element</var></code> in the array.</dd>
       <dt><code><var>array</var></code> {{optional_inline}}</dt>
       <dd>The array <code>forEach()</code> was called upon.</dd>
     </dl>
   </dd>
   <dt><code><var>thisArg</var></code> {{optional_inline}}</dt>
-  <dd>Value to use as <code>this</code> when executing <code><var>callback</var></code>.
+  <dd>Value to use as <code>this</code> when executing <code><var>callbackFn</var></code>.
   </dd>
 </dl>
 
@@ -62,12 +62,12 @@ forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 <h2 id="Description">Description</h2>
 
-<p><code>forEach()</code> calls a provided <code><var>callback</var></code> function once
+<p><code>forEach()</code> calls a provided <code><var>callbackFn</var></code> function once
   for each element in an array in ascending index order. It is not invoked for index properties
   that have been deleted or are uninitialized. (For sparse arrays, <a
     href="#sparseArray">see example below</a>.)</p>
 
-<p><code><var>callback</var></code> is invoked with three arguments:</p>
+<p><code><var>callbackFn</var></code> is invoked with three arguments:</p>
 
 <ol>
   <li>the value of the element</li>
@@ -78,15 +78,15 @@ forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
 <p>If a <code><var>thisArg</var></code> parameter is provided to <code>forEach()</code>,
   it will be used as callback's <code>this</code> value. The
   <code><var>thisArg</var></code> value ultimately observable by
-  <code><var>callback</var></code> is determined according to <a
+  <code><var>callbackFn</var></code> is determined according to <a
     href="/en-US/docs/Web/JavaScript/Reference/Operators/this">the usual rules for
     determining the <code>this</code> seen by a function</a>.</p>
 
 <p>The range of elements processed by <code>forEach()</code> is set before the first
-  invocation of <code><var>callback</var></code>. Elements which are appended to the array
+  invocation of <code><var>callbackFn</var></code>. Elements which are appended to the array
   after the call to <code>forEach()</code> begins will not be visited by
-  <code><var>callback</var></code>. If existing elements of the array are changed or
-  deleted, their value as passed to <code><var>callback</var></code> will be the value at
+  <code><var>callbackFn</var></code>. If existing elements of the array are changed or
+  deleted, their value as passed to <code><var>callbackFn</var></code> will be the value at
   the time <code>forEach()</code> visits them; elements that are deleted before being
   visited are not visited. If elements that are already visited are removed (e.g. using
   {{jsxref("Array.prototype.shift()", "shift()")}}) during the iteration, later elements
@@ -94,14 +94,14 @@ forEach(function callbackFn(currentValue, index, array) { ... }, thisArg)
     href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Modifying_the_array_during_iteration">See
     this example, below</a>.)</p>
 
-<p><code>forEach()</code> executes the <code><var>callback</var></code> function once for
+<p><code>forEach()</code> executes the <code><var>callbackFn</var></code> function once for
   each array element; unlike {{jsxref("Array.prototype.map()", "map()")}} or
   {{jsxref("Array.prototype.reduce()", "reduce()")}} it always returns the value
   {{jsxref("undefined")}} and is not chainable. The typical use case is to execute side
   effects at the end of a chain.</p>
 
 <p><code>forEach()</code> does not mutate the array on which it is called. (However,
-  <code><var>callback</var></code> may do so)</p>
+  <code><var>callbackFn</var></code> may do so)</p>
 
 <div class="note">
   <p><strong>Note:</strong> There is no way to stop or break a <code>forEach()</code> loop other than by throwing

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.html
@@ -22,19 +22,19 @@ browser-compat: javascript.builtins.Array.from
 
 <pre class="brush: js">
 // Arrow function
-Array.from(arrayLike, (currentValue) => { ... } )
-Array.from(arrayLike, (currentValue, index) => { ... } )
-Array.from(arrayLike, (currentValue, index, array) => { ... } )
+Array.from(arrayLike, (element) => { ... } )
+Array.from(arrayLike, (element, index) => { ... } )
+Array.from(arrayLike, (element, index, array) => { ... } )
 
 // Mapping function
 Array.from(arrayLike, mapFn)
 Array.from(arrayLike, mapFn, thisArg)
 
 // Inline mapping function
-Array.from(arrayLike, function mapFn(currentValue) { ... })
-Array.from(arrayLike, function mapFn(currentValue, index) { ... })
-Array.from(arrayLike, function mapFn(currentValue, index, array){ ... })
-Array.from(arrayLike, function mapFn(currentValue, index, array) { ... }, thisArg)
+Array.from(arrayLike, function mapFn(element) { ... })
+Array.from(arrayLike, function mapFn(element, index) { ... })
+Array.from(arrayLike, function mapFn(element, index, array){ ... })
+Array.from(arrayLike, function mapFn(element, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>

--- a/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/includes/index.html
@@ -24,14 +24,14 @@ browser-compat: javascript.builtins.Array.includes
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js">
-includes(valueToFind)
-includes(valueToFind, fromIndex)
+includes(searchElement)
+includes(searchElement, fromIndex)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>valueToFind</var></code></dt>
+  <dt><code><var>searchElement</var></code></dt>
   <dd>
     <p>The value to search for.</p>
 
@@ -43,7 +43,7 @@ includes(valueToFind, fromIndex)
   <dt><code><var>fromIndex</var></code> {{optional_inline}}</dt>
   <dd>
     <p>The position in this array at which to begin searching for
-    <code><var>valueToFind</var></code>.</p>
+    <code><var>searchElement</var></code>.</p>
     <p>The first element to be searched is found at <code><var>fromIndex</var></code> for
     positive values of <code><var>fromIndex</var></code>, or at
     <code><var>arr</var>.length + <var>fromIndex</var></code> for negative values of
@@ -57,7 +57,7 @@ includes(valueToFind, fromIndex)
 <h3 id="Return_value">Return value</h3>
 
 <p>A {{jsxref("Boolean")}} which is <code>true</code> if the value
-  <code><var>valueToFind</var></code> is found within the array (or the part of the array
+  <code><var>searchElement</var></code> is found within the array (or the part of the array
   indicated by the index <code><var>fromIndex</var></code>, if specified).</p>
 
 <p>Values of zero are all considered to be equal, regardless of sign. (That is,
@@ -95,7 +95,7 @@ arr.includes('c', 100)  // false
 
 <p>If <code><var>fromIndex</var></code> is negative, the computed index is calculated to
   be used as a position in the array at which to begin searching for
-  <code><var>valueToFind</var></code>. If the computed index is less or equal than
+  <code><var>searchElement</var></code>. If the computed index is less or equal than
   <code>-1 * <var>arr</var>.length</code>, the entire array will be searched.</p>
 
 <pre class="brush: js">// array length is 3

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.html
@@ -24,34 +24,34 @@ browser-compat: javascript.builtins.Array.map
 
 <pre class="brush: js">
 // Arrow function
-map((currentValue) => { ... } )
-map((currentValue, index) => { ... } )
-map((currentValue, index, array) => { ... } )
+map((element) => { ... } )
+map((element, index) => { ... } )
+map((element, index, array) => { ... } )
 
 // Callback function
 map(callbackFn)
 map(callbackFn, thisArg)
 
 // Inline callback function
-map(function callbackFn(currentValue) { ... })
-map(function callbackFn(currentValue, index) { ... })
-map(function callbackFn(currentValue, index, array){ ... })
-map(function callbackFn(currentValue, index, array) { ... }, thisArg)
+map(function callbackFn(element) { ... })
+map(function callbackFn(element, index) { ... })
+map(function callbackFn(element, index, array){ ... })
+map(function callbackFn(element, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>
     <p>Function that is called for every element of <code><var>arr</var></code>. Each time
-      <code><var>callback</var></code> executes, the returned value is added to
+      <code><var>callbackFn</var></code> executes, the returned value is added to
       <code><var>newArray</var></code>.</p>
 
-    <p>The <code><var>callback</var></code> function accepts the following arguments:</p>
+    <p>The <code><var>callbackFn</var></code> function accepts the following arguments:</p>
 
     <dl>
-      <dt><code><var>currentValue</var></code></dt>
+      <dt><code><var>element</var></code></dt>
       <dd>The current element being processed in the array.</dd>
       <dt><code><var>index</var></code>{{optional_inline}}</dt>
       <dd>The index of the current element being processed in the array.</dd>
@@ -60,7 +60,7 @@ map(function callbackFn(currentValue, index, array) { ... }, thisArg)
     </dl>
   </dd>
   <dt><code>thisArg</code>{{optional_inline}}</dt>
-  <dd>Value to use as <code>this</code> when executing <code><var>callback</var></code>.
+  <dd>Value to use as <code>this</code> when executing <code><var>callbackFn</var></code>.
   </dd>
 </dl>
 
@@ -70,9 +70,9 @@ map(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 <h2 id="Description">Description</h2>
 
-<p><code>map</code> calls a provided <code><var>callback</var></code> function
+<p><code>map</code> calls a provided <code><var>callbackFn</var></code> function
   <strong>once for each element</strong> in an array, in order, and constructs a new array
-  from the results. <code><var>callback</var></code> is invoked only for indexes of the
+  from the results. <code><var>callbackFn</var></code> is invoked only for indexes of the
   array which have assigned values (including {{jsxref("undefined")}}).</p>
 
 <p>It is <em>not</em> called for missing elements of the array; that is:</p>
@@ -97,24 +97,24 @@ map(function callbackFn(currentValue, index, array) { ... }, thisArg)
 
 <h3 id="Parameters_in_Detail">Parameters in Detail</h3>
 
-<p><code><var>callback</var></code> is invoked with three arguments: the value of the
+<p><code><var>callbackFn</var></code> is invoked with three arguments: the value of the
   element, the index of the element, and the array object being mapped.</p>
 
 <p>If a <code>thisArg</code> parameter is provided, it will be used as callback's
   <code>this</code> value. Otherwise, the value {{jsxref("undefined")}} will be used as
   its <code>this</code> value. The <code>this</code> value ultimately observable by
-  <code><var>callback</var></code> is determined according to <a
+  <code><var>callbackFn</var></code> is determined according to <a
     href="/en-US/docs/Web/JavaScript/Reference/Operators/this">the usual rules for
     determining the <code>this</code> seen by a function</a>.</p>
 
 <p><code>map</code> does not mutate the array on which it is called (although
-  <code><var>callback</var></code>, if invoked, may do so).</p>
+  <code><var>callbackFn</var></code>, if invoked, may do so).</p>
 
 <p>The range of elements processed by <code>map</code> is set before the first invocation
-  of <code><var>callback</var></code>. Elements which are appended to the array after the
-  call to <code>map</code> begins will not be visited by <code><var>callback</var></code>.
+  of <code><var>callbackFn</var></code>. Elements which are appended to the array after the
+  call to <code>map</code> begins will not be visited by <code><var>callbackFn</var></code>.
   If existing elements of the array are changed after the call to <code>map</code>, their
-  value will be the value at the time <code><var>callback</var></code> visits them.
+  value will be the value at the time <code><var>callbackFn</var></code> visits them.
   Elements that are deleted after the call to <code>map</code> begins and before being
   visited are not visited.</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -43,21 +43,21 @@ reduce((accumulator, currentValue, index) => { ... } )
 reduce((accumulator, currentValue, index, array) => { ... } )
 reduce((accumulator, currentValue, index, array) => { ... }, initialValue)
 
-// Reducer function
-reduce(reducerFn)
-reduce(reducerFn, initialValue)
+// Callback function
+reduce(callbackFn)
+reduce(callbackFn, initialValue)
 
-// Inline reducer function
-reduce(function reducerFn(accumulator, currentValue) { ... })
-reduce(function reducerFn(accumulator, currentValue, index) { ... })
-reduce(function reducerFn(accumulator, currentValue, index, array){ ... })
-reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, initialValue)
+// Inline callback function
+reduce(function callbackFn(accumulator, currentValue) { ... })
+reduce(function callbackFn(accumulator, currentValue, index) { ... })
+reduce(function callbackFn(accumulator, currentValue, index, array){ ... })
+reduce(function callbackFn(accumulator, currentValue, index, array) { ... }, initialValue)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>
     <p>A function to execute on each element in the array (except for the first, if no
       <code><var>initialValue</var></code> is supplied).</p>
@@ -66,7 +66,7 @@ reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, init
 
     <dl>
       <dt><code><var>accumulator</var></code></dt>
-      <dd>The accumulator accumulates <var>callback</var>'s return values. It is the
+      <dd>The accumulator accumulates <var>callbackFn</var>'s return values. It is the
         accumulated value previously returned in the last invocation of the callback—or
         <code><var>initialValue</var></code>, if it was supplied (see below).</dd>
       <dt><code><var>currentValue</var></code></dt>
@@ -81,7 +81,7 @@ reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, init
   </dd>
   <dt><code><var>initialValue</var></code> {{optional_inline}}</dt>
   <dd>A value to use as the first argument to the first call of the
-    <code><var>callback</var></code>. If no <code><var>initialValue</var></code> is
+    <code><var>callbackFn</var></code>. If no <code><var>initialValue</var></code> is
     supplied, the first element in the array will be used as the initial
     <code><var>accumulator</var></code> value and skipped as
     <code><var>currentValue</var></code>. Calling <code>reduce()</code> on an empty array
@@ -95,7 +95,7 @@ reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, init
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>reduce()</code> method executes the <code><var>callback</var></code> once for
+<p>The <code>reduce()</code> method executes the <code><var>callbackFn</var></code> once for
   each assigned value present in the array, taking four arguments:</p>
 
 <ol>
@@ -127,7 +127,7 @@ reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, init
 <p>If the array only has one element (regardless of position) and no
   <code><var>initialValue</var></code> is provided, or if
   <code><var>initialValue</var></code> is provided but the array is empty, the solo value
-  will be returned <em>without</em> calling <em><code>callback</code>.</em></p>
+  will be returned <em>without</em> calling <em><code>callbackFn</code>.</em></p>
 
 <p>It is almost always safer to provide an <code><var>initialValue</var></code>, because
   there can be up to <em>four</em> possible output types without

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.html
@@ -29,21 +29,21 @@ reduceRight((accumulator, currentValue, index) => { ... } )
 reduceRight((accumulator, currentValue, index, array) => { ... } )
 reduceRight((accumulator, currentValue, index, array) => { ... }, initialValue)
 
-// Reducer function
-reduceRight(reducerFn)
-reduceRight(reducerFn, initialValue)
+// Callback function
+reduceRight(callbackFn)
+reduceRight(callbackFn, initialValue)
 
-// Inline reducer function
-reduceRight(function reducerFn(accumulator, currentValue) { ... })
-reduceRight(function reducerFn(accumulator, currentValue, index) { ... })
-reduceRight(function reducerFn(accumulator, currentValue, index, array){ ... })
-reduceRight(function reducerFn(accumulator, currentValue, index, array) { ... }, thisArg)
+// Callback reducer function
+reduceRight(function callbackFn(accumulator, currentValue) { ... })
+reduceRight(function callbackFn(accumulator, currentValue, index) { ... })
+reduceRight(function callbackFn(accumulator, currentValue, index, array){ ... })
+reduceRight(function callbackFn(accumulator, currentValue, index, array) { ... }, thisArg)
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code><var>callback</var></code></dt>
+  <dt><code><var>callbackFn</var></code></dt>
   <dd>Function to execute on each value in the array, taking four arguments:
     <dl>
       <dt><code><var>accumulator</var></code></dt>
@@ -59,7 +59,7 @@ reduceRight(function reducerFn(accumulator, currentValue, index, array) { ... },
   </dd>
   <dt><code><var>initialValue</var></code> {{optional_inline}}</dt>
   <dd>Value to use as accumulator to the first call of the
-    <code><var>callback</var></code>. If no initial value is supplied, the last element in
+    <code><var>callbackFn</var></code>. If no initial value is supplied, the last element in
     the array will be used and skipped. Calling reduce or reduceRight on an empty array
     without an initial value creates a <code>TypeError</code>.</dd>
 </dl>
@@ -75,7 +75,7 @@ reduceRight(function reducerFn(accumulator, currentValue, index, array) { ... },
   (or value from the previous callback call), the value of the current element, the
   current index, and the array over which iteration is occurring.</p>
 
-<p>The call to the reduceRight <code><var>callback</var></code> would look something like
+<p>The call to the reduceRight <code><var>callbackFn</var></code> would look something like
   this:</p>
 
 <pre class="brush: js">arr.reduceRight(function(accumulator, currentValue, index, array) {
@@ -97,7 +97,7 @@ reduceRight(function reducerFn(accumulator, currentValue, index, array) { ... },
   {{jsxref("TypeError")}} would be thrown. If the array has only one element (regardless
   of position) and no <code><var>initialValue</var></code> was provided, or if
   <code><var>initialValue</var></code> is provided but the array is empty, the solo value
-  would be returned without calling <code><var>callback</var></code>.</p>
+  would be returned without calling <code><var>callbackFn</var></code>.</p>
 
 <p>Some example run-throughs of the function would look like this:</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.html
@@ -56,7 +56,7 @@ some(function callbackFn(element, index, array) { ... }, thisArg)
     </dl>
   </dd>
   <dt><code><var>thisArg</var></code>{{optional_inline}}</dt>
-  <dd>A value to use as <code>this</code> when executing <code><var>callback</var></code>.
+  <dd>A value to use as <code>this</code> when executing <code><var>callbackFn</var></code>.
   </dd>
 </dl>
 
@@ -67,22 +67,22 @@ some(function callbackFn(element, index, array) { ... }, thisArg)
 
 <h2 id="Description">Description</h2>
 
-<p>The <code>some()</code> method executes the <code><var>callback</var></code> function
+<p>The <code>some()</code> method executes the <code><var>callbackFn</var></code> function
   once for each element present in the array until it finds the one where
-  <code><var>callback</var></code> returns a <em>truthy</em> value (a value that becomes
+  <code><var>callbackFn</var></code> returns a <em>truthy</em> value (a value that becomes
   true when converted to a Boolean). If such an element is found, <code>some()</code>
   immediately returns <code>true</code>. Otherwise, <code>some()</code> returns
-  <code>false</code>. <code><var>callback</var></code> is invoked only for indexes of the
+  <code>false</code>. <code><var>callbackFn</var></code> is invoked only for indexes of the
   array with assigned values. It is not invoked for indexes which have been deleted or
   which have never been assigned values.</p>
 
-<p><code><var>callback</var></code> is invoked with three arguments: the value of the
+<p><code><var>callbackFn</var></code> is invoked with three arguments: the value of the
   element, the index of the element, and the Array object being traversed.</p>
 
 <p>If a <code><var>thisArg</var></code> parameter is provided to <code>some()</code>, it
   will be used as the callback's <code>this</code> value. Otherwise, the value
   {{jsxref("undefined")}} will be used as its <code>this</code> value. The
-  <code>this</code> value ultimately observable by <code><var>callback</var></code> is
+  <code>this</code> value ultimately observable by <code><var>callbackFn</var></code> is
   determined according to <a
     href="/en-US/docs/Web/JavaScript/Reference/Operators/this">the usual rules for
     determining the <code>this</code> seen by a function</a>.</p>
@@ -90,11 +90,11 @@ some(function callbackFn(element, index, array) { ... }, thisArg)
 <p><code>some()</code> does not mutate the array on which it is called.</p>
 
 <p>The range of elements processed by <code>some()</code> is set before the first
-  invocation of <code><var>callback</var></code>. Elements appended to the array after the
+  invocation of <code><var>callbackFn</var></code>. Elements appended to the array after the
   call to <code>some()</code> begins will not be visited by
-  <code><var>callback</var></code>. If an existing, unvisited element of the array is
-  changed by <code><var>callback</var></code>, its value passed to the visiting
-  <code><var>callback</var></code> will be the value at the time that <code>some()</code>
+  <code><var>callbackFn</var></code>. If an existing, unvisited element of the array is
+  changed by <code><var>callbackFn</var></code>, its value passed to the visiting
+  <code><var>callbackFn</var></code> will be the value at the time that <code>some()</code>
   visits that element's index. Elements that are deleted are not visited.</p>
 
 <div class="notecard note">


### PR DESCRIPTION
Some fixes for Array pages as discovered in https://github.com/mdn/content/pull/4677 for TypedArray pages