### PR TITLE
Your second extension: replace deprecated calls to getUrl()

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.html
@@ -236,11 +236,11 @@ function listenForClicks() {
     function beastNameToURL(beastName) {
       switch (beastName) {
         case "Frog":
-          return browser.extension.getURL("beasts/frog.jpg");
+          return browser.runtime.getURL("beasts/frog.jpg");
         case "Snake":
-          return browser.extension.getURL("beasts/snake.jpg");
+          return browser.runtime.getURL("beasts/snake.jpg");
         case "Turtle":
-          return browser.extension.getURL("beasts/turtle.jpg");
+          return browser.runtime.getURL("beasts/turtle.jpg");
       }
     }
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`browser.extension.getURL()` is deprecated,  `browser.runtim.getURL()` should be used instead. 

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension