### PR TITLE
add missing semicolon

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.html
@@ -139,7 +139,7 @@ boundGetX();
 }
 
 function addArguments(arg1, arg2) {
-  return arg1 + arg2
+  return arg1 + arg2;
 }
 
 const list1 = list(1, 2, 3);


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
A semicolon is missing.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind

> Issue number (if there is an associated issue)
None

> Anything else that could help us review it
None
