### PR TITLE
Removed top level await from experimental features page

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -584,42 +584,6 @@ tags:
  </tbody>
 </table>
 
-<h3 id="Top_level_await">Top level await</h3>
-
-<p>Top level await is enabled for use within <a href="/en-US/docs/Web/JavaScript/Guide/Modules">JavaScript modules</a>. You can use the <code>await</code> keyword on it's own (outside of an async function) within a module. This means modules, with child modules that use <code>await</code>, wait for the child module to execute before they themselves run. All while not blocking other child modules from loading.</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col" style="vertical-align: bottom;">Release channel</th>
-   <th scope="col" style="vertical-align: bottom;">Version added</th>
-   <th scope="col" style="vertical-align: bottom;">Enabled by default?</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <th scope="row">Nightly</th>
-   <td>85</td>
-   <td>Yes</td>
-  </tr>
-  <tr>
-   <th scope="row">Developer Edition</th>
-   <td>85</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Beta</th>
-   <td>85</td>
-   <td>No</td>
-  </tr>
-  <tr>
-   <th scope="row">Release</th>
-   <td>85</td>
-   <td>No</td>
-  </tr>
- </tbody>
-</table>
-
 <h3 id="Private_class_fields">Private class fields</h3>
 
 <p>See <a href="/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields">Private class fields</a> for more details.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Feature was already enabled in Nightly but will be out on FF Release 89 so the Experimental Feature entry is no longer needed. 
Fixes https://github.com/mdn/content/issues/4313
Related issue: https://github.com/mdn/browser-compat-data/pull/10420