### PR TITLE
Change example HTML list in @counter-style/negative from <ul> to <ol>

### DIFF
--- a/files/en-us/web/css/@counter-style/negative/index.html
+++ b/files/en-us/web/css/@counter-style/negative/index.html
@@ -46,13 +46,13 @@ negative: "(" ")";   /* Surrounds value by '(' and ')' if it is negative */
 
 <h4 id="HTML">HTML</h4>
 
-<pre class="brush: html">&lt;ul class="list" start="-3"&gt;
+<pre class="brush: html">&lt;ol class="list" start="-3"&gt;
   &lt;li&gt;One&lt;/li&gt;
   &lt;li&gt;Two&lt;/li&gt;
   &lt;li&gt;Three&lt;/li&gt;
   &lt;li&gt;Four&lt;/li&gt;
   &lt;li&gt;Five&lt;/li&gt;
-&lt;/ul&gt;</pre>
+&lt;/ol&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Unordered lists have no start attribute, naturally, which caused the example to effectively fail

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/negative

