### PR TITLE
Remove page macro use in AudioContext

### DIFF
--- a/files/en-us/web/api/audiocontext/audiocontext/index.html
+++ b/files/en-us/web/api/audiocontext/audiocontext/index.html
@@ -23,17 +23,15 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">var <em>audioCtx</em> = new AudioContext();
-var <em>audioCtx</em> = new AudioContext(<em>options</em>);
-</pre>
+<pre class="brush: js">new AudioContext();
+new AudioContext(options);</pre>
 
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
   <dt><code>options</code> {{optional_inline}}</dt>
   <dd>An object based on the {{domxref("AudioContextOptions")}} dictionary that contains
-    zero or more optional properties to configure the new context. Available properties
-    are as follows: {{page("/en-US/docs/Web/API/AudioContextOptions", "Properties")}}</dd>
+    zero or more optional properties to configure the new context (see dictionary for details of the available properties).</dd>
 </dl>
 
 <h3 id="Return_value">Return value</h3>

--- a/files/en-us/web/api/audiocontextlatencycategory/index.html
+++ b/files/en-us/web/api/audiocontextlatencycategory/index.html
@@ -15,7 +15,7 @@ tags:
   - Web Audio API
   - latency
 ---
-<div>{{APIRef("Web Audio API")}}{{draft}}</div>
+<div>{{APIRef("Web Audio API")}}</div>
 
 <p><span class="seoSummary">The <code><strong>AudioContextLatencyCategory</strong></code> type is an enumerated set of strings which are used to select one of a number of default values for acceptable maximum latency of an audio context.</span> By using these strings rather than a numeric value when specifying a latency to a {{domxref("AudioContext")}}, you can allow the {{Glossary("user agent")}} to select an appropriate latency for your use case that makes sense on the device on which your content is being used.</p>
 

--- a/files/en-us/web/api/audiocontextoptions/index.html
+++ b/files/en-us/web/api/audiocontextoptions/index.html
@@ -33,9 +33,8 @@ tags:
 
 <h3 id="Standard_values_for_latencyHint">Standard values for latencyHint</h3>
 
-<p>The {{domxref("AudioContextOptions.latencyHint", "latencyHint")}} property can be number specifying a preferred maximum latency in seconds or a string from the {{domxref("AudioContextLatencyCategory")}} enumerated string, which selects a standard value for a given type of audio usage:</p>
-
-<p>{{page("/en-US/docs/Web/API/AudioContextLatencyCategory", "Values")}}</p>
+<p><em>Standard</em> values for the {{domxref("AudioContextOptions.latencyHint", "latencyHint")}} property are provided in the {{domxref("AudioContextLatencyCategory")}} enumerated string. These select an appropriate value for a given type of audio usage, e.g. <code>"balanced"</code>, <code>"interactive"</code> or <code>"playback"</code>.
+You can also specify a preferred maximum latency in seconds.</p>
 
 <h2 id="Example">Example</h2>
 

--- a/files/en-us/web/api/audiocontextoptions/latencyhint/index.html
+++ b/files/en-us/web/api/audiocontextoptions/latencyhint/index.html
@@ -37,7 +37,7 @@ var <em>latencyHint</em> = <em>audioContextOptions</em>.latencyHint;</pre>
 <p>The preferred maximum latency for the <code>AudioContext</code>. There are two ways
   this value can be specified.</p>
 
-<p>The best way to specify the preferred latency is to use a value form the string enum
+<p>The best way to specify the preferred latency is to use a value from the string enum
   {{domxref("AudioContextLatencyCategory")}}. In fact, the default value of
   <code>latencyHint</code> is <code>"interactive"</code> (meaning the browser should try
   to use the lowest possible and reliable latency it can).</p>


### PR DESCRIPTION
This is part of fixing #3196

It removes two uses of the `{{page}}` macro (and does some other minor tidy up).