### PR TITLE
Remove CSS inline styles, part 1

### DIFF
--- a/files/en-us/web/css/-webkit-mask-box-image/index.html
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.html
@@ -30,11 +30,11 @@ tags:
 
 <dl>
  <dt>&lt;mask-box-image&gt;</dt>
- <dd><code style="font: normal normal normal 100%/normal 'Courier New', 'Andale Mono', monospace; color: inherit; font-weight: inherit;">{{cssxref("&lt;uri&gt;")}} | &lt;gradient&gt; | none</code></dd>
+ <dd><code>{{cssxref("&lt;uri&gt;")}} | &lt;gradient&gt; | none</code></dd>
  <dt>&lt;top&gt; &lt;right&gt; &lt;bottom&gt; &lt;left&gt;</dt>
- <dd><code style="font: normal normal normal 100%/normal 'Courier New', 'Andale Mono', monospace; color: inherit; font-weight: inherit;">&lt;length&gt; | &lt;percentage&gt;</code></dd>
+ <dd><code>&lt;length&gt; | &lt;percentage&gt;</code></dd>
  <dt>&lt;x-repeat&gt; &lt;y-repeat&gt;</dt>
- <dd><code style="font: normal normal normal 100%/normal 'Courier New', 'Andale Mono', monospace; color: inherit; font-weight: inherit;">repeat | stretch | round | space</code></dd>
+ <dd><code>repeat | stretch | round | space</code></dd>
 </dl>
 
 <h3 id="Values">Values</h3>
@@ -42,15 +42,15 @@ tags:
 <dl>
  <dt>&lt;uri&gt;</dt>
  <dd>The location of the image resource to be used as a mask image.</dd>
- <dt style="font-style: normal; font-weight: bold;">&lt;gradient&gt;</dt>
- <dd style="margin-bottom: 20px; padding-left: 16px; border-bottom-width: 1px; border-bottom-style: dashed; margin-top: 0px; margin-right: 0px; margin-left: 0px; padding-top: 2px; padding-right: 0px; padding-bottom: 4px;">A <span style="font-family: courier new;">-webkit-gradient</span> function to be used as a mask image.</dd>
+ <dt>&lt;gradient&gt;</dt>
+ <dd>A <code>-webkit-gradient</code> function to be used as a mask image.</dd>
  <dt>none</dt>
  <dd>Used to specify that a border box is to have no mask image.</dd>
  <dt>&lt;length&gt;</dt>
  <dd>The size of the mask image's offset. See {{cssxref("&lt;length&gt;")}} for possible units.</dd>
  <dt>&lt;percentage&gt;</dt>
  <dd>The mask image's offset has a percentage value relative to the border box's corresponding dimension (width or height).</dd>
- <dt style="font-style: normal; font-weight: bold;">repeat</dt>
+ <dt>repeat</dt>
  <dd>The mask image is repeated as many times as is necessary to span the border box. May include a partial image if the mask image does not divide evenly into the border box.</dd>
  <dt>stretch</dt>
  <dd>The mask image is stretched to contain the border box exactly.</dd>

--- a/files/en-us/web/css/@charset/index.html
+++ b/files/en-us/web/css/@charset/index.html
@@ -35,8 +35,8 @@ tags:
 <p>where:</p>
 
 <dl>
