### PR TITLE
add info about pseudo-elements

### DIFF
--- a/files/en-us/web/css/_colon_is/index.html
+++ b/files/en-us/web/css/_colon_is/index.html
@@ -36,6 +36,8 @@ footer p:hover {
 }
 </pre>
 
+<p>Pseudo-elements are not valid in the selector list for <code>:is()</code>.</p>
+
 <p>Note that older browsers support this functionality as <code>:matches()</code>, or through an older, prefixed pseudo-class — <code>:any()</code>, including older versions of Chrome, Firefox, and Safari. <code>:any()</code> works in exactly the same way as <code>:matches()</code>/<code>:is()</code>, except that it requires vendor prefixes and doesn't support <a href="/en-US/docs/Learn/CSS/Building_blocks/Selectors">complex selectors</a>.</p>
 
 <p>These legacy pseudo-classes can be used to provide backwards compatibility.</p>


### PR DESCRIPTION
Fixes #4848 

Adds a line about the fact pseudo-elements can't be used in the selector list.
