### PR TITLE
Provide clarification for <div>'s implicit role

### DIFF
--- a/files/en-us/web/html/element/div/index.html
+++ b/files/en-us/web/html/element/div/index.html
@@ -71,6 +71,10 @@ tags:
  <li>The <code>&lt;div&gt;</code> element should be used only when no other semantic element (such as {{HTMLElement("article")}} or {{HTMLElement("nav")}}) is appropriate.</li>
 </ul>
 
+<h2 id="Accessibility_concerns">Accessibility concerns</h2>
+
+The <code>&lt;div&gt;</code> element has <a href="https://www.w3.org/TR/wai-aria-1.2/#generic">an implicit role of <code>generic</code></a>, and not none. This may affect certain ARIA combination declarations that expect a direct descendant element with a certain role to function properly.
+
 <h2 id="Examples">Examples</h2>
 
 <h3 id="A_simple_example">A simple example</h3>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There is a common misconception that a `div` element has no role. This PR adds information about its implicit role of `generic`, and how it may affect certain ARIA declarations.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
