### PR TITLE
Add dl syntax to Markdown spec

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -231,7 +231,7 @@ const greeting = "I'm a good example";
 <ul>
   <li>The GFM <code>&lt;ul&gt;</code> contains any number of top-level GFM <code>&lt;li&gt;</code> elements.</li>
   <li>Each of these top-level GFM <code>&lt;li&gt;</code> elements must contain, as its final element, one GFM <code>&lt;ul&gt;</code> element.</li>
-  <li>This final nested <code>&lt;ul&gt;</code> must contain a single GFM <code>&lt;li&gt;</code> element, whose text content must start with <code>:&nbsp;</code> (a colon followed by a space).</li>
+  <li>This final nested <code>&lt;ul&gt;</code> must contain a single GFM <code>&lt;li&gt;</code> element, whose text content must start with <code>:&nbsp;</code> (a colon followed by a space). This element may contain block elements, including paragraphs, code blocks, embedded lists, and notes.</li>
 </ul>
 
 <p>Each of these top-level GFM <code>&lt;li&gt;</code> elements will be transformed into a
@@ -246,11 +246,11 @@ const greeting = "I'm a good example";
 For example, this is a <code>&lt;dl&gt;</code>:
 
 <pre>
-* `param1`
-    * : My description of param 1
+* term1
+    * : My description of term1
 
-* `param2`
-    * : My description of param 2
+* `term2`
+    * : My description of term2
 
       It can have multiple paragraphs, and code blocks too:
 
@@ -264,16 +264,16 @@ In GFM/CommonMark, this would produce the following HTML:
 <pre class="brush: html">
 &lt;ul&gt;
   &lt;li&gt;
-    &lt;p&gt;&lt;code&gt;param1&lt;/code&gt;&lt;/p&gt;
+    &lt;p&gt;term1&lt;/p&gt;
     &lt;ul&gt;
-      &lt;li&gt;: My description of param 1&lt;/li&gt;
+      &lt;li&gt;: My description of term1&lt;/li&gt;
     &lt;/ul&gt;
   &lt;/li&gt;
   &lt;li&gt;
-    &lt;p&gt;&lt;code&gt;param2&lt;/code&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;code&gt;term2&lt;/code&gt;&lt;/p&gt;
     &lt;ul&gt;
       &lt;li&gt;
-        &lt;p&gt;: My description of param 2&lt;/p&gt;
+        &lt;p&gt;: My description of term2&lt;/p&gt;
         &lt;p&gt;It can have multiple paragraphs, and code blocks too:&lt;/p&gt;
         &lt;pre&gt;
           &lt;code class="brush: js"&gt;const thing = 1;&lt;/code&gt;
@@ -289,14 +289,14 @@ On MDN, this would produce the following HTML:
 <pre class="brush: html">
 &lt;dl&gt;
   &lt;dt&gt;
-    &lt;p&gt;&lt;code&gt;param1&lt;/code&gt;&lt;/p&gt;
+    &lt;p&gt;term1&lt;/p&gt;
   &lt;/dt&gt;
-  &lt;dd&gt;My description of param 1&lt;/dd&gt;
+  &lt;dd&gt;My description of term1&lt;/dd&gt;
   &lt;dt&gt;
-    &lt;p&gt;&lt;code&gt;param2&lt;/code&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;code&gt;term2&lt;/code&gt;&lt;/p&gt;
   &lt;/dt&gt;
   &lt;dd&gt;
-    &lt;p&gt;My description of param 2&lt;/p&gt;
+    &lt;p&gt;My description of term2&lt;/p&gt;
     &lt;p&gt;It can have multiple paragraphs, and code blocks too:&lt;/p&gt;
     &lt;pre&gt;
        &lt;code class="brush: js"&gt;const thing = 1;&lt;/code&gt;

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -307,6 +307,13 @@ On MDN, this would produce the following HTML:
 
 <p>Definition lists written using this syntax must consist of pairs of <code>&lt;dt&gt;</code>/<code>&lt;dd&gt;</code> elements. Using this syntax, it's not possible to write a list with more than one consecutive <code>&lt;dt&gt;</code> element or more than one consecutive <code>&lt;dd&gt;</code> element: the parser will treat this as an error. We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.</p>
 
+<p>As a workaround for cases where an author needs to associate multiple <code>&lt;dt&gt;</code> items with a single <code>&lt;dd&gt;</code>, consider providing them as a single <code>&lt;dt&gt;</code> that holds multiple terms, separated by commas, like this:<p>
+
+<pre>
+* `param1`, `param2`, `param3`
+    * : My description of params 1, 2, and 3
+</pre>
+
 <p>The rationale for the syntax described here is that it works well enough with tools that expect CommonMark (for example, Prettier or GitHub previews) while being reasonably easy to write and to parse.</p>
 
 <h2>Tables</h2>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -226,6 +226,89 @@ const greeting = "I'm a good example";
 
 <h2>Definition lists</h2>
 
