### PR TITLE
Remove tabindex from <area> attribute list

### DIFF
--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -126,8 +126,6 @@ tags:
  <p>Since HTML5, omitting the <code>href</code> attribute is sufficient.</p>
  </div>
  </dd>
- <dt>{{htmlattrdef("tabindex")}} {{deprecated_inline}}</dt>
- <dd>A numeric value specifying the position of the defined area in the browser tabbing order. This attribute is global in HTML5.</dd>
  <dt>{{htmlattrdef("type")}} {{deprecated_inline}}</dt>
  <dd>No effect. Browsers ignore it. (The W3C 5.3 fork of the HTML specification defines it as valid, but <a href="https://html.spec.whatwg.org/multipage/#the-area-element">the canonical HTML specification</a> doesn’t, and it has no effect in any user agents.)</dd>
 </dl>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I don't think the `tabindex` needs to be listed here at all.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

None.