### PR TITLE
Update Web/JavaScript/Guide/Expressions_and_Operators

### DIFF
--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.html
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.html
@@ -943,7 +943,7 @@ void expression
 
 <h3 id="Relational_operators">Relational operators</h3>
 
-<p>A relational operator compares its operands and returns a <code>Boolean</code> value
+<p>A relational operator compares its operands and returns a Boolean value
   based on whether the comparison is true.</p>
 
 <h4 id="in"><code>in</code></h4>
@@ -1113,17 +1113,16 @@ if (theDay instanceof Date) {
 
 <p>The code <code>3 + 4</code> is an example of the second expression type. This
   expression uses the + operator to add three and four together without assigning the
-  result, seven, to a variable.<br>
-  <br>
-  JavaScript has the following expression categories:
-</p>
+  result, seven, to a variable.</p>
+
+<p>JavaScript has the following expression categories:</p>
 
 <ul>
   <li>Arithmetic: evaluates to a number, for example 3.14159. (Generally uses <a
-      href="#arithmetic">arithmetic operators</a>.)</li>
+      href="#arithmetic_operators">arithmetic operators</a>.)</li>
   <li>String: evaluates to a character string, for example, "Fred" or "234". (Generally
-    uses <a href="#string">string operators</a>.)</li>
-  <li>Logical: evaluates to true or false. (Often involves <a href="#logical">logical
+    uses <a href="#string_operators">string operators</a>.)</li>
+  <li>Logical: evaluates to true or false. (Often involves <a href="#logical_operators">logical
       operators</a>.)</li>
   <li>Primary expressions: Basic keywords and general expressions in JavaScript.</li>
   <li>Left-hand-side expressions: Left values are the destination of an assignment.</li>


### PR DESCRIPTION
- remove \<code> from a non-code string
- correct link fragments

> What was wrong/why is this fix needed? (quick summary only)

- There is a \<code>Boolean\</code> which isn't an object
- There are broken links of fragments

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators

> Issue number (if there is an associated issue)

> Anything else that could help us review it
