### PR TITLE
Fix aria-expanded & aria-haspopup links in “ARIA: button role”

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/button_role/index.html
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.html
@@ -266,8 +266,8 @@ function toggleButton(element) {
 <ul>
  <li><code><a href="https://www.w3.org/TR/wai-aria/roles#button">button</a></code></li>
  <li><code><a href="https://www.w3.org/TR/wai-aria-1.1/#aria-pressed">aria-pressed</a></code></li>
- <li><code>aria-expanded</code></li>
- <li><code>aria-haspopup</code></li>
+ <li><code><a href="https://www.w3.org/TR/wai-aria-1.1/#aria-expanded">aria-expanded</a></code></li>
+ <li><code><a href="https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup">aria-haspopup</a></code></li>
 </ul>
 
 <h3 id="Additional_resources">Additional resources</h3>


### PR DESCRIPTION
Add 2 missed links on aria page

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
