### PR TITLE
Remove term "Modern web app"

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -3827,6 +3827,7 @@
 /en-US/docs/Glossary/Instance_method	/en-US/docs/Glossary/Method
 /en-US/docs/Glossary/Instance_property	/en-US/docs/Glossary/property/JavaScript
 /en-US/docs/Glossary/Internationalization	/en-US/docs/Glossary/I18N
+/en-US/docs/Glossary/Modern_web_apps	/en-US/docs/Glossary/Progressive_web_apps
 /en-US/docs/Glossary/NodeJs	/en-US/docs/Glossary/Node.js
 /en-US/docs/Glossary/Node_(networking)	/en-US/docs/Glossary/Node/networking
 /en-US/docs/Glossary/Node_DOM	/en-US/docs/Glossary/Node/DOM

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -4029,13 +4029,6 @@
       "sebastien-bartoli"
     ]
   },
-  "Glossary/Modern_web_apps": {
-    "modified": "2019-01-16T22:23:06.813Z",
-    "contributors": [
-      "klez",
-      "chrisdavidmills"
-    ]
-  },
   "Glossary/Mozilla_Firefox": {
     "modified": "2020-11-12T08:10:18.622Z",
     "contributors": [

--- a/files/en-us/glossary/modern_web_apps/index.html
+++ b/files/en-us/glossary/modern_web_apps/index.html
@@ -1,9 +1,0 @@
----
-title: Modern web apps
-slug: Glossary/Modern_web_apps
-tags:
-  - Composing
-  - Glossary
-  - Modern web apps
----
-<p>See {{glossary("Progressive web apps")}}</p>

--- a/files/en-us/web/progressive_web_apps/index.html
+++ b/files/en-us/web/progressive_web_apps/index.html
@@ -5,7 +5,6 @@ tags:
   - App
   - Application
   - Apps
-  - Modern web apps
   - PWA
   - Progressive web apps
   - Web app


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

MDN has a glossary page for "Modern web apps" which says "See Progressive web apps".

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Glossary/Modern_web_apps

> Issue number (if there is an associated issue)

> Anything else that could help us review it

I just deleted "Modern web app" glossary page. I also removed the only remaining occurence of "Modern web apps" tag.