### PR TITLE
updated link to developer guide

### DIFF
--- a/files/en-us/mozilla/firefox/index.html
+++ b/files/en-us/mozilla/firefox/index.html
@@ -24,7 +24,7 @@ tags:
  <dt>Project documentation</dt>
  <dd>Get detailed information about <a href="/en-US/docs/Mozilla">the internals of Firefox</a> and its build system, so you can find your way around in the code.</dd>
  <dt>Developer guide</dt>
- <dd>Our <a href="/en-US/docs/Mozilla/Developer_guide">developer guide</a> provides details on how to get and compile the Firefox source code, how to find your way around, and how to contribute to the project.</dd>
+ <dd>Our <a href="https://firefox-source-docs.mozilla.org/contributing/index.html">developer guide</a> provides details on how to get and compile the Firefox source code, how to find your way around, and how to contribute to the project.</dd>
 </dl>
 
 <h2 id="Firefox_channels">Firefox channels</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
developer guide was redirecting to mdn/archived-content

> MDN URL of the main page changed
https://github.com/mdn/archived-content/tree/main/files/en-us/mozilla/developer_guide
> Issue number (if there is an associated issue)
#4826 Part 3
> Anything else that could help us review it
