### PR TITLE
Mark Accept-CH-Lifetime deprecated

### DIFF
--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.html
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.html
@@ -6,7 +6,7 @@ tags:
 - HTTP
 - header
 ---
-<div>{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}</div>
+<div>{{HTTPSidebar}}{{securecontext_header}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
 <p>The <code><strong>Accept-CH-Lifetime</strong></code> header is set by the server to
   specify the persistence of {{HTTPHeader("Accept-CH")}} header value that specifies for


### PR DESCRIPTION
https://github.com/httpwg/http-extensions/pull/878 removed the `Accept-CH-Lifetime` HTTP header from the Client Hints spec, and it’s not part of any other spec — so this change adds Deprecated and Non-standard headers to the Accept-CH-Lifetime article..

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10414