### PR TITLE
Fix tab mixed with spaces

### DIFF
--- a/files/en-us/web/houdini/index.html
+++ b/files/en-us/web/houdini/index.html
@@ -29,7 +29,7 @@ tags:
 <p>The CSS <code>paint()</code> function parameters include the name of the worklet, along with optional parameters. The worklet also has access to the element's custom properties: they don't need to be passed as function arguments.</p>
 
 <pre class="brush: css">li {
-	background-image: paint(myComponent, stroke, 10px);
+    background-image: paint(myComponent, stroke, 10px);
     --highlights: blue;
     --lowlights: green;
 }</pre>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was a tab indent mixed in with space indentation.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Houdini

> Issue number (if there is an associated issue)

> Anything else that could help us review it
