### PR TITLE
Add wss to permitted schemes for Web Extensions CSP sources

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
@@ -48,7 +48,7 @@ tags:
  <li>Remote sources must use <code>https:</code> schemes.</li>
  <li>Remote sources must not use wildcards for any domains in the <a href="https://publicsuffix.org/list/">public suffix list</a> (so "*.co.uk" and "*.blogspot.com" are not allowed, although "*.foo.blogspot.com" is allowed).</li>
  <li>All sources must specify a host.</li>
- <li>The only permitted schemes for sources are: <code>blob:</code>, <code>filesystem:</code>, <code>moz-extension:</code>, and <code>https:</code>.</li>
+ <li>The only permitted schemes for sources are: <code>blob:</code>, <code>filesystem:</code>, <code>moz-extension:</code>, <code>https:</code>, and <code>wss:</code>.</li>
  <li>The only permitted <a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#sources">keywords</a> are: <code>'none'</code>, <code>'self'</code>, and <code>'unsafe-eval'</code>.</li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`wss:` (WebSocket secure) isn't included in the list of allowed schemes for CSP sources. However this scheme can be used in CSP directives for Web Extensions. 

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy

> Issue number (if there is an associated issue)

> Anything else that could help us review it

This scheme only works in chromium-based browsers and Firefox. So I've opened up another PR to have a browser compatibility note added here: https://github.com/mdn/browser-compat-data/pull/10373