### PR TITLE
Fix bind usage in example in addEventListener doc

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -579,9 +579,8 @@ function nonePassiveHandler(event) {
 
 <h4 id="Specifying_this_using_bind">Specifying "this" using bind()</h4>
 
-<p>The {{jsxref("Function.prototype.bind()")}} method lets you specify the value that
-  should be used as <code>this</code> for all calls to a given function. This lets you
-  easily bypass problems where it's unclear what <code>this</code> will be, depending on
+<p>The {{jsxref("Function.prototype.bind()")}} method creates a new function for a given function that lets you specify the value that
+  should be used as <code>this</code> for all calls. This easily bypass problems where it's unclear what <code>this</code> will be, depending on
   the context from which your function was called. Note, however, that you'll need to keep
   a reference to the listener around so you can remove it later.</p>
 
@@ -593,12 +592,14 @@ function nonePassiveHandler(event) {
   this.onclick1 = function(event) {
     console.log(this.name); // undefined, as |this| is the element
   };
-  // bind creates a new instance of the method and we can assign it to own method if `this` instance is fixed for the method
-  this.onclick1 = this.onclick1.bind(this);
   
   this.onclick2 = function(event) {
     console.log(this.name); // 'Something Good', as |this| is bound to newly created object
   };
+  
+  // bind creates a new method with fixed `this` context assigned to onclick2
+  this.onclick2 = this.onclick2.bind(this);
+  
   element.addEventListener('click', this.onclick1, false);
   element.addEventListener('click', this.onclick2, false); // Trick
 }

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -593,11 +593,14 @@ function nonePassiveHandler(event) {
   this.onclick1 = function(event) {
     console.log(this.name); // undefined, as |this| is the element
   };
+  // bind creates a new instance of the method and we can assign it to own method if `this` instance is fixed for the method
+  this.onclick1 = this.onclick1.bind(this);
+  
   this.onclick2 = function(event) {
     console.log(this.name); // 'Something Good', as |this| is bound to newly created object
   };
   element.addEventListener('click', this.onclick1, false);
-  element.addEventListener('click', this.onclick2.bind(this), false); // Trick
+  element.addEventListener('click', this.onclick2, false); // Trick
 }
 const s = new Something(document.body);
 </pre>

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -597,7 +597,7 @@ function nonePassiveHandler(event) {
     console.log(this.name); // 'Something Good', as |this| is bound to newly created object
   };
   
-  // bind creates a new method with fixed `this` context assigned to onclick2
+  // bind causes a fixed `this` context to be assigned to onclick2
   this.onclick2 = this.onclick2.bind(this);
   
   element.addEventListener('click', this.onclick1, false);

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -579,8 +579,8 @@ function nonePassiveHandler(event) {
 
 <h4 id="Specifying_this_using_bind">Specifying "this" using bind()</h4>
 
-<p>The {{jsxref("Function.prototype.bind()")}} method creates a new function for a given function that lets you specify the value that
-  should be used as <code>this</code> for all calls. This easily bypass problems where it's unclear what <code>this</code> will be, depending on
+<p>The {{jsxref("Function.prototype.bind()")}} method lets you establish a fixed 
+  <code>this</code> context for all subsequent calls — bypassing problems where it's unclear what <code>this</code> will be, depending on
   the context from which your function was called. Note, however, that you'll need to keep
   a reference to the listener around so you can remove it later.</p>
 


### PR DESCRIPTION
Remove bind directly used in addEventListener method to avoid memory leak as removeListener on current method will not work

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
