### PR TITLE
Correct transform function links

### DIFF
--- a/files/en-us/web/css/transform-function/translatex/index.html
+++ b/files/en-us/web/css/transform-function/translatex/index.html
@@ -259,8 +259,8 @@ transform: translateX(50%);
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li>{{cssxref("translate")}}</li>
-  <li>{{cssxref("translateY")}}</li>
+  <li><code><a href="/en-US/docs/Web/CSS/transform-function/translate">translate()</a></code></li>
+  <li><code><a href="/en-US/docs/Web/CSS/transform-function/translateY">translateY()</a></code></li>
   <li>{{cssxref("transform")}}</li>
   <li>{{cssxref("&lt;transform-function&gt;")}}</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

## What was wrong/why is this fix needed? (quick summary only)
A 'See also' link `translate()` in `translateX()` page incorrectly forwards to [CSS attribute `translate`](https://developer.mozilla.org/en-US/docs/Web/CSS/translate)

## MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translateX
