### PR TITLE
Websockets API: add flask-socketio

### DIFF
--- a/files/en-us/web/api/websockets_api/index.html
+++ b/files/en-us/web/api/websockets_api/index.html
@@ -62,6 +62,7 @@ tags:
  <li><a href="https://websocketking.com">WebSocket King</a>: A client tool to help develop, test and work with WebSocket servers.</li>
  <li><a href="https://github.com/napengam/phpWebSocketServer">PHP WebSocket Server</a>: Server written in PHP to handle connections via websocksets wss:// or ws://and normal sockets over ssl:// ,tcp://</li>
  <li><a href="https://channels.readthedocs.io/en/stable/index.html">Channels</a>: Django library that adds support for WebSockets (and other protocols that require long running asynchronous connections).</li>
+ <li><a href="https://flask-socketio.readthedocs.io/en/latest/">Flask-SocketIO</a>: gives Flask applications access to low latency bi-directional communications between the clients and the server.</li>
 </ul>
 
 <h2 id="Related_Topics">Related Topics</h2>


### PR DESCRIPTION
add flask-socketio library that enables support WebSocket for the flask to list of WebSocket tools.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

None
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
> Issue number (if there is an associated issue)

> Anything else that could help us review it