+<p>To create definition lists in MDN authors write a modified form of a GFM unordered list ({{HTMLElement("ul")}}). In this form:</p>
+
+<ul>
+  <li>The GFM <code>&lt;ul&gt;</code> contains any number of top-level GFM <code>&lt;li&gt;</code> elements.</li>
+  <li>Each of these top-level GFM <code>&lt;li&gt;</code> elements must contain, as its final element, one GFM <code>&lt;ul&gt;</code> element.</li>
+  <li>This final nested <code>&lt;ul&gt;</code> must contain a single GFM <code>&lt;li&gt;</code> element, whose text content must start with <code>:&nbsp;</code> (a colon followed by a space).</li>
+</ul>
+
+<p>Each of these top-level GFM <code>&lt;li&gt;</code> elements will be transformed into a
+  <code>&lt;dt&gt;</code>/<code>&lt;dd&gt;</code> pair, as follows:</p>
+
+<ul>
+  <li>The top-level GFM <code>&lt;li&gt;</code> element will be parsed as a GFM <code>&lt;li&gt;</code> element
+    and its internal contents will comprise the contents of the <code>&lt;dt&gt;</code>, except for the final nested <code>&lt;ul&gt;</code>, which will not be included in the <code>&lt;dt&gt;</code>.
+  <li>The <code>&lt;li&gt;</code> element in the final nested <code>&lt;ul&gt;</code> will be parsed as a GFM <code>&lt;li&gt;</code> element and its internal contents will comprise the contents of the <code>&lt;dd&gt;</code>, except for the leading <code>:&nbsp;</code>, which will be discarded.</li>
+</ul>
+
+For example, this is a <code>&lt;dl&gt;</code>:
+
+<pre>
+* `param1`
+    * : My description of param 1
+
+* `param2`
+    * : My description of param 2
+
+      It can have multiple paragraphs, and code blocks too:
+
+      ```js
+      const thing = 1;
+      ```
+</pre>
+
+In GFM/CommonMark, this would produce the following HTML:
+
+<pre class="brush: html">
+&lt;ul&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;code&gt;param1&lt;/code&gt;&lt;/p&gt;
+    &lt;ul&gt;
+      &lt;li&gt;: My description of param 1&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/li&gt;
+  &lt;li&gt;
+    &lt;p&gt;&lt;code&gt;param2&lt;/code&gt;&lt;/p&gt;
+    &lt;ul&gt;
+      &lt;li&gt;
+        &lt;p&gt;: My description of param 2&lt;/p&gt;
+        &lt;p&gt;It can have multiple paragraphs, and code blocks too:&lt;/p&gt;
+        &lt;pre&gt;
+          &lt;code class="brush: js"&gt;const thing = 1;&lt;/code&gt;
+        &lt;/pre&gt;
+      &lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/li&gt;
+&lt;/ul&gt;
+</pre>
+
+On MDN, this would produce the following HTML:
+
+<pre class="brush: html">
+&lt;dl&gt;
+  &lt;dt&gt;
+    &lt;p&gt;&lt;code&gt;param1&lt;/code&gt;&lt;/p&gt;
+  &lt;/dt&gt;
+  &lt;dd&gt;My description of param 1&lt;/dd&gt;
+  &lt;dt&gt;
+    &lt;p&gt;&lt;code&gt;param2&lt;/code&gt;&lt;/p&gt;
+  &lt;/dt&gt;
+  &lt;dd&gt;
+    &lt;p&gt;My description of param 2&lt;/p&gt;
+    &lt;p&gt;It can have multiple paragraphs, and code blocks too:&lt;/p&gt;
+    &lt;pre&gt;
+       &lt;code class="brush: js"&gt;const thing = 1;&lt;/code&gt;
+    &lt;/pre&gt;
+  &lt;/dd&gt;
+&lt;/dl&gt;
+</pre>
+
+<p>Definition lists written using this syntax must consist of pairs of <code>&lt;dt&gt;</code>/<code>&lt;dd&gt;</code> elements. Using this syntax, it's not possible to write a list with more than one consecutive <code>&lt;dt&gt;</code> element or more than one consecutive <code>&lt;dd&gt;</code> element: the parser will treat this as an error. We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.</p>
+
+<p>Definition lists ({{HTMLElement("dl")}}) are not supported in GFM. There is an Markdown syntax for them that is used in <a href="https://kramdown.gettalong.org/syntax.html#definition-lists">Kramdown</a>, but it's incompatible with tooling that expects to see GFM or CommonMark (for example, Prettier or GitHub previews). The rationale for the syntax described here is that it works well enough with tools that expect CommonMark while being reasonably easy to write and to parse.</p>
+
 <h2>Tables</h2>
 
 <p>In GFM (but not CommonMark) there is a syntax for tables: <a href="https://github.github.com/gfm/#tables-extension-">https://github.github.com/gfm/#tables-extension-</a>. We will make use of this but the GFM syntax only supports a subset of the features available in HTML.</p>

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -307,7 +307,7 @@ On MDN, this would produce the following HTML:
 
 <p>Definition lists written using this syntax must consist of pairs of <code>&lt;dt&gt;</code>/<code>&lt;dd&gt;</code> elements. Using this syntax, it's not possible to write a list with more than one consecutive <code>&lt;dt&gt;</code> element or more than one consecutive <code>&lt;dd&gt;</code> element: the parser will treat this as an error. We expect almost all definition lists on MDN will work with this limitation, and for those that do not, authors can fall back to raw HTML.</p>
 
-<p>Definition lists ({{HTMLElement("dl")}}) are not supported in GFM. There is an Markdown syntax for them that is used in <a href="https://kramdown.gettalong.org/syntax.html#definition-lists">Kramdown</a>, but it's incompatible with tooling that expects to see GFM or CommonMark (for example, Prettier or GitHub previews). The rationale for the syntax described here is that it works well enough with tools that expect CommonMark while being reasonably easy to write and to parse.</p>
+<p>The rationale for the syntax described here is that it works well enough with tools that expect CommonMark (for example, Prettier or GitHub previews) while being reasonably easy to write and to parse.</p>
 
 <h2>Tables</h2>
 


### PR DESCRIPTION
This attempts to document the Markdown syntax for `<dl>` that we have discussed in https://github.com/mdn/content/issues/4367.