### PR TITLE
fix glitch http:// link

### DIFF
--- a/files/en-us/web/houdini/index.html
+++ b/files/en-us/web/houdini/index.html
@@ -82,5 +82,5 @@ tags:
 
 <ul>
   <li>The <a href="https://houdini.how/">Worklet library</a> for examples and code.</li>
-  <li><a href="http://houdini.glitch.me/">Interactive introduction to Houdini</a></li>
+  <li><a href="https://houdini.glitch.me/">Interactive introduction to Houdini</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Source was using `http://` for an external link

> MDN URL of the main page changed

See Review Companion

> Issue number (if there is an associated issue)

n/a

