### PR TITLE
Less confusing fallback example for the audio tag

### DIFF
--- a/files/en-us/web/html/element/audio/index.html
+++ b/files/en-us/web/html/element/audio/index.html
@@ -194,7 +194,7 @@ tags:
   &lt;source src="myAudio.mp3" type="audio/mpeg"&gt;
   &lt;source src="myAudio.ogg" type="audio/ogg"&gt;
   &lt;p&gt;Your browser doesn't support HTML5 audio. Here is
-     a &lt;a href="myAudio.mp4"&gt;link to the audio&lt;/a&gt; instead.&lt;/p&gt;
+     a &lt;a href="myAudio.mp3"&gt;link to the audio&lt;/a&gt; instead.&lt;/p&gt;
 &lt;/audio&gt;</pre>
 
 <p>We offer a substantive and thorough <a href="/en-US/docs/Web/Media/Formats">guide to media file types</a> and the <a href="/en-US/docs/Web/Media/Formats/Audio_codecs">audio codecs that can be used within them</a>. Also available is <a href="/en-US/docs/Web/Media/Formats/Video_codecs">a guide to the codecs supported for video</a>.</p>
@@ -323,7 +323,7 @@ Welcome to the Time Keeper's podcast! In this episode we're discussing which Swi
   &lt;source src="myAudio.ogg" type="audio/ogg"&gt;
   &lt;p&gt;
     Your browser doesn't support HTML5 audio.
-    Here is a &lt;a href="myAudio.mp4"&gt;link to download the audio&lt;/a&gt; instead.
+    Here is a &lt;a href="myAudio.mp3"&gt;link to download the audio&lt;/a&gt; instead.
   &lt;/p&gt;
 &lt;/audio&gt;
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I don't think it's intentional to have a different file to download when you provide a fallback to the audio element. I guess it would be less confusing to show that the same file can be downloaded (and avoid extra work from the author side).

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#usage_notes
