### PR TITLE
Remove legacy browser compatibility table footnote

### DIFF
--- a/files/en-us/web/api/worker/postmessage/index.html
+++ b/files/en-us/web/api/worker/postmessage/index.html
@@ -154,8 +154,6 @@ from worker, POST send back aBuf.byteLength: 0                 myWorker.js:7:2</
 
 <p>{{Compat("api.Worker.postMessage")}}</p>
 
-<p>[1] Internet Explorer does not support {{domxref("Transferable")}} objects.</p>
-
 <h2 id="See_also">See also</h2>
 
 <ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The footnote is included in BCD.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

None.