### PR TITLE
Drop unneeded divs from RTCConfiguration.iceServers doc

### DIFF
--- a/files/en-us/web/api/rtcconfiguration/iceservers/index.html
+++ b/files/en-us/web/api/rtcconfiguration/iceservers/index.html
@@ -18,7 +18,6 @@ tags:
   - WebRTC Device API
   - iceServers
 ---
-<div id="show_cache">
   <p>{{DefaultAPISidebar("WebRTC API")}}</p>
 
   <p>The {{domxref("RTCConfiguration")}} dictionary's
@@ -104,8 +103,6 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
   <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-  <div>
-
     <p>{{Compat("api.RTCConfiguration.iceServers")}}</p>
 
     <h2 id="See_also">See also</h2>
@@ -119,5 +116,3 @@ var pc = new RTCPeerConnection(configuration);</pre>
       <li><a href="/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation">Establishing a
           connection: The WebRTC perfect negotiation pattern</a></li>
     </ul>
-  </div>
-</div>


### PR DESCRIPTION
This change drops some unnecessary `div` elements from the RTCConfiguration.iceServers article.

Otherwise, without this change, the article doesn’t render correctly — the browser-compat table shows up at the top of article, rather than near the end of the article as expected.