### PR TITLE
Deprecate PaymentAddress, PayerErrors, and related members

### DIFF
--- a/files/en-us/web/api/payererrors/email/index.html
+++ b/files/en-us/web/api/payererrors/email/index.html
@@ -14,7 +14,7 @@ tags:
 - Validation
 - payment
 ---
-<div>{{APIRef("Payment Request API")}}{{draft}}</div>
+<div>{{APIRef("Payment Request API")}} {{Deprecated_header}} {{Non-standard_header}}</div>
 
 <p>The <code><strong>email</strong></code> property is included in a
   {{domxref("PayerErrors")}} object if the {{domxref("PaymentResponse.payerEmail")}}
@@ -58,23 +58,6 @@ tags:
   //
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-payererrors-email','PayerErrors.email')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/payererrors/index.html
+++ b/files/en-us/web/api/payererrors/index.html
@@ -15,7 +15,7 @@ tags:
   - payment
   - paymentAddress
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}} {{Deprecated_header}} {{Non-standard_header}}</div>
 
 <p><span class="seoSummary">The <strong><code>PayerErrors</code></strong> dictionary is used by the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> to indicate the presence of—and to explain how to correct—validation errors in the payer details.</span> For each field in the payment information that fails validation, the <code>PayerErrors</code> object contains a string explaining the error.</p>
 
@@ -24,32 +24,13 @@ tags:
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref("PayerErrors.email", "email")}} {{optional_inline}}</dt>
+ <dt>{{domxref("PayerErrors.email", "email")}} {{optional_inline}}{{Deprecated_inline}}</dt>
  <dd>If present, this {{domxref("DOMString")}} is a string describing the validation error from which the payer's email address—as given by {{domxref("PaymentResponse.payerEmail")}}—currently suffers. If this property is absent from the <code>PayerErrors</code> object, the email address passed validation.</dd>
- <dt>{{domxref("PayerErrors.name", "name")}} {{optional_inline}}</dt>
+ <dt>{{domxref("PayerErrors.name", "name")}} {{optional_inline}}{{Deprecated_inline}}</dt>
  <dd>If this {{domxref("DOMString")}} is present in the object, the {{domxref("PaymentResponse.payerName")}} property failed validation, and this string explains what needs to be corrected. If this property is absent, the paer name is fine</dd>
- <dt>{{domxref("PayerErrors.phone", "phone")}} {{optional_inline}}</dt>
+ <dt>{{domxref("PayerErrors.phone", "phone")}} {{optional_inline}}{{Deprecated_inline}}</dt>
  <dd>If present, this string is an error message explaining why the payer's phone number ({{domxref("PaymentResponse.payerPhone")}}) failed validation. This property is absent if the phone number passed validation.</dd>
 </dl>
-
-<h2 id="Example">Example</h2>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dom-payererrors','PayerErrors')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/payererrors/name/index.html
+++ b/files/en-us/web/api/payererrors/name/index.html
@@ -16,7 +16,7 @@ tags:
 - name
 - payment
 ---
-<div>{{APIRef("Payment Request API")}}{{draft}}</div>
+<div>{{APIRef("Payment Request API")}} {{Deprecated_header}} {{Non-standard_header}}</div>
 
 <p>The <strong><code>name</code></strong> property is included in a
   {{domxref("PayerErrors")}} object if the {{domxref("PaymentResponse.payerName",
@@ -63,23 +63,6 @@ tags:
   //
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-payererrors-name','PayerErrors.name')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/payererrors/phone/index.html
+++ b/files/en-us/web/api/payererrors/phone/index.html
@@ -17,7 +17,7 @@ tags:
 - Validation
 - payment
 ---
-<div>{{APIRef("Payment Request API")}}{{draft}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The <strong><code>phone</code></strong> property is found in a
   {{domxref("PayerErrors")}} object if the {{domxref("PaymentResponse.payerPhone",
@@ -66,23 +66,6 @@ tags:
   //
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-payererrors-phone','PayerErrors.phone')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/addressline/index.html
+++ b/files/en-us/web/api/paymentaddress/addressline/index.html
@@ -13,7 +13,7 @@ tags:
 - payment
 - paymentAddress
 ---
-<p>{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p><span class="seoSummary">The <strong><code>addressLine</code></strong> read-only
     property of the {{domxref('PaymentAddress')}} interface is an array of
@@ -67,25 +67,6 @@ tags:
   30 Great Guildford Street<br>
   London SE1 0HS<br>
   United Kingdom</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentaddress-addressline','PaymentAddress.addressLine')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/city/index.html
+++ b/files/en-us/web/api/paymentaddress/city/index.html
@@ -16,7 +16,7 @@ tags:
 - town
 - village
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}}</div>
 
 <p><span class="seoSummary">The <strong><code>city</code></strong> read-only property of
     the {{domxref('PaymentAddress')}} interface returns a string containing the city or
@@ -31,23 +31,6 @@ tags:
 
 <p>A {{domxref("DOMString")}} indicating the city or town portion of the address described
   by the {{domxref("PaymentAddress")}} object.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentaddress-city','PaymentAddress.city')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/country/index.html
+++ b/files/en-us/web/api/paymentaddress/country/index.html
@@ -13,7 +13,7 @@ tags:
 - payment
 - paymentAddress
 ---
-<p>{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>country</code></strong> read-only property of the
   {{domxref('PaymentAddress')}} interface is a string identifying the address's country
@@ -44,23 +44,6 @@ tags:
   field. That field contains an {{domxref("AddressErrors")}}-compliant object whose
   {{domxref("AddressErrors.country", "country")}} property is a string indicating the
   validation error that occurred and, if possible, suggests how to fix it.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentaddress','PaymentAddress.country')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/dependentlocality/index.html
+++ b/files/en-us/web/api/paymentaddress/dependentlocality/index.html
@@ -10,7 +10,7 @@ tags:
 - Reference
 - paymentAddress
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p><span class="seoSummary">The read-only <strong><code>dependentLocality</code></strong>
     property of the {{domxref('PaymentAddress')}} interface is a string containing a
@@ -34,25 +34,6 @@ tags:
   United Kingdom (known officially by the Royal Mail as the <strong>dependent
     locality</strong>). This is a disambiguating feature of addresses in places where a
   city may have areas that duplicate street names.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentaddress-dependentlocality','PaymentAddress.dependentLocality')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/index.html
+++ b/files/en-us/web/api/paymentaddress/index.html
@@ -10,7 +10,7 @@ tags:
   - Reference
   - paymentAddress
 ---
-<div>{{APIRef("Payment Request API")}}{{SecureContext_Header}}</div>
+<div>{{APIRef("Payment Request API")}}{{SecureContext_Header}} {{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p><span class="seoSummary">The <strong><code>PaymentAddress</code></strong> interface of the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> is used to store shipping or payment address information.</span></p>
 
@@ -19,27 +19,27 @@ tags:
 <h2 id="Properties">Properties</h2>
 
 <dl>
- <dt>{{domxref('PaymentAddress.addressLine')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.addressLine')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>An array of {{domxref("DOMString")}} objects providing each line of the address not included among the other properties. The exact size and content varies by country or location and can include, for example, a street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box number.</dd>
- <dt>{{domxref('PaymentAddress.country')}} {{readonlyinline}} </dt>
+ <dt>{{domxref('PaymentAddress.country')}} {{readonlyinline}}{{deprecated_inline}} </dt>
  <dd>A {{domxref("DOMString")}} specifying the country in which the address is located, using the {{interwiki("wikipedia", "ISO-3166-1 alpha-2")}} standard. The string is always given in its canonical upper-case form. Some examples of valid <code>country</code> values: <code>"US"</code>, <code>"GB"</code>, <code>"CN"</code>, or <code>"JP"</code>.</dd>
- <dt>{{domxref('PaymentAddress.city')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.city')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} which contains the city or town portion of the address.</dd>
- <dt>{{domxref('PaymentAddress.dependentLocality')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.dependentLocality')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} giving the dependent locality or sublocality within a city, for example, a neighborhood, borough, district, or UK dependent locality.</dd>
- <dt>{{domxref('PaymentAddress.organization')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.organization')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} specifying the name of the organization, firm, company, or institution at the payment address.</dd>
- <dt>{{domxref('PaymentAddress.phone')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.phone')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} specifying the telephone number of the recipient or contact person.</dd>
- <dt>{{domxref('PaymentAddress.postalCode')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.postalCode')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} specifying a code used by a jurisdiction for mail routing, for example, the ZIP code in the United States or the PIN code in India.</dd>
- <dt>{{domxref('PaymentAddress.recipient')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.recipient')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} giving the name of the recipient, purchaser, or contact person at the payment address.</dd>
- <dt>{{domxref('PaymentAddress.region')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.region')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} containing the top level administrative subdivision of the country, for example a state, province, oblast, or prefecture.</dd>
- <dt>{{domxref('PaymentAddress.regionCode')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.regionCode')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} specifying the region of the address, represented as a "code element" of an <a href="https://en.wikipedia.org/wiki/ISO_3166-2">ISO3166-2</a> country subdivision name (e.g. "QLD" for Queensland, Australia, "CA" for California, and so on).</dd>
- <dt>{{domxref('PaymentAddress.sortingCode')}} {{readonlyinline}}</dt>
+ <dt>{{domxref('PaymentAddress.sortingCode')}} {{readonlyinline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} providing a postal sorting code such as is used in France.</dd>
 </dl>
 
@@ -59,7 +59,7 @@ tags:
 <h2 id="Methods">Methods</h2>
 
 <dl>
- <dt>{{domxref('PaymentAddress.toJSON()')}}</dt>
+ <dt>{{domxref('PaymentAddress.toJSON()')}}{{deprecated_inline}}</dt>
  <dd>A standard serializer that returns a JSON representation of the <code>PaymentAddress</code> object's properties.</dd>
 </dl>
 
@@ -123,23 +123,6 @@ doPaymentRequest();
     // etc. billing address is a <a href="/en-US/docs/Web/API/PaymentAddress">PaymentAddress</a> object
   }
 }</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#paymentaddress-interface','PaymentAddress')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/languagecode/index.html
+++ b/files/en-us/web/api/paymentaddress/languagecode/index.html
@@ -17,7 +17,7 @@ tags:
 - WebRTC API
 - rtc
 ---
-<p>{{deprecated_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{deprecated_header}}{{APIRef("Payment Request API")}}{{Non-standard_header}}</p>
 
 <p><span class="seoSummary">The <strong><code>languageCode</code></strong> read-only
     property of the {{domxref('PaymentAddress')}} interface returns a string containing

--- a/files/en-us/web/api/paymentaddress/organization/index.html
+++ b/files/en-us/web/api/paymentaddress/organization/index.html
@@ -16,7 +16,7 @@ tags:
 - organization
 - paymentAddress
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p><span class="seoSummary">The <strong><code>organization</code></strong> read-only
     property of the {{domxref('PaymentAddress')}} interface returns a string containing
@@ -33,25 +33,6 @@ tags:
   located at the address described by the <code>PaymentAddress</code> object. This should
   be the name of the organization that is to receive the shipment for shipping addresses,
   or which is repsonsible for payment for payment addresses.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentaddress-organization','PaymentAddress.organization')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/phone/index.html
+++ b/files/en-us/web/api/paymentaddress/phone/index.html
@@ -16,7 +16,7 @@ tags:
 - payment
 - paymentAddress
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The read-only <strong><code>phone</code></strong> property of the
   {{domxref('PaymentAddress')}} interface returns a string containing the telephone number
@@ -32,23 +32,6 @@ tags:
 <p>A {{domxref("DOMString")}} containing the telephone number for the recipient of the
   shipment or of the responsible party for payment. If no phone number is available, this
   value is an empty string.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentaddress-phone','PaymentAddress.phone')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/postalcode/index.html
+++ b/files/en-us/web/api/paymentaddress/postalcode/index.html
@@ -20,7 +20,7 @@ tags:
 - paymentAddress
 - postalCode
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The <strong><code>postalCode</code></strong> read-only property of the
   {{domxref('PaymentAddress')}} interface returns a string containing a code used by a
@@ -42,25 +42,6 @@ tags:
 <p>Various countries use different terms for this. In most of the world, it's known as the
   "post code" or "postal code." In the United States, the ZIP code is used. India uses PIN
   codes.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentaddress-postalcode','PaymentAddress.postalCode')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/recipient/index.html
+++ b/files/en-us/web/api/paymentaddress/recipient/index.html
@@ -10,7 +10,7 @@ tags:
 - Reference
 - paymentAddress
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The read-only <strong><code>recipient</code></strong> property of the
   {{domxref('PaymentAddress')}} interface returns a string containing the name of the
@@ -26,25 +26,6 @@ tags:
 <p>A {{domxref("DOMString")}} giving the name of the person receiving  or paying for the
   purchase, or the name of a contact person in other contexts. If no name is available,
   this string is empty.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentaddress-recipient','PaymentAddress.recipient')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/region/index.html
+++ b/files/en-us/web/api/paymentaddress/region/index.html
@@ -18,7 +18,7 @@ tags:
 - region
 - state
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The read-only <strong><code>region</code></strong> property of the
   {{domxref('PaymentAddress')}} interface returns a string containing the top-level
@@ -43,24 +43,6 @@ tags:
   of <code>region</code>. However, the address should still be acceptable to use for its
   intended purpose (e.g., to ship a product). However, always verify addresses to make
   sure what the user provides is usable.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentaddress-region','PaymentAddress.region')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/regioncode/index.html
+++ b/files/en-us/web/api/paymentaddress/regioncode/index.html
@@ -18,7 +18,7 @@ tags:
 - regionCode
 - state
 ---
-<p>{{APIRef("Payment Request API")}}{{deprecated_header}}</p>
+<p>{{APIRef("Payment Request API")}}{{deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>regionCode</code></strong> read-only attribute of the
   {{domxref('PaymentAddress')}} interface returns a one-, two-, or three-alphanumeric code

--- a/files/en-us/web/api/paymentaddress/sortingcode/index.html
+++ b/files/en-us/web/api/paymentaddress/sortingcode/index.html
@@ -14,7 +14,7 @@ tags:
 - paymentAddress
 - sortingCode
 ---
-<div>{{APIRef("Payment Request API")}}</div>
+<div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The <strong><code>sortingCode</code></strong> read-only property of the
   {{domxref('PaymentAddress')}} interface returns a string containing a postal sorting
@@ -28,25 +28,6 @@ tags:
 <h3 id="Value">Value</h3>
 
 <p>A {{domxref("DOMString")}} containing the sorting code portion of the address.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentaddress-sortingcode','PaymentAddress.sortingCode')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentaddress/tojson/index.html
+++ b/files/en-us/web/api/paymentaddress/tojson/index.html
@@ -11,7 +11,7 @@ tags:
 - paymentAddress
 - toJSON
 ---
-<p>{{APIRef("Payment Request API")}}{{SeeCompatTable}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>toJSON()</code></strong> property of the
   {{domxref("PaymentAddress")}} interface is a standard serializer that returns a JSON
@@ -31,23 +31,6 @@ tags:
     value</span></h3>
 
 <p>A JSON object.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('WebIDL','#default-tojson-steps','toJSON()')}}</td>
-      <td>{{Spec2('WebIDL')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentdetailsupdate/error/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/error/index.html
@@ -11,7 +11,7 @@ tags:
 - Reference
 - payment
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p><span class="seoSummary">The {{domxref("PaymentDetailsUpdate")}} dictionary's
     <code><strong>error</strong></code> property is a human-readable
@@ -44,25 +44,6 @@ tags:
   currently specified—whether that's because the selected products cannot be shipped to
   their region or because their address is not served by any of the shipping companies you
   use.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentdetailsupdate-error','PaymentDetailsUpdate.error')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentdetailsupdate/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/index.html
@@ -24,11 +24,11 @@ tags:
 <dl>
  <dt>{{domxref("PaymentDetailsBase.displayItems", "displayItems")}} {{optional_inline}}</dt>
  <dd>An array of {{domxref("PaymentItem")}} objects, each describing one line item for the payment request. These represent the line items on a receipt or invoice.</dd>
- <dt>{{domxref("PaymentDetailsUpdate.error", "error")}} {{optional_inline}}</dt>
+ <dt>{{domxref("PaymentDetailsUpdate.error", "error")}} {{optional_inline}}{{deprecated_inline}}</dt>
  <dd>A {{domxref("DOMString")}} specifying an error message to present to the user<em>.</em> When calling {{domxref("PaymentDetailsUpdate.updateWith", "updateWith()")}}, including <code>error</code> in the updated data causes the {{Glossary("user agent")}} to display the text as a general error message. For address field specific errors, use <code>shippingAddressErrors</code>.</dd>
  <dt>{{domxref("PaymentDetailsBase.modifiers", "modifiers")}} {{optional_inline}}</dt>
  <dd>An array of {{domxref("PaymentDetailsModifier")}} objects, each describing a modifier for particular payment method identifiers. For example, you can use one to adjust the total payment amount based on the selected payment method ("5% cash discount!").</dd>
- <dt>{{domxref("PaymentDetailsUpdate.shippingAddressErrors", "shippingAddressErrors")}} {{optional_inline}}</dt>
+ <dt>{{domxref("PaymentDetailsUpdate.shippingAddressErrors", "shippingAddressErrors")}} {{optional_inline}}{{deprecated_inline}}</dt>
  <dd>An {{domxref("AddressErrors")}} object which includes an error message for each property of the shipping address that could not be validated.</dd>
  <dt>{{domxref("PaymentDetailsBase.shippingOptions", "shippingOptions")}} {{optional_inline}}</dt>
  <dd>An array of {{domxref("PaymentShippingOption")}} objects, each describing one available shipping option from which the user may choose.</dd>

--- a/files/en-us/web/api/paymentdetailsupdate/shippingaddresserrors/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/shippingaddresserrors/index.html
@@ -15,7 +15,7 @@ tags:
 - payment
 - shippingAddressErrors
 ---
-<div>{{APIRef("Payment Request API")}}{{securecontext_header}}</div>
+<div>{{APIRef("Payment Request API")}}{{securecontext_header}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p><span class="seoSummary">The {{domxref("PaymentDetailsUpdate")}} dictionary's
     <code><strong>shippingAddressErrors</strong></code> property, if present,  contains an
@@ -37,25 +37,6 @@ tags:
   property. In that case, the property in <code>shippingAddressErrors</code> is a string
   describing the validation error, ideally including suggestions about fixing the error.
 </p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Payment','#dom-paymentdetailsupdate-shippingaddresserrors','PaymentDetailsUpdate.shippingAddressErrors')}}
-      </td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/index.html
@@ -30,11 +30,11 @@ tags:
 <dl>
  <dt>{{domxref('PaymentRequest.id')}} {{readonlyinline}}{{securecontext_inline}}</dt>
  <dd>An unique identifier for a particular <code>PaymentRequest</code>, which can be set via <code>details.id</code>. When none is set, it defaults to a UUID.</dd>
- <dt>{{domxref('PaymentRequest.shippingAddress')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+ <dt>{{domxref('PaymentRequest.shippingAddress')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
  <dd>If requested via payment options, returns the shipping address chosen by the user for the purposes of calculating shipping. This property is only populated if the constructor is called with the <code>requestShipping</code> flag set to true. Additionally, in some browsers, the parts of the address will be redacted for privacy until the user indicates they are ready to complete the transaction (i.e., they hit "Pay").</dd>
- <dt>{{domxref('PaymentRequest.shippingOption')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+ <dt>{{domxref('PaymentRequest.shippingOption')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
  <dd>Returns the identifier of the selected shipping option. This property is only populated if the constructor is called with the <code>requestShipping</code> flag set to true.</dd>
- <dt>{{domxref('PaymentRequest.shippingType')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+ <dt>{{domxref('PaymentRequest.shippingType')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
  <dd>Returns the type of shipping used to fulfill the transaction. This will be one of <code>shipping</code>, <code>delivery</code>, <code>pickup</code>, or <code>null</code> if a value was not provided in the constructor.</dd>
 </dl>
 
@@ -58,10 +58,10 @@ tags:
  <dt>{{domxref("PaymentRequest.paymentmethodchange_event", "paymentmethodchange")}} {{securecontext_inline}}</dt>
  <dd>With some payment handlers (e.g., Apple Pay), dispatched whenever the user changes payment instrument, like switching from a credit card to a debit card.<br>
  Also available using the {{domxref("PaymentRequest.onpaymentmethodchange", "onpaymentmethodchange")}} event handler property.</dd>
- <dt>{{domxref("PaymentRequest.shippingaddresschange_event", "shippingaddresschange")}} {{securecontext_inline}}</dt>
+ <dt>{{domxref("PaymentRequest.shippingaddresschange_event", "shippingaddresschange")}} {{securecontext_inline}}{{deprecated_inline}}</dt>
  <dd>Dispatched whenever the user changes their shipping address.<br>
  Also available using the {{domxref("PaymentRequest.onshippingaddresschange", "onshippingaddresschange")}} event handler property.</dd>
- <dt>{{domxref("PaymentRequest.shippingoptionchange_event", "shippingoptionchange")}} {{securecontext_inline}}</dt>
+ <dt>{{domxref("PaymentRequest.shippingoptionchange_event", "shippingoptionchange")}} {{securecontext_inline}}{{deprecated_inline}}</dt>
  <dd>Dispatched whenever the user changes a shipping option.<br>
  Also available using the {{domxref("PaymentRequest.onshippingoptionchange", "onshippingoptionchange")}} event handler property.</dd>
 </dl>

--- a/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.html
+++ b/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.html
@@ -12,7 +12,7 @@ tags:
   - Secure context
   - onshippingaddresschange
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>onshippingaddresschange</code></strong> event of the
   {{domxref("PaymentRequest")}} interface is fired whenever the user changes their
@@ -49,24 +49,6 @@ payment.show().then(function(paymentResponse) {
   console.error("Uh oh, something bad happened", err.message);
 });
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment', '#onshippingaddresschange-attribute',
-        'onshippingaddresschange')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.html
+++ b/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.html
@@ -11,7 +11,7 @@ tags:
   - Secure context
   - onshippingoptionchange
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>onshippingoptionchange</code></strong> event of the
   {{domxref("PaymentRequest")}} interface is fired whenever the user changes a shipping
@@ -76,24 +76,6 @@ request.addEventListener('shippingaddresschange', e =&gt; {
   })(details, request.shippingAddress));
 });
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment', '#onshippingoptionchange-attribute',
-        'onshippingoptionchange')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingaddress/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingaddress/index.html
@@ -12,7 +12,7 @@ tags:
   - Secure context
   - shippingAddress
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>shippingAddress</code></strong> read-only property of
   the {{domxref('PaymentRequest')}} interface returns the shipping address provided by the
@@ -78,23 +78,6 @@ function updateDetails(details, shippingAddress, resolve) {
   resolve(details);
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#shippingaddress-attribute','shippingaddress')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingaddresschange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingaddresschange_event/index.html
@@ -15,7 +15,7 @@ tags:
   - payment
   - shippingaddresschange
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p><span class="seoSummary">The <strong><code>shippingaddresschange</code></strong> event is sent to the {{domxref("PaymentRequest")}} object when the user selects a shipping address or changes details of their shipping address.</span></p>
 
@@ -71,23 +71,6 @@ const checkAddress = theAddress =&gt; {
   let detailsUpdate = checkAddress(paymentRequest.shippingAddress);
   event.updateWith(detailsUpdate);
 };</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dfn-shippingaddresschange','shippingaddresschange')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingoption/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingoption/index.html
@@ -11,7 +11,7 @@ tags:
   - Secure context
   - shippingOption
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>shippingOption</code></strong> read-only attribute of
   the {{domxref('PaymentRequest')}} interface returns either the id of a selected shipping
@@ -68,23 +68,6 @@ async function checkShipping(request) {
   }
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#shippingoption-attribute','shippingOption')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingoptionchange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingoptionchange_event/index.html
@@ -14,7 +14,7 @@ tags:
   - payment
   - shippingoptionchange
 ---
-<p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p><span class="seoSummary">For payment requests that request shipping information, and for which shipping options are offered, the <code><strong>shippingoptionchange</strong></code> event is sent to the {{domxref("PaymentRequest")}} whenever the user chooses a shipping option from the list of available options.</span> The string identifying the currently-selected shipping option can be found in the {{domxref("PaymentRequest.shippingOption", "shippingOption")}} property.</p>
 
@@ -67,23 +67,6 @@ tags:
   };
   event.updateWith({ total });
 };</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment','#dfn-shippingoptionchange','shippingoptionchange')}}</td>
-   <td>{{Spec2('Payment')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingtype/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingtype/index.html
@@ -11,7 +11,7 @@ tags:
 - Secure context
 - shippingType
 ---
-<p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>shippingType</code></strong> read-only property of the
   {{domxref("PaymentRequest")}} interface returns one of <code>"shipping"</code>,
@@ -27,23 +27,6 @@ tags:
 
 <p>One of <code>"shipping"</code>, <code>"delivery"</code>, <code>"pickup"</code>, or
   <code>null</code>.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentrequest-shippingtype','shippingType')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/index.html
+++ b/files/en-us/web/api/paymentresponse/index.html
@@ -21,17 +21,17 @@ tags:
 	<dd>Returns a JSON-serializable object that provides a payment method specific message used by the merchant to process the transaction and determine successful fund transfer. The contents of the object depend on the payment method being used; for example, if the Basic Card payment method is used, this object must conform to the structure defined in the {{domxref("BasicCardResponse")}} dictionary.</dd>
 	<dt>{{domxref('PaymentResponse.methodName')}} {{readonlyinline}} {{securecontext_inline}}</dt>
 	<dd>Returns the payment method identifier for the payment method that the user selected, for example, Visa, Mastercard, Paypal, etc.. </dd>
-	<dt>{{domxref('PaymentResponse.payerEmail')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+	<dt>{{domxref('PaymentResponse.payerEmail')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
 	<dd>Returns the email address supplied by the user. This option is only present when the <code>requestPayerEmail</code> option is set to <code>true</code> in the <code>options</code> parameter of the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.</dd>
-	<dt>{{domxref('PaymentResponse.payerName')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+	<dt>{{domxref('PaymentResponse.payerName')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
 	<dd>Returns the name supplied by the user. This option is only present when the <code>requestPayerName</code> option is set to true in the <code>options</code> parameter of the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.</dd>
-	<dt>{{domxref('PaymentResponse.payerPhone')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+	<dt>{{domxref('PaymentResponse.payerPhone')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
 	<dd>Returns the phone number supplied by the user. This option is only present when the <code>requestPayerPhone</code> option is set to <code>true</code> in the <code>options</code> parameter of the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.</dd>
 	<dt>{{domxref('PaymentResponse.requestId')}} {{readonlyinline}} {{securecontext_inline}}</dt>
 	<dd>Returns the identifier of the {{domxref('PaymentRequest')}} that produced the current response. This is the same value supplied in the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor by <code>details.id</code>.</dd>
-	<dt>{{domxref('PaymentResponse.shippingAddress')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+	<dt>{{domxref('PaymentResponse.shippingAddress')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
 	<dd>Returns the shipping Address supplied by the user. This option is only present when the <code>requestShipping</code> option is set to <code>true</code> in the <code>options</code> parameter of the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.</dd>
-	<dt>{{domxref('PaymentResponse.shippingOption')}} {{readonlyinline}} {{securecontext_inline}}</dt>
+	<dt>{{domxref('PaymentResponse.shippingOption')}} {{readonlyinline}} {{securecontext_inline}}{{deprecated_inline}}</dt>
 	<dd>Returns the ID attribute of the shipping option selected by the user. This option is only present when the <code>requestShipping</code> option is set to <code>true</code> in the <code>options</code> parameter of the {{domxref('PaymentRequest.PaymentRequest','PaymentRequest()')}} constructor.</dd>
 </dl>
 
@@ -49,7 +49,7 @@ tags:
 <p>Listen to this event using <code><a href="/en-US/docs/Web/API/EventTarget/addEventListener">addEventListener()</a></code> or by assigning an event listener to the <code>on<em>eventname</em></code> property of this interface.</p>
 
 <dl>
-	<dt><code><a href="/en-US/docs/Web/API/PaymentResponse/payerdetailchange_event">payerdetailchange</a></code>{{securecontext_inline}}</dt>
+	<dt><code><a href="/en-US/docs/Web/API/PaymentResponse/payerdetailchange_event">payerdetailchange</a></code>{{securecontext_inline}}{{deprecated_inline}}</dt>
 	<dd>Fired during a retry when the user makes changes to their personal information while filling out a payment request form. Allows the developer to revalidate any requested user data (e.g., the phone number or the email address) if it changes.<br>
 	Also available via the <code><a href="/en-US/docs/Web/API/PaymentResponse/onpayerdetailchange">onpayerdetailchange</a></code> property.</dd>
 </dl>

--- a/files/en-us/web/api/paymentresponse/onpayerdetailchange/index.html
+++ b/files/en-us/web/api/paymentresponse/onpayerdetailchange/index.html
@@ -16,7 +16,7 @@ tags:
 - payment
 - validate
 ---
-<div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
+<div>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p><span class="seoSummary">The {{domxref("PaymentResponse")}} object's
     <code><strong>onpayerdetailchange</strong></code> property is an event handler which
@@ -110,24 +110,6 @@ await response.retry({
   },
 });
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment', '#dom-paymentresponse-onpayerdetailchange',
-        'onpayerdetailchange')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/payerdetailchange_event/index.html
+++ b/files/en-us/web/api/paymentresponse/payerdetailchange_event/index.html
@@ -13,7 +13,7 @@ tags:
   - payment
   - validate
 ---
-<div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
+<div>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p><code><strong>payerdetailchange</strong></code> events are delivered by the <a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a> to a {{domxref("PaymentResponse")}} object when the user makes changes to their personal information while filling out a payment request form.</p>
 
@@ -121,23 +121,6 @@ await response.retry({
 <pre class="brush: js">response.addEventListener("payerdetailchange", async ev =&gt; {
   ...
 }</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Payment', '#dfn-payerdetailchange', 'payerdetailchange event')}}</td>
-   <td>{{Spec2("Payment")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/payeremail/index.html
+++ b/files/en-us/web/api/paymentresponse/payeremail/index.html
@@ -12,7 +12,7 @@ tags:
   - Secure context
   - payerEmail
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <code>payerEmail</code> read-only property of the {{domxref("PaymentResponse")}}
   interface returns the email address supplied by the user. This option is only present
@@ -24,23 +24,6 @@ tags:
 
 <pre
   class="brush: js">var payerEmail = PaymentResponse.payerEmail;</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/payername/index.html
+++ b/files/en-us/web/api/paymentresponse/payername/index.html
@@ -11,7 +11,7 @@ tags:
 - Reference
 - Secure context
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>payerName</code></strong> read-only property of the
   {{domxref("PaymentResponse")}} interface returns the name supplied by the user. This
@@ -27,23 +27,6 @@ tags:
 <h3 id="Value">Value</h3>
 
 <p>A string containing the payer name.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment','#dom-paymentresponse-payername','payerName')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/payerphone/index.html
+++ b/files/en-us/web/api/paymentresponse/payerphone/index.html
@@ -12,7 +12,7 @@ tags:
   - Secure context
   - payerPhone
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <code>payerPhone</code> read-only property of the {{domxref("PaymentResponse")}}
   interface returns the phone number supplied by the user. This option is only present
@@ -24,23 +24,6 @@ tags:
 
 <pre
   class="brush: js">var payerPhone = PaymentResponse.payerPhone;</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.html
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.html
@@ -12,7 +12,7 @@ tags:
 - Secure context
 - shippingAddress
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>shippingAddress</code></strong> read-only property of
   the <code>PaymentRequest</code> interface returns a {{domxref('PaymentAddress')}} object
@@ -83,23 +83,6 @@ function updateDetails(details, shippingAddress, resolve) {
   resolve(details);
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/paymentresponse/shippingoption/index.html
+++ b/files/en-us/web/api/paymentresponse/shippingoption/index.html
@@ -12,7 +12,7 @@ tags:
   - Secure context
   - shippingOption
 ---
-<p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
+<p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
 <p>The <strong><code>shippingOption</code></strong> read-only property of
   the <code>PaymentRequest</code> interface returns the ID attribute of the shipping
@@ -68,23 +68,6 @@ function updateDetails(details, shippingOption, resolve, reject) {
   resolve(details);
 }
 </pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Payment')}}</td>
-      <td>{{Spec2('Payment')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
https://github.com/w3c/payment-request/commit/486c07a (https://github.com/w3c/payment-request/pull/955) removed the `PaymentAddress` and `PayerErrors` objects from the Payment Request specification — as well as removing related members from the `PaymentRequest`, `PaymentResponse`, and `PaymentDetailsUpdate` objects.

So this change adds Deprecated and Non-standard banners to the `PaymentAddress` and `PayerErrors` articles, as well as to the articles for all their member, and to the articles for the related members of the `PaymentRequest`, `PaymentResponse`, and `PaymentDetailsUpdate` objects.

The change also removes all the Specifications tables for the deprecated features (they’re no longer in the spec).

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10413