### PR TITLE
fix: Document.cookie live examples

### DIFF
--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -213,30 +213,16 @@ function alertCookieValue() {
 
 <pre class="brush: js">document.cookie = "reader=1; SameSite=None; Secure";
 
-//ES5
-
-function checkACookieExistsES5() {
-  if (document.cookie.split(';').some(function(item) {
-    return item.trim().indexOf('reader=') == 0
-  })) {
-    console.log('The cookie "reader" exists (ES5)')
-  }
-}
-
-//ES2016
-
-function checkACookieExistsES2016() {
+function checkACookieExists() {
   if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
-    console.log('The cookie "reader" exists (ES6)')
+    console.log('The cookie "reader" exists')
   }
 }
 
 </pre>
 
 <pre
-	class="brush: html">&lt;button onclick="checkACookieExistsES5()"&gt;Check a cookie exists (ES5)&lt;/button&gt;
-
-&lt;button onclick="checkACookieExistenceES2016()"&gt;Check a cookie existence (ES2016)&lt;/button&gt;
+	class="brush: html">&lt;button onclick="checkACookieExists()"&gt;Check a cookie existence&lt;/button&gt;
 </pre>
 
 <p>{{EmbedLiveSample('Example_5_Check_a_cookie_existence', 200, 36)}}</p>
@@ -244,19 +230,7 @@ function checkACookieExistsES2016() {
 <h3 id="Example_6_Check_that_a_cookie_has_a_specific_value">Example #6: Check that a
 	cookie has a specific value</h3>
 
-<pre class="brush: js">//ES5
-
-function checkCookieHasASpecificValueES5() {
-  if (document.cookie.split(';').some(function(item) {
-    return item.indexOf('reader=1') &gt;= 0
-  })) {
-    console.log('The cookie "reader" has a value of "1"')
-  }
-}
-
-//ES2016
-
-function checkCookieHasASpecificValueES2016() {
+<pre class="brush: js">function checkCookieHasASpecificValue() {
   if (document.cookie.split(';').some((item) =&gt; item.includes('reader=1'))) {
     console.log('The cookie "reader" has "1" for value')
   }
@@ -264,12 +238,8 @@ function checkCookieHasASpecificValueES2016() {
 </pre>
 
 <pre
-	class="brush: html">&lt;button onclick="checkCookieHasASpecificValueES5()"&gt;
-  Check that a cookie has a specific value (ES5)
-&lt;/button&gt;
-
-&lt;button onclick="checkCookieHasASpecificValueES2016()"&gt;
-  Check that a cookie has a specific value (ES2016)
+	class="brush: html">&lt;button onclick="checkCookieHasASpecificValue()"&gt;
+  Check that a cookie has a specific value
 &lt;/button&gt;
 </pre>
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -222,7 +222,7 @@ function checkACookieExistsES5() {
 
 //ES2016
 
-function checkACookieExistenceES2016() {
+function checkACookieExistsES2016() {
   if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
     console.log('The cookie "reader" exists (ES6)')
   }

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -231,7 +231,7 @@ function checkACookieExistenceES2016() {
 </pre>
 
 <pre
-	class="brush: html">&lt;button onclick="checkACookieExistenceES5()"&gt;Check a cookie existence (ES5)&lt;/button&gt;
+	class="brush: html">&lt;button onclick="checkACookieExistsES5()"&gt;Check a cookie exists (ES5)&lt;/button&gt;
 
 &lt;button onclick="checkACookieExistenceES2016()"&gt;Check a cookie existence (ES2016)&lt;/button&gt;
 </pre>

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -232,7 +232,7 @@ document.cookie = "reader=1; SameSite=None; Secure";
 
 function checkACookieExists() {
   if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
-		const output = document.getElementById('a-cookie-existence')
+    const output = document.getElementById('a-cookie-existence')
     output.textContent = '>> The cookie "reader" exists'
   }
 }

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -160,7 +160,10 @@ function alertCookie() {
 <h3 id="Example_2_Get_a_sample_cookie_named_test2">Example #2: Get a sample cookie named
 	<em>test2</em></h3>
 
-<pre class="brush: js">document.cookie = "test1=Hello; SameSite=None; Secure";
+<pre class="brush: js">// Note that we are setting `SameSite=None;` in this example because the example.
+// `SameSite=None;` needs to work cross-origin.
+// It is more common not to set the `SameSite` attribute, which results in the default, and more secure, value of `SameSite=Lax;`
+document.cookie = "test1=Hello; SameSite=None; Secure";
 document.cookie = "test2=World; SameSite=None; Secure";
 
 const cookieValue = document.cookie

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -145,7 +145,11 @@ tags:
 
 <h3 id="Example_1_Simple_usage">Example #1: Simple usage</h3>
 
-<pre class="brush: js">document.cookie = "name=oeschger; SameSite=None; Secure";
+<pre class="brush: js">// Note that we are setting `SameSite=None;` in this example because the example
+// needs to work cross-origin.
+// It is more common not to set the `SameSite` attribute, which results in the default,
+// and more secure, value of `SameSite=Lax;`
+document.cookie = "name=oeschger; SameSite=None; Secure";
 document.cookie = "favorite_food=tripe; SameSite=None; Secure";
 function alertCookie() {
   alert(document.cookie);
@@ -190,6 +194,10 @@ function alertCookieValue() {
 <pre class="brush: js">function doOnce() {
   if (!document.cookie.split('; ').find(row =&gt; row.startsWith('doSomethingOnlyOnce'))) {
     alert("Do something here!");
+    // Note that we are setting `SameSite=None;` in this example because the example
+    // needs to work cross-origin.
+    // It is more common not to set the `SameSite` attribute, which results in the default,
+    // and more secure, value of `SameSite=Lax;`
     document.cookie = "doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=None; Secure";
   }
 }</pre>
@@ -202,6 +210,10 @@ function alertCookieValue() {
 <h3 id="Example_4_Reset_the_previous_cookie">Example #4: Reset the previous cookie</h3>
 
 <pre class="brush: js">function resetOnce() {
+  // Note that we are setting `SameSite=None;` in this example because the example
+  // needs to work cross-origin.
+  // It is more common not to set the `SameSite` attribute, which results in the default,
+  // and more secure, value of `SameSite=Lax;`
   document.cookie = "doSomethingOnlyOnce=; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=None; Secure";
 }</pre>
 
@@ -212,7 +224,11 @@ function alertCookieValue() {
 
 <h3 id="Example_5_Check_a_cookie_existence">Example #5: Check a cookie existence</h3>
 
-<pre class="brush: js">document.cookie = "reader=1; SameSite=None; Secure";
+<pre class="brush: js">// Note that we are setting `SameSite=None;` in this example because the example
+// needs to work cross-origin.
+// It is more common not to set the `SameSite` attribute, which results in the default,
+// and more secure, value of `SameSite=Lax;`
+document.cookie = "reader=1; SameSite=None; Secure";
 
 function checkACookieExists() {
   if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -160,9 +160,10 @@ function alertCookie() {
 <h3 id="Example_2_Get_a_sample_cookie_named_test2">Example #2: Get a sample cookie named
 	<em>test2</em></h3>
 
-<pre class="brush: js">// Note that we are setting `SameSite=None;` in this example because the example.
-// `SameSite=None;` needs to work cross-origin.
-// It is more common not to set the `SameSite` attribute, which results in the default, and more secure, value of `SameSite=Lax;`
+<pre class="brush: js">// Note that we are setting `SameSite=None;` in this example because the example
+// needs to work cross-origin.
+// It is more common not to set the `SameSite` attribute, which results in the default,
+// and more secure, value of `SameSite=Lax;`
 document.cookie = "test1=Hello; SameSite=None; Secure";
 document.cookie = "test2=World; SameSite=None; Secure";
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -151,15 +151,30 @@ tags:
 // and more secure, value of `SameSite=Lax;`
 document.cookie = "name=oeschger; SameSite=None; Secure";
 document.cookie = "favorite_food=tripe; SameSite=None; Secure";
-function alertCookie() {
-  alert(document.cookie);
+
+function showCookies() {
+  const output = document.getElementById('cookies')
+  output.textContent = '> ' + document.cookie
+}
+
+function clearOutputCookies() {
+  const output = document.getElementById('cookies')
+  output.textContent = ''
 }
 </pre>
 
-<pre class="brush: html">&lt;button onclick="alertCookie()"&gt;Show cookies&lt;/button&gt;
+<pre class="brush: html">&lt;button onclick="showCookies()"&gt;Show cookies&lt;/button&gt;
+
+&lt;button onclick="clearOutputCookies()"&gt;
+  Clear
+&lt;/button&gt;
+
+&lt;div&gt;
+  &lt;code id="cookies"&gt;&lt;/code&gt;
+&lt;/div&gt;
 </pre>
 
-<p>{{EmbedLiveSample('Example_1_Simple_usage', 200, 36)}}</p>
+<p>{{EmbedLiveSample('Example_1_Simple_usage', 200, 72)}}</p>
 
 <h3 id="Example_2_Get_a_sample_cookie_named_test2">Example #2: Get a sample cookie named
 	<em>test2</em></h3>
@@ -176,15 +191,30 @@ const cookieValue = document.cookie
   .find(row =&gt; row.startsWith('test2='))
   .split('=')[1];
 
-function alertCookieValue() {
-  alert(cookieValue);
+function showCookieValue() {
+  const output = document.getElementById('cookie-value')
+  output.textContent = '> ' + cookieValue
+}
+
+function clearOutputCookieValue() {
+  const output = document.getElementById('cookie-value')
+  output.textContent = ''
 }
 </pre>
 
 <pre
-	class="brush: html">&lt;button onclick="alertCookieValue()"&gt;Show cookie value&lt;/button&gt;</pre>
+	class="brush: html">&lt;button onclick="showCookieValue()"&gt;Show cookie value&lt;/button&gt;
 
-<p>{{EmbedLiveSample('Example_2_Get_a_sample_cookie_named_test2', 200, 36)}}</p>
+&lt;button onclick="clearOutputCookieValue()"&gt;
+  Clear
+&lt;/button&gt;
+
+&lt;div&gt;
+  &lt;code id="cookie-value"&gt;&lt;/code&gt;
+&lt;/div&gt;
+</pre>
+
+<p>{{EmbedLiveSample('Example_2_Get_a_sample_cookie_named_test2', 200, 72)}}</p>
 
 <h3 id="Example_3_Do_something_only_once">Example #3: Do something only once</h3>
 
@@ -193,19 +223,27 @@ function alertCookieValue() {
 
 <pre class="brush: js">function doOnce() {
   if (!document.cookie.split('; ').find(row =&gt; row.startsWith('doSomethingOnlyOnce'))) {
-    alert("Do something here!");
     // Note that we are setting `SameSite=None;` in this example because the example
     // needs to work cross-origin.
     // It is more common not to set the `SameSite` attribute, which results in the default,
     // and more secure, value of `SameSite=Lax;`
     document.cookie = "doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=None; Secure";
+
+    const output = document.getElementById('do-once')
+    output.textContent = '> Do something here!'
   }
-}</pre>
+}
+</pre>
 
 <pre
-	class="brush: html">&lt;button onclick="doOnce()"&gt;Only do something once&lt;/button&gt;</pre>
+	class="brush: html">&lt;button onclick="doOnce()"&gt;Only do something once&lt;/button&gt;
 
-<p>{{EmbedLiveSample('Example_3_Do_something_only_once', 200, 36)}}</p>
+&lt;div&gt;
+  &lt;code id="do-once"&gt;&lt;/code&gt;
+&lt;/div&gt;
+</pre>
+
+<p>{{EmbedLiveSample('Example_3_Do_something_only_once', 200, 72)}}</p>
 
 <h3 id="Example_4_Reset_the_previous_cookie">Example #4: Reset the previous cookie</h3>
 
@@ -215,12 +253,22 @@ function alertCookieValue() {
   // It is more common not to set the `SameSite` attribute, which results in the default,
   // and more secure, value of `SameSite=Lax;`
   document.cookie = "doSomethingOnlyOnce=; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=None; Secure";
-}</pre>
+
+  const output = document.getElementById('reset-once')
+  output.textContent = '> Reset!'
+}
+</pre>
 
 <pre
-	class="brush: html">&lt;button onclick="resetOnce()"&gt;Reset only once cookie&lt;/button&gt;</pre>
+	class="brush: html">&lt;button onclick="resetOnce()"&gt;Reset only once cookie&lt;/button&gt;
 
-<p>{{EmbedLiveSample('Example_4_Reset_the_previous_cookie', 200, 36)}}</p>
+
+&lt;div&gt;
+  &lt;code id="reset-once"&gt;&lt;/code&gt;
+&lt;/div&gt;
+</pre>
+
+<p>{{EmbedLiveSample('Example_4_Reset_the_previous_cookie', 200, 72)}}</p>
 
 <h3 id="Example_5_Check_a_cookie_existence">Example #5: Check a cookie existence</h3>
 
@@ -233,11 +281,11 @@ document.cookie = "reader=1; SameSite=None; Secure";
 function checkACookieExists() {
   if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
     const output = document.getElementById('a-cookie-existence')
-    output.textContent = '>> The cookie "reader" exists'
+    output.textContent = '> The cookie "reader" exists'
   }
 }
 
-function resetOutputACookieExists() {
+function clearOutputACookieExists() {
   const output = document.getElementById('a-cookie-existence')
   output.textContent = ''
 }
@@ -248,8 +296,9 @@ function resetOutputACookieExists() {
 	class="brush: html">&lt;button onclick="checkACookieExists()"&gt;
   Check a cookie exists
 &lt;/button&gt;
-&lt;button onclick="resetOutputACookieExists()"&gt;
-  Reset
+
+&lt;button onclick="clearOutputACookieExists()"&gt;
+  Clear
 &lt;/button&gt;
 
 &lt;div&gt;
@@ -265,11 +314,11 @@ function resetOutputACookieExists() {
 <pre class="brush: js">function checkCookieHasASpecificValue() {
   if (document.cookie.split(';').some((item) =&gt; item.includes('reader=1'))) {
     const output = document.getElementById('a-specific-value-of-the-cookie')
-    output.textContent = '>> The cookie "reader" has a value of "1"'
+    output.textContent = '> The cookie "reader" has a value of "1"'
   }
 }
 
-function resetASpecificValueOfTheCookie() {
+function clearASpecificValueOfTheCookie() {
   const output = document.getElementById('a-specific-value-of-the-cookie')
   output.textContent = ''
 }
@@ -279,8 +328,9 @@ function resetASpecificValueOfTheCookie() {
 	class="brush: html">&lt;button onclick="checkCookieHasASpecificValue()"&gt;
   Check that a cookie has a specific value
 &lt;/button&gt;
-&lt;button onclick="resetASpecificValueOfTheCookie()"&gt;
-  Reset
+
+&lt;button onclick="clearASpecificValueOfTheCookie()"&gt;
+  Clear
 &lt;/button&gt;
 
 &lt;div&gt;

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -208,38 +208,69 @@ function alertCookieValue() {
 
 <h3 id="Example_5_Check_a_cookie_existence">Example #5: Check a cookie existence</h3>
 
-<pre class="brush: js">//ES5
+<pre class="brush: js">document.cookie = "reader=1; SameSite=None; Secure";
 
-if (document.cookie.split(';').some(function(item) {
+//ES5
+
+function checkACookieExistenceES5() {
+  if (document.cookie.split(';').some(function(item) {
     return item.trim().indexOf('reader=') == 0
-})) {
+  })) {
     console.log('The cookie "reader" exists (ES5)')
+  }
 }
 
 //ES2016
 
-if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
+function checkACookieExistenceES2016() {
+  if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
     console.log('The cookie "reader" exists (ES6)')
+  }
 }
+
 </pre>
+
+<pre
+	class="brush: html">&lt;button onclick="checkACookieExistenceES5()"&gt;Check a cookie existence (ES5)&lt;/button&gt;
+
+&lt;button onclick="checkACookieExistenceES2016()"&gt;Check a cookie existence (ES2016)&lt;/button&gt;
+</pre>
+
+<p>{{EmbedLiveSample('Example_5_Check_a_cookie_existence', 200, 36)}}</p>
 
 <h3 id="Example_6_Check_that_a_cookie_has_a_specific_value">Example #6: Check that a
 	cookie has a specific value</h3>
 
 <pre class="brush: js">//ES5
 
-if (document.cookie.split(';').some(function(item) {
+function checkCookieHasASpecificValueES5() {
+  if (document.cookie.split(';').some(function(item) {
     return item.indexOf('reader=1') &gt;= 0
-})) {
+  })) {
     console.log('The cookie "reader" has "1" for value')
+  }
 }
 
 //ES2016
 
-if (document.cookie.split(';').some((item) =&gt; item.includes('reader=1'))) {
+function checkCookieHasASpecificValueES2016() {
+  if (document.cookie.split(';').some((item) =&gt; item.includes('reader=1'))) {
     console.log('The cookie "reader" has "1" for value')
+  }
 }
 </pre>
+
+<pre
+	class="brush: html">&lt;button onclick="checkCookieHasASpecificValueES5()"&gt;
+  Check that a cookie has a specific value (ES5)
+&lt;/button&gt;
+
+&lt;button onclick="checkCookieHasASpecificValueES2016()"&gt;
+  Check that a cookie has a specific value (ES2016)
+&lt;/button&gt;
+</pre>
+
+<p>{{EmbedLiveSample('Example_6_Check_that_a_cookie_has_a_specific_value', 200, 36)}}</p>
 
 <h2 id="Security">Security</h2>
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -240,7 +240,7 @@ function checkACookieExists() {
 <pre class="brush: js">function checkCookieHasASpecificValue() {
   if (document.cookie.split(';').some((item) =&gt; item.includes('reader=1'))) {
     const output = document.getElementById('a-specific-value-of-the-cookie')
-    output.textContent = '>> The cookie "reader" has "1" for value'
+    output.textContent = '>> The cookie "reader" has a value of "1"'
   }
 }
 </pre>

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -212,7 +212,7 @@ function alertCookieValue() {
 
 //ES5
 
-function checkACookieExistenceES5() {
+function checkACookieExistsES5() {
   if (document.cookie.split(';').some(function(item) {
     return item.trim().indexOf('reader=') == 0
   })) {

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -233,10 +233,19 @@ function clearOutputCookieValue() {
     output.textContent = '> Do something here!'
   }
 }
+
+function clearOutputDoOnce() {
+  const output = document.getElementById('do-once')
+  output.textContent = ''
+}
 </pre>
 
 <pre
 	class="brush: html">&lt;button onclick="doOnce()"&gt;Only do something once&lt;/button&gt;
+
+&lt;button onclick="clearOutputDoOnce()"&gt;
+  Clear
+&lt;/button&gt;
 
 &lt;div&gt;
   &lt;code id="do-once"&gt;&lt;/code&gt;
@@ -257,11 +266,19 @@ function clearOutputCookieValue() {
   const output = document.getElementById('reset-once')
   output.textContent = '> Reset!'
 }
+
+function clearOutputResetOnce() {
+  const output = document.getElementById('reset-once')
+  output.textContent = ''
+}
 </pre>
 
 <pre
 	class="brush: html">&lt;button onclick="resetOnce()"&gt;Reset only once cookie&lt;/button&gt;
 
+&lt;button onclick="clearOutputResetOnce()"&gt;
+  Clear
+&lt;/button&gt;
 
 &lt;div&gt;
   &lt;code id="reset-once"&gt;&lt;/code&gt;

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -247,7 +247,7 @@ function checkCookieHasASpecificValueES5() {
   if (document.cookie.split(';').some(function(item) {
     return item.indexOf('reader=1') &gt;= 0
   })) {
-    console.log('The cookie "reader" has "1" for value')
+    console.log('The cookie "reader" has a value of "1"')
   }
 }
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -224,7 +224,7 @@ function checkACookieExists() {
 
 <pre
 	class="brush: html">&lt;button onclick="checkACookieExists()"&gt;
-  Check a cookie existence
+  Check a cookie exists
 &lt;/button&gt;
 
 &lt;div&gt;

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -237,11 +237,19 @@ function checkACookieExists() {
   }
 }
 
+function resetOutputACookieExists() {
+  const output = document.getElementById('a-cookie-existence')
+  output.textContent = ''
+}
+
 </pre>
 
 <pre
 	class="brush: html">&lt;button onclick="checkACookieExists()"&gt;
   Check a cookie exists
+&lt;/button&gt;
+&lt;button onclick="resetOutputACookieExists()"&gt;
+  Reset
 &lt;/button&gt;
 
 &lt;div&gt;
@@ -260,11 +268,19 @@ function checkACookieExists() {
     output.textContent = '>> The cookie "reader" has a value of "1"'
   }
 }
+
+function resetASpecificValueOfTheCookie() {
+  const output = document.getElementById('a-specific-value-of-the-cookie')
+  output.textContent = ''
+}
 </pre>
 
 <pre
 	class="brush: html">&lt;button onclick="checkCookieHasASpecificValue()"&gt;
   Check that a cookie has a specific value
+&lt;/button&gt;
+&lt;button onclick="resetASpecificValueOfTheCookie()"&gt;
+  Reset
 &lt;/button&gt;
 
 &lt;div&gt;

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -215,24 +215,32 @@ function alertCookieValue() {
 
 function checkACookieExists() {
   if (document.cookie.split(';').some((item) =&gt; item.trim().startsWith('reader='))) {
-    console.log('The cookie "reader" exists')
+		const output = document.getElementById('a-cookie-existence')
+    output.textContent = '>> The cookie "reader" exists'
   }
 }
 
 </pre>
 
 <pre
-	class="brush: html">&lt;button onclick="checkACookieExists()"&gt;Check a cookie existence&lt;/button&gt;
+	class="brush: html">&lt;button onclick="checkACookieExists()"&gt;
+  Check a cookie existence
+&lt;/button&gt;
+
+&lt;div&gt;
+  &lt;code id="a-cookie-existence"&gt;&lt;/code&gt;
+&lt;/div&gt;
 </pre>
 
-<p>{{EmbedLiveSample('Example_5_Check_a_cookie_existence', 200, 36)}}</p>
+<p>{{EmbedLiveSample('Example_5_Check_a_cookie_existence', 200, 72)}}</p>
 
 <h3 id="Example_6_Check_that_a_cookie_has_a_specific_value">Example #6: Check that a
 	cookie has a specific value</h3>
 
 <pre class="brush: js">function checkCookieHasASpecificValue() {
   if (document.cookie.split(';').some((item) =&gt; item.includes('reader=1'))) {
-    console.log('The cookie "reader" has "1" for value')
+    const output = document.getElementById('a-specific-value-of-the-cookie')
+    output.textContent = '>> The cookie "reader" has "1" for value'
   }
 }
 </pre>
@@ -241,9 +249,13 @@ function checkACookieExists() {
 	class="brush: html">&lt;button onclick="checkCookieHasASpecificValue()"&gt;
   Check that a cookie has a specific value
 &lt;/button&gt;
+
+&lt;div&gt;
+  &lt;code id="a-specific-value-of-the-cookie"&gt;&lt;/code&gt;
+&lt;/div&gt;
 </pre>
 
-<p>{{EmbedLiveSample('Example_6_Check_that_a_cookie_has_a_specific_value', 200, 36)}}</p>
+<p>{{EmbedLiveSample('Example_6_Check_that_a_cookie_has_a_specific_value', 200, 72)}}</p>
 
 <h2 id="Security">Security</h2>
 

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -145,8 +145,8 @@ tags:
 
 <h3 id="Example_1_Simple_usage">Example #1: Simple usage</h3>
 
-<pre class="brush: js">document.cookie = "name=oeschger";
-document.cookie = "favorite_food=tripe";
+<pre class="brush: js">document.cookie = "name=oeschger; SameSite=None; Secure";
+document.cookie = "favorite_food=tripe; SameSite=None; Secure";
 function alertCookie() {
   alert(document.cookie);
 }
@@ -160,8 +160,8 @@ function alertCookie() {
 <h3 id="Example_2_Get_a_sample_cookie_named_test2">Example #2: Get a sample cookie named
 	<em>test2</em></h3>
 
-<pre class="brush: js">document.cookie = "test1=Hello";
-document.cookie = "test2=World";
+<pre class="brush: js">document.cookie = "test1=Hello; SameSite=None; Secure";
+document.cookie = "test2=World; SameSite=None; Secure";
 
 const cookieValue = document.cookie
   .split('; ')
@@ -186,7 +186,7 @@ function alertCookieValue() {
 <pre class="brush: js">function doOnce() {
   if (!document.cookie.split('; ').find(row =&gt; row.startsWith('doSomethingOnlyOnce'))) {
     alert("Do something here!");
-    document.cookie = "doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+    document.cookie = "doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=None; Secure";
   }
 }</pre>
 
@@ -198,7 +198,7 @@ function alertCookieValue() {
 <h3 id="Example_4_Reset_the_previous_cookie">Example #4: Reset the previous cookie</h3>
 
 <pre class="brush: js">function resetOnce() {
-  document.cookie = "doSomethingOnlyOnce=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  document.cookie = "doSomethingOnlyOnce=; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=None; Secure";
 }</pre>
 
 <pre


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

I have made some fixes to live examples in `Document.cookie`

> MDN URL of the main page changed

<https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie>

> Issue number (if there is an associated issue)

https://github.com/mdn/content/issues/3288

> Anything else that could help us review it

- `Samesite` specification changed in Chromium : https://www.chromium.org/updates/same-site
