### PR TITLE
Experimental firefox

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -11,7 +11,7 @@ tags:
 
 <p>This page lists Firefox's experimental and partially implemented features, including those for proposed or cutting-edge Web platform standards, along with: information on the builds in which they are present, whether or not they are activated "by default", and which <em>preference</em> can be used to activate or deactivate them. This allows you to test the features with your web sites and applications before they are released.</p>
 
-<p>New features appear first in the <a href="https://nightly.mozilla.org/">Firefox Nightly</a> build, which is updated every day (where it is more common for them to be enabled by default). They later propagate though to <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and eventually to the release build. Once a feature is enabled by default in a release build it is no longer experimentaal, and should be removed from the topic.</p>
+<p>New features appear first in the <a href="https://nightly.mozilla.org/">Firefox Nightly</a> build, where they are often enabled by default. They later propagate though to <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and eventually to the release build. Once a feature is enabled by default in a release build it is no longer experimentaal, and should be removed from the topic.</p>
 
 <p>Experimental features can be enabled or disabled  using the <a href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">Firefox Configuration Editor</a> (enter <code>about:config</code> in the Firefox address bar) by modifying the associated <em>preference</em> listed below.</p>
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -9,11 +9,11 @@ tags:
 ---
 <div>{{FirefoxSidebar}}</div>
 
-<p>This page lists Firefox's experimental and partially implemented features, including those for proposed or cutting-edge Web platform standards, along with: information on the builds in which they are present, whether or not they are activated "by default", and which <em>preference</em> can be used to activate or deactivate them. This allows you to test the features with your web sites and applications before they are released.</p>
+<p>This page lists Firefox's experimental and partially implemented features, including those for proposed or cutting-edge web platform standards, along with information on the builds in which they are present, whether or not they are activated "by default", and which <em>preference</em> can be used to activate or deactivate them. This allows you to test the features before they are released.</p>
 
-<p>New features appear first in the <a href="https://nightly.mozilla.org/">Firefox Nightly</a> build, where they are often enabled by default. They later propagate though to <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and eventually to the release build. Once a feature is enabled by default in a release build it is no longer experimentaal, and should be removed from the topic.</p>
+<p>New features appear first in the <a href="https://nightly.mozilla.org/">Firefox Nightly</a> build, where they are often enabled by default. They later propagate though to <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and eventually to the release build. Once a feature is enabled by default in a release build it is no longer experimental, and should be removed from the topic.</p>
 
-<p>Experimental features can be enabled or disabled  using the <a href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">Firefox Configuration Editor</a> (enter <code>about:config</code> in the Firefox address bar) by modifying the associated <em>preference</em> listed below.</p>
+<p>Experimental features can be enabled or disabled using the <a href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">Firefox Configuration Editor</a> (enter <code>about:config</code> in the Firefox address bar) by modifying the associated <em>preference</em> listed below.</p>
 
 <div class="notecard note">
   <h4>Editor's notes</h4>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -9,14 +9,15 @@ tags:
 ---
 <div>{{FirefoxSidebar}}</div>
 
-<p class="summary">In order to test new features, Mozilla publishes a test version of the Firefox browser, <a href="https://nightly.mozilla.org/">Firefox Nightly</a>, every day. These nightly builds of Firefox typically include experimental or partially-implemented features, including those for proposed or cutting-edge Web platform standards.</p>
+<p>In order to test new features, Mozilla publishes a test version of the Firefox browser, <a href="https://nightly.mozilla.org/">Firefox Nightly</a>, every day. These nightly builds of Firefox typically include experimental or partially-implemented features, including those for proposed or cutting-edge Web platform standards.</p>
 
-<p class="summary"><span class="seoSummary">This page lists features that are in Nightly versions of Firefox along with information on how to activate them, if necessary.</span> You can test your Web sites and applications before these features get released and ensure everything will still work with the latest Web technology capabilities.</p>
+<p>This page lists features that are in Nightly versions of Firefox along with information on how to activate them, if necessary. You can test your Web sites and applications before these features get released and ensure everything will still work with the latest Web technology capabilities.</p>
 
 <p>To test these experimental features, you need to download <a href="https://nightly.mozilla.org/">Firefox Nightly</a> or <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and set the appropriate preference in the <a href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">Firefox Configuration Editor</a>. The preference that you need to set is described alongside each feature's description below.</p>
 
 <div class="notecard note">
-<p><strong>Editor's note:</strong> When adding features to these tables, please try to include a link to the relevant bug or bugs using the {{TemplateLink("bug")}} macro: <code>\{{bug(<em>bug-number</em>)}}</code>.</p>
+  <h4>Editor's note</h4>
+  <p>When adding features to these tables, please try to include a link to the relevant bug or bugs using the {{TemplateLink("bug")}} macro: <code>\{{bug(<em>bug-number</em>)}}</code>.</p>
 </div>
 
 <h2 id="HTML">HTML</h2>

--- a/files/en-us/mozilla/firefox/experimental_features/index.html
+++ b/files/en-us/mozilla/firefox/experimental_features/index.html
@@ -9,14 +9,14 @@ tags:
 ---
 <div>{{FirefoxSidebar}}</div>
 
-<p>In order to test new features, Mozilla publishes a test version of the Firefox browser, <a href="https://nightly.mozilla.org/">Firefox Nightly</a>, every day. These nightly builds of Firefox typically include experimental or partially-implemented features, including those for proposed or cutting-edge Web platform standards.</p>
+<p>This page lists Firefox's experimental and partially implemented features, including those for proposed or cutting-edge Web platform standards, along with: information on the builds in which they are present, whether or not they are activated "by default", and which <em>preference</em> can be used to activate or deactivate them. This allows you to test the features with your web sites and applications before they are released.</p>
 
-<p>This page lists features that are in Nightly versions of Firefox along with information on how to activate them, if necessary. You can test your Web sites and applications before these features get released and ensure everything will still work with the latest Web technology capabilities.</p>
+<p>New features appear first in the <a href="https://nightly.mozilla.org/">Firefox Nightly</a> build, which is updated every day (where it is more common for them to be enabled by default). They later propagate though to <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and eventually to the release build. Once a feature is enabled by default in a release build it is no longer experimentaal, and should be removed from the topic.</p>
 
-<p>To test these experimental features, you need to download <a href="https://nightly.mozilla.org/">Firefox Nightly</a> or <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a> and set the appropriate preference in the <a href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">Firefox Configuration Editor</a>. The preference that you need to set is described alongside each feature's description below.</p>
+<p>Experimental features can be enabled or disabled  using the <a href="https://support.mozilla.org/en-US/kb/about-config-editor-firefox">Firefox Configuration Editor</a> (enter <code>about:config</code> in the Firefox address bar) by modifying the associated <em>preference</em> listed below.</p>
 
 <div class="notecard note">
-  <h4>Editor's note</h4>
+  <h4>Editor's notes</h4>
   <p>When adding features to these tables, please try to include a link to the relevant bug or bugs using the {{TemplateLink("bug")}} macro: <code>\{{bug(<em>bug-number</em>)}}</code>.</p>
 </div>
 


### PR DESCRIPTION
The [Experimental features in Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features) page is a little over-focused on Nightly builds, and doesn't make it clear that the preferences 
- might be in release
- might be enabled by default
- are removed from the topic once they are enabled by default in a release build. 

This tidies those details. 

This follows on from discussion in https://github.com/mdn/content/issues/4924#issuecomment-841080967