### PR TITLE
format fix for HTML button doc

### DIFF
--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{HTMLRef}}</div>
 
-<p><span class="seoSummary">The <strong>HTML <code>&lt;button&gt;</code> element</strong> represents a clickable button, used to submit <a href="/en-US/docs/Learn/Forms">forms</a> or anywhere in a document for accessible, standard button functionality.</span> By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons’ appearance with <a href="/en-US/docs/Web/CSS">CSS</a>.</p>
+<p><span class="seoSummary">The <strong>HTML <code>&lt;button&gt;</code></strong> element represents a clickable button, used to submit <a href="/en-US/docs/Learn/Forms">forms</a> or anywhere in a document for accessible, standard button functionality.</span> By default, HTML buttons are presented in a style resembling the platform the {{Glossary("user agent")}} runs on, but you can change buttons’ appearance with <a href="/en-US/docs/Web/CSS">CSS</a>.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/button.html", "tabbed-shorter")}}</div>
 


### PR DESCRIPTION
relocate a </strong> tag in the intro to be consistent with more common MDN styling

MDN URL
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
