### PR TITLE
Fix up self links in javascript building blocks

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.html
+++ b/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.html
@@ -253,7 +253,7 @@ displayMessage('Brian: Hi there, how are you today?','chat');</pre>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/conditionals">Making decisions in your code — conditionals</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code">Looping code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
+ <li><strong>Build your own function</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Image_gallery">Image gallery</a></li>

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.html
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.html
@@ -774,7 +774,7 @@ textarea.onkeyup = function(){
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/conditionals">Making decisions in your code — conditionals</a></li>
+ <li><strong>Making decisions in your code — conditionals</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code">Looping code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>

--- a/files/en-us/learn/javascript/building_blocks/events/index.html
+++ b/files/en-us/learn/javascript/building_blocks/events/index.html
@@ -612,6 +612,6 @@ video.onclick = function() {
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+ <li><strong>Introduction to events</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Image_gallery">Image gallery</a></li>
 </ul>

--- a/files/en-us/learn/javascript/building_blocks/functions/index.html
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.html
@@ -398,7 +398,7 @@ function subFunction3(value) {
 <ul>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/conditionals">Making decisions in your code — conditionals</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code">Looping code</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
+ <li><strong>Functions — reusable blocks of code</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>

--- a/files/en-us/learn/javascript/building_blocks/image_gallery/index.html
+++ b/files/en-us/learn/javascript/building_blocks/image_gallery/index.html
@@ -149,7 +149,7 @@ overlay.style.backgroundColor = xxx;</pre>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Image_gallery">Image gallery</a></li>
+ <li><strong>Image gallery</strong></li>
 </ul>
 
 <div id="gtx-trans" style="position: absolute; left: 1355px; top: 3393px;">

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.html
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.html
@@ -926,7 +926,7 @@ do {
 
 <ul>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/conditionals">Making decisions in your code — conditionals</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code">Looping code</a></li>
+ <li><strong>Looping code</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>

--- a/files/en-us/learn/javascript/building_blocks/return_values/index.html
+++ b/files/en-us/learn/javascript/building_blocks/return_values/index.html
@@ -191,7 +191,7 @@ function factorial(num) {
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code">Looping code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>
+ <li><strong>Function return values</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Image_gallery">Image gallery</a></li>
 </ul>


### PR DESCRIPTION
Learn sections have an "In this module" section listing all their modules. That creates a flaw for the current module, which is self linking. This turns the link for the current doc to a strong markup for the Javascript building blocks docs.