### PR TITLE
Websockets API: Add Django channels and fix flaws

### DIFF
--- a/files/en-us/web/api/websockets_api/index.html
+++ b/files/en-us/web/api/websockets_api/index.html
@@ -50,17 +50,18 @@ tags:
  <li><a href="https://github.com/ClusterWS/ClusterWS">ClusterWS</a>:  Lightweight, fast and powerful framework for building scalable WebSocket applications in <a href="https://nodejs.org">Node.js</a>.</li>
  <li><a href="https://github.com/ClusterWS/cWS">CWS</a>: Fast C++ WebSocket implementation for Node.js (uWebSockets v0.14 fork)</li>
  <li><a href="https://socket.io">Socket.IO</a>: A long polling/WebSocket based third party transfer protocol for <a href="https://nodejs.org">Node.js</a>.</li>
- <li><a href="http://socketcluster.io/">SocketCluster</a>: A pub/sub WebSocket framework for <a href="https://nodejs.org">Node.js</a> with a focus on scalability.</li>
+ <li><a href="https://socketcluster.io/">SocketCluster</a>: A pub/sub WebSocket framework for <a href="https://nodejs.org">Node.js</a> with a focus on scalability.</li>
  <li><a class="link-https" href="https://github.com/Worlize/WebSocket-Node">WebSocket-Node</a>: A WebSocket server API implementation for <a href="https://nodejs.org">Node.js</a>.</li>
- <li><a href="http://www.totaljs.com">Total.js</a>: Web application framework for <a href="https://www.nodejs.org">Node.js</a> (Example: <a href="https://github.com/totaljs/examples/tree/master/websocket">WebSocket chat</a>)</li>
- <li><a href="https://www.npmjs.com/package/faye-websocket">Faye</a>: A <a href="/en-US/docs/Web/API/WebSockets_API">WebSocket</a> (two-ways connections) and <a href="/en-US/docs/Web/API/EventSource">EventSource</a> (one-way connections) for <a href="https://nodejs.org">Node.js</a> Server and Client.</li>
- <li><a href="http://signalr.net/">SignalR</a>: SignalR will use WebSockets under the covers when it's available, and gracefully fallback to other techniques and technologies when it isn't, while your application code stays the same.</li>
+ <li><a href="https://www.totaljs.com">Total.js</a>: Web application framework for <a href="https://www.nodejs.org">Node.js</a> (Example: <a href="https://github.com/totaljs/examples/tree/master/websocket">WebSocket chat</a>)</li>
+ <li><a href="https://www.npmjs.com/package/faye-websocket">Faye</a>: A {{DOMxRef("WebSocket")}} (two-ways connections) and <a href="/en-US/docs/Web/API/EventSource">EventSource</a> (one-way connections) for <a href="https://nodejs.org">Node.js</a> Server and Client.</li>
+ <li><a href="https://signalr.net/">SignalR</a>: SignalR will use WebSockets under the covers when it's available, and gracefully fallback to other techniques and technologies when it isn't, while your application code stays the same.</li>
  <li><a href="https://caddyserver.com/docs/websocket">Caddy</a>: A web server capable of proxying arbitrary commands (stdin/stdout) as a websocket.</li>
  <li><a href="https://github.com/websockets/ws">ws</a>: a popular WebSocket client &amp; server library for <a href="https://nodejs.org/">Node.js</a>.</li>
  <li><a href="https://github.com/bigstepinc/jsonrpc-bidirectional">jsonrpc-bidirectional</a>: Asynchronous RPC which, on a single connection, may have functions exported on the server and, and the same time, on the client (client may call server, server may also call client).</li>
  <li><a href="https://github.com/ninenines/cowboy">cowboy</a>: Cowboy is a small, fast and modern HTTP server for Erlang/OTP with WebSocket support.</li>
  <li><a href="https://websocketking.com">WebSocket King</a>: A client tool to help develop, test and work with WebSocket servers.</li>
- <li><a href="https://github.com/napengam/phpWebSocketServer">PHP WebSocket Server</a>:Server written in PHP to handle connections via websocksets wss:// or ws://and normal sockets over ssl:// ,tcp://</li>
+ <li><a href="https://github.com/napengam/phpWebSocketServer">PHP WebSocket Server</a>: Server written in PHP to handle connections via websocksets wss:// or ws://and normal sockets over ssl:// ,tcp://</li>
+ <li><a href="https://channels.readthedocs.io/en/stable/index.html">Channels</a>: Django library that adds support for WebSockets (and other protocols that require long running asynchronous connections).</li>
 </ul>
 
 <h2 id="Related_Topics">Related Topics</h2>


### PR DESCRIPTION
Fixes #4837

https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API lists a bunch of popular frameworks etc for supporting WebSockets. This adds Channels, which is a library that can be used for WebSocket support (and other protocols) on Django.

Also fixes flaws.

