### PR TITLE
DelayNode and DelayNode.delayTime pagemacro removal

### DIFF
--- a/files/en-us/web/api/delaynode/delaytime/index.html
+++ b/files/en-us/web/api/delaynode/delaytime/index.html
@@ -34,7 +34,7 @@ myDelay.delayTime.value = 3.0;
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDelay","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDelay#example"><code>BaseAudioContext.createDelay()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/index.html
@@ -64,7 +64,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDelay","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDelay#example"><code>BaseAudioContext.createDelay()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
Part of addressing #3196

[DelayNode](https://developer.mozilla.org/en-US/docs/Web/API/DelayNode) and [DelayNode.delayTime](https://developer.mozilla.org/en-US/docs/Web/API/DelayNode/delayTime) both used the `{{page}}` macro to include the example in [BaseAudioContext.createDelay](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createDelay). This replaces the macro with "See xxx for example code" link.
