### PR TITLE
use --diff-file for the pr review companion

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -116,8 +116,10 @@ jobs:
 
           poetry run deployer analyze-pr-build \
             --prefix="pr$PR_NUMBER" \
-            --analyze-flaws --analyze-dangerous-content \
+            --analyze-flaws \
+            --analyze-dangerous-content \
             --github-token="${{secrets.GITHUB_TOKEN}}" \
             --repo=$GITHUB_REPOSITORY \
             --pr-number=$PR_NUMBER \
+            --diff-file=build/DIFF \
             $BUILD_OUT_ROOT


### PR DESCRIPTION
Following https://github.com/mdn/yari/pull/3709 we can now give the review companion a `git diff` file and it will use this to judge external URLs it finds in the built pages. 