### PR TITLE
Fix broken aria-valuetext spec link

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuetext_attribute/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_aria-valuetext_attribute/index.html
@@ -6,7 +6,7 @@ tags:
   - Accessibility
   - Attribute
 ---
-<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuetext" rel="external">aria-valuetext</a> attribute is used to define the human readable text alternative of <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> for a range widget such as progressbar, spinbutton or slider.</span></p>
+<p><span class="seoSummary">The <a href="https://www.w3.org/TR/wai-aria/#aria-valuetext" rel="external">aria-valuetext</a> attribute is used to define the human readable text alternative of <a class="property-reference" href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> for a range widget such as progressbar, spinbutton or slider.</span></p>
 
 <p>Authors<strong class="rfc2119"> SHOULD</strong> only set the <code>aria-valuetext</code> attribute when the rendered value cannot be accurately represented as a number. For example, a slider may have rendered values of <code>small</code>, <code>medium</code>, and <code>large</code>. In this case, the values of <a href="/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute"><code>aria-valuenow</code></a> could range from 1 through 3, which indicate the position of each value in the value space, but the<code>aria-valuetext</code> would be one of the strings: <code>small</code>, <code>medium</code>, or <code>large</code>.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was a broken link to the aria-valuetext spec.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute

> Issue number (if there is an associated issue)

> Anything else that could help us review it
