### PR TITLE
A typo in Global_attributes/lang

### DIFF
--- a/files/en-us/web/html/global_attributes/lang/index.html
+++ b/files/en-us/web/html/global_attributes/lang/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>WCAG Success Criterion 3.1.1 <strong>requires</strong> that a page language is specified in a way which may be 'programmatically determined' (i.e. via the <strong><code>lang</code></strong> attribute).</p>
 
-<p>WCAG Success criterion 3.1.2 requires that pages with <strong>parts</strong> in different languages have the languages of those parts specified too. Again, the <strong><code>lang</code></strong> attribute is the correct mechanism for this.</p>
+<p>WCAG Success Criterion 3.1.2 requires that pages with <strong>parts</strong> in different languages have the languages of those parts specified too. Again, the <strong><code>lang</code></strong> attribute is the correct mechanism for this.</p>
 
 <p>The purpose of these requirements is primarily to allow assistive technologies such as screen readers to invoke the correct pronunciation.</p>
 

--- a/files/en-us/web/html/global_attributes/lang/index.html
+++ b/files/en-us/web/html/global_attributes/lang/index.html
@@ -47,7 +47,7 @@ tags:
 
 <p>WCAG Success Criterion 3.1.1 <strong>requires</strong> that a page language is specified in a way which may be 'programmatically determined' (i.e. via the <strong><code>lang</code></strong> attribute).</p>
 
-<p>WCAG Sucesss criterion 3.1.2 requires that pages with <strong>parts</strong> in different languages have the languages of those parts specified too. Again, the <strong><code>lang</code></strong> attribute is the correct mechanism for this.</p>
+<p>WCAG Success criterion 3.1.2 requires that pages with <strong>parts</strong> in different languages have the languages of those parts specified too. Again, the <strong><code>lang</code></strong> attribute is the correct mechanism for this.</p>
 
 <p>The purpose of these requirements is primarily to allow assistive technologies such as screen readers to invoke the correct pronunciation.</p>
 


### PR DESCRIPTION
Fixed a typo: Sucesss → Success

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang

> Issue number (if there is an associated issue)
no

> Anything else that could help us review it
