### PR TITLE
AudioParamDescriptor - replace page macro with code fragment

### DIFF
--- a/files/en-us/web/api/audioparamdescriptor/index.html
+++ b/files/en-us/web/api/audioparamdescriptor/index.html
@@ -71,3 +71,10 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.AudioParamDescriptor")}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
+ <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
+</ul>

--- a/files/en-us/web/api/audioparamdescriptor/index.html
+++ b/files/en-us/web/api/audioparamdescriptor/index.html
@@ -13,7 +13,7 @@ tags:
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p><span class="seoSummary">The <code><strong>AudioParamDescriptor</strong></code> dictionary of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> specifies properties for an {{domxref("AudioParam")}} objects.</span> It is used to create custom <code>AudioParam</code>s on an {{domxref("AudioWorkletNode")}}. If the underlying {{domxref("AudioWorkletProcessor")}} has a {{domxref("AudioWorkletProcessor.parameterDescriptors", "parameterDescriptors")}} static getter, then the returned array of objects based on this dictionary is used internally by <code>AudioWorkletNode</code> constructor to populate its {{domxref("AudioWorkletNode.parameters", "parameters")}} property accordingly.
+<p><span class="seoSummary">The <code><strong>AudioParamDescriptor</strong></code> dictionary of the <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> specifies properties for {{domxref("AudioParam")}} objects.</span> It is used to create custom <code>AudioParam</code>s on an {{domxref("AudioWorkletNode")}}. If the underlying {{domxref("AudioWorkletProcessor")}} has a {{domxref("AudioWorkletProcessor.parameterDescriptors", "parameterDescriptors")}} static getter, then the returned array of objects based on this dictionary is used internally by <code>AudioWorkletNode</code> constructor to populate its {{domxref("AudioWorkletNode.parameters", "parameters")}} property accordingly.
 
 </p><h2 id="Properties">Properties</h2>
 
@@ -32,7 +32,24 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-{{page("/en-US/docs/Web/API/AudioWorkletNode/parameters", "Examples")}}
+<p>The code fragment below shows a descriptor of this type being returned by a static {{domxref("AudioWorkletProcessor.parameterDescriptors", "parameterDescriptors")}} method defined in a custom <code>AudioWorkletProcessor</code> (this is part of the more complete example in <a href="/en-US/docs/Web/API/AudioWorkletNode/parameters#examples">AudioWorkletNode.parameters</a>).</p>
+
+<pre class="brush: js">// white-noise-processor.js
+class WhiteNoiseProcessor extends AudioWorkletProcessor {
+  static get parameterDescriptors () {
+    return [{
+      name: 'customGain',
+      defaultValue: 1,
+      minValue: 0,
+      maxValue: 1,
+      automationRate: 'a-rate'
+    }]
+  }
+
+...
+}</pre>
+
+
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.html
@@ -32,8 +32,20 @@ tags:
 <h3 id="Value">Value</h3>
 
 <p>An iterable of {{domxref("AudioParamDescriptor")}}-based objects. The properties of
-  these objects are as follows: {{page("/en-US/docs/Web/API/AudioParamDescriptor",
-  "Properties")}}</p>
+  these objects are as follows:</p>
+
+  <dl>
+    <dt><code>name</code></dt>
+    <dd>The {{domxref("DOMString")}} which represents the name of the <code>AudioParam</code>. Under this name the <code>AudioParam</code> will be available in the {{domxref("AudioWorkletNode.parameters", "parameters")}} property of the node, and under this name the {{domxref("AudioWorkletProcessor.process")}} method will acquire the calculated values of this <code>AudioParam</code>.</dd>
+    <dt><code>automationRate</code> {{optional_inline}}</dt>
+    <dd>Either <code><a href="/en-US/docs/Web/API/AudioParam#a-rate">"a-rate"</a></code>, or <code><a href="/en-US/docs/Web/API/AudioParam#k-rate">"k-rate"</a></code> string which represents an automation rate of this <code>AudioParam</code>. Defaults to <code>"a-rate"</code>.</dd>
+    <dt><code>minValue</code> {{optional_inline}}</dt>
+    <dd>A <code>float</code> which represents minimum value of the <code>AudioParam</code>. Defaults to <code>-3.4028235e38</code>.</dd>
+    <dt><code>maxValue</code> {{optional_inline}}</dt>
+    <dd>A <code>float</code> which represents maximum value of the <code>AudioParam</code>. Defaults to <code>3.4028235e38</code>.</dd>
+    <dt><code>defaultValue</code> {{optional_inline}}</dt>
+    <dd>A <code>float</code> which represents initial value of the <code>AudioParam</code>. Defaults to <code>0</code>.</dd>
+   </dl>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

The [AudioParamDescriptor](https://developer.mozilla.org/en-US/docs/Web/API/AudioParamDescriptor#examples) example was pulled from [AudioWorkletNode/parameters](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletNode/parameters#examples) using page macro. This cuts out just the relevant part of the example that shows this code being used and links to the larger example.

Further, the [AudioWorkletProcessor.parameterDescriptors()](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor/parameterDescriptors) static getter was pulling the values of `AudioParamDescriptor` using the page macro. Here I decided to just copy in the values. I could have just linked but really it seems like duplicating is worthwhile for understanding easily how to use the getter.

