### PR TITLE
Fix example log output in “HTML Sanitizer API” doc

### DIFF
--- a/files/en-us/web/api/html_sanitizer_api/index.html
+++ b/files/en-us/web/api/html_sanitizer_api/index.html
@@ -45,7 +45,8 @@ console.log(result);
 <pre class="brush: js">// our input string to clean
 const stringToClean = 'Some text &lt;b&gt;&lt;i&gt;with&lt;/i&gt;&lt;/b&gt; &lt;blink&gt;tags&lt;/blink&gt;, including a rogue script &lt;script&gt;alert(1)&lt;/script&gt; def.';
 
-const result = new Sanitizer().sanitize(stringToClean);
+const dropElements = Sanitizer.defaultConfig().dropElements.concat('blink');
+const result = new Sanitizer({ dropElements }).sanitize(stringToClean);
 // Result: A DocumentFragment containing text nodes and a &lt;b&gt; element, with a &lt;i&gt; child element
 </pre>
 

--- a/files/en-us/web/api/html_sanitizer_api/index.html
+++ b/files/en-us/web/api/html_sanitizer_api/index.html
@@ -37,7 +37,7 @@ const stringToClean = 'Some text &lt;b&gt;&lt;i&gt;with&lt;/i&gt;&lt;/b&gt; &lt;
 
 const result = new Sanitizer().sanitizeToString(stringToClean);
 console.log(result);
-// Logs: "Some text &lt;b&gt;&lt;i&gt;with&lt;/i&gt;&lt;/b&gt; &lt;blink&gt;tags&lt;/blink&gt;, including a rogue script def."
+// Logs: "Some text &lt;b&gt;&lt;i&gt;with&lt;/i&gt;&lt;/b&gt;, including a rogue script def."
 </pre>
 
 <p>The other method available is the {{domxref('Sanitizer.sanitize()')}} method. Which is very similar to above, however returns a {{domxref('DocumentFragment')}} with disallowed <code>script</code> and <code>blink</code> elements removed.</p>
@@ -45,8 +45,7 @@ console.log(result);
 <pre class="brush: js">// our input string to clean
 const stringToClean = 'Some text &lt;b&gt;&lt;i&gt;with&lt;/i&gt;&lt;/b&gt; &lt;blink&gt;tags&lt;/blink&gt;, including a rogue script &lt;script&gt;alert(1)&lt;/script&gt; def.';
 
-const dropElements = Sanitizer.defaultConfig().dropElements.concat('blink');
-const result = new Sanitizer({ dropElements }).sanitize(stringToClean);
+const result = new Sanitizer().sanitize(stringToClean);
 // Result: A DocumentFragment containing text nodes and a &lt;b&gt; element, with a &lt;i&gt; child element
 </pre>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

It seems like the two examples with the same config behave the same. Since `<blink>` is not in `allowElements`, it should be dropped in both examples by default.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API

> Issue number (if there is an associated issue)

> Anything else that could help us review it

Based on https://wicg.github.io/sanitizer-api/#config
