### PR TITLE
close #4825 by linking to node+npm for convenience

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_first_component/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_first_component/index.html
@@ -29,7 +29,7 @@ tags:
    <td>
     <p>Familiarity with the core <a href="/en-US/docs/Learn/HTML">HTML</a>, <a href="/en-US/docs/Learn/CSS">CSS</a>, and <a href="/en-US/docs/Learn/JavaScript">JavaScript</a> languages, knowledge of the <a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line">terminal/command line</a>.</p>
 
-    <p>Vue components are written as a combination of JavaScript objects that manage the app's data and an HTML-based template syntax that maps to the underlying DOM structure. For installation, and to use some of the more advanced features of Vue (like Single File Components or render functions), you'll need a terminal with node + npm installed.</p>
+    <p>Vue components are written as a combination of JavaScript objects that manage the app's data and an HTML-based template syntax that maps to the underlying DOM structure. For installation, and to use some of the more advanced features of Vue (like Single File Components or render functions), you'll need a terminal with <a href="https://nodejs.org/en/download/" rel="noopener noreferrer" target="_blank">Node</a> and <a href="https://www.npmjs.com/get-npm" rel="noopener noreferrer" target="_blank">npm</a> installed.</p>
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
This commit seeks to close https://github.com/mdn/content/issues/4825.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Linking to Node and npm might be more convenient to readers.
> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_first_component
> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/4825
> Anything else that could help us review it
