### PR TITLE
improve flex-basis: auto explanation

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.html
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.html
@@ -181,7 +181,7 @@ tags:
 
 <ol>
  <li>Is <code>flex-basis</code> set to <code>auto</code>, and does the item have a width set? If so, the size will be based on that width.</li>
- <li>Is <code>flex-basis</code> set to <code>auto</code> or <code>content</code> (in a supporting browser)? If so, the size is based on the item size.</li>
+ <li>Is <code>flex-basis</code> set to <code>auto</code> or <code>content</code> (in a supporting browser)? If so, the size is based on the item's max-content size.</li>
  <li>Is <code>flex-basis</code> a length unit, but not zero? If so this is the size of the item.</li>
  <li>Is <code>flex-basis</code> set to <code>0</code>? if so then the item size is not taken into consideration for the space-sharing calculation.</li>
 </ol>

--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.html
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.html
@@ -181,7 +181,7 @@ tags:
 
 <ol>
  <li>Is <code>flex-basis</code> set to <code>auto</code>, and does the item have a width set? If so, the size will be based on that width.</li>
- <li>Is <code>flex-basis</code> set to <code>auto</code> or <code>content</code> (in a supporting browser)? If so, the size is based on the item's max-content size.</li>
+ <li>Is <code>flex-basis</code> set to <code>auto</code> or <code>content</code> (in a supporting browser)? If so, the size is based on the item's content size.</li>
  <li>Is <code>flex-basis</code> a length unit, but not zero? If so this is the size of the item.</li>
  <li>Is <code>flex-basis</code> set to <code>0</code>? if so then the item size is not taken into consideration for the space-sharing calculation.</li>
 </ol>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

I think the description of the `flex-basis: auto` behavior came out a little vague.
The author talked about the `max-content` sizing fallback during the whole article, so it seemed to me that quoting it in this section made sense.
I'm suggesting a subjective and minor improvement, please feel free to decline if you don't agree with me (:

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax