### PR TITLE
Update Markdown spec with guidance for sup and sub

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -279,6 +279,7 @@ cell 4    | cell 5    | cell 6
 <ul>
   <li>For exponentiation, use the caret: <code>2^53</code>.</li>
   <li>For ordinal expressions like 1<sup>st</sup>, prefer words like "first".</li>
+  <li>For footnotes, don’t mark up the footnote references with, e.g., <code>&lt;sup&gt;[1]&lt;/sup&gt;</code>; it’s unnecessary.</li>
 </ul>
 
 <h2>KumaScript</h2>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -272,6 +272,15 @@ cell 4    | cell 5    | cell 6
 
 <h2>Inline styles</h2>
 
+<h2>Superscript and subscript</h2>
+
+<p>Writers will be able to use the HTML {{HTMLElement("sup")}}> and {{HTMLElement("sub")}} elements if necessary, but should use alternatives if possible. In particular:</p>
+
+<ul>
+  <li>For exponentiation, use the caret: <code>2^53</code>.</li>
+  <li>For ordinal expressions like 1<sup>st</sup>, prefer words like "first".</li>
+</ul>
+
 <h2>KumaScript</h2>
 
 <p>Writers will be able to include KumaScript macro calls in prose content:</p>


### PR DESCRIPTION
This updates the ["Markdown in MDN"](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN) page with an attempt to capture the discussion in https://github.com/mdn/content/issues/4578.
