### PR TITLE
Add missing word

### DIFF
--- a/files/en-us/web/api/history/pushstate/index.html
+++ b/files/en-us/web/api/history/pushstate/index.html
@@ -46,7 +46,7 @@ tags:
   <dd><a href="https://github.com/whatwg/html/issues/2174">Most browsers currently ignore
       this parameter</a>, although they may use it in the future. Passing the empty string
     here should be safe against future changes to the method. Alternatively, you could
-    pass a short title for the state to which you're moving. If you need the title to be
+    pass a short title for the state to which you're moving. If you don't need the title to be
     changed you could use {{domxref("Document.title", "document.title")}}.</dd>
   <dt><code>url</code> {{optional_inline}}</dt>
   <dd>The new history entry's URL is given by this parameter. Note that the browser won't


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The sentence as it exists does not make logical sense. I believe a word was left out inadvertently. Passing `document.title` as the `title` parameter to `pushState` will cause the title to remain the same as it currently is. So you would do this if you **don't** want the title to change. If you **do** want the title to change, you would pass something else in the `title` parameter.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/API/History/pushState

> Issue number (if there is an associated issue)

> Anything else that could help us review it
