### PR TITLE
SVGStylable - deprecated or not?

### DIFF
--- a/files/en-us/web/api/svgstylable/index.html
+++ b/files/en-us/web/api/svgstylable/index.html
@@ -9,7 +9,7 @@ tags:
   - SVG DOM
 browser-compat: api.SVGStylable
 ---
-<div>{{deprecated_header}}{{APIRef("SVG")}}</div>
+<div>{{APIRef("SVG")}}</div>
 
 <p>The <code>SVGStylable</code> interface is implemented on all objects corresponding to SVG elements that can have {{ SVGAttr("style") }}, {{SVGAttr("class")}} and presentation attributes specified on them.</p>
 

--- a/files/en-us/web/api/svgstylable/index.html
+++ b/files/en-us/web/api/svgstylable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG DOM
+browser-compat: api.SVGStylable
 ---
 <div>{{deprecated_header}}{{APIRef("SVG")}}</div>
 
@@ -70,23 +71,13 @@ tags:
 
 <h2 id="Methods">Methods</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Name &amp; Arguments</th>
-   <th>Return</th>
-   <th>Description</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code><strong>getPresentationAttribute</strong>(in {{ domxref("DOMString") }} <em>name</em>)</code></td>
-   <td>{{ domxref("CSSValue") }}</td>
-   <td>Returns the base (i.e., static) value of a given presentation attribute as an object of type {{ domxref("CSSValue") }}. The returned object is live; changes to the objects represent immediate changes to the objects to which the {{ domxref("CSSValue") }} is attached.</td>
-  </tr>
- </tbody>
-</table>
+<dl>
+  <dt>{{domxref("SVGStylable.getPresentationAttribute()")}} {{deprecated_inline}}</dt>
+  <dd>Returns the base (i.e., static) value of a given presentation attribute as an object of type {{ domxref("CSSValue") }}. The returned object is live; changes to the objects represent immediate changes to the objects to which the {{ domxref("CSSValue") }} is attached.</dd>
+ </dl>
+ <!-- original syntax getPresentationAttribute(in {{ domxref("DOMString") }} name) -->
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.SVGStylable")}}</p>
+<p>{{Compat}}</p>
+


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/SVGStylable

This is marked as deprecated on MDN but not in BCD. I did a search and found `SVGStylable.getPresentationAttribute()` is deprecated - see https://www.w3.org/Graphics/SVG/WG/track/actions/2696 and the spec https://www.w3.org/TR/SVG11/types.html#InterfaceSVGStylable - but not whole of `SVGStylable`.

So what this does is remove the top level deprecation macro and add the inline deprecation for `SVGStylable.getPresentationAttribute()`

While here I added the bcd compatibility tag/macro, and tidied up the methods section to match MDN standards.

Before I go update BCD, any suggestions on how I can confirm this? 