### PR TITLE
Adds the SVGMarkerElement Interface

### DIFF
--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -1,0 +1,122 @@
+---
+title: SVGMarkerElement
+slug: Web/API/SVGMarkerElement
+tags:
+  - API
+  - Interface
+  - Reference
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>SVGMarkerElement</code></strong> interface provides access to the properties of {{SVGElement("marker")}} elements, as well as methods to manipulate them. The {{SVGElement("marker")}} element defines the graphics used for drawing marks on a shape.</p>
+
+<p>{{InheritanceDiagram(600, 140)}}</p>
+
+<p>The following properties and methods all return, or act on the attributes of the {{SVGElement("marker")}} element represented by <code>SVGMarkerElement</code>.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>This interface also inherits properties from its parent, {{domxref("SVGElement")}}, and implements properties from {{domxref("SVGFitToViewBox")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("SVGMarkerElement.markerUnits")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedEnumeration")}} object, with one of the following values:
+    <dl>
+      <dt>0</dt>
+      <dd><code>SVG_MARKERUNITS_UNKNOWN</code> which means that the {{SVGattr("markerUnits")}} attribute has a value other than the two predefined keywords.</dd>
+      <dt>1</dt>
+      <dd><code>SVG_MARKERUNITS_USERSPACEONUSE</code> which means that the {{SVGattr("markerUnits")}} attribute has the keyword value <code>userSpaceOnUse</code>.</dd>
+      <dt>2</dt>
+      <dd><code>SVG_MARKERUNITS_STROKEWIDTH</code> which means that the {{SVGattr("markerUnits")}} attribute has the keyword value <code>strokeWidth</code>.</dd>
+    </dl>
+  </dd>
+  <dt>{{domxref("SVGMarkerElement.markerWidth")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the width of the {{SVGElement("marker")}} viewport.</dd>
+  <dt>{{domxref("SVGMarkerElement.markerHeight")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the height of the {{SVGElement("marker")}} viewport.</dd>
+  <dt>{{domxref("SVGMarkerElement.orientType")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedEnumeration")}} object, with one of the following values:
+    <dl>
+      <dt>0</dt>
+      <dd><code>SVG_MARKER_ORIENT_UNKNOWN</code> which means that the {{SVGattr("orient")}} attribute has a value other than the two predefined keywords.</dd>
+      <dt>1</dt>
+      <dd><code>SVG_MARKERUNITS_ORIENT_AUTO</code> which means that the {{SVGattr("orient")}} attribute has the keyword value <code>auto</code>.</dd>
+      <dt>2</dt>
+      <dd><code>SVG_MARKERUNITS_ORIENT_ANGLE</code> which means that the {{SVGattr("orient")}} attribute has an {{cssxref("angle")}} or {{cssxref("number")}} value indicating the angle.</dd>
+    </dl>
+  </dd>
+  <dt>{{domxref("SVGMarkerElement.orientAngle")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedAngle")}} object containing the angle of the {{SVGattr("orient")}} attribute.</dd>
+  <dt>{{domxref("SVGMarkerElement.refX")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.</dd>
+  <dt>{{domxref("SVGMarkerElement.refY")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>This interface also inherits methods from its parent, {{domxref("SVGElement")}}, and implements methods from {{domxref("SVGFitToViewBox")}}</em></p>
+
+<dl>
+  <dt>{{domxref("SVGMarkerElement.setOrientToAuto()")}}</dt>
+  <dd>Sets the value of the {{SVGattr("orient")}} attribute to <code>auto</code>.</dd>
+  <dt>{{domxref("SVGMarkerElement.setOrientToAngle()")}}</dt>
+  <dd>Sets the value of the {{SVGattr("orient")}} attribute to a specific angle value.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>SVG</h3>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="90"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<h3>Fidning the width of the marker</h3>
+
+<p>The <code>markerWidth</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("markerWidth")}} attribute.</p>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.markerWidth.baseVal.value); // 6</pre>
+
+<h3>Updating the orientation angle</h3>
+
+<p>In the following example the value of the <code>orient</code> attribute is updated using <code>setOrientToAngle()</code> using an {{domxref("SVGAngle")}} created using {{domxref("SVGElement.createSVGAngle()")}}.</p>
+
+<pre class="brush: js">let svg = document.getElementById("svg");
+let marker = document.getElementById("arrow");
+console.log(marker.orientAngle.baseVal.value); // value in SVG above - 90
+let angle = svg.createSVGAngle();
+angle.value = "110";
+marker.setOrientToAngle(angle);
+console.log(marker.orientAngle.baseVal.value); // new value - 110</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#InterfaceSVGMarkerElement", "SVGMarkerElement")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -79,7 +79,7 @@ tags:
   &lt;/defs&gt;
 &lt;/svg&gt;</pre>
 
-<h3>Fidning the width of the marker</h3>
+<h3>Finding the Width of the Marker</h3>
 
 <p>The <code>markerWidth</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("markerWidth")}} attribute.</p>
 

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -53,7 +53,7 @@ tags:
   <dt>{{domxref("SVGMarkerElement.refY")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.</dd>
   <dt>{{domxref("SVGMarkerElement.viewBox")}}{{ReadOnlyInline}}</dt>
-  <dd>Returns an {{domxref("SVGAnimatedRect")}} object containing a {{domxref("SVGRect")}} which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.</dd>
+  <dd>Returns an {{domxref("SVGAnimatedRect")}} object containing an {{domxref("SVGRect")}} which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.</dd>
   <dt>{{domxref("SVGMarkerElement.preserveAspectRatio")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an {{domxref("SVGPreserveAspectRatio")}} object which contains the values set by the {{SVGattr("preserveAspectRatio")}} attribute on the {{SVGElement("marker")}} viewport.</dd>
 </dl>

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -67,7 +67,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<h3>SVG</h3>
+<p>The following SVG will be referenced in the examples.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -17,7 +17,7 @@ tags:
 
 <h2 id="Properties">Properties</h2>
 
-<p><em>This interface also inherits properties from its parent, {{domxref("SVGElement")}}, and implements properties from {{domxref("SVGFitToViewBox")}}.</em></p>
+<p><em>This interface also inherits properties from its parent, {{domxref("SVGElement")}}.</em></p>
 
 <dl>
   <dt>{{domxref("SVGMarkerElement.markerUnits")}}{{ReadOnlyInline}}</dt>
@@ -52,11 +52,15 @@ tags:
   <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.</dd>
   <dt>{{domxref("SVGMarkerElement.refY")}}{{ReadOnlyInline}}</dt>
   <dd>Returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.</dd>
+  <dt>{{domxref("SVGMarkerElement.viewBox")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGAnimatedRect")}} object containing a {{domxref("SVGRect")}} which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.</dd>
+  <dt>{{domxref("SVGMarkerElement.preserveAspectRatio")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns an {{domxref("SVGPreserveAspectRatio")}} object which contains the values set by the {{SVGattr("preserveAspectRatio")}} attribute on the {{SVGElement("marker")}} viewport.</dd>
 </dl>
 
 <h2 id="Methods">Methods</h2>
 
-<p><em>This interface also inherits methods from its parent, {{domxref("SVGElement")}}, and implements methods from {{domxref("SVGFitToViewBox")}}</em></p>
+<p><em>This interface also inherits methods from its parent, {{domxref("SVGElement")}}.</em></p>
 
 <dl>
   <dt>{{domxref("SVGMarkerElement.setOrientToAuto()")}}</dt>

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -86,7 +86,7 @@ tags:
 <pre class="brush: js">let marker = document.getElementById("arrow");
 console.log(marker.markerWidth.baseVal.value); // 6</pre>
 
-<h3>Updating the orientation angle</h3>
+<h3>Updating the Orientation Angle</h3>
 
 <p>In the following example the value of the <code>orient</code> attribute is updated using <code>setOrientToAngle()</code> using an {{domxref("SVGAngle")}} created using {{domxref("SVGElement.createSVGAngle()")}}.</p>
 

--- a/files/en-us/web/api/svgmarkerelement/markerheight/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerheight/index.html
@@ -1,0 +1,61 @@
+---
+title: SVGMarkerElement.markerHeight
+slug: Web/API/SVGMarkerElement/markerHeight
+tags:
+  - API
+  - Property
+  - Reference
+  - markerHeight
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>markerHeight</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the height of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerHeight")}} attribute.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let height = SVGMarkerElement.markerHeight;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>markerHeight</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("markerHeight")}} attribute.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="auto-start-reverse"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.markerHeight.baseVal.value); // 6</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerHeight", "SVGMarkerElement.markerHeight")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.markerHeight")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/markerheight/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerheight/index.html
@@ -17,7 +17,7 @@ tags:
 <pre class="syntaxbox">let height = SVGMarkerElement.markerHeight;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+<p>An {{domxref("SVGAnimatedLength")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGLength")}}, the value of which returns the <code>height</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.html
@@ -17,7 +17,7 @@ tags:
 <pre class="syntaxbox">let markerUnits = SVGMarkerElement.markerUnits;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedEnumeration")}} object. This contains one of the following values:</p>
+<p>An {{domxref("SVGAnimatedEnumeration")}} object. The <code>baseVal</code> property of this object contains one of the following values:</p>
 
 <dl>
   <dt>0</dt>

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.html
@@ -1,0 +1,71 @@
+---
+title: SVGMarkerElement.markerUnits
+slug: Web/API/SVGMarkerElement/markerUnits
+tags:
+  - API
+  - Property
+  - Reference
+  - markerUnits
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>markerUnits</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object. This object returns an integer which represents the keyword values that the {{SVGattr("markerUnits")}} attribute accepts.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let markerUnits = SVGMarkerElement.markerUnits;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedEnumeration")}} object. This contains one of the following values:</p>
+
+<dl>
+  <dt>0</dt>
+  <dd><code>SVG_MARKERUNITS_UNKNOWN</code> which means that the {{SVGattr("markerUnits")}} attribute has a value other than the two predefined keywords.</dd>
+  <dt>1</dt>
+  <dd><code>SVG_MARKERUNITS_USERSPACEONUSE</code> which means that the {{SVGattr("markerUnits")}} attribute has the keyword value <code>userSpaceOnUse</code>.</dd>
+  <dt>2</dt>
+  <dd><code>SVG_MARKERUNITS_STROKEWIDTH</code> which means that the {{SVGattr("markerUnits")}} attribute has the keyword value <code>strokeWidth</code>.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>markerUnits</code> property returns an {{domxref("SVGAnimatedEnumeration")}} object that contains the value of the {{SVGattr("markerUnits")}} attribute.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="auto-start-reverse"
+        markerUnits="strokeWidth"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.markerUnits.baseVal.value); // 2</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerUnits", "SVGMarkerElement.markerUnits")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.markerUnits")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.html
@@ -44,7 +44,7 @@ tags:
 &lt;/svg&gt;</pre>
 
 <pre class="brush: js">let marker = document.getElementById("arrow");
-console.log(marker.markerUnits.baseVal.value); // 2</pre>
+console.log(marker.markerUnits.baseVal); // 2</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
@@ -1,0 +1,62 @@
+---
+title: SVGMarkerElement.markerWidth
+slug: Web/API/SVGMarkerElement/markerWidth
+tags:
+  - API
+  - Property
+  - Reference
+  - markerWidth
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>markerWidth</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the width of the {{SVGElement("marker")}} viewport as defined by the {{SVGattr("markerWidth")}} attribute.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let width = SVGMarkerElement.markerWidth;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>markerWidth</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("markerWidth")}} attribute.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="auto-start-reverse"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.markerWidth.baseVal.value); // 6</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerWidth", "SVGMarkerElement.markerWidth")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.markerWidth")}}</p>
+

--- a/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
@@ -17,7 +17,7 @@ tags:
 <pre class="syntaxbox">let width = SVGMarkerElement.markerWidth;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+<p>An {{domxref("SVGAnimatedLength")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGLength")}}, the value of which returns the <code>width</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/orientangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orientangle/index.html
@@ -17,7 +17,7 @@ tags:
 <pre class="syntaxbox">let angle = SVGMarkerElement.orientAngle;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedAngle")}} object.</p>
+<p>An {{domxref("SVGAnimatedAngle")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGAngle")}}, the value of which returns the <code>angle</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/orientangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orientangle/index.html
@@ -1,0 +1,60 @@
+---
+title: SVGMarkerElement.orientAngle
+slug: Web/API/SVGMarkerElement/orientAngle
+tags:
+  - API
+  - Property
+  - Reference
+  - orientAngle
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>orientAngle</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedAngle")}} object containing the angle of the {{SVGattr("orient")}} attribute.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let angle = SVGMarkerElement.orientAngle;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedAngle")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>orientAngle</code> property returns an {{domxref("SVGAnimatedAngle")}} which contains an {{domxref("SVGAngle")}} with the angle set by the {{SVGattr("orient")}} attribute as a number representing the number of degrees the marker is turned.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient=".5turn"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.orientAngle.baseVal.value); // 180 as .5turn is 180deg.</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__orientAngle", "SVGMarkerElement.orientAngle")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.orientAngle")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.html
@@ -30,7 +30,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The <code>orientType</code> property returns an {{domxref("SVGAnimatedEnumeration")}} object, as the value of the {{SVGattr("orient")}} attribute is an angle, returning the <code>SVGAnimatedEnumeration.baseVal</code> returns <code>2</code>.</p>
+<p>The <code>orientType</code> property returns an {{domxref("SVGAnimatedEnumeration")}} object. As the value of the {{SVGattr("orient")}} attribute is an angle, returning the <code>SVGAnimatedEnumeration.baseVal</code> returns <code>2</code>.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
@@ -68,4 +68,3 @@ console.log(marker.orientType.baseVal); // 2</pre>
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.SVGMarkerElement.orientType")}}</p>
-

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.html
@@ -1,0 +1,71 @@
+---
+title: SVGMarkerElement.orientType
+slug: Web/API/SVGMarkerElement/orientType
+tags:
+  - API
+  - Property
+  - Reference
+  - orientType
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>orientType</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object indicatign whether the {{SVGattr("orient")}} attribute is <code>auto</code>, an angle value, or something else.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let orientType = SVGMarkerElement.orientType;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedEnumeration")}} object. This contains one of the following values:</p>
+
+<dl>
+  <dt>0</dt>
+  <dd><code>SVG_MARKER_ORIENT_UNKNOWN</code> which means that the {{SVGattr("orient")}} attribute has a value other than the two predefined keywords.</dd>
+  <dt>1</dt>
+  <dd><code>SVG_MARKERUNITS_ORIENT_AUTO</code> which means that the {{SVGattr("orient")}} attribute has the keyword value <code>auto</code>.</dd>
+  <dt>2</dt>
+  <dd><code>SVG_MARKERUNITS_ORIENT_ANGLE</code> which means that the {{SVGattr("orient")}} attribute has an {{cssxref("angle")}} or {{cssxref("number")}} value indicating the angle.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>orientType</code> property returns an {{domxref("SVGAnimatedEnumeration")}} object, as the value of the {{SVGattr("orient")}} attribute is an angle, returning the <code>SVGAnimatedEnumeration.baseVal</code> returns <code>2</code>.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient=".63deg"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.orientType.baseVal); // 2</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__markerUnits", "SVGMarkerElement.orientType")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.orientType")}}</p>
+

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.html
@@ -10,7 +10,9 @@ tags:
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>orientType</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object indicatign whether the {{SVGattr("orient")}} attribute is <code>auto</code>, an angle value, or something else.</p>
+<p class="summary">The <strong><code>orientType</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedEnumeration")}} object indicating whether the {{SVGattr("orient")}} attribute is <code>auto</code>, an angle value, or something else.</p>
+
+<p>This <em>something else</em> is most likely to be the keyword <code>auto-start-reverse</code> however the spec leaves it open for this to be other values. Unsupported values will generally be thrown away by the parser, leaving the value the default of <code>auto</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -21,7 +23,7 @@ tags:
 
 <dl>
   <dt>0</dt>
-  <dd><code>SVG_MARKER_ORIENT_UNKNOWN</code> which means that the {{SVGattr("orient")}} attribute has a value other than the two predefined keywords.</dd>
+  <dd><code>SVG_MARKER_ORIENT_UNKNOWN</code> which means that the {{SVGattr("orient")}} attribute has a value other than <code>auto</code> or an angle.</dd>
   <dt>1</dt>
   <dd><code>SVG_MARKERUNITS_ORIENT_AUTO</code> which means that the {{SVGattr("orient")}} attribute has the keyword value <code>auto</code>.</dd>
   <dt>2</dt>

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -1,0 +1,65 @@
+---
+title: SVGMarkerElement.preserveAspectRatio
+slug: Web/API/SVGMarkerElement/preserveAspectRatio
+tags:
+  - API
+  - Property
+  - Reference
+  - preserveAspectRatio
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>preserveAspectRatio</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedPreserveAspectRatio")}} object containing the value of the {{SVGattr("preserveAspectRatio")}} attribute of the {{SVGElement("marker")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let preserveAspectRatio = SVGMarkerElement.preserveAspectRatio;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedPreserveAspectRatio")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGPreserveAspectRatio")}} object, which has the properties <code>align</code> and <code>meetOrSlice</code>.</p>
+
+<p>These properties return a numeric value representing the <a href="/en-US/docs/Web/API/SVGPreserveAspectRatio#constants">constants</a> for these values.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>This example demonstrates how to return the numeric constants for <code>align</code> and <code>meetOrSlice</code> which relate to the values set for the {{SVGattr("preserveAspectRatio")}} attribute of {{SVGElement("marker")}}.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        preserveAspectRatio="xMidYMid meet"
+        markerWidth="6" markerHeight="6"
+        orient="auto-start-reverse"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.preserveAspectRatio.baseVal.align); // 6
+console.log(marker.preserveAspectRatio.baseVal.meetOrSlice); // 1 </pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGFitToViewBox__preserveAspectRatio", "SVGMarkerElement.preserveAspectRatio")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.preserveAspectRatio")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -17,9 +17,46 @@ tags:
 <pre class="syntaxbox">let preserveAspectRatio = SVGMarkerElement.preserveAspectRatio;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedPreserveAspectRatio")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGPreserveAspectRatio")}} object, which has the properties <code>align</code> and <code>meetOrSlice</code>.</p>
+<p>An {{domxref("SVGAnimatedPreserveAspectRatio")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGPreserveAspectRatio")}} object, with the following properties:</p>
 
-<p>These properties return a numeric value representing the <a href="/en-US/docs/Web/API/SVGPreserveAspectRatio#constants">constants</a> for these values.</p>
+<dl>
+  <dt><code>align</code></dt>
+    <dd>One of the following numeric constants:
+      <dl>
+        <dt><code>0</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_UNKNOWN</code></dd>
+        <dt><code>1</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_NONE</code></dd>
+        <dt><code>2</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMINYMIN</code></dd>
+        <dt><code>3</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMIDYMIN</code></dd>
+        <dt><code>4</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMAXYMIN</code></dd>
+        <dt><code>5</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMINYMID</code></dd>
+        <dt><code>6</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMIDYMID</code></dd>
+        <dt><code>7</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMAXYMID</code></dd>
+        <dt><code>8</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMINYMAX</code></dd>
+        <dt><code>9</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMIDYMAX</code></dd>
+        <dt><code>10</code></dt>
+        <dd><code>SVG_PRESERVEASPECTRATIO_XMAXYMAX</code></dd>
+      </dl>
+    </dd>
+  <dt><code>meetOrSlice</code></dt>
+  <dl>
+    <dt><code>0</code></dt>
+    <dd><code>SVG_MEETORSLICE_UNKNOWN</code></dd>
+    <dt><code>1</code></dt>
+    <dd><code>SVG_MEETORSLICE_MEET</code></dd>
+    <dt><code>2</code></dt>
+    <dd><code>SVG_MEETORSLICE_SLICE</code></dd>
+   </dl>
+</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -14,7 +14,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">let preserveAspectRatio = SVGMarkerElement.preserveAspectRatio;</pre>
+<pre  class="brush: js">let preserveAspectRatio = SVGMarkerElement.preserveAspectRatio;</pre>
 
 <h3>Value</h3>
 <p>An {{domxref("SVGAnimatedPreserveAspectRatio")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGPreserveAspectRatio")}} object, which has the properties <code>align</code> and <code>meetOrSlice</code>.</p>

--- a/files/en-us/web/api/svgmarkerelement/refx/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refx/index.html
@@ -1,0 +1,62 @@
+---
+title: SVGMarkerElement.refX
+slug: Web/API/SVGMarkerElement/refX
+tags:
+  - API
+  - Property
+  - Reference
+  - refX
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>refX</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let refX = SVGMarkerElement.refX;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>markerWidth</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("refX")}} attribute.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="auto-start-reverse"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.refX.baseVal.value); // 5</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__refX", "SVGMarkerElement.refX")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.refX")}}</p>
+

--- a/files/en-us/web/api/svgmarkerelement/refy/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refy/index.html
@@ -1,0 +1,63 @@
+---
+title: SVGMarkerElement.refY
+slug: Web/API/SVGMarkerElement/refY
+tags:
+  - API
+  - Property
+  - Reference
+  - refY
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>refY</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refY")}} attribute of the {{SVGElement("marker")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">let refY = SVGMarkerElement.refY;</pre>
+
+<h3>Value</h3>
+<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The <code>markerWidth</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("refY")}} attribute.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="auto-start-reverse"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.refY.baseVal.value); // 5</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__refY", "SVGMarkerElement.refY")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.refY")}}</p>
+
+

--- a/files/en-us/web/api/svgmarkerelement/refy/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refy/index.html
@@ -17,7 +17,7 @@ tags:
 <pre class="syntaxbox">let refY = SVGMarkerElement.refY;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedLength")}} object.</p>
+<p>An {{domxref("SVGAnimatedLength")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGLength")}}, the value of which returns the <code>refY</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
@@ -25,7 +25,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>In the following example the value of the <code>orient</code> attribute is updated using <code>setOrientToAngle()</code> using an {{domxref("SVGAngle")}} created using {{domxref("SVGElement.createSVGAngle()")}}.</p>
+<p>In the following example the value of the <code>orient</code> attribute is updated using <code>setOrientToAngle()</code> using an {{domxref("SVGAngle")}} created using {{domxref("SVGSVGElement.createSVGAngle()")}}.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
@@ -1,0 +1,71 @@
+---
+title: SVGMarkerElement.setOrientToAngle()
+slug: Web/API/SVGMarkerElement/setOrientToAngle
+tags:
+  - API
+  - Method
+  - Reference
+  - setOrientToAngle
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>setOrientToAngle()</code></strong> method of the {{domxref("SVGMarkerElement")}} interface sets the value of the <code>orient</code> attribute to the value in the {{domxref("SVGAngle")}} passed in.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">setOrientToAngle(angle);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>angle</code></dt>
+  <dd>An {{domxref("SVGAngle")}}.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example the value of the <code>orient</code> attribute is updated using <code>setOrientToAngle()</code> using an {{domxref("SVGAngle")}} created using {{domxref("SVGElement.createSVGAngle()")}}.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="90"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let svg = document.getElementById("svg");
+let marker = document.getElementById("arrow");
+console.log(marker.orientAngle.baseVal.value); // value in SVG above - 90
+let angle = svg.createSVGAngle();
+angle.value = "110";
+marker.setOrientToAngle(angle);
+console.log(marker.orientAngle.baseVal.value); // new value - 110</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__setOrientToAngle", "SVGMarkerElement.setOrientToAngle()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.setOrientToAngle")}}</p>
+

--- a/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
@@ -1,0 +1,66 @@
+---
+title: SVGMarkerElement.setOrientToAuto()
+slug: Web/API/SVGMarkerElement/setOrientToAuto
+tags:
+  - API
+  - Method
+  - Reference
+  - setOrientToAuto
+  - SVGMarkerElement
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>setOrientToAuto()</code></strong> method of the {{domxref("SVGMarkerElement")}} interface  sets the value of the <code>orient</code> attribute to <code>auto</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="syntaxbox">setOrientToAuto();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example the value of the <code>orient</code> attribute is updated using <code>setOrientToAuto()</code>.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;defs&gt;
+    &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6"
+        orient="90"&gt;
+      &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
+    &lt;/marker&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</pre>
+
+<pre class="brush: js">let marker = document.getElementById("arrow");
+console.log(marker.orientAngle.baseVal.value);
+marker.setOrientToAuto();
+console.log(marker.orientAngle.baseVal.value);</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__setOrientToAuto", "SVGMarkerElement.setOrientToAuto()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGMarkerElement.setOrientToAuto")}}</p>
+
+

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.html
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.html
@@ -1,31 +1,32 @@
 ---
-title: SVGMarkerElement.refX
-slug: Web/API/SVGMarkerElement/refX
+title: SVGMarkerElement.viewBox
+slug: Web/API/SVGMarkerElement/viewBox
 tags:
   - API
   - Property
   - Reference
-  - refX
+  - viewBox
   - SVGMarkerElement
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>refX</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("refX")}} attribute of the {{SVGElement("marker")}}.</p>
+<p class="summary">The <strong><code>viewBox</code></strong> read-only property of the {{domxref("SVGMarkerElement")}} interface returns an {{domxref("SVGAnimatedRect")}} object which contains the values set by the {{SVGattr("viewBox")}} attribute on the {{SVGElement("marker")}}.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">let refX = SVGMarkerElement.refX;</pre>
+<pre class="syntaxbox">let viewBox = SVGMarkerElement.viewBox;</pre>
 
 <h3>Value</h3>
-<p>An {{domxref("SVGAnimatedLength")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGLength")}}, the value of which returns the <code>refX</code>.</p>
+<p>An {{domxref("SVGAnimatedRect")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGRect")}} object, from which can be returned the <code>x</code> and <code>y</code> co-ordinates, plus the <code>width</code> and <code>height</code> of the {{SVGElement("marker")}} {{SVGattr("viewBox")}} attribute.</p>
 
 <h2 id="Examples">Examples</h2>
 
-<p>The <code>markerWidth</code> property returns an {{domxref("SVGAnimatedLength")}} which contains an {{domxref("SVGLength")}} with the value of the {{SVGattr("refX")}} attribute.</p>
+<p>This example demonstrates how to return the value of the <code>width</code> set for the {{SVGattr("viewBox")}} attribute of {{SVGElement("marker")}}.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;defs&gt;
     &lt;marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        viewBox="xMidYMid meet"
         markerWidth="6" markerHeight="6"
         orient="auto-start-reverse"&gt;
       &lt;path d="M 0 0 L 10 5 L 0 10 z" /&gt;
@@ -34,7 +35,7 @@ tags:
 &lt;/svg&gt;</pre>
 
 <pre class="brush: js">let marker = document.getElementById("arrow");
-console.log(marker.refX.baseVal.value); // 5</pre>
+console.log(marker.viewBox.baseVal.width); //10</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -46,7 +47,7 @@ console.log(marker.refX.baseVal.value); // 5</pre>
     <th scope="col">Comment</th>
    </tr>
    <tr>
-    <td>{{SpecName("SVG2", "painting.html#__svg__SVGMarkerElement__refX", "SVGMarkerElement.refX")}}</td>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGFitToViewBox__viewBox", "SVGMarkerElement.viewBox")}}</td>
     <td>{{Spec2("SVG2")}}</td>
     <td>Initial definition</td>
    </tr>
@@ -58,5 +59,4 @@ console.log(marker.refX.baseVal.value); // 5</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGMarkerElement.refX")}}</p>
-
+<p>{{Compat("api.SVGMarkerElement.viewBox")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.html
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.html
@@ -14,7 +14,7 @@ tags:
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox">let viewBox = SVGMarkerElement.viewBox;</pre>
+<pre c class="brush: js">let viewBox = SVGMarkerElement.viewBox;</pre>
 
 <h3>Value</h3>
 <p>An {{domxref("SVGAnimatedRect")}} object. The <code>baseVal</code> property of this object returns an {{domxref("SVGRect")}} object, from which can be returned the <code>x</code> and <code>y</code> co-ordinates, plus the <code>width</code> and <code>height</code> of the {{SVGElement("marker")}} {{SVGattr("viewBox")}} attribute.</p>


### PR DESCRIPTION
Adds SVGMarkerElement.

Spec: https://www.w3.org/TR/SVG2/painting.html#InterfaceSVGMarkerElement

Reviewer: @jpmedley 

This was a fairly fiddly one, the SVG API docs are pretty inconsistent. There is no overview page I can find for Interfaces, and lots of missing bits.