### PR TITLE
HTTP DELETE example: add host header

### DIFF
--- a/files/en-us/web/http/methods/delete/index.html
+++ b/files/en-us/web/http/methods/delete/index.html
@@ -50,7 +50,9 @@ tags:
 
 <h3 id="Request">Request</h3>
 
-<pre>DELETE /file.html HTTP/1.1</pre>
+<pre>DELETE /file.html HTTP/1.1
+Host: example.com
+</pre>
 
 <h3 id="Responses">Responses</h3>
 


### PR DESCRIPTION
Fixes #4758

The example https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE#example is an HTTP/1.1 request to delete a file. All HTTP/1.1 requests must have the header, so it makes sense to include it in the example.
