### PR TITLE
Note in Origin doc how no-cors mode affects GET/HEAD vs POST

### DIFF
--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -19,7 +19,7 @@ tags:
     <li>all {{Glossary("CORS", "cross origin")}} requests.</li>
     <li><a href="/en-US/docs/Web/Security/Same-origin_policy">same-origin</a> requests except for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} requests (i.e. they are added to same-origin {{HTTPMethod("POST")}}, {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("PUT")}}, {{HTTPMethod("PATCH")}}, and {{HTTPMethod("DELETE")}} requests).</li>
   </ul>
-  <p>There are some exceptions to the above rules; for example if a cross-origin request is made in <a href="/en-US/docs/Web/API/Request/mode#value">no-cors mode</a> the <code>Origin</code> header will not be added.</p>
+  <p>There are some exceptions to the above rules; for example if a cross-origin {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request is made in <a href="/en-US/docs/Web/API/Request/mode#value">no-cors mode</a> the <code>Origin</code> header will not be added.</p>
 </div>
 
 <table class="properties">


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The Origin header is however added for cross-origin POST requests, even if they are simple POST requests. This becomes clear in Point 3. of the Origin header algorithm in https://fetch.spec.whatwg.org/#append-a-request-origin-header
I have verified this behaviour in both Chrome and Firefox latest.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin

> Issue number (if there is an associated issue)
-

> Anything else that could help us review it
