### PR TITLE
remove link wrapping period

### DIFF
--- a/files/en-us/learn/css/building_blocks/values_and_units/index.html
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.html
@@ -78,7 +78,7 @@ tags:
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/Web/CSS/dimension">&lt;dimension&gt;</a></code></td>
-   <td>A <code>&lt;dimension&gt;</code> is a <code>&lt;number&gt;</code> with a unit attached to it. For example, <code>45deg</code>, <code>5s</code>, or <code>10px</code>. <code>&lt;dimension&gt;</code> is an umbrella category that includes the <code><a href="/en-US/docs/Web/CSS/length">&lt;length&gt;</a></code>, <code><a href="/en-US/docs/Web/CSS/angle">&lt;angle&gt;</a></code>, <code><a href="/en-US/docs/Web/CSS/time">&lt;time&gt;</a></code>, and <code><a href="/en-US/docs/Web/CSS/resolution">&lt;resolution&gt;</a></code> types<a href="/en-US/docs/Web/CSS/resolution">.</a></td>
+   <td>A <code>&lt;dimension&gt;</code> is a <code>&lt;number&gt;</code> with a unit attached to it. For example, <code>45deg</code>, <code>5s</code>, or <code>10px</code>. <code>&lt;dimension&gt;</code> is an umbrella category that includes the <code><a href="/en-US/docs/Web/CSS/length">&lt;length&gt;</a></code>, <code><a href="/en-US/docs/Web/CSS/angle">&lt;angle&gt;</a></code>, <code><a href="/en-US/docs/Web/CSS/time">&lt;time&gt;</a></code>, and <code><a href="/en-US/docs/Web/CSS/resolution">&lt;resolution&gt;</a></code> types.</td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/Web/CSS/percentage">&lt;percentage&gt;</a></code></td>


### PR DESCRIPTION
MDN URL: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units
Hi, There's a link wrapping period at the end of a sentence.

#### What information was incorrect, unhelpful, or incomplete?
In [line 81](https://github.com/mdn/content/blob/e048641c1539f251c34db0341bcf47c75070d8e8/files/en-us/learn/css/building_blocks/values_and_units/index.html#L81), the last period is a link to `resolution` page: 
![image](https://user-images.githubusercontent.com/24941629/117976838-e109fa00-b338-11eb-8c65-30b380a801e0.png)

#### Specific section or headline?
Numbers, lengths, and percentages section, table, <dimension> row.


<!-- Do not make changes below this line -->
<details>
<summary>MDN Content page report details</summary>

* Folder: `en-us/learn/css/building_blocks/values_and_units`
* MDN URL: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/learn/css/building_blocks/values_and_units/index.html
* Last commit: https://github.com/mdn/content/commit/fc36604b19a172f3fbedb2629e2403180f2eda55
* Document last modified: 2021-03-19T23:16:59.000Z

</details>

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
