### PR TITLE
Remove spec and compat sections from non-reference pages

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.html
+++ b/files/en-us/web/javascript/data_structures/index.html
@@ -438,24 +438,10 @@ Infinity
 
 <p>Please read the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/typeof">reference page</a> for more details and edge cases.</p>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-ecmascript-data-types-and-values', 'ECMAScript Data Types and Values')}}</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
  <li><a class="link-https" href="https://github.com/nzakas/computer-science-in-javascript/">Nicholas Zakas collection of common data structure and common algorithms in JavaScript.</a></li>
  <li><a href="https://github.com/monmohan/DataStructures_In_Javascript">Search Tre(i)es implemented in JavaScript</a></li>
+ <li><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Data Types and Values in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/eventloop/index.html
+++ b/files/en-us/web/javascript/eventloop/index.html
@@ -138,18 +138,9 @@ while (true) {
 
 <p>Legacy exceptions exist like <code>alert</code> or synchronous XHR, but it is considered a good practice to avoid them. Beware: <a href="http://stackoverflow.com/questions/2734025/is-javascript-guaranteed-to-be-single-threaded/2734311#2734311">exceptions to the exception do exist</a> (but are usually implementation bugs, rather than anything else).</p>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="See_also">See also</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', 'webappapis.html#event-loops', 'Event loops')}}</td>
-  </tr>
-  <tr>
-   <td><a href="https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#what-is-the-event-loop">Node.js Event Loop</a></td>
-  </tr>
- </tbody>
-</table>
+<ul>
+  <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loops">Event loops in the HTML standard</a></li>
+  <li><a href="https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#what-is-the-event-loop">Node.js Event Loop</a></li>
+</ul>

--- a/files/en-us/web/javascript/guide/regular_expressions/assertions/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/assertions/index.html
@@ -213,23 +213,6 @@ let ripe_oranges = oranges.filter( fruit =&gt; fruit.match(/(?&lt;=ripe )orange/
 console.log(ripe_oranges); // [ 'ripe orange A ', 'ripe orange C' ]
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-assertion', 'RegExp: Assertions')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>For browser compatibility information, check out the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">main Regular Expressions compatibility table</a>.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
@@ -243,4 +226,5 @@ console.log(ripe_oranges); // [ 'ripe orange A ', 'ripe orange C' ]
   </ul>
  </li>
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">The <code>RegExp()</code> constructor</a></li>
+ <li><a href="https://tc39.es/ecma262/#sec-assertion">Assertions in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.html
@@ -185,24 +185,6 @@ console.table(nonEnglishText.match(regexpBMPWord));
 [ 'Приключения', 'Алисы', 'в', 'Стране', 'чудес' ]
 </pre>
 
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-characterclass', 'RegExp: Character classes')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>For browser compatibility information, check out the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">main Regular Expressions compatibility table</a>.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
@@ -216,4 +198,5 @@ console.table(nonEnglishText.match(regexpBMPWord));
   </ul>
  </li>
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">The <code>RegExp()</code> constructor</a></li>
+ <li><a href="https://tc39.es/ecma262/#sec-characterclass">CharacterClass in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
@@ -141,23 +141,6 @@ do {
 <p><strong>Note:</strong> Not all browsers support this feature; refer to the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">compatibility table</a>.</p>
 </div>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-classranges', 'RegExp: Ranges')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>For browser compatibility information, check out the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">main Regular Expressions compatibility table</a>.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
@@ -171,4 +154,5 @@ do {
   </ul>
  </li>
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">The <code>RegExp()</code> constructor</a></li>
+ <li><a href="https://tc39.es/ecma262/#sec-classranges">ClassRanges in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/quantifiers/index.html
@@ -147,23 +147,6 @@ console.log(text.match(nonGreedyRegexp));
 // The match is the smallest one possible
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-quantifier', 'RegExp: Quantifiers')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>For browser compatibility information, check out the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">main Regular Expressions compatibility table</a>.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
@@ -177,4 +160,5 @@ console.log(text.match(nonGreedyRegexp));
   </ul>
  </li>
  <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">The <code>RegExp()</code> constructor</a></li>
+ <li><a href="https://tc39.es/ecma262/#sec-quantifier">Quantifiers in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.html
+++ b/files/en-us/web/javascript/guide/regular_expressions/unicode_property_escapes/index.html
@@ -139,23 +139,6 @@ const regexpUPE = /\p{L}+/gu;
 console.table(nonEnglishText.match(regexpUPE));
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-runtime-semantics-unicodematchproperty-p', 'RegExp: Unicode property escapes')}}</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<p>For browser compatibility information, check out the <a href="/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility">main Regular Expressions compatibility table</a>.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
@@ -173,4 +156,5 @@ console.table(nonEnglishText.match(regexpUPE));
  <li><a href="https://en.wikipedia.org/wiki/Unicode_character_property">Unicode character property — Wikipedia</a></li>
  <li><a href="https://2ality.com/2017/07/regexp-unicode-property-escapes.html">A blog post from Axel Rauschmayer about Unicode property escapes</a></li>
  <li><a href="https://unicode.org/reports/tr18/#Categories">The Unicode document for Unicode properties</a></li>
+ <li><a href="https://tc39.es/ecma262/#sec-runtime-semantics-unicodematchproperty-p">UnicodeMatchProperty in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.html
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.html
@@ -380,24 +380,10 @@ console.log(Symbol.iterator in aGeneratorObject)
 
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-iteration', 'Iteration')}}</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="See_also_2">See also</h2>
 
 <ul>
- <li>To learn more about ES2015 generators, see:<br>
-  {{jsxref("Statements/function*", "the <code>function*</code> documentation", "", 1)}}</li>
+ <li>{{jsxref("Statements/function*", "the <code>function*</code> documentation", "", 1)}}</li>
+ <li><a href="https://tc39.es/ecma262/#sec-iteration">Iteration in the ECMAScript specification</a></li>
 </ul>

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.html
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.html
@@ -622,21 +622,6 @@ return;
 a + b;
 </pre>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName('ESDraft', '#sec-ecmascript-language-lexical-grammar', 'Lexical Grammar')}}</td>
-		</tr>
-	</tbody>
-</table>
-
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
@@ -644,7 +629,8 @@ a + b;
 <h2 id="See_also">See also</h2>
 
 <ul>
-	<li><a href="http://whereswalden.com/2013/08/12/micro-feature-from-es6-now-in-firefox-aurora-and-nightly-binary-and-octal-numbers/">Jeff Walden: Binary and octal numbers</a></li>
+	<li><a href="https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar">Lexical grammar in the ECMAScript specification</a></li>
+  <li><a href="http://whereswalden.com/2013/08/12/micro-feature-from-es6-now-in-firefox-aurora-and-nightly-binary-and-octal-numbers/">Jeff Walden: Binary and octal numbers</a></li>
 	<li><a href="http://mathiasbynens.be/notes/javascript-escapes">Mathias Bynens: JavaScript character escape sequences</a></li>
 	<li>{{jsxref("Boolean")}}</li>
 	<li>{{jsxref("Number")}}</li>

--- a/files/en-us/web/javascript/reference/strict_mode/index.html
+++ b/files/en-us/web/javascript/reference/strict_mode/index.html
@@ -343,22 +343,10 @@ function baz() { // kosher
 
 <p>The major browsers now implement strict mode. However, don't blindly depend on it since there still are numerous <a href="https://caniuse.com/use-strict" rel="external" title="caniuse.com availability of strict mode">Browser versions used in the wild that only have partial support for strict mode</a> or do not support it at all (e.g. Internet Explorer below version 10!). <em>Strict mode changes semantics.</em> Relying on those changes will cause mistakes and errors in browsers which don't implement strict mode. Exercise caution in using strict mode, and back up reliance on strict mode with feature tests that check whether relevant parts of strict mode are implemented. Finally, make sure to <em>test your code in browsers that do and don't support strict mode</em>. If you test only in browsers that don't support strict mode, you're very likely to have problems in browsers that do, and vice versa.</p>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-strict-mode-code', 'Strict Mode Code')}}</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="See_also">See also</h2>
 
 <ul>
+ <li><a href="https://tc39.es/ecma262/#sec-strict-mode-code">Strict Mode Code in the ECMAScript specification</a></li>
  <li><a href="http://whereswalden.com/2010/09/08/new-es5-strict-mode-support-now-with-poison-pills/">Where's Walden? » New ES5 strict mode support: now with poison pills!</a></li>
  <li><a href="http://whereswalden.com/2011/01/24/new-es5-strict-mode-requirement-function-statements-not-at-top-level-of-a-program-or-function-are-prohibited/">Where's Walden? » New ES5 strict mode requirement: function statements not at top level of a program or function are prohibited</a></li>
  <li><a href="http://whereswalden.com/2011/01/10/new-es5-strict-mode-support-new-vars-created-by-strict-mode-eval-code-are-local-to-that-code-only/">Where's Walden? » New ES5 strict mode support: new vars created by strict mode eval code are local to that code only</a></li>


### PR DESCRIPTION
See https://github.com/mdn/content/pull/4691#issuecomment-832106047
Guide pages shouldn't use formal specification or compat sections.

With this PR there are 0 uses of the old spec macros in javascript/.