### PR TITLE
Update GitHub pages instructions

### DIFF
--- a/files/en-us/learn/common_questions/using_github_pages/index.html
+++ b/files/en-us/learn/common_questions/using_github_pages/index.html
@@ -83,9 +83,9 @@ tags:
 git commit -m 'adding my files to my repository'</pre>
  </li>
  <li>Finally, push the code up to GitHub by going to the GitHub web page you're on and entering into the terminal the second of the two commands we saw the <em>…or push an existing repository from the command line</em> section:
-  <pre class="brush: bash">git push -u origin master</pre>
+  <pre class="brush: bash">git push -u origin main</pre>
  </li>
- <li>Now you need to turn GitHub pages on for your repository. To do this, from the homepage of your repository choose <em>Settings</em>, then scroll down until  you get to the <em>GitHub Pages</em> section. Underneath <em>Source</em>, choose Master branch. The page should refresh.</li>
+ <li>Now you need to turn GitHub pages on for your repository. To do this, from the homepage of your repository choose <em>Settings</em>, then select <em>Pages</em> from the sidebar on the left. Underneath <em>Source</em>, choose the "main" branch. The page should refresh.</li>
  <li>Go to the GitHub Pages section again, and you should see a line of the form "Your site is ready to be published at https://xxxxxx."</li>
  <li>If you click on this URL, you should go to a live version of your example, provided the home page is called <code>index.html</code> — it goes to this entry point by default. If your site's entry point is called something else, for example <code>myPage.html</code>, you'll need to go to <code>https://xxxxxx/myPage.html</code>.</li>
 </ol>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/4953.

But IMO we should not document GitHub on MDN, we should just point to their docs: https://pages.github.com/. Maybe I should rework this article to do that instead?