### PR TITLE
HTTP Trailer and Transfer-Encoding headers to General

### DIFF
--- a/files/en-us/glossary/general_header/index.html
+++ b/files/en-us/glossary/general_header/index.html
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - WebMechanics
 ---
-<p>A <strong>general header</strong> is an {{glossary('Header', 'HTTP header')}} that can be used in both request and response messages but doesn't apply to the content itself. Depending on the context they are used in, general headers are either {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} (e.g. {{HTTPheader("Cache-Control")}}).</p>
+<p>A <strong>general header</strong> is an {{glossary('HTTP_header', 'HTTP header')}} that can be used in both request and response messages but doesn't apply to the content itself. Depending on the context they are used in, general headers are either {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} (e.g. {{HTTPheader("Cache-Control")}}).</p>
 
 <div class="notecard note">
 <p>Current versions of the HTTP/1.1 specification do not specifically categorize headers as "general headers". Historically the general headers did not include headers that describe the payload ({{glossary("entity header", "entity headers")}}).</p>

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -13,7 +13,8 @@ tags:
   dynamically generated while the message body is sent, such as a message integrity check,
   digital signature, or post-processing status.</p>
 
-<div class="note">
+<div class="notecard note">
+  <h4>Note</h4>
   <p>The {{HTTPHeader("TE")}} request header needs to be set to "trailers" to allow
     trailer fields.</p>
 </div>
@@ -22,7 +23,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Response header")}}</td>
+      <td>{{Glossary("General header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
@@ -102,8 +103,8 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
+  If you'd like to contribute to the data, please check out 
+  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
   and send us a pull request.</p>
 
 <p>{{Compat("http.headers.Trailer")}}</p>
@@ -114,7 +115,6 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n
   <li>{{HTTPHeader("Transfer-Encoding")}}</li>
   <li>{{HTTPHeader("TE")}}</li>
   <li>
-    <p><a href="https://en.wikipedia.org/wiki/Chunked_transfer_encoding">Chunked transfer
-        encoding</a></p>
+    <p><a href="https://en.wikipedia.org/wiki/Chunked_transfer_encoding">Chunked transfer encoding</a></p>
   </li>
 </ul>

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -12,9 +12,12 @@ tags:
   encoding used to safely transfer the {{Glossary("Payload body","payload body")}} to the
   user.</p>
 
-<div class="note"><a href="https://wikipedia.org/wiki/HTTP/2">HTTP/2</a> doesn't support
-  HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient,
-  mechanisms for data streaming.</div>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p><a href="https://wikipedia.org/wiki/HTTP/2">HTTP/2</a> doesn't support
+    HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient,
+    mechanisms for data streaming.</p>
+</div>
 
 <p><code>Transfer-Encoding</code> is a <a
     href="/en-US/docs/Web/HTTP/Headers#hbh">hop-by-hop header</a>, that is applied to a
@@ -31,7 +34,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Response header")}}</td>
+      <td>{{Glossary("General header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
@@ -62,7 +65,7 @@ Transfer-Encoding: gzip, chunked</pre>
     regular chunk, with the exception that its length is zero. It is followed by the
     trailer, which consists of a (possibly empty) sequence of entity header fields.</dd>
   <dt><code>compress</code></dt>
-  <dd>A format using the <a       href="https://en.wikipedia.org/wiki/LZW">Lempel-Ziv-Welch</a> (LZW) algorithm. The
+  <dd>A format using the <a href="https://en.wikipedia.org/wiki/LZW">Lempel-Ziv-Welch</a> (LZW) algorithm. The
     value name was taken from the UNIX <em>compress</em> program, which implemented this
     algorithm.<br>
     Like the compress program, which has disappeared from most UNIX distributions, this
@@ -70,9 +73,9 @@ Transfer-Encoding: gzip, chunked</pre>
     (which expired in 2003).</dd>
   <dt><code>deflate</code></dt>
   <dd>Using the <a href="https://en.wikipedia.org/wiki/Zlib">zlib</a>
-    structure (defined in <a       href="https://datatracker.ietf.org/doc/html/rfc1950">RFC 1950</a>), with the <a
+    structure (defined in <a href="https://datatracker.ietf.org/doc/html/rfc1950">RFC 1950</a>), with the <a
       href="https://en.wikipedia.org/wiki/DEFLATE"><em>deflate</em></a>
-    compression algorithm (defined in <a       href="https://datatracker.ietf.org/doc/html/rfc1952">RFC 1951</a>).</dd>
+    compression algorithm (defined in <a href="https://datatracker.ietf.org/doc/html/rfc1952">RFC 1951</a>).</dd>
   <dt><code>gzip</code></dt>
   <dd>A format using the <a       href="https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77">Lempel-Ziv coding</a>
     (LZ77), with a 32-bit CRC. This is originally the format of the UNIX <em>gzip</em>


### PR DESCRIPTION
Fixes #4889

This changes HTTP `Trailer` and `Transfer-Encoding` from indicating that these are response headers to general headers. They are definitely not response headers because they can be used in requests too. 

General headers does not quite feel right for the reasons given in https://github.com/mdn/content/issues/4889#issuecomment-837605671 - but is better than Response.
