### PR TITLE
Fix incorrectly displayed text

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.html
@@ -73,7 +73,7 @@ Object.getPrototypeOf('foo');
 <ul>
   <li>{{jsxref("Object.prototype.isPrototypeOf()")}}</li>
   <li>{{jsxref("Object.setPrototypeOf()")}}</li>
-  <li>{{jsxref("Object/proto")}}</li>
+  <li>{{jsxref("Object/proto","Object.__proto__")}}</li>
   <li>John Resig's post on <a       href="http://ejohn.org/blog/objectgetprototypeof/">getPrototypeOf</a></li>
   <li>{{jsxref("Reflect.getPrototypeOf()")}}</li>
 </ul>

--- a/files/en-us/web/javascript/reference/global_objects/object/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.html
@@ -92,7 +92,7 @@ browser-compat: javascript.builtins.Object
 <dl>
  <dt>{{jsxref("Object.prototype.constructor")}}</dt>
  <dd>Specifies the function that creates an object's prototype.</dd>
- <dt>{{jsxref("Object/proto")}}</dt>
+ <dt>{{jsxref("Object/proto","Object.__proto__")}}</dt>
  <dd>Points to the object which was used as prototype when the object was instantiated.</dd>
 </dl>
 


### PR DESCRIPTION
### What was wrong/why is this fix needed? (quick summary only)
The PR #3581 causes [`Object.__proto__`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) to be displayed as `Object/proto` and this PR fixes the display issue without changing the referenced object.
### MDN URL of main page changed
[`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#instance_properties) and [`Object.getPrototypeOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf#see_also)