### PR TITLE
Mark unoptimized-images Permission Policy feature non-standard

### DIFF
--- a/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
@@ -8,7 +8,7 @@ tags:
   - Image
   - Reference
 ---
-<p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}}{{Non-standard_header}}</p>
 
 <p>The HTTP {{HTTPHeader("Feature-Policy")}} header <code>unoptimized-images</code> directive controls whether the current document is allowed to download and display unoptimized images.</p>
 
@@ -20,25 +20,6 @@ tags:
  <dt>&lt;allowlist&gt;</dt>
  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
 </dl>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
There is no spec for the `unoptimized-images` policy-controlled feature, so this change adds a Non-standard banner to its MDN article.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10418