### PR TITLE
adds border-block and inline interactive examples

### DIFF
--- a/files/en-us/web/css/border-block-color/index.html
+++ b/files/en-us/web/css/border-block-color/index.html
@@ -13,13 +13,15 @@ tags:
 
 <p>The <strong><code>border-block-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the color of the logical block borders of an element, which maps to a physical border color depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-color")}} and {{cssxref("border-bottom-color")}}, or {{cssxref("border-right-color")}} and {{cssxref("border-left-color")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
-<pre class="brush:css no-line-numbers">border-block-color: yellow;
-border-block-color: #F5F6F7;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-block-color.html")}}</div>
 
 <p>The border color in the other dimension can be set with {{cssxref("border-inline-color")}} which sets {{cssxref("border-inline-start-color")}}, and {{cssxref("border-inline-end-color")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">border-block-color: yellow;
+border-block-color: #F5F6F7;
+</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-block-style/index.html
+++ b/files/en-us/web/css/border-block-style/index.html
@@ -14,15 +14,16 @@ tags:
 
 <p>The <strong><code>border-block-style</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the style of the logical block borders of an element, which maps to a physical border style depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-style")}} and {{cssxref("border-bottom-style")}}, or {{cssxref("border-left-style")}} and {{cssxref("border-right-style")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
-<pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
-border-block-style: dashed;
-border-block-style: dotted;
-border-block-style: groove;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-block-style.html")}}</div>
 
 <p>The border style in the other dimension can be set with {{cssxref("border-inline-style")}}, which sets {{cssxref("border-inline-start-style")}}, and {{cssxref("border-inline-end-style")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
+border-block-style: dashed;
+border-block-style: dotted;
+border-block-style: groove;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-block-width/index.html
+++ b/files/en-us/web/css/border-block-width/index.html
@@ -13,14 +13,15 @@ tags:
 
 <p>The <strong><code>border-block-width</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the width of the logical block borders of an element, which maps to a physical border width depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-width")}} and {{cssxref("border-bottom-width")}}, or {{cssxref("border-left-width")}}, and {{cssxref("border-right-width")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
-<pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
-border-block-width: 5px;
-border-block-width: thick;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-block-width.html")}}</div>
 
 <p>The border width in the other dimension can be set with {{cssxref("border-inline-width")}}, which sets {{cssxref("border-inline-start-width")}}, and {{cssxref("border-inline-end-width")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
+border-block-width: 5px;
+border-block-width: thick;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-block/index.html
+++ b/files/en-us/web/css/border-block/index.html
@@ -14,10 +14,7 @@ tags:
 
 <p>The <strong><code>border-block</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> for setting the individual logical block border property values in a single place in the style sheet.</p>
 
-<pre class="brush:css no-line-numbers">border-block: 1px;
-border-block: 2px dotted;
-border-block: medium dashed blue;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-block.html")}}</div>
 
 <p><code>border-block</code> can be used to set the values for one or more of {{cssxref("border-block-width")}}, {{cssxref("border-block-style")}}, and {{cssxref("border-block-color")}} setting both the start and end in the block dimension at once. The physical borders to which it maps depends on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}} and {{cssxref("border-bottom")}} or {{cssxref("border-right")}}, and {{cssxref("border-left")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
@@ -34,6 +31,10 @@ border-block: medium dashed blue;
 </ul>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">border-block: 1px;
+border-block: 2px dotted;
+border-block: medium dashed blue;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-inline-color/index.html
+++ b/files/en-us/web/css/border-inline-color/index.html
@@ -13,13 +13,14 @@ tags:
 
 <p>The <strong><code>border-inline-color</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the color of the logical inline borders of an element, which maps to a physical border color depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-color")}} and {{cssxref("border-bottom-color")}}, or {{cssxref("border-right-color")}} and {{cssxref("border-left-color")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
-<pre class="brush:css no-line-numbers">border-inline-color: yellow;
-border-inline-color: #F5F6F7;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-inline-color.html")}}</div>
 
 <p>The border color in the other dimension can be set with {{cssxref("border-block-color")}} which sets {{cssxref("border-block-start-color")}}, and {{cssxref("border-block-end-color")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">border-inline-color: yellow;
+border-inline-color: #F5F6F7;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-inline-style/index.html
+++ b/files/en-us/web/css/border-inline-style/index.html
@@ -13,15 +13,16 @@ tags:
 
 <p>The <strong><code>border-inline-style</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the style of the logical inline borders of an element, which maps to a physical border style depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-style")}} and {{cssxref("border-bottom-style")}}, or {{cssxref("border-left-style")}} and {{cssxref("border-right-style")}} properties depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
-<pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
-border-inline-style: dashed;
-border-inline-style: dotted;
-border-inline-style: groove;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-inline-style.html")}}</div>
 
 <p>The border style in the other dimension can be set with {{cssxref("border-block-style")}}, which sets {{cssxref("border-block-start-style")}}, and {{cssxref("border-block-end-style")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">/* &lt;'border-style'&gt; values */
+border-inline-style: dashed;
+border-inline-style: dotted;
+border-inline-style: groove;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-inline-width/index.html
+++ b/files/en-us/web/css/border-inline-width/index.html
@@ -13,15 +13,16 @@ tags:
 
 <p>The <strong><code>border-inline-width</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property defines the width of the logical inline borders of an element, which maps to a physical border width depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-width")}} and {{cssxref("border-bottom-width")}}, or {{cssxref("border-left-width")}}, and {{cssxref("border-right-width")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
-<pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
-border-inline-width: 5px 10px;
-border-inline-width: 5px;
-border-inline-width: thick;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-inline-width.html")}}</div>
 
 <p>The border width in the other dimension can be set with {{cssxref("border-block-width")}}, which sets {{cssxref("border-block-start-width")}}, and {{cssxref("border-block-end-width")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">/* &lt;'border-width'&gt; values */
+border-inline-width: 5px 10px;
+border-inline-width: 5px;
+border-inline-width: thick;</pre>
 
 <h3 id="Values">Values</h3>
 

--- a/files/en-us/web/css/border-inline/index.html
+++ b/files/en-us/web/css/border-inline/index.html
@@ -13,16 +13,11 @@ tags:
 
 <p>The <strong><code>border-inline</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> property is a <a href="/en-US/docs/Web/CSS/Shorthand_properties">shorthand property</a> for setting the individual logical inline border property values in a single place in the style sheet.</p>
 
-<pre class="brush:css no-line-numbers">border-inline: 1px;
-border-inline: 2px dotted;
-border-inline: medium dashed blue;
-</pre>
+<div>{{EmbedInteractiveExample("pages/css/border-inline.html")}}</div>
 
 <p>The physical borders to which <code>border-inline</code> maps depends on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top")}} and {{cssxref("border-bottom")}} or {{cssxref("border-right")}}, and {{cssxref("border-left")}} properties, depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.</p>
 
 <p>The borders in the other dimension can be set with {{cssxref("border-block")}}, which sets {{cssxref("border-block-start")}}, and {{cssxref("border-block-end")}}.</p>
-
-<p>{{cssinfo}}</p>
 
 <h2 id="Constituent_properties">Constituent properties</h2>
 
@@ -35,6 +30,10 @@ border-inline: medium dashed blue;
 </ul>
 
 <h2 id="Syntax">Syntax</h2>
+
+<pre class="brush:css no-line-numbers">border-inline: 1px;
+border-inline: 2px dotted;
+border-inline: medium dashed blue;</pre>
 
 <h3 id="Values">Values</h3>
 


### PR DESCRIPTION
I created some Interactive Examples for the `border-block`, `border-inline` and longhand versions of these, this PR adds them in.