### PR TITLE
Replace deprecation with warning in hgroup

### DIFF
--- a/files/en-us/web/guide/html/content_categories/index.html
+++ b/files/en-us/web/guide/html/content_categories/index.html
@@ -19,8 +19,9 @@ tags:
  <li>Specific content categories, which describe rare categories shared only by a few elements, sometimes only in a specific context.</li>
 </ul>
 
-<div class="note">
-<p><strong>Note:</strong> A more detailed discussion of these content categories and their comparative functionalities is beyond the scope of this article; for that, you may wish to read the <a href="https://html.spec.whatwg.org/multipage/dom.html#kinds-of-content">relevant portions of the HTML specification</a>.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>A more detailed discussion of these content categories and their comparative functionalities is beyond the scope of this article; for that, you may wish to read the <a href="https://html.spec.whatwg.org/multipage/dom.html#kinds-of-content">relevant portions of the HTML specification</a>.</p>
 </div>
 
 <p><a href="/en-US/docs/Web/Guide/HTML/Content_categories/content_categories_venn.png"><img alt="A Venn diagram showing how the various content categories interrelate. The following sections explain these relationships in text." class="default internal" src="content_categories_venn.png"></a></p>
@@ -68,8 +69,9 @@ tags:
 <p>Though likely to contain heading content, the {{HTMLElement("header")}} is not heading content itself.</p>
 </div>
 
-<div class="note">
-<p><strong>Note:</strong> The {{HTMLElement("hgroup")}} element was removed from the W3C HTML specification prior to HTML 5 being finalized, but is still part of the WHATWG specification and is at least partially supported by most browsers.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>The {{HTMLElement("hgroup")}} element is not recommended as it does not work properly with assistive technologies. It was removed from the W3C HTML specification prior to HTML 5 being finalized, but is still part of the WHATWG specification and is at least partially supported by most browsers.</p>
 </div>
 
 <h3 id="Phrasing_content">Phrasing content</h3>

--- a/files/en-us/web/html/element/hgroup/index.html
+++ b/files/en-us/web/html/element/hgroup/index.html
@@ -10,7 +10,14 @@ tags:
   - Reference
   - Web
 ---
-<div>{{HTMLRef}}{{deprecated_header}}</div>
+<div>{{HTMLRef}}</div>
+
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p><code>&lt;hgroup&gt;</code> should not be used because no assistive technology supports it, and because has a detrimental effect on assistance for headings placed within it.</p>
+  <p>For more information see the <a href="#usage_notes">Usage notes below</a>.</p>
+
+</div>
 
 <p>The <strong>HTML <code>&lt;hgroup&gt;</code> element</strong> represents a multi-level heading for a section of a document. It groups a set of <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> elements.</p>
 

--- a/files/en-us/web/html/element/hgroup/index.html
+++ b/files/en-us/web/html/element/hgroup/index.html
@@ -14,9 +14,8 @@ tags:
 
 <div class="notecard warning">
   <h4>Warning</h4>
-  <p><code>&lt;hgroup&gt;</code> should not be used because no assistive technology supports it, and because has a detrimental effect on assistance for headings placed within it.</p>
+  <p><code>&lt;hgroup&gt;</code> should not be used because no assistive technology supports it, and as a result it has a detrimental effect on assistance for headings placed within it.</p>
   <p>For more information see the <a href="#usage_notes">Usage notes below</a>.</p>
-
 </div>
 
 <p>The <strong>HTML <code>&lt;hgroup&gt;</code> element</strong> represents a multi-level heading for a section of a document. It groups a set of <code><a href="/en-US/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> elements.</p>

--- a/files/en-us/web/html/element/index.html
+++ b/files/en-us/web/html/element/index.html
@@ -125,7 +125,7 @@ tags:
 
 <div class="notecard warning">
   <h4>Warning</h4>
-  <p>These are old HTML elements which are deprecated and should not be used. <strong>You should never use them in new projects, and should replace them in old projects as soon as you can.</strong> They are listed here for informational purposes only.</p>
+  <p>These are old HTML elements which are deprecated and should not be used. <strong>You should never use them in new projects, and should replace them in old projects as soon as you can.</strong> They are listed here for completeness only.</p>
 </div>
 
 <p>{{HTMLRefTable({"include":["Deprecated","Obsolete"]})}}</p>

--- a/files/en-us/web/html/element/index.html
+++ b/files/en-us/web/html/element/index.html
@@ -13,8 +13,9 @@ tags:
 
 <p><span class="seoSummary">This page lists all the {{Glossary("HTML")}} {{Glossary("Element","elements")}}, which are created using {{Glossary("Tag", "tags")}}.</span> They are grouped by function to help you find what you have in mind easily. An alphabetical list of all elements is provided in the sidebar on every element's page as well as this one.</p>
 
-<div class="note">
-<p>For more information about the basics of HTML elements and attributes, see <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML#elements_%e2%80%94_the_basic_building_blocks">the section on elements in the Introduction to HTML article</a>.</p>
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>For more information about the basics of HTML elements and attributes, see <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML#elements_%e2%80%94_the_basic_building_blocks">the section on elements in the Introduction to HTML article</a>.</p>
 </div>
 
 <h2 id="Main_root">Main root</h2>
@@ -122,8 +123,9 @@ tags:
 
 <h2 id="Obsolete_and_deprecated_elements">Obsolete and deprecated elements</h2>
 
-<div class="warning">
-<p><strong>Warning:</strong> These are old HTML elements which are deprecated and should not be used. <strong>You should never use them in new projects, and should replace them in old projects as soon as you can.</strong> They are listed here for informational purposes only.</p>
+<div class="notecard warning">
+  <h4>Warning</h4>
+  <p>These are old HTML elements which are deprecated and should not be used. <strong>You should never use them in new projects, and should replace them in old projects as soon as you can.</strong> They are listed here for informational purposes only.</p>
 </div>
 
 <p>{{HTMLRefTable({"include":["Deprecated","Obsolete"]})}}</p>


### PR DESCRIPTION
This changes the deprecation at top of the [hgroup](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup) to a warning note. The reason is that while the API should not be used until it properly supports assistive technologies, it is still in at least some formal specifications and not officially deprecated (and as such there is a mismatch with browser compatibility data too). This follows on from discussed in https://github.com/mdn/content/pull/2902#issuecomment-835348857

I have not removed the tag "Deprecated" from `hgroup` which means that it is still listed in [HTML elements reference > Obsolete and deprecated elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#obsolete_and_deprecated_elements). That is technically incorrect, but I still don't want to promote it's use.

Note that when/if this is really deprecated we should do a much more thorough tagging exercise as mention of hgroup is scattered through the docs (e.g. anywhere we list that the 