### PR TITLE
npm run serverstart

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.html
@@ -357,7 +357,7 @@ GET /stylesheets/style.css 200 4.886 ms - 111
 <pre class="brush: json">  "scripts": {
     "start": "node ./bin/www",
     "devstart": "nodemon ./bin/www",
-    "serverstart": "DEBUG=express-locallibrary-tutorial:* npm run devstart"
+    "serverstart": "SET DEBUG=express-locallibrary-tutorial:* & npm run devstart"
   },
 </pre>
 


### PR DESCRIPTION
Fixed config mistake

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Config script was not working

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/skeleton_website

> Issue number (if there is an associated issue)
-

> Anything else that could help us review it
