### PR TITLE
Mark ServiceWorkerContainer.p.onerror deprecated

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/index.html
@@ -34,8 +34,7 @@ tags:
  <dd>Occurs when the document's associated {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active","active")}} worker.<br>
  Also available via the {{domxref("ServiceWorkerContainer.oncontrollerchange")}} property.</dd>
  <dt><code>error</code></dt>
- <dd>Fired whenever an error occurs in the associated service workers.<br>
- Also available via the {{domxref("ServiceWorkerContainer.onerror")}} property.</dd>
+ <dd>Fired whenever an error occurs in the associated service workers.</dd>
  <dt><code><a href="/en-US/docs/Web/API/ServiceWorkerContainer/message_event">message</a></code></dt>
  <dd>Occurs when incoming messages are received by the {{domxref("ServiceWorkerContainer")}} object (e.g. via a {{domxref("MessagePort.postMessage()")}} call.)<br>
  Also available via the {{domxref("ServiceWorkerContainer.onmessage")}} property.</dd>

--- a/files/en-us/web/api/serviceworkercontainer/onerror/index.html
+++ b/files/en-us/web/api/serviceworkercontainer/onerror/index.html
@@ -11,7 +11,7 @@ tags:
 - ServiceWorkerContainer
 - onerror
 ---
-<p>{{APIRef("Service Workers API")}}{{ SeeCompatTable() }}</p>
+<p>{{APIRef("Service Workers API")}}{{Deprecated_header}}</p>
 
 <p>The <strong><code>onerror</code></strong> property of the
   {{domxref("ServiceWorkerContainer")}} interface is an event handler fired whenever an


### PR DESCRIPTION
https://github.com/w3c/ServiceWorker/commit/c240d9d (https://github.com/w3c/ServiceWorker/issues/912) dropped `ServiceWorkerContainer.p.onerror` from the spec. So this change marks it deprecated.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10278