### PR TITLE
Increases the height of the live sample

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/introducing/index.html
+++ b/files/en-us/learn/javascript/asynchronous/introducing/index.html
@@ -71,7 +71,7 @@ btn.addEventListener('click', () =&gt; {
 <pre class="brush: html">&lt;<span class="pl-ent">button</span>&gt;Click me&lt;/<span class="pl-ent">button</span>&gt;</pre>
 </div>
 
-<p>{{EmbedLiveSample('Synchronous_JavaScript', '100%', '70px')}}</p>
+<p>{{EmbedLiveSample('Synchronous_JavaScript', '100%', '110px')}}</p>
 
 <div class="notecard note">
 <p><strong>Note</strong>: It is important to remember that <code><a href="/en-US/docs/Web/API/Window/alert">alert()</a></code>, while being very useful for demonstrating a synchronous blocking operation, is terrible for use in real world applications.</p>


### PR DESCRIPTION
> What was wrong/why is this fix needed?

The text that appears after clicking the button can't be seen without scrolling.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Introducing

> What does this PR do?

Increases the height of the live sample. So that, when the button is clicked, the text that appears can be seen without scrolling.
