### PR TITLE
Mark several Permission Policy features non-standard

### DIFF
--- a/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
+++ b/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - layout-animations
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
 
 <p>The HTTP {{HTTPHeader("Feature-Policy")}} header <code>layout-animations</code> directive controls whether the current document is allowed to show layout animations.</p>
 
@@ -20,25 +20,6 @@ tags:
  <dt>&lt;allowlist&gt;</dt>
  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
 </dl>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
+++ b/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - legacy-image-formats
 ---
-<p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
 <p>The HTTP {{HTTPHeader("Feature-Policy")}} header <code>legacy-image-formats</code> directive controls whether the current document is allowed to display images in legacy formats.</p>
 
@@ -20,25 +20,6 @@ tags:
  <dt>&lt;allowlist&gt;</dt>
  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
 </dl>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
@@ -7,7 +7,7 @@ tags:
   - HTTP
   - Reference
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
 
 <p>The HTTP {{HTTPHeader("Feature-Policy")}} header <code>oversized-images</code> directive controls whether the current document is allowed to download and display large images.</p>
 
@@ -23,25 +23,6 @@ tags:
 <h2 id="Default_value">Default value</h2>
 
 <p>The default value is <code>'*'</code>.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
@@ -7,7 +7,7 @@ tags:
   - HTTP
   - Reference
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
 
 <p>The HTTP {{HTTPHeader('Feature-Policy')}} header <code>unsized-media</code> directive controls whether the current document is allowed to change the size of media elements after the initial layout is complete.</p>
 
@@ -25,25 +25,6 @@ tags:
 <h2 id="Default_value">Default value</h2>
 
 <p>The default value for unsized-media is <code>'*'</code>, that is unsized media elements are allowed for all origins by default. The page will re-flow every time an image with unknown dimensions is loaded.</p>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
There is no spec for the following policy-controlled features:

* layout-animations
* legacy-image-formats
* oversized-images
* unsized-media

So this change adds a Non-standard banner to the MDN articles which document them.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10418