### PR TITLE
fix reduce() examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.html
@@ -129,22 +129,27 @@ reduce(function reducerFn(accumulator, currentValue, index, array) { ... }, init
   <code><var>initialValue</var></code> is provided but the array is empty, the solo value
   will be returned <em>without</em> calling <em><code>callback</code>.</em></p>
 
-<p>It is almost always safer to provide an <code><var>initialValue</var></code>, because
-  there can be up to <em>four</em> possible output types without
-  <code><var>initialValue</var></code>, as shown in the following example:</p>
+<p>If <code><var>initialValue</var></code> is provided and the array is not empty then the
+  reduce method will always invoke the callback function starting at index 0. If
+  <code><var>initialValue</var></code> is not provided then the reduce method will act
+  differently for arrays with length larger than 1, equal to 1 and 0, as shown in the
+  following example:</p>
 
-<pre class="brush: js">let maxCallback = ( acc, cur ) =&gt; Math.max( acc.x, cur.x );
-let maxCallback2 = ( max, cur ) =&gt; Math.max( max, cur );
+<pre class="brush: js">
+const getMax = (a, b) =&gt; Math.max(a, b);
 
-// reduce without initialValue
-[ { x: 2 }, { x: 22 }, { x: 42 } ].reduce( maxCallback ); // NaN
-[ { x: 2 }, { x: 22 }            ].reduce( maxCallback ); // 22
-[ { x: 2 }                       ].reduce( maxCallback ); // { x: 2 }
-[                                ].reduce( maxCallback ); // TypeError
+// callback is invoked for each element in the array starting at index 0
+[1, 100].reduce(getMax, 50); // 100
+[    50].reduce(getMax, 10); // 50
 
-// map &amp; reduce with initialValue; better solution, also works for empty or larger arrays
-[ { x: 22 }, { x: 42 } ].map( el =&gt; el.x )
-                        .reduce( maxCallback2, -Infinity );
+// callback is invoked once for element at index 1
+[1, 100].reduce(getMax);     // 100
+
+// callback is not invoked
+[    50].reduce(getMax);     // 50
+[      ].reduce(getMax, 1);  // 1
+
+[      ].reduce(getMax);     // TypeError
 </pre>
 
 <h3 id="How_reduce_works">How reduce() works</h3>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The "_four possible output types without initialValue_" in the method description are due to incorrect usage of `reduce` rather than the lack of `initialValue` argument.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/495

I've added examples that illustrate how the `reduce` method behaves with/without the `initialValue` argument and for arrays of different lengths. These examples are a direct follow-up to the explanations in the ["Description" chapter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#description).
