### PR TITLE
add link to Node Dev Environment doc

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/Introduction", "Learn/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn/Server-side/Express_Nodejs")}}</div>
 
-<p class="summary">Now that you know what Express is for, we'll show you how to set up and test a Node/Express development environment on Windows, Linux (Ubuntu), and macOS. Whatever common operating system you are using, this article should give you what you need to be able to start developing Express apps.</p>
+<p class="summary">Now that you know what <a href="https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction#introducing_express">Express</a> is for, we'll show you how to set up and test a Node/Express development environment on Windows, or Linux (Ubuntu), or macOS. For any of those operating systems, this article provides what you need to start developing Express apps.</p>
 
 <table class="learn-box standard-table">
  <tbody>
@@ -27,7 +27,7 @@ tags:
   </tr>
   <tr>
    <th scope="row">Objective:</th>
-   <td>To set up a development environment for Express (X.XX) on your computer.</td>
+   <td>To set up a development environment for Express on your computer.</td>
   </tr>
  </tbody>
 </table>

--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.html
@@ -17,7 +17,7 @@ tags:
 
 <div>{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/Introduction", "Learn/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn/Server-side/Express_Nodejs")}}</div>
 
-<p class="summary">Now that you know what <a href="https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction#introducing_express">Express</a> is for, we'll show you how to set up and test a Node/Express development environment on Windows, or Linux (Ubuntu), or macOS. For any of those operating systems, this article provides what you need to start developing Express apps.</p>
+<p class="summary">Now that you know what <a href="/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction#introducing_express">Express</a> is for, we'll show you how to set up and test a Node/Express development environment on Windows, or Linux (Ubuntu), or macOS. For any of those operating systems, this article provides what you need to start developing Express apps.</p>
 
 <table class="learn-box standard-table">
  <tbody>


### PR DESCRIPTION
1. added a link back to [MDN Intro to Express](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction#introducing_express)
2. text revisions in the intro for clarity
3. removed "X.XX" placeholder text under the Objective section

On this page, I also notice a lack of consistency in referring to Node and in the use of emphasis. To make it easier to review this PR, but I will leave these issues for another PR.

MDN URL
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/development_environment