### PR TITLE
Fixable flaws in MediaRecorder

### DIFF
--- a/files/en-us/web/api/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/index.html
@@ -69,18 +69,18 @@ tags:
  <dt>{{domxref("MediaRecorder.ondataavailable")}}</dt>
  <dd>Called to handle the {{event("dataavailable")}} event, which is periodically triggered each time <code>timeslice</code> milliseconds of media have been recorded (or when the entire media has been recorded, if <code>timeslice</code> wasn't specified). The event, of type {{domxref("BlobEvent")}}, contains the recorded media in its {{domxref("BlobEvent.data", "data")}} property. You can then collect and act upon that recorded media data using this event handler.</dd>
  <dt>{{domxref("MediaRecorder.onerror")}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("error")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording. The received event is based on the {{domxref("MediaRecorderErrorEvent")}} interface, whose {{domxref("MediaRecorderErrorEvent.error", "error")}} property contains a {{domxref("DOMException")}} that describes the actual error that occurred.</dd> 
+ <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("error")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording. The received event is based on the {{domxref("MediaRecorderErrorEvent")}} interface, whose {{domxref("MediaRecorderErrorEvent.error", "error")}} property contains a {{domxref("DOMException")}} that describes the actual error that occurred.</dd> 
  <dt>{{domxref("MediaRecorder.onpause")}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("pause")}} event, which occurs when media recording is paused.</dd>
+ <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("pause")}} event, which occurs when media recording is paused.</dd>
  <dt>{{domxref("MediaRecorder.onresume")}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("resume")}} event, which occurs when media recording resumes after being paused.</dd>
+ <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("resume")}} event, which occurs when media recording resumes after being paused.</dd>
  <dt>{{domxref("MediaRecorder.onstart")}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("start")}} event, which occurs when media recording starts.</dd>
+ <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("start")}} event, which occurs when media recording starts.</dd>
  <dt>{{domxref("MediaRecorder.onstop")}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("stop")}} event, which occurs when media recording ends, either when the {{domxref("MediaStream")}} ends — or after the {{domxref("MediaRecorder.stop()")}} method is called.</dd>
+ <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("stop")}} event, which occurs when media recording ends, either when the {{domxref("MediaStream")}} ends — or after the {{domxref("MediaRecorder.stop()")}} method is called.</dd>
 
  <dt>{{domxref("MediaRecorder.onwarning")}} {{deprecated_inline}}</dt>
- <dd>An {{domxref("EventHandler")}} called to handle the {{event("warning")}} event, which occurs when media recording has a non-fatal error, or after the {{domxref("MediaRecorder.onwarning()")}} method is called.</dd>
+ <dd>An {{event("Event_handlers", "Event handler")}} called to handle the {{event("warning")}} event, which occurs when media recording has a non-fatal error, or after the {{domxref("MediaRecorder.onwarning()")}} method is called.</dd>
 </dl>
 
 <h2 id="Events">Events</h2>


### PR DESCRIPTION
Fixes macro flaws in https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder

Correct macro to use here is `{{event}}` according to https://github.com/mdn/content/pull/4226/files/30034cbf05c728e83bea2af438f8df3c1b7ade1f#r628333708