- <dt style="margin: 0 40px;"><em>charset</em></dt>
- <dd style="margin: 0 40px;">Is a {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the <a href="http://www.iana.org/assignments/character-sets">IANA-registry</a>, and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with <em>preferred</em> must be used.</dd>
+ <dt><em>charset</em></dt>
+ <dd>Is a {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the <a href="http://www.iana.org/assignments/character-sets">IANA-registry</a>, and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with <em>preferred</em> must be used.</dd>
 </dl>
 
 <h2 id="Formal_syntax">Formal syntax</h2>

--- a/files/en-us/web/css/_colon_-moz-only-whitespace/index.html
+++ b/files/en-us/web/css/_colon_-moz-only-whitespace/index.html
@@ -14,7 +14,7 @@ tags:
 <p>{{Non-standard_Header}}</p>
 
 <div class="notecard note">
-<p><strong>Note:</strong> In {{SpecName("CSS4 Selectors", "#the-empty-pseudo")}} the {{CSSxRef(":empty")}} selector was changed to act like <code style="white-space: nowrap;">:-moz-only-whitespace</code>, but no browser currently supports this yet.</p>
+<p><strong>Note:</strong> In {{SpecName("CSS4 Selectors", "#the-empty-pseudo")}} the {{CSSxRef(":empty")}} selector was changed to act like <code>:-moz-only-whitespace</code>, but no browser currently supports this yet.</p>
 </div>
 
 <p>The <strong><code>:-moz-only-whitespace</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> matches elements that only contains text nodes that only contain {{Glossary("whitespace")}}. (This includes elements with empty text nodes and elements with no child nodes.)</p>

--- a/files/en-us/web/css/_colon_empty/index.html
+++ b/files/en-us/web/css/_colon_empty/index.html
@@ -15,7 +15,7 @@ tags:
 <p>The <strong><code>:empty</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> represents any element that has no children. Children can be either element nodes or text (including whitespace). Comments, processing instructions, and CSS {{cssxref("content")}} do not affect whether an element is considered empty.</p>
 
 <div class="notecard note">
-<p><strong>Note:</strong> In {{SpecName("CSS4 Selectors", "#the-empty-pseudo")}} the <code>:empty</code> pseudo-class was changed to act like <span style="white-space: nowrap;">{{CSSxRef(":-moz-only-whitespace")}}</span>, but no browser currently supports this yet.</p>
+<p><strong>Note:</strong> In {{SpecName("CSS4 Selectors", "#the-empty-pseudo")}} the <code>:empty</code> pseudo-class was changed to act like {{CSSxRef(":-moz-only-whitespace")}}, but no browser currently supports this yet.</p>
 </div>
 
 <pre class="brush: css no-line-numbers">/* Selects any &lt;div&gt; that contains no content */

--- a/files/en-us/web/css/_colon_is/index.html
+++ b/files/en-us/web/css/_colon_is/index.html
@@ -14,7 +14,7 @@ tags:
 <p>{{CSSRef}}</p>
 
 <div class="notecard note">
-<p><strong>Note:</strong> <code>:matches()</code> was renamed to <code>:is()</code> in <a href="https://github.com/w3c/csswg-drafts/issues/3258" style="white-space: nowrap;">CSSWG issue #3258</a>.</p>
+<p><strong>Note:</strong> <code>:matches()</code> was renamed to <code>:is()</code> in <a href="https://github.com/w3c/csswg-drafts/issues/3258">CSSWG issue #3258</a>.</p>
 </div>
 
 <p>The <strong><code>:is()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-class</a> function takes a selector list as its argument, and selects any element that can be selected by one of the selectors in that list. This is useful for writing large selectors in a more compact form.</p>

--- a/files/en-us/web/css/_colon_user-invalid/index.html
+++ b/files/en-us/web/css/_colon_user-invalid/index.html
@@ -27,7 +27,7 @@ tags:
 
 <h3 id="Setting_invalid">Setting a color and symbol on :user-invalid</h3>
 
-<p>In the following example, the red border and <span style="color:red">X</span> only display once the user has interacted with the field.
+<p>In the following example, the red border and ❌ only display once the user has interacted with the field.
 Try typing something other than an email address to see it in action.</p>
 
 <pre class="brush: html">&lt;form&gt;

--- a/files/en-us/web/css/_colon_user-valid/index.html
+++ b/files/en-us/web/css/_colon_user-valid/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h3 id="Setting_valid">Setting a color and symbol on :user-valid</h3>
 
-<p>In the following example, the green border and <span style="color:green">✓</span> only display once the user has interacted with the field.
+<p>In the following example, the green border and ✅ only display once the user has interacted with the field.
 Try changing the email address to another valid email to see it in action.</p>
 
 <pre class="brush: html">&lt;form&gt;

--- a/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.html
+++ b/files/en-us/web/css/_doublecolon_-webkit-slider-runnable-track/index.html
@@ -15,7 +15,7 @@ tags:
 ---
 <p>{{CSSRef}}{{Non-standard_Header}}</p>
 
-<p>The <strong><code>::-webkit-slider-runnable-track</code></strong> CSS <a href="/en-US/docs/Web/CSS/Pseudo-elements">pseudo-element</a> represents the "track" (the groove in which the indicator slides) of an <code style="white-space: nowrap;">{{HTMLElement("input/range", '&lt;input type="range"&gt;')}}</code>.</p>
+<p>The <strong><code>::-webkit-slider-runnable-track</code></strong> CSS <a href="/en-US/docs/Web/CSS/Pseudo-elements">pseudo-element</a> represents the "track" (the groove in which the indicator slides) of an {{HTMLElement("input/range", '&lt;input type="range"&gt;')}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/en-us/web/css/all/index.html
+++ b/files/en-us/web/css/all/index.html
@@ -82,7 +82,7 @@ blockquote {
 
 <h3 id="Result">Result</h3>
 
-<div id="ex0" style="display: inline-block; width: 225px; vertical-align: top;">
+<div id="ex0">
 <h4 id="No_all_property">No <code>all</code> property</h4>
 
 <pre class="brush: html hidden">&lt;blockquote id="quote"&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/blockquote&gt; Phasellus eget velit sagittis.</pre>
@@ -94,7 +94,7 @@ blockquote { background-color: skyblue;  color: red; }</pre>
 <p>The {{HTMLElement("blockquote")}} uses the browser's default styling which gives it a margin, together with a specific background and text color. It also behaves as a <em>block</em> element: the text that follows it is beneath it.</p>
 </div>
 
-<div id="ex1" style="display: inline-block; width: 225px; vertical-align: top;">
+<div id="ex1">
 <h4 id="allunset"><code>all:unset</code></h4>
 
 <pre class="brush: html hidden">&lt;blockquote id="quote"&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/blockquote&gt; Phasellus eget velit sagittis.</pre>
@@ -107,7 +107,7 @@ blockquote { all: unset; }</pre>
 <p>The {{HTMLElement("blockquote")}} doesn't use the browser default styling: it is an <em>inline</em> element now (initial value), its {{cssxref("background-color")}} is <code>transparent</code> (initial value), but its {{cssxref("font-size")}} is still <code>small</code> (inherited value) and its {{cssxref("color")}} is <code>blue</code> (inherited value).</p>
 </div>
 
-<div id="ex2" style="display: inline-block; width: 225px; vertical-align: top;">
+<div id="ex2">
 <h4 id="allinitial"><code>all:initial</code></h4>
 
 <pre class="brush: html hidden">&lt;blockquote id="quote"&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/blockquote&gt; Phasellus eget velit sagittis.</pre>
@@ -120,7 +120,7 @@ blockquote { all: initial; }</pre>
 <p>The {{HTMLElement("blockquote")}} doesn't use the browser default styling: it is an <em>inline</em> element now (initial value), its {{cssxref("background-color")}} is <code>transparent</code> (initial value), its {{cssxref("font-size")}} is <code>normal</code> (initial value) and its {{cssxref("color")}} is <code>black</code> (initial value).</p>
 </div>
 
-<div id="ex3" style="display: inline-block; width: 225px; vertical-align: top;">
+<div id="ex3">
 <h4 id="allinherit"><code>all:inherit</code></h4>
 
 <pre class="brush: html hidden">&lt;blockquote id="quote"&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/blockquote&gt; Phasellus eget velit sagittis.</pre>

--- a/files/en-us/web/css/angle/index.html
+++ b/files/en-us/web/css/angle/index.html
@@ -39,7 +39,7 @@ tags:
 
 <h3 id="Setting_a_clockwise_right_angle">Setting a clockwise right angle</h3>
 
-<table style="width: 100%;">
+<table class="standard-table">
  <tbody>
   <tr>
    <td><img class="default internal" src="angle90.png"></td>
@@ -50,7 +50,7 @@ tags:
 
 <h3 id="Setting_a_flat_angle">Setting a flat angle</h3>
 
-<table style="width: 100%;">
+<table class="standard-table">
  <tbody>
   <tr>
    <td><img class="default internal" src="angle180.png"></td>
@@ -61,7 +61,7 @@ tags:
 
 <h3 id="Setting_a_counterclockwise_right_angle">Setting a counterclockwise right angle</h3>
 
-<table style="width: 100%;">
+<table class="standard-table">
  <tbody>
   <tr>
    <td><img class="default internal" src="angleminus90.png"></td>
@@ -72,7 +72,7 @@ tags:
 
 <h3 id="Setting_a_null_angle">Setting a null angle</h3>
 
-<table style="width: 100%;">
+<table class="standard-table">
  <tbody>
   <tr>
    <td><img class="default internal" src="angle0.png"></td>

--- a/files/en-us/web/css/attr()/index.html
+++ b/files/en-us/web/css/attr()/index.html
@@ -39,7 +39,7 @@ attr(data-something, "default");
 <dl>
  <dt><code>attribute-name</code></dt>
  <dd>Is the name of an attribute on the HTML element referenced in the CSS.</dd>
- <dt><code style="white-space: nowrap;">&lt;type-or-unit&gt;</code> {{Experimental_Inline}}</dt>
+ <dt><code ="white-space: nowrap;">&lt;type-or-unit&gt;</code> {{Experimental_Inline}}</dt>
  <dd>Is a keyword representing either the type of the attribute's value, or its unit, as in HTML some attributes have implicit units. If the use of <code>&lt;type-or-unit&gt;</code> as a value for the given attribute is invalid, the <code>attr()</code> expression will be invalid too. If omitted, it defaults to <code>string</code>. The list of valid values are:
  <table class="standard-table">
   <thead>

--- a/files/en-us/web/css/attr()/index.html
+++ b/files/en-us/web/css/attr()/index.html
@@ -39,7 +39,7 @@ attr(data-something, "default");
 <dl>
  <dt><code>attribute-name</code></dt>
  <dd>Is the name of an attribute on the HTML element referenced in the CSS.</dd>
- <dt><code ="white-space: nowrap;">&lt;type-or-unit&gt;</code> {{Experimental_Inline}}</dt>
+ <dt><code>&lt;type-or-unit&gt;</code> {{Experimental_Inline}}</dt>
  <dd>Is a keyword representing either the type of the attribute's value, or its unit, as in HTML some attributes have implicit units. If the use of <code>&lt;type-or-unit&gt;</code> as a value for the given attribute is invalid, the <code>attr()</code> expression will be invalid too. If omitted, it defaults to <code>string</code>. The list of valid values are:
  <table class="standard-table">
   <thead>

--- a/files/en-us/web/css/border-bottom-width/index.html
+++ b/files/en-us/web/css/border-bottom-width/index.html
@@ -37,37 +37,17 @@ border-bottom-width: unset;
 <dl>
  <dt><code>&lt;line-width&gt;</code></dt>
  <dd>Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
- <table class="standard-table">
-  <tbody>
-   <tr>
-    <td style="vertical-align: middle;"><code>thin</code></td>
-    <td style="vertical-align: middle;">
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-bottom-style: solid; border-bottom-width: thin; background-color: palegreen; display: block;"></div>
-    </td>
-    <td style="vertical-align: middle;">A thin border</td>
-   </tr>
-   <tr>
-    <td style="vertical-align: middle;"><code>medium</code></td>
-    <td style="vertical-align: middle;">
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-bottom-style: solid; border-bottom-width: medium; background-color: palegreen; display: block;"></div>
-    </td>
-    <td style="vertical-align: middle;">A medium border</td>
-   </tr>
-   <tr>
-    <td style="vertical-align: middle;"><code>thick</code></td>
-    <td style="vertical-align: middle;">
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-bottom-style: solid; border-bottom-width: thick; background-color: palegreen; display: block;"></div>
-    </td>
-    <td style="vertical-align: middle;">A thick border</td>
-   </tr>
-  </tbody>
- </table>
-
- <div class="note">
- <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
- </div>
+   <ul>
+     <li><code>thin</code></li>
+     <li><code>medium</code></li>
+     <li><code>thick</code></li>
+  </ul>
  </dd>
 </dl>
+
+<div class="note">
+ <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
+</div>
 
 <h2 id="Formal_definition">Formal definition</h2>
 

--- a/files/en-us/web/css/border-image-slice/index.html
+++ b/files/en-us/web/css/border-image-slice/index.html
@@ -17,7 +17,7 @@ tags:
 
 <p>The slicing process creates nine regions in total: four corners, four edges, and a middle region. Four slice lines, set a given distance from their respective sides, control the size of the regions.</p>
 
-<p><a href="/en-US/docs/Web/CSS/border-image-slice/border-image-slice.png"><img alt="The nine regions defined by the border-image or border-image-slice properties" src="border-image-slice.png" style="margin: 1px; padding: 1em;"></a></p>
+<p><a href="/en-US/docs/Web/CSS/border-image-slice/border-image-slice.png"><img alt="The nine regions defined by the border-image or border-image-slice properties" src="border-image-slice.png"></a></p>
 
 <p>The above diagram illustrates the location of each region.</p>
 
@@ -88,7 +88,7 @@ border-image-slice: unset;
 
 <p>The following example shows a simple <code>&lt;div&gt;</code> with a border image set on it. The source image for the borders is as follows:</p>
 
-<p><img alt="nice multi-colored diamonds" src="border-diamonds.png" style="display: block; margin: 0 auto;"></p>
+<p><img alt="nice multi-colored diamonds" src="border-diamonds.png"></p>
 
 <p>The diamonds are 30px across, therefore setting 30 pixels as the value for both <code><a href="/en-US/docs/Web/CSS/border-width">border-width</a></code> and <code>border-image-slice</code> will get you complete and fairly crisp diamonds in your border:</p>
 

--- a/files/en-us/web/css/border-left-width/index.html
+++ b/files/en-us/web/css/border-left-width/index.html
@@ -37,37 +37,17 @@ border-left-width: unset;
 <dl>
  <dt><code>&lt;line-width&gt;</code></dt>
  <dd>Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
- <table class="standard-table">
-  <tbody>
-   <tr>
-    <td><code>thin</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-left-style: solid; border-left-width: thin; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A thin border</td>
-   </tr>
-   <tr>
-    <td><code>medium</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-left-style: solid; border-left-width: medium; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A medium border</td>
-   </tr>
-   <tr>
-    <td><code>thick</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-left-style: solid; border-left-width: thick; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A thick border</td>
-   </tr>
-  </tbody>
- </table>
-
- <div class="note">
- <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
- </div>
+   <ul>
+     <li><code>thin</code></li>
+     <li><code>medium</code></li>
+     <li><code>thick</code></li>
+  </ul>
  </dd>
 </dl>
+
+<div class="note">
+ <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
+</div>
 
 <h2 id="Formal_definition">Formal definition</h2>
 

--- a/files/en-us/web/css/border-right-width/index.html
+++ b/files/en-us/web/css/border-right-width/index.html
@@ -37,37 +37,17 @@ border-right-width: unset;
 <dl>
  <dt><code>&lt;line-width&gt;</code></dt>
  <dd>Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
- <table class="standard-table">
-  <tbody>
-   <tr>
-    <td><code>thin</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-right-style: solid; border-right-width: thin; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A thin border</td>
-   </tr>
-   <tr>
-    <td><code>medium</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-right-style: solid; border-right-width: medium; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A medium border</td>
-   </tr>
-   <tr>
-    <td><code>thick</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-right-style: solid; border-right-width: thick; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A thick border</td>
-   </tr>
-  </tbody>
- </table>
-
- <div class="note">
- <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
- </div>
+   <ul>
+     <li><code>thin</code></li>
+     <li><code>medium</code></li>
+     <li><code>thick</code></li>
+  </ul>
  </dd>
 </dl>
+
+<div class="note">
+ <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
+</div>
 
 <h2 id="Formal_definition">Formal definition</h2>
 

--- a/files/en-us/web/css/border-top-width/index.html
+++ b/files/en-us/web/css/border-top-width/index.html
@@ -37,37 +37,18 @@ border-top-width: unset;
 <dl>
  <dt><code>&lt;line-width&gt;</code></dt>
  <dd>Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
- <table class="standard-table">
-  <tbody>
-   <tr>
-    <td><code>thin</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-top-style: solid; border-top-width: thin; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A thin border</td>
-   </tr>
-   <tr>
-    <td><code>medium</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-top-style: solid; border-top-width: medium; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A medium border</td>
-   </tr>
-   <tr>
-    <td><code>thick</code></td>
-    <td>
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-top-style: solid; border-top-width: thick; background-color: palegreen; display: block;"></div>
-    </td>
-    <td>A thick border</td>
-   </tr>
-  </tbody>
- </table>
-
- <div class="note">
- <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
- </div>
+   <ul>
+     <li><code>thin</code></li>
+     <li><code>medium</code></li>
+     <li><code>thick</code></li>
+  </ul>
  </dd>
 </dl>
+
+
+<div class="note">
+ <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
+</div>
 
 <h2 id="Formal_definition">Formal definition</h2>
 

--- a/files/en-us/web/css/border-width/index.html
+++ b/files/en-us/web/css/border-width/index.html
@@ -64,37 +64,17 @@ border-width: unset;
 <dl>
  <dt><code>&lt;line-width&gt;</code></dt>
  <dd>Defines the width of the border, either as an explicit nonnegative {{cssxref("&lt;length&gt;")}} or a keyword. If it's a keyword, it must be one of the following values:
- <table class="standard-table">
-  <tbody>
-   <tr>
-    <td style="vertical-align: middle;"><code>thin</code></td>
-    <td style="vertical-align: middle;">
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-style: solid; border-width: thin; background-color: palegreen; display: block;"></div>
-    </td>
-    <td style="vertical-align: middle;">A thin border</td>
-   </tr>
-   <tr>
-    <td style="vertical-align: middle;"><code>medium</code></td>
-    <td style="vertical-align: middle;">
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-style: solid; border-width: medium; background-color: palegreen; display: block;"></div>
-    </td>
-    <td style="vertical-align: middle;">A medium border</td>
-   </tr>
-   <tr>
-    <td style="vertical-align: middle;"><code>thick</code></td>
-    <td style="vertical-align: middle;">
-     <div style="margin: 0.5em; width: 3em; height: 3em; border-style: solid; border-width: thick; background-color: palegreen; display: block;"></div>
-    </td>
-    <td style="vertical-align: middle;">A thick border</td>
-   </tr>
-  </tbody>
- </table>
-
- <div class="note">
- <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
- </div>
+   <ul>
+     <li><code>thin</code></li>
+     <li><code>medium</code></li>
+     <li><code>thick</code></li>
+  </ul>
  </dd>
 </dl>
+
+<div class="note">
+ <p><strong>Note:</strong> Because the specification doesn't define the exact thickness denoted by each keyword, the precise result when using one of them is implementation-specific. Nevertheless, they always follow the pattern <code>thin ≤ medium ≤ thick</code>, and the values are constant within a single document.</p>
+</div>
 
 <h2 id="Formal_definition">Formal definition</h2>
 

--- a/files/en-us/web/css/box-align/index.html
+++ b/files/en-us/web/css/box-align/index.html
@@ -53,18 +53,10 @@ box-lines: unset;
 
 <p>The edge of the box designated the <em>start</em> for alignment purposes depends on the box's orientation:</p>
 
-<table class="standard-table" style="text-align: center;">
- <tbody>
-  <tr>
-   <th style="text-align: right;"><strong>Horizontal</strong></th>
-   <td>top</td>
-  </tr>
-  <tr>
-   <th style="text-align: right;"><strong>Vertical</strong></th>
-   <td>left</td>
-  </tr>
- </tbody>
-</table>
+<ul>
+  <li>For horizontal elements, the <em>start</em> is the top edge.</li>
+  <li>For vertical elements, the <em>start</em> is the left edge.</li>
+</ul>
 
 <p>The edge opposite to the start is designated the <em>end</em>.</p>
 

--- a/files/en-us/web/css/box-decoration-break/index.html
+++ b/files/en-us/web/css/box-decoration-break/index.html
@@ -111,13 +111,13 @@ box-decoration-break: clone;
 
 <p>Fragmenting the above block into three columns results in:</p>
 
-<p><img alt="A screenshot of the rendering of the fragmented block used in the examples styled with box-decoration-break:slice." src="box-decoration-break-block-slice.png" style="max-width: none;"></p>
+<p><img alt="A screenshot of the rendering of the fragmented block used in the examples styled with box-decoration-break:slice." src="box-decoration-break-block-slice.png"></p>
 
 <p>Note that stacking these pieces vertically will result in the non-fragmented rendering.</p>
 
 <p>Now, the same example but styled with <code>box-decoration-break: clone</code> results in:</p>
 
-<p><img alt="A screenshot of the rendering of the fragmented block used in the examples styled with box-decoration-break:clone." src="box-decoration-break-block-clone.png" style="max-width: none;"></p>
+<p><img alt="A screenshot of the rendering of the fragmented block used in the examples styled with box-decoration-break:clone." src="box-decoration-break-block-clone.png"></p>
 
 <p>Note here that each fragment has an identical replicated border, box-shadow, and background.</p>
 

--- a/files/en-us/web/css/box-direction/index.html
+++ b/files/en-us/web/css/box-direction/index.html
@@ -42,18 +42,10 @@ box-direction: unset;
 
 <p>The edge of the box designated the <em>start</em> for layout purposes depends on the box's orientation:</p>
 
-<table class="standard-table" style="text-align: center;">
- <tbody>
-  <tr>
-   <th style="text-align: right;"><strong>Horizontal</strong></th>
-   <td>left</td>
-  </tr>
-  <tr>
-   <th style="text-align: right;"><strong>Vertical</strong></th>
-   <td>top</td>
-  </tr>
- </tbody>
-</table>
+<ul>
+  <li>For horizontal elements, the <em>start</em> is the top edge.</li>
+  <li>For vertical elements, the <em>start</em> is the left edge.</li>
+</ul>
 
 <p>The edge opposite to the start is designated the <em>end</em>.</p>
 

--- a/files/en-us/web/css/box-pack/index.html
+++ b/files/en-us/web/css/box-pack/index.html
@@ -52,6 +52,11 @@ box-pack: unset;
 
 <p>The edge of the box designated the <em>start</em> for packing purposes depends on the box's orientation and direction:</p>
 
+<ul>
+  <li>For horizontal elements, the <em>start</em> is the top edge.</li>
+  <li>For vertical elements, the <em>start</em> is the left edge.</li>
+</ul>
+
 <table class="standard-table" style="text-align: center;">
  <tbody>
   <tr>
@@ -60,12 +65,12 @@ box-pack: unset;
    <th><strong>Reverse</strong></th>
   </tr>
   <tr>
-   <th style="text-align: right;"><strong>Horizontal</strong></th>
+   <th><strong>Horizontal</strong></th>
    <td>left</td>
    <td>right</td>
   </tr>
   <tr>
-   <th style="text-align: right;"><strong>Vertical</strong></th>
+   <th><strong>Vertical</strong></th>
    <td>top</td>
    <td>bottom</td>
   </tr>


### PR DESCRIPTION
To help with the move to Markdown we'd like to get rid of as many inline styles as possible. I think there are 83 pages in the CSS docs that use inline styles, and this PR removes the first batch of these.

In most cases it seems to work fine to just remove the styles, and in some I've tried to rearrange things a bit.

Note that it will be possible to have inline styles inside tables, since we expect people will sometimes need to use raw HTML for tables (see https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#tables). But even so I'd like to avoid it unless it's adding a significant amount of value, and in many cases perhaps we can replace use of inline styles in the CSS docs with live samples.
