### PR TITLE
Updated return link to point to Summary

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.html
@@ -91,5 +91,5 @@ block content
 <h2 id="Next_steps">Next steps</h2>
 
 <ul>
- <li>Return to <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data">Express Tutorial Part 5: Displaying library data</a>.</li>
+ <li>Return to <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data#summary">Express Tutorial Part 5: Displaying library data</a>.</li>
 </ul>

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.html
@@ -76,8 +76,9 @@ block content
 
 <p>Currently most <em>dates</em> displayed on the site use the default JavaScript format (e.g. <em>Tue Oct 06 2020 15:49:58 GMT+1100 (AUS Eastern Daylight Time))</em>. The challenge for this article is to improve the appearance of the date display for <code>Author</code> lifespan information (date of death/birth) and for <em>BookInstance detail</em> pages to use the format: Oct 6th, 2016.</p>
 
-<div class="note">
-<p><strong>Note:</strong> You can use the <a href="#">same approach</a> as we used for the <em>Book Instance List</em> (adding the virtual property for the lifespan to the <code>Author</code> model and use <a href="https://www.npmjs.com/package/luxon">luxon</a> to format the date strings).</p>
+<div class="notecard note">
+  <h4>Note<h4>
+  <p>You can use the <a href="#">same approach</a> as we used for the <em>Book Instance List</em> (adding the virtual property for the lifespan to the <code>Author</code> model and use <a href="https://www.npmjs.com/package/luxon">luxon</a> to format the date strings).</p>
 </div>
 
 <p>To complete this challenge, you must:</p>
@@ -91,5 +92,5 @@ block content
 <h2 id="Next_steps">Next steps</h2>
 
 <ul>
- <li>Return to <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data#summary">Express Tutorial Part 5: Displaying library data</a>.</li>
+ <li>Return to <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data#displaying_library_data_tutorial_subarticles">Express Tutorial Part 5: Displaying library data</a>.</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The current return link at the end of the page [BookInstance Detail page and challenge](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_detail_page_and_challenge) points to the top of the [Express Tutorial Part 5: Displaying library data](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data) page. If readers are at the end of [BookInstance Detail page and challenge](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_detail_page_and_challenge) page, it means that they've finished the tutorial and the backlink they are expecting is **Summary** section of [Express Tutorial Part 5: Displaying library data](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data) page.

By updating the link at the end of the BookInstance tutorial page to directly point to the Summary section (the section which is followed just after the BookInstance tutorial) in [Express Tutorial Part 5: Displaying library data](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data) page, it better suits to a reader's expectations.

> MDN URL of main page changed: https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_detail_page_and_challenge

> Issue number (if there is an associated issue)

> Anything else that could help us review it
