### PR TITLE
Align DOMContentLoaded example with compat table

### DIFF
--- a/files/en-us/web/api/window/domcontentloaded_event/index.html
+++ b/files/en-us/web/api/window/domcontentloaded_event/index.html
@@ -41,7 +41,7 @@ tags:
 
 <h3 id="Basic_usage">Basic usage</h3>
 
-<pre class="brush: js">window.addEventListener('DOMContentLoaded', (event) =&gt; {
+<pre class="brush: js">window.addEventListener('DOMContentLoaded', function(event) {
     console.log('DOM fully loaded and parsed');
 });
 </pre>


### PR DESCRIPTION
The example was not compatible in all browsers where DOMContentLoaded is. This creates confusion when copy/pasting it in a project.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
