### PR TITLE
Update the browser compatibility for Web Components

### DIFF
--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -199,9 +199,8 @@ tags:
 <p>In general:</p>
 
 <ul>
- <li>Web components are supported by default in Firefox (version 63), Chrome, and Opera.</li>
+ <li>Web components are supported by default in Firefox (version 63), Chrome, Opera and Edge (version 79).</li>
  <li>Safari supports a number of web component features, but less than the above browsers.</li>
- <li>Edge is working on an implementation.</li>
 </ul>
 
 <p>For detailed browser support of specific features, you'll have to consult the reference pages listed above.</p>

--- a/files/en-us/web/web_components/index.html
+++ b/files/en-us/web/web_components/index.html
@@ -199,7 +199,7 @@ tags:
 <p>In general:</p>
 
 <ul>
- <li>Web components are supported by default in Firefox (version 63), Chrome, Opera and Edge (version 79).</li>
+ <li>Web components are supported by default in Firefox (version 63), Chrome, Opera, and Edge (version 79).</li>
  <li>Safari supports a number of web component features, but less than the above browsers.</li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The browser compatibility data for Microsoft Edge is outdated. Now that Edge is based on Chromium, it's supposed to support Web Components out of the box.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Web_Components
> Issue number (if there is an associated issue)

> Anything else that could help us review it

I've based my changes on the browser compatibility data for [`Element.attachShadow`](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow) and [`Window.customElements`](https://developer.mozilla.org/en-US/docs/Web/API/Window/customElements).