### PR TITLE
Mark all features from DNT spec deprecated

### DIFF
--- a/files/en-us/web/api/navigator/donottrack/index.html
+++ b/files/en-us/web/api/navigator/donottrack/index.html
@@ -9,7 +9,7 @@ tags:
   - Property
   - Reference
 ---
-<div>{{ApiRef("HTML DOM")}}</div>
+<div>{{ApiRef("HTML DOM")}}{{Deprecated_header}}</div>
 
 <p>The <code><strong>Navigator.doNotTrack</strong></code> property returns the user's Do Not Track setting, which indicates whether the user is requesting web sites and advertisers to not track them.</p>
 

--- a/files/en-us/web/http/headers/dnt/index.html
+++ b/files/en-us/web/http/headers/dnt/index.html
@@ -7,7 +7,7 @@ tags:
 - Reference
 - header
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}}{{Deprecated_header}}</div>
 
 <p>The <strong><code>DNT</code></strong> (<strong>D</strong>o <strong>N</strong>ot
   <strong>T</strong>rack) request header indicates the user's tracking preference. It lets

--- a/files/en-us/web/http/headers/index.html
+++ b/files/en-us/web/http/headers/index.html
@@ -200,15 +200,6 @@ tags:
  <dd>Specifies origins that are allowed to see values of attributes retrieved via features of the <a href="/en-US/docs/Web/API/Resource_Timing_API">Resource Timing API</a>, which would otherwise be reported as zero due to cross-origin restrictions.</dd>
 </dl>
 
-<h2 id="Do_Not_Track">Do Not Track</h2>
-
-<dl>
- <dt>{{HTTPHeader("DNT")}}</dt>
- <dd>Expresses the user's tracking preference.</dd>
- <dt>{{HTTPHeader("Tk")}}</dt>
- <dd>Indicates the tracking status of the corresponding response.</dd>
-</dl>
-
 <h2 id="Downloads">Downloads</h2>
 
 <dl>

--- a/files/en-us/web/http/headers/tk/index.html
+++ b/files/en-us/web/http/headers/tk/index.html
@@ -9,7 +9,7 @@ tags:
 - header
 - tracking
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}}{{Deprecated_header}}</div>
 
 <p>The <strong><code>Tk</code></strong> response header indicates the tracking status that
   applied to the corresponding request.</p>

--- a/files/en-us/web/http/resources_and_specifications/index.html
+++ b/files/en-us/web/http/resources_and_specifications/index.html
@@ -249,11 +249,6 @@ tags:
    <td>{{Spec2("HTML WHATWG")}}</td>
   </tr>
   <tr>
-   <td><a href="https://www.w3.org/2011/tracking-protection/drafts/tracking-dnt.html">Tracking Preference Expression</a></td>
-   <td>DNT header</td>
-   <td>Editor's draft / Candidate recommendation</td>
-  </tr>
-  <tr>
    <td><a href="https://wicg.github.io/reporting/">Reporting API</a></td>
    <td><code>Report-To</code> header</td>
    <td>Draft</td>


### PR DESCRIPTION
The https://www.w3.org/TR/tracking-dnt/ spec never made it to W3C Recommendation; instead it was retired as a Working Group Note:

https://www.w3.org/TR/2019/NOTE-tracking-dnt-20190117/

In the W3C spec database its formal status is Retired:

https://www.w3.org/TR/?tag=privacy&status=ret

And the Status section of https://www.w3.org/TR/tracking-dnt/ itself says:

> Since its last publication as a Candidate Recommendation, there has not been sufficient deployment of these extensions (as defined) to justify further advancement, nor have there been indications of planned support among user agents, third parties, and the ecosystem at large.

All of that is sufficient to merit the features being marked as deprecated in BCD.

So this change adds a Deprecated banner to the following articles:

* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Tk
* https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack

Related BCD change: https://github.com/mdn/browser-compat-data/pull/10469