### PR TITLE
Fix bugs in element.scrollHeight example

### DIFF
--- a/files/en-us/web/api/element/scrollheight/index.html
+++ b/files/en-us/web/api/element/scrollheight/index.html
@@ -151,7 +151,7 @@ nascetur ridiculus mus. Cras vulputate libero sed arcu iaculis nec lobortis orci
   if (checkReading.read) {
     return;
   }
-  checkReading.read = this.scrollHeight - Math.abs(this.scrollTop) === element.clientHeight;
+  checkReading.read = this.scrollHeight - Math.round(this.scrollTop) === this.clientHeight;
   document.registration.accept.disabled = document.getElementById("nextstep").disabled = !checkReading.read;
   checkReading.noticeBox.textContent = checkReading.read ? "Thank you." : "Please, scroll and read the following text.";
 }


### PR DESCRIPTION
There are likely bugs in example code in "scrollHeight Demo" section in function checkReading().
1.  "element.clientHeight" should be replaced with "this.clientHeight"
2.  Math.abs(this.scrollTop) should be replaced with "Math.round(this.scrollTop)"   ('scrollTop' is not supposed to have negatve values and instead of it can have non-integer value in Edge browser)

Best Regards
Dariusz Dziara

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
