### PR TITLE
Fix typo in description of the behavior of auto

### DIFF
--- a/files/en-us/web/css/grid-template-rows/index.html
+++ b/files/en-us/web/css/grid-template-rows/index.html
@@ -77,7 +77,7 @@ grid-template-rows: unset;
  <dt><code>auto</code></dt>
  <dd><p>As a maximum represents the largest {{cssxref("max-content")}} size of the items in that track.</p>
   <p>As a minimum represents the largest minimum size of items in that track (specified by the {{cssxref("min-width")}}/{{cssxref("min-height")}} of the items). This is often, though not always, the {{cssxref("min-content")}} size.</p>
-  <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maxium described above. This behaves similarly to <code>min-content(min-content,max-content)</code> in most cases.</p>
+  <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maxium described above. This behaves similarly to <code>minmax(min-content,max-content)</code> in most cases.</p>
 
  <div class="notecard note">
    <h4>Note:</h4>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->
First of all thanks for the amazing resource and work!

> What was wrong/why is this fix needed? (quick summary only)

There was a typo for the description of `grid-template-rows: auto`. If used outside of minmax() notation, auto ... behaves similarly to minmax(min-content,max-content) in most cases (not min-content(min-content,max-content) as previously stated).

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it
