### PR TITLE
Fix typo in rgba() syntax

### DIFF
--- a/files/en-us/web/css/color_value/rgba()/index.html
+++ b/files/en-us/web/css/color_value/rgba()/index.html
@@ -22,7 +22,7 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: css">rgba(255,255,255,.5) /* white with 50% opacity */
-rgba(255 255 255,.5); /* CSS Colors 4 space-separated values */
+rgba(255 255 255/.5); /* CSS Colors 4 space-separated values */
 </pre>
 
 <h3 id="Values">Values</h3>

--- a/files/en-us/web/css/color_value/rgba()/index.html
+++ b/files/en-us/web/css/color_value/rgba()/index.html
@@ -22,7 +22,7 @@ tags:
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: css">rgba(255,255,255,.5) /* white with 50% opacity */
-rgba(255 255 255/.5); /* CSS Colors 4 space-separated values */
+rgba(255 255 255 / 0.5); /* CSS Colors 4 space-separated values */
 </pre>
 
 <h3 id="Values">Values</h3>


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`rgba(255 255 255,.5);` is invalid, it should be `rgba(255 255 255/.5);` or styled in other ways like `rgba(255 255 255 / .5);`

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgba()

> Issue number (if there is an associated issue)

NA

> Anything else that could help us review it

* Spec: https://www.w3.org/TR/css-color-4/#rgb-functions
* Related MDN page: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb()