### PR TITLE
Modify HTTP General headers to refer to Request/Response headers

### DIFF
--- a/files/en-us/web/http/headers/cache-control/index.html
+++ b/files/en-us/web/http/headers/cache-control/index.html
@@ -16,7 +16,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>{{Glossary("General header")}}</td>
+   <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/cache-control/index.html
+++ b/files/en-us/web/http/headers/cache-control/index.html
@@ -3,9 +3,10 @@ title: Cache-Control
 slug: Web/HTTP/Headers/Cache-Control
 tags:
   - Cache-Control
-  - General Header
   - HTTP
   - HTTP Header
+  - Request header
+  - Response header
   - Reference
 ---
 <div>{{HTTPSidebar}}</div>

--- a/files/en-us/web/http/headers/connection/index.html
+++ b/files/en-us/web/http/headers/connection/index.html
@@ -3,7 +3,9 @@ title: Connection
 slug: Web/HTTP/Headers/Connection
 tags:
 - HTTP
-- Headers
+- HTTP Header
+- Request header
+- Response header
 - Reference
 - Web
 ---
@@ -15,6 +17,7 @@ tags:
   subsequent requests to the same server to be done.</p>
 
 <div class="notecard warning">
+  <h4>Warning</h4>
   <p>Connection-specific header fields such as {{HTTPHeader("Connection")}} and
     {{HTTPHeader("Keep-Alive")}} are <a
       href="https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2">prohibited in HTTP/2</a>.

--- a/files/en-us/web/http/headers/connection/index.html
+++ b/files/en-us/web/http/headers/connection/index.html
@@ -34,7 +34,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/content-disposition/index.html
+++ b/files/en-us/web/http/headers/content-disposition/index.html
@@ -18,8 +18,8 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>{{Glossary("Response header")}} (for the main body)<br>
-    {{Glossary("General header")}} (for a subpart of a multipart body)</td>
+   <td>{{Glossary("Response header")}} (for the main body),
+      <br>{{Glossary("Request header")}}, {{Glossary("Response header")}} (for a subpart of a multipart body)</td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/content-disposition/index.html
+++ b/files/en-us/web/http/headers/content-disposition/index.html
@@ -3,8 +3,10 @@ title: Content-Disposition
 slug: Web/HTTP/Headers/Content-Disposition
 tags:
   - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
   - Reference
-  - header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/date/index.html
+++ b/files/en-us/web/http/headers/date/index.html
@@ -29,7 +29,7 @@ tags:
 	<tbody>
 		<tr>
 			<th scope="row">Header type</th>
-			<td>{{Glossary("General header")}}</td>
+			<td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
 		</tr>
 		<tr>
 			<th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/date/index.html
+++ b/files/en-us/web/http/headers/date/index.html
@@ -2,10 +2,11 @@
 title: Date
 slug: Web/HTTP/Headers/Date
 tags:
-- General Header
 - HTTP
+- HTTP Header
+- Request header
+- Response header
 - Reference
-- header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/keep-alive/index.html
+++ b/files/en-us/web/http/headers/keep-alive/index.html
@@ -2,9 +2,10 @@
 title: Keep-Alive
 slug: Web/HTTP/Headers/Keep-Alive
 tags:
-  - General Header
   - HTTP
   - HTTP Header
+  - Request header
+  - Response header
   - Reference
 ---
 <div>{{HTTPSidebar}}</div>

--- a/files/en-us/web/http/headers/keep-alive/index.html
+++ b/files/en-us/web/http/headers/keep-alive/index.html
@@ -23,7 +23,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>{{Glossary("General header")}}</td>
+   <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/pragma/index.html
+++ b/files/en-us/web/http/headers/pragma/index.html
@@ -13,7 +13,7 @@ tags:
 <p>The <code><strong>Pragma</strong></code> HTTP/1.0 general header is an
   implementation-specific header that may have various effects along the request-response
   chain. It is used for backwards compatibility with HTTP/1.0 caches where the
-  <code>Cache-Control</code> HTTP/1.1 header is not yet present.</p>
+  {{HTTPHeader("Cache-Control")}} HTTP/1.1 header is not yet present.</p>
 
 <div class="note">
   <p><strong>Note</strong>: <code>Pragma</code> is not specified for HTTP responses and is
@@ -28,8 +28,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}, but response behavior is not specified and thus
-        implementation-specific.</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}} (response behavior is not specified and thus implementation-specific).</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/pragma/index.html
+++ b/files/en-us/web/http/headers/pragma/index.html
@@ -2,11 +2,12 @@
 title: Pragma
 slug: Web/HTTP/Headers/Pragma
 tags:
-- Caching
-- Deprecated
-- HTTP
-- header
-- request
+  - Caching
+  - Deprecated
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -2,9 +2,10 @@
 title: Trailer
 slug: Web/HTTP/Headers/Trailer
 tags:
-- HTTP
-- Reference
-- header
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -23,7 +23,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -2,9 +2,11 @@
 title: Transfer-Encoding
 slug: Web/HTTP/Headers/Transfer-Encoding
 tags:
-- HTTP
-- Reference
-- header
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
+  - Reference
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -34,7 +34,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/upgrade/index.html
+++ b/files/en-us/web/http/headers/upgrade/index.html
@@ -18,7 +18,7 @@ tags:
 	<tbody>
 		<tr>
 			<th scope="row">Header type</th>
-			<td>{{Glossary("General header")}}</td>
+			<td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
 		</tr>
 		<tr>
 			<th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/upgrade/index.html
+++ b/files/en-us/web/http/headers/upgrade/index.html
@@ -4,6 +4,8 @@ slug: Web/HTTP/Headers/Upgrade
 tags:
   - HTTP
   - HTTP Header
+  - Request header
+  - Response header
   - Upgrade
 ---
 <p>{{HTTPSidebar}}</p>

--- a/files/en-us/web/http/headers/via/index.html
+++ b/files/en-us/web/http/headers/via/index.html
@@ -17,7 +17,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/via/index.html
+++ b/files/en-us/web/http/headers/via/index.html
@@ -2,9 +2,11 @@
 title: Via
 slug: Web/HTTP/Headers/Via
 tags:
-- HTTP
-- Reference
-- header
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
+  - Reference
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/want-digest/index.html
+++ b/files/en-us/web/http/headers/want-digest/index.html
@@ -35,7 +35,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/want-digest/index.html
+++ b/files/en-us/web/http/headers/want-digest/index.html
@@ -2,8 +2,10 @@
 title: Want-Digest
 slug: Web/HTTP/Headers/Want-Digest
 tags:
-- HTTP
-- HTTP Header
+  - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/warning/index.html
+++ b/files/en-us/web/http/headers/warning/index.html
@@ -2,10 +2,11 @@
 title: Warning
 slug: Web/HTTP/Headers/Warning
 tags:
-  - General Header
   - HTTP
+  - HTTP Header
+  - Request header
+  - Response header
   - Reference
-  - header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/warning/index.html
+++ b/files/en-us/web/http/headers/warning/index.html
@@ -2,10 +2,10 @@
 title: Warning
 slug: Web/HTTP/Headers/Warning
 tags:
-- General Header
-- HTTP
-- Reference
-- header
+  - General Header
+  - HTTP
+  - Reference
+  - header
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -29,7 +29,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
@@ -75,7 +75,7 @@ tags:
 <h2 id="Warning_codes">Warning codes</h2>
 
 <p>The <a
-    href="http://www.iana.org/assignments/http-warn-codes/http-warn-codes.xhtml">HTTP Warn
+    href="https://www.iana.org/assignments/http-warn-codes/http-warn-codes.xhtml">HTTP Warn
     Codes registry at iana.org</a> defines the namespace for warn codes.</p>
 
 <table class="standard-table">


### PR DESCRIPTION
The term "General header" is no longer used in the HTTP/1.1 spec. This change replaces that glossary term in the HTTP header doc information tables that are affected by a comma separate list of the Request, Response headers. 

Discussion on this in https://github.com/mdn/content/issues/4889#issuecomment-838212373

There is more work to be done around this, but will do as separate PR.