### PR TITLE
close #4957 by linking to slice() from splice() pg

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Array.splice
 
 <p>The <strong><code>splice()</code></strong> method changes the contents of an array by
   removing or replacing existing elements and/or adding new elements <a
-    href="https://en.wikipedia.org/wiki/In-place_algorithm">in place</a>.</p>
+    href="https://en.wikipedia.org/wiki/In-place_algorithm">in place</a>. If you would like to access part of an array without modifying it, please see {{jsxref("Array.prototype.slice()", "slice()")}} instead.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-splice.html")}}</div>
 

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.html
@@ -16,7 +16,7 @@ browser-compat: javascript.builtins.Array.splice
 
 <p>The <strong><code>splice()</code></strong> method changes the contents of an array by
   removing or replacing existing elements and/or adding new elements <a
-    href="https://en.wikipedia.org/wiki/In-place_algorithm">in place</a>. If you would like to access part of an array without modifying it, please see {{jsxref("Array.prototype.slice()", "slice()")}} instead.</p>
+    href="https://en.wikipedia.org/wiki/In-place_algorithm">in place</a>. To access part of an array without modifying it, see {{jsxref("Array.prototype.slice()", "slice()")}}.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-splice.html")}}</div>
 


### PR DESCRIPTION
This commit tries to close https://github.com/mdn/content/issues/4957.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I think it would be helpful to readers if we linked to [`Array.prototype.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) from [`Array.prototype.splice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)'s page since a reader might look for one while on the page of the other.
> MDN URL of the main page changed

[`Array.prototype.splice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)
> Issue number (if there is an associated issue)

#4957 
> Anything else that could help us review it
