### PR TITLE
AudioBufferSourceNode: include SeeAlso rather than use page macro

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.html
@@ -33,15 +33,13 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<div class="note">
-  <p>For a full working example, see<a class="external external-icon"
-      href="https://mdn.github.io/webaudio-examples/audio-buffer/"> this code running
-      live</a>, or <a class="external external-icon"
-      href="https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html">view
-      the source</a>.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>For a full working example, see <a href="https://mdn.github.io/webaudio-examples/audio-buffer/"> this code running
+      live</a>, or <a href="https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html">view the source</a>.</p>
 </div>
 
-<pre class="brush: js;highlight[19]">var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
+<pre class="brush: js">var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);
 
 button.onclick = function() {
   // Fill the buffer with white noise;
@@ -88,4 +86,7 @@ button.onclick = function() {
 
 <h2 id="See_also">See also</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioBufferSourceNode","See_also")}}</p>
+<ul>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
+</ul>

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.html
@@ -85,6 +85,6 @@ source.start();
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a>
-  </li>
-</ul>
+  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+  <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
+ </ul>

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.html
@@ -128,7 +128,6 @@ loopendControl.oninput = function() {
 <h2 id="See_also">See also</h2>
 
 <ul>
+  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
   <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
-  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio
-      API</a></li>
-</ul>
+ </ul>

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.html
@@ -135,6 +135,6 @@ playbackControl.oninput = function() {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio
-      API</a></li>
-</ul>
+  <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+  <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
+ </ul>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/buffer was using page macro to pull in See Also from https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode.

This replaces macro by duplicating the see also section. Also updates the docs for other AudioBufferSourceNode properties to match.

This is part of #3196