### PR TITLE
Fix a typo in the example for CacheStorage.keys()

### DIFF
--- a/files/en-us/web/api/cachestorage/keys/index.html
+++ b/files/en-us/web/api/cachestorage/keys/index.html
@@ -52,7 +52,7 @@ tags:
   <code>keys()</code>, then check each key to see if it is in the whitelist. If not, we
   delete it using {{domxref("CacheStorage.delete()")}}.</p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(

--- a/files/en-us/web/api/serviceworkerglobalscope/onactivate/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/onactivate/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>The following snippet shows how you could use an <code>activate</code> event handler to upgrade a cache.</p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I think it's a typo in the example code (`then` :arrow_right:  `this`). `then` has no meaning here.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/keys