### PR TITLE
notes for dynamic module import via content script in webext

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
@@ -75,9 +75,10 @@ tags:
 
 <p>Using method (3), you can also load scripts into pages packaged with your extension, but you can't load scripts into privileged browser pages (like "<code>about:debugging</code>" or "<code>about:addons</code>").</p>
 
-<div class="note">
-  <p> <strong>Note:</strong> Importing a module in a webextenions content script is now working via dynamic import. For more details, see {{bug(1536094)}}.
-  Also note that only URLs with the <em>moz-extension</em> scheme are allowed, which excludes data:-URLs ({{bug(1587336)}}).</p>
+<div class="note notecard">
+  <h4>Note</h4>
+  <p><a href="/en-US/docs/Web/JavaScript/Guide/Modules#dynamic_module_loading">Dynamic JS module imports</a> are now working in content scripts. For more details, see {{bug(1536094)}}.
+  Only URLs with the <em>moz-extension</em> scheme are allowed, which excludes data URLs ({{bug(1587336)}}).</p>
   </div>
 
 <h2 id="Content_script_environment">Content script environment</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.html
@@ -75,6 +75,11 @@ tags:
 
 <p>Using method (3), you can also load scripts into pages packaged with your extension, but you can't load scripts into privileged browser pages (like "<code>about:debugging</code>" or "<code>about:addons</code>").</p>
 
+<div class="note">
+  <p> <strong>Note:</strong> Importing a module in a webextenions content script is now working via dynamic import. For more details, see {{bug(1536094)}}.
+  Also note that only URLs with the <em>moz-extension</em> scheme are allowed, which excludes data:-URLs ({{bug(1587336)}}).</p>
+  </div>
+
 <h2 id="Content_script_environment">Content script environment</h2>
 
 <h3 id="DOM_access">DOM access</h3>

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -77,8 +77,8 @@ tags:
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
 <ul>
-  <li>Webextension dynamic module imports are now working through content scripts ({{bug(1536094)}}).</li>
- </ul>
+  <li><a href="/en-US/docs/Web/JavaScript/Guide/Modules#dynamic_module_loading">Dynamic JS module imports</a> are now working in WebExtension content scripts ({{bug(1536094)}}).</li>
+</ul>
 
 <h4 id="removals_webext">Removals</h4>
 

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -76,6 +76,10 @@ tags:
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 
+<ul>
+  <li>Webextension dynamic module imports are now working through content scripts ({{bug(1536094)}}).</li>
+ </ul>
+
 <h4 id="removals_webext">Removals</h4>
 
 <h2 id="Older_versions">Older versions</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Dynamic module import is now working via content scripts, as noted in [1536094](https://bugzilla.mozilla.org/show_bug.cgi?id=1536094). 
Added line in FF 89 Release notes under _Changes for add-on developers_ regarding this development. 
Added note on the Content Scripts page to mark the functionality, as requested in [comment 34](https://bugzilla.mozilla.org/show_bug.cgi?id=1536094#c34) of the same bug.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/89#changes_for_add-on_developers
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#loading_content_scripts

> Issue number (if there is an associated issue)

Fixes https://github.com/mdn/content/issues/4307

> Anything else that could help us review it
