### PR TITLE
at first if the session don't exist it set default value to 1 and the…

### DIFF
--- a/files/en-us/learn/server-side/django/sessions/index.html
+++ b/files/en-us/learn/server-side/django/sessions/index.html
@@ -126,7 +126,7 @@ request.session.modified = True
     num_authors = Author.objects.count()  # The 'all()' is implied by default.
 
     # Number of visits to this view, as counted in the session variable.
-    num_visits = request.session.get('num_visits', 1)
+    num_visits = request.session.get('num_visits', 0)
     request.session['num_visits'] = num_visits + 1
 
     context = {


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
if the `num_visits` key does not exist in the session. it will assign 1 to the num_visits variable but it should be 0.
> MDN URL of the main page changed

> Issue number (if there is an associated issue)
> Anything else that could help us review it
