### PR TITLE
Add serialization/parsing info to Map vs Object comparison table

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.html
@@ -45,7 +45,7 @@ browser-compat: javascript.builtins.Map
   <code>Object</code> has been used as <code>Map</code> historically.</p>
 
 <p>However, there are important differences that make <code>Map</code> preferable in
-  certain cases:</p>
+  some cases:</p>
 
 <table class="standard-table">
   <thead>
@@ -149,6 +149,15 @@ browser-compat: javascript.builtins.Map
       </td>
       <td>
         <p>Not optimized for frequent additions and removals of key-value pairs.</p>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Serialization</th>
+      <td>
+        <p>No native serialzation.</p>
+      </td>
+      <td>
+        <p>Serialization supported for <code>Object</code> via native functions JSON.stringify() and JSON.parse() as of ECMAScript 5.</p>
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.html
@@ -154,7 +154,8 @@ browser-compat: javascript.builtins.Map
     <tr>
       <th scope="row">Serialization and parsing</th>
       <td>
-        <p>No native serialzation.</p>
+        <p>No native support for serialization or parsing.</p>
+        <p>(But you can build your own serialization and parsing support for <code>Map</code> by using {{jsxref("JSON.stringify()")}} with its <em>replacer</em> argument, and by using {{jsxref("JSON.parse()")}} with its <em>reviver</em> argument. See the Stack Overflow question <a href="https://stackoverflow.com/q/29085197/">How do you JSON.stringify an ES6 Map?</a>).</p>
       </td>
       <td>
         <p>Native support for serialization from {{jsxref("Object")}} to JSON, using {{jsxref("JSON.stringify()")}}.</p>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.html
@@ -152,7 +152,7 @@ browser-compat: javascript.builtins.Map
       </td>
     </tr>
     <tr>
-      <th scope="row">Serialization</th>
+      <th scope="row">Serialization and parsing</th>
       <td>
         <p>No native serialzation.</p>
       </td>

--- a/files/en-us/web/javascript/reference/global_objects/map/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.html
@@ -157,7 +157,9 @@ browser-compat: javascript.builtins.Map
         <p>No native serialzation.</p>
       </td>
       <td>
-        <p>Serialization supported for <code>Object</code> via native functions JSON.stringify() and JSON.parse() as of ECMAScript 5.</p>
+        <p>Native support for serialization from {{jsxref("Object")}} to JSON, using {{jsxref("JSON.stringify()")}}.</p>
+        <p>Native support for parsing from JSON to {{jsxref("Object")}}, using {{jsxref("JSON.parse()")}}.</p>
+
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
The comparison table for Map vs Object shows only advantages of Map over JavaScript object which could cause the reader think that Map is superior to object in every way, which is not true.  This change adds to the table an significant difference between the 2 data types in regard to serialization that may be important when the reader is choosing between the two options.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map

> Issue number (if there is an associated issue)

> Anything else that could help us review it
