### PR TITLE
Add a Stack Overflow question link to WindowProxy doc

### DIFF
--- a/files/en-us/glossary/windowproxy/index.html
+++ b/files/en-us/glossary/windowproxy/index.html
@@ -11,5 +11,6 @@ tags:
 <h2 id="see_also">See also</h2>
 
 <ul>
- <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#the-windowproxy-exotic-object">the WindowProxy section of the HTML specification</a></li>
+ <li>HTML specification: <a href="https://html.spec.whatwg.org/multipage/window-object.html#the-windowproxy-exotic-object">WindowProxy section</a></li>
+ <li>Stack Overflow question: <a href="https://stackoverflow.com/q/16092835/">WindowProxy and Window objects?</a></li>
 </ul>


### PR DESCRIPTION
This adds a See Also link to https://stackoverflow.com/q/16092835/441757 in the Glossary page for “WindowProxy”.