### PR TITLE
DynamicsCompressorNode - remove page macro

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -35,7 +35,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>The below code demonstrates a simple usage of <code>createDynamicsCompressor()</code>
+<p>The code below demonstrates a simple usage of <code>createDynamicsCompressor()</code>
   to add compression to an audio track. For a more complete example, have a look at our <a
     href="https://mdn.github.io/webaudio-examples/compressor-example/">basic Compressor
     example</a> (<a

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.html
@@ -28,13 +28,18 @@ compressor.attack.value = 0;
 
 <p>An {{domxref("AudioParam")}}.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDynamicsCompressor","Example")}}</p>
+<pre class="brush: js">var audioCtx = new AudioContext();
+var compressor = audioCtx.createDynamicsCompressor();
+compressor.attack.value = 0;</pre>
+
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> for more complete example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
@@ -30,18 +30,16 @@ tags:
   <dd>Options are as follows:
     <ul>
       <li><code>attack</code>: The amount of time (in seconds) to reduce the gain by 10dB.
-        Its default value is 0.003. This parameter is k-rate. Its nominal range is [0, 1].
-      </li>
+        Its default value is 0.003. This parameter is k-rate. Its nominal range is [0, 1].</li>
       <li><code>knee</code>: A decibel value representing the range above the threshold
         where the curve smoothly transitions to the "ratio" portion. Its default value is
         30. This parameter is k-rate. Its nominal range is [0, 40].</li>
       <li><code>ratio</code>: The amount of dB change in input for a 1 dB change in
         output. Its default value is 12. This parameter is k-rate. Its nominal range is
         [1, 20].</li>
-      <li>release: The amount of time (in seconds) to increase the gain by 10dB. Its
-        default value is 0.250. This parameter is k-rate. Its nominal range is [0, 1].
-      </li>
-      <li>threshold: The decibel value above which the compression will start taking
+      <li><code>release</code>: The amount of time (in seconds) to increase the gain by 10dB. Its
+        default value is 0.250. This parameter is k-rate. Its nominal range is [0, 1].</li>
+      <li><code>threshold</code>: The decibel value above which the compression will start taking
         effect. Its default value is -24. This parameter is k-rate. Its nominal range is
         [-100, 0].</li>
     </ul>

--- a/files/en-us/web/api/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/index.html
@@ -73,7 +73,7 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDynamicsCompressor","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.html
@@ -23,20 +23,24 @@ tags:
 
 <pre class="brush: js">var audioCtx = new AudioContext();
 var compressor = audioCtx.createDynamicsCompressor();
-compressor.knee.value = 40;
-</pre>
+compressor.knee.value = 40;</pre>
 
 <h3 id="Value">Value</h3>
 
 <p>An {{domxref("AudioParam")}}.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDynamicsCompressor","Example")}}</p>
+<pre class="brush: js">var audioCtx = new AudioContext();
+var compressor = audioCtx.createDynamicsCompressor();
+compressor.knee.value = 40;</pre>
+
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> for more complete example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.html
@@ -30,13 +30,18 @@ compressor.ratio.value = 12;
 
 <p>An {{domxref("AudioParam")}}.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDynamicsCompressor","Example")}}</p>
+<pre class="brush: js">var audioCtx = new AudioContext();
+var compressor = audioCtx.createDynamicsCompressor();
+compressor.ratio.value = 12;</pre>
+
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> for more complete example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/reduction/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/reduction/index.html
@@ -30,6 +30,8 @@ tags:
 var compressor = audioCtx.createDynamicsCompressor();
 var myReduction = compressor.reduction;</pre>
 
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> for more complete example code.</p>
+
 <h2 id="Specifications">Specifications</h2>
 
 <table class="standard-table">

--- a/files/en-us/web/api/dynamicscompressornode/release/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.html
@@ -28,13 +28,18 @@ compressor.release.value = 0.25;
 
 <p>An {{domxref("AudioParam")}}.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDynamicsCompressor","Example")}}</p>
+<pre class="brush: js">var audioCtx = new AudioContext();
+var compressor = audioCtx.createDynamicsCompressor();
+compressor.release.value = 0.25;</pre>
+
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> for more complete example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.html
@@ -30,13 +30,18 @@ compressor.threshold.value = -50;
 
 <p>An {{domxref("AudioParam")}}.</p>
 
-<div class="note">
-<p><strong>Note</strong>: Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.</p>
 </div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createDynamicsCompressor","Example")}}</p>
+<pre class="brush: js">var audioCtx = new AudioContext();
+var compressor = audioCtx.createDynamicsCompressor();
+compressor.threshold.value = -50;</pre>
+
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example"><code>BaseAudioContext.createDynamicsCompressor()</code></a> for more complete example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This is part of fixing #3196

[DynamicsCompressorNode](https://developer.mozilla.org/en-US/docs/Web/API/DynamicsCompressorNode) and it's properties were importing the example from [BaseAudioContext.createDynamicsCompressor](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createDynamicsCompressor#example) using the page macro.

This replaces that with the information from the syntax section + a link to the example (the syntax section has a minimal usage). Note that there is discussion ongoing about whether the syntax section should be removed for properties. 

