### PR TITLE
Update Web/JavaScript/Guide/Details_of_the_Object_Model

### DIFF
--- a/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
+++ b/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
@@ -131,7 +131,6 @@ tags:
     this.dept = 'general';
   }
 }
-
 </pre>
 
 <h4 id="JavaScript_**_use_this_instead">JavaScript ** (use this instead)</h4>
@@ -140,7 +139,6 @@ tags:
     this.name = '';
     this.dept = 'general';
 }
-
 </pre>
 
 <h4 id="Java">Java</h4>
@@ -180,7 +178,6 @@ WorkerBee.prototype.constructor = WorkerBee;
 public class WorkerBee extends Employee {
    public String[] projects = new String[0];
 }
-
 </pre>
 
 <p>The <code>Engineer</code> and <code>SalesPerson</code> definitions create objects that descend from <code>WorkerBee</code> and hence from <code>Employee</code>. An object of these types has properties of all the objects above it in the chain. In addition, these definitions override the inherited value of the <code>dept</code> property with new values specific to these objects.</p>
@@ -215,7 +212,6 @@ public class Engineer extends WorkerBee {
    public String dept = "engineering";
    public String machine = "";
 }
-
 </pre>
 
 <p>Using these definitions, you can create instances of these objects that get the default values for their properties. The next figure illustrates using these JavaScript definitions to create new objects and shows the property values for the new objects.</p>
@@ -310,15 +306,19 @@ mark.projects = ['navigator'];</pre>
 
 <p>As soon as JavaScript executes this statement, the <code>mark</code> object also has the <code>specialty</code> property with the value of <code>"none"</code>. The following figure shows the effect of adding this property to the <code>Employee</code> prototype and then overriding it for the <code>Engineer</code> prototype.</p>
 
-<p><img alt="" class="internal" src="figure8.4.png"><br>
- <small><strong>Adding properties</strong></small></p>
+<figure>
+  <img alt="" class="internal" src="figure8.4.png">
+  <figcaption>Adding properties</figcaption>
+</figure>
 
 <h2 id="More_flexible_constructors">More flexible constructors</h2>
 
 <p>The constructor functions shown so far do not let you specify property values when you create an instance. As with Java, you can provide arguments to constructors to initialize property values for instances. The following figure shows one way to do this.</p>
 
-<p><img alt="" class="internal" src="figure8.5.png"><br>
- <small><strong>Specifying properties in a constructor, take 1</strong></small></p>
+<figure>
+  <img alt="" class="internal" src="figure8.5.png">
+  <figcaption>Specifying properties in a constructor, take 1</figcaption>
+</figure>
 
 <p>The following pairs of examples show the Java and JavaScript definitions for these objects.</p>
 
@@ -410,8 +410,10 @@ jane.machine == 'belau';
 
 <p>So far, the constructor function has created a generic object and then specified local properties and values for the new object. You can have the constructor add more properties by directly calling the constructor function for an object higher in the prototype chain. The following figure shows these new definitions.</p>
 
-<p><img alt="" class="internal" src="figure8.6.png"><br>
- <small><strong>Specifying properties in a constructor, take 2</strong></small></p>
+<figure>
+  <img alt="" class="internal" src="figure8.6.png">
+  <figcaption>Specifying properties in a constructor, take 2</figcaption>
+</figure>
 
 <p>Let's look at one of these definitions in detail. Here's the new definition for the <code>Engineer</code> constructor:</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

Non-semantic markups are used for figures.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model

> Issue number (if there is an associated issue)

> Anything else that could help us review it
