### PR TITLE
HTTP Headers - further tidy of general/entity headers

### DIFF
--- a/files/en-us/glossary/fetch_metadata_request_header/index.html
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.html
@@ -27,8 +27,8 @@ tags:
  </li>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>
-   <li>{{Glossary("Entity header")}}</li>
-   <li>{{Glossary("Header")}}</li>
+   <li>{{Glossary("Representation header")}}</li>
+   <li>{{Glossary("HTTP_header","HTTP header")}}</li>
    <li>{{Glossary("Response header")}}</li>
    <li>{{Glossary("Request header")}}</li>
   </ol>

--- a/files/en-us/glossary/general_header/index.html
+++ b/files/en-us/glossary/general_header/index.html
@@ -5,8 +5,9 @@ tags:
   - Glossary
   - WebMechanics
 ---
-<p>A <strong>general header</strong> is an {{glossary('HTTP_header', 'HTTP header')}} that can be used in both request and response messages but doesn't apply to the content itself. Depending on the context they are used in, general headers are either {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} (e.g. {{HTTPheader("Cache-Control")}}).</p>
+<p><strong>General header</strong> is an outdated term used to refer to an {{glossary('HTTP_header', 'HTTP header')}} that can be used in both request and response messages, but which doesn't apply to the content itself (a header that applied to the content was called an {{glossary("entity header")}}). Depending on the context they are used in, general headers might either be {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} (e.g. {{HTTPheader("Cache-Control")}}).</p>
 
 <div class="notecard note">
-<p>Current versions of the HTTP/1.1 specification do not specifically categorize headers as "general headers". Historically the general headers did not include headers that describe the payload ({{glossary("entity header", "entity headers")}}).</p>
+  <h4>Note</h4>
+  <p>Current versions of the HTTP/1.1 specification do not specifically categorize headers as "general headers". These are now simply refered to as {{glossary("Response header", "response")}} or {{glossary("request header", "request headers")}} depending on context.</p>
 </div>

--- a/files/en-us/glossary/http_header/index.html
+++ b/files/en-us/glossary/http_header/index.html
@@ -8,22 +8,13 @@ tags:
 ---
 <p>An <strong>HTTP header</strong> is a field of an HTTP request or response that passes additional context and metadata about the request or response. For example, a request message can use headers to indicate it's preferred media formats, while a response can use header to indicate the media format of the returned body. Headers are case-insensitive, begin at the start of a line and are immediately followed by a <code>':'</code> and a header-dependent value. The value finishes at the next CRLF or at the end of the message.</p>
 
-<p>The current specification has a number of header categories, including:</p>
+<p>The current HTTP specifications refer to a number of header categories, including:</p>
 
 <ul>
  <li>{{Glossary("Request header")}}: Headers containing more information about the resource to be fetched or about the client itself.</li>
  <li>{{Glossary("Response header")}}: Headers with additional information about the response, like its location or about the server itself (name, version, …).</li>
  <li>{{Glossary("Representation header")}}: metadata about the resource in the message body (e.g. encoding, media type, etc.).</li>
 </ul>
-
-<div class="notecard note">
-<p>Older versions of the specification referred to:</p>
-
-<ul>
- <li>{{Glossary("General header")}}: Headers applying to both requests and responses but with no relation to the data eventually transmitted in the body.</li>
- <li>{{Glossary("Entity header")}}: Headers containing more information about the body of the entity, like its content length or its MIME-type (this is a superset of what are now referred to as the Representation metadata headers)</li>
-</ul>
-</div>
 
 <p>A basic request with one header:</p>
 
@@ -53,6 +44,17 @@ X-Backend-Server: developer6.webapp.scl3.mozilla.com
 X-Cache: Hit from cloudfront
 X-Cache-Info: cached
 </pre>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Older versions of the specification referred to:</p>
+  
+  <ul>
+   <li>{{Glossary("General header")}}: Headers applying to both requests and responses but with no relation to the data eventually transmitted in the body.</li>
+   <li>{{Glossary("Entity header")}}: Headers containing more information about the body of the entity, like its content length or its MIME-type (this is a superset of what are now referred to as the Representation metadata headers)</li>
+  </ul>
+  </div>
+  
 
 <section id="Quick_links">
 <ol>

--- a/files/en-us/glossary/representation_header/index.html
+++ b/files/en-us/glossary/representation_header/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>Representation headers may be present in both HTTP request and response messages. If sent as a response to a <code>HEAD</code> request, they describe the body content that <em>would</em> be sent if the resource was actually requested.</p>
 
-<p>The representation headers include {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Content-Encoding")}}, {{HTTPHeader("Content-Language")}}, and {{HTTPHeader("Content-Location")}}.</p>
+<p>Rpresentation headers include: {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Content-Encoding")}}, {{HTTPHeader("Content-Language")}}, and {{HTTPHeader("Content-Location")}}.</p>
 
 <h2 id="see_also">See also</h2>
 

--- a/files/en-us/glossary/representation_header/index.html
+++ b/files/en-us/glossary/representation_header/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p>Representation headers may be present in both HTTP request and response messages. If sent as a response to a <code>HEAD</code> request, they describe the body content that <em>would</em> be sent if the resource was actually requested.</p>
 
-<p>Rpresentation headers include: {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Content-Encoding")}}, {{HTTPHeader("Content-Language")}}, and {{HTTPHeader("Content-Location")}}.</p>
+<p>Representation headers include: {{HTTPHeader("Content-Type")}}, {{HTTPHeader("Content-Encoding")}}, {{HTTPHeader("Content-Language")}}, and {{HTTPHeader("Content-Location")}}.</p>
 
 <h2 id="see_also">See also</h2>
 

--- a/files/en-us/glossary/request_header/index.html
+++ b/files/en-us/glossary/request_header/index.html
@@ -5,9 +5,9 @@ tags:
   - Glossary
   - WebMechanics
 ---
-<p>A <strong>request header</strong> is an {{glossary("header", "HTTP header")}} that can be used in an HTTP request to provide information about the request context, so that the server can tailor the response. For example, the {{HTTPHeader("Accept", "Accept-*")}} headers indicate the allowed and preferred formats of the response. Other headers can be used to supply authentication credentials (e.g.  {{HTTPHeader("Authorization")}}), to control caching, or to get information about the user agent or referrer, etc. </p>
+<p>A <strong>request header</strong> is an {{glossary("HTTP header")}} that can be used in an HTTP request to provide information about the request context, so that the server can tailor the response. For example, the {{HTTPHeader("Accept", "Accept-*")}} headers indicate the allowed and preferred formats of the response. Other headers can be used to supply authentication credentials (e.g.  {{HTTPHeader("Authorization")}}), to control caching, or to get information about the user agent or referrer, etc. </p>
 
-<p>Not all headers appearing in a request are referred to as <em>request headers</em> by the specification. For example, the {{HTTPHeader("Content-Length")}} header (which indicates the size of the message body) is referred to as an {{glossary("entity header")}} in older versions of the specification and as representational metadata in more recent versions.</p>
+<p>Not all headers that can appear in a request are referred to as <em>request headers</em> by the specification. For example, the {{HTTPHeader("Content-Type")}} header is referred to as a {{glossary("representation header")}}.</p>
 
 <p>In addition, <a href="/en-US/docs/Glossary/CORS">CORS</a> defines a subset of request headers as {{glossary('simple header', 'simple headers')}}, request headers that are always considered authorized and are not explicitly listed in responses to {{glossary("preflight request", "preflight")}} requests.</p>
 

--- a/files/en-us/glossary/response_header/index.html
+++ b/files/en-us/glossary/response_header/index.html
@@ -5,11 +5,11 @@ tags:
   - Glossary
   - WebMechanics
 ---
-<p>A <strong>response header</strong> is an {{glossary("header", "HTTP header")}} that can be used in an HTTP response and that doesn't relate to the content of the message. Response headers, like {{HTTPHeader("Age")}}, {{HTTPHeader("Location")}} or {{HTTPHeader("Server")}} are used to give a more detailed context of the response.</p>
+<p>A <strong>response header</strong> is an {{glossary("HTTP header")}} that can be used in an HTTP response and that doesn't relate to the content of the message. Response headers, like {{HTTPHeader("Age")}}, {{HTTPHeader("Location")}} or {{HTTPHeader("Server")}} are used to give a more detailed context of the response.</p>
 
-<p>Not all headers appearing in a response are categorized as <em>response headers</em> by the specification. For example, the {{HTTPHeader("Content-Length")}} header is an <em>Representation metadata header</em> indicating the size of the body of the response message (and as an {{glossary("entity header")}} in older versions of the specification). However, "conversationally" all headers are usually referred to as response headers in a response message.</p>
+<p>Not all headers appearing in a response are categorized as <em>response headers</em> by the specification. For example, the {{HTTPHeader("Content-Type")}} header is a {{glossary("representation header")}} indicating the original type of data in the body of the response message (prior to the encoding in the {{HTTPHeader("Content-Encoding")}} representation header being applied). However, "conversationally" all headers are usually referred to as response headers in a response message.</p>
 
-<p>The following shows a few response headers after a {{HTTPMethod("GET")}} request. Note that strictly speaking, the {{HTTPHeader("Content-Encoding")}} and {{HTTPHeader("Content-Type")}} headers are {{glossary("entity header")}}:</p>
+<p>The following shows a few response and representation headers after a {{HTTPMethod("GET")}} request.</p>
 
 <pre class="brush: bash">200 OK
 Access-Control-Allow-Origin: *
@@ -38,8 +38,8 @@ x-frame-options: DENY</pre>
  </li>
  <li><a href="/en-US/docs/Glossary">Glossary</a>
   <ol>
-   <li>{{Glossary("Entity header")}}</li>
-   <li>{{Glossary("Header")}}</li>
+   <li>{{Glossary("Representation header")}}</li>
+   <li>{{Glossary("HTTP header")}}</li>
    <li>{{Glossary("Response header")}}
     <ol>
      <li>{{Glossary("Fetch metadata response header")}}</li>

--- a/files/en-us/mdn/contribute/howto/document_an_http_header/index.html
+++ b/files/en-us/mdn/contribute/howto/document_an_http_header/index.html
@@ -30,8 +30,8 @@ tags:
 
 <ul>
  <li>Existing HTTP headers are documented <a href="/en-US/docs/Web/HTTP/Headers">here</a>.</li>
- <li>There are different header categories: {{Glossary("General header")}}, {{Glossary("Request header")}}, {{Glossary("Response header")}} and {{Glossary("Entity header")}}.</li>
- <li>Find the category the header you are about to document.</li>
+ <li>There are different header categories: {{Glossary("Request header")}}, {{Glossary("Response header")}},  and {{Glossary("Representation header")}}.</li>
+ <li>Find the category of the header you are about to document (note that some headers can be both request and response headers, depending on context).</li>
  <li>Go to an existing header reference page that has the same category.</li>
 </ul>
 
@@ -45,7 +45,7 @@ tags:
 <h2 id="Step_4_–_write_content">Step 4 – write content</h2>
 
 <ul>
- <li>Either use a copied structure from one of the existing HTTP header documents that you found in step 2 or start from scratch. It's your choice.</li>
+ <li>Either start from our <a href="/en-US/docs/MDN/Structures/Page_types#http_header_reference_page">template HTTP header page</a> or use a copied structure from one of the existing HTTP header documents that you found in step 2. It's your choice.</li>
  <li>Write about your new HTTP header.</li>
  <li>Make sure you have these sections:
   <ul>

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
@@ -48,7 +48,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>Include header category(s), e.g. {{Glossary("Response header")}}</td>
+   <td>Include header category (or categories), e.g. {{Glossary("Response header")}}</td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
@@ -31,7 +31,7 @@ tags:
 
 <h3 id="Tags">Tags</h3>
 
-<p>In an HTTP header element subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>HTTP</strong>, <strong>Reference</strong>, <strong>HTTP Headers</strong>, <em>the name of the HTTP Header</em> (e.g. <strong>Cache-Control</strong>), <strong>General Header</strong>/<strong>Caching</strong>/<strong>Entity Header</strong> or other header category as appropriate, <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+<p>In an HTTP header element subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>HTTP</strong>, <strong>Reference</strong>, <strong>HTTP Header</strong>, <em>the name of the HTTP Header</em> (e.g. <strong>Cache-Control</strong>), <strong>Response Header</strong>/<strong>Request header</strong>/<strong>Representation header</strong>, <strong>Caching</strong>/ or other header category as appropriate, <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
 
 <h3 id="Browser_compatibility">Browser compatibility</h3>
 
@@ -48,7 +48,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>Include header category, e.g. {{Glossary("General header")}}</td>
+   <td>Include header category(s), e.g. {{Glossary("Response header")}}</td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/allow/index.html
+++ b/files/en-us/web/http/headers/allow/index.html
@@ -18,7 +18,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>{{Glossary("Entity header")}}</td>
+   <td>{{Glossary("Entity header")}} </td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/allow/index.html
+++ b/files/en-us/web/http/headers/allow/index.html
@@ -2,11 +2,10 @@
 title: Allow
 slug: Web/HTTP/Headers/Allow
 tags:
-  - Entity header
   - HTTP
   - HTTP Header
+  - Response header
   - Reference
-  - header
 ---
 <div>{{HTTPSidebar}}</div>
 

--- a/files/en-us/web/http/headers/allow/index.html
+++ b/files/en-us/web/http/headers/allow/index.html
@@ -18,7 +18,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Header type</th>
-   <td>{{Glossary("Entity header")}} </td>
+   <td>{{Glossary("Response header")}} </td>
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/content-length/index.html
+++ b/files/en-us/web/http/headers/content-length/index.html
@@ -16,7 +16,7 @@ browser-compat: http.headers.Content-Length
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Response header")}}, {{Glossary("Response header")}}</td>
+      <td>{{Glossary("Request header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>

--- a/files/en-us/web/http/headers/content-length/index.html
+++ b/files/en-us/web/http/headers/content-length/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Headers
 - Reference
+browser-compat: http.headers.Content-Length
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -15,7 +16,7 @@ tags:
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("Entity header")}}</td>
+      <td>{{Glossary("Response header")}}, {{Glossary("Response header")}}</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
@@ -59,12 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
-<p>{{Compat("http.headers.Content-Length")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-length/index.html
+++ b/files/en-us/web/http/headers/content-length/index.html
@@ -2,15 +2,17 @@
 title: Content-Length
 slug: Web/HTTP/Headers/Content-Length
 tags:
-- HTTP
-- Headers
-- Reference
+  - Content-Length
+  - HTTP
+  - HTTP header
+  - Request header
+  - Response header
+  - Reference
 browser-compat: http.headers.Content-Length
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <strong><code>Content-Length</code></strong> entity header indicates the size of
-  the entity-body, in bytes, sent to the recipient.</p>
+<p>The <strong><code>Content-Length</code></strong> header indicates the size of the message body, in bytes, sent to the recipient.</p>
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/content-type/index.html
+++ b/files/en-us/web/http/headers/content-type/index.html
@@ -3,14 +3,14 @@ title: Content-Type
 slug: Web/HTTP/Headers/Content-Type
 tags:
   - Content-Type
-  - Entity header
   - HTTP
+  - HTTP header
+  - Representation header
   - Reference
-  - header
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p>The <strong><code>Content-Type</code></strong> entity header is used to indicate the {{Glossary("MIME type","media type")}} of the resource.</p>
+<p>The <strong><code>Content-Type</code></strong> representation header is used to indicate the original {{Glossary("MIME type","media type")}} of the resource (prior to any content encoding applied for sending).</p>
 
 <p>In responses, a <code>Content-Type</code> header tells the client what the content type of the returned content actually is. Browsers will do MIME sniffing in some cases and will not necessarily follow the value of this header; to prevent this behavior, the header {{HTTPHeader("X-Content-Type-Options")}} can be set to <code>nosniff</code>.</p>
 

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -63,7 +63,7 @@ Transfer-Encoding: gzip, chunked</pre>
     the current chunk in hexadecimal format, followed by '<code>\r\n</code>' and then the
     chunk itself, followed by another '<code>\r\n</code>'. The terminating chunk is a
     regular chunk, with the exception that its length is zero. It is followed by the
-    trailer, which consists of a (possibly empty) sequence of entity header fields.</dd>
+    trailer, which consists of a (possibly empty) sequence of entity header fields. </dd>
   <dt><code>compress</code></dt>
   <dd>A format using the <a href="https://en.wikipedia.org/wiki/LZW">Lempel-Ziv-Welch</a> (LZW) algorithm. The
     value name was taken from the UNIX <em>compress</em> program, which implemented this

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -63,7 +63,7 @@ Transfer-Encoding: gzip, chunked</pre>
     the current chunk in hexadecimal format, followed by '<code>\r\n</code>' and then the
     chunk itself, followed by another '<code>\r\n</code>'. The terminating chunk is a
     regular chunk, with the exception that its length is zero. It is followed by the
-    trailer, which consists of a (possibly empty) sequence of entity header fields. </dd>
+    trailer, which consists of a (possibly empty) sequence of header fields. </dd>
   <dt><code>compress</code></dt>
   <dd>A format using the <a href="https://en.wikipedia.org/wiki/LZW">Lempel-Ziv-Welch</a> (LZW) algorithm. The
     value name was taken from the UNIX <em>compress</em> program, which implemented this

--- a/files/en-us/web/http/messages/index.html
+++ b/files/en-us/web/http/messages/index.html
@@ -64,9 +64,9 @@ tags:
 <p>Many different headers can appear in requests. They can be divided in several groups:</p>
 
 <ul>
- <li><em>General headers</em>, like {{HTTPHeader("Via")}}, apply to the message as a whole.</li>
- <li><em>Request headers</em>, like {{HTTPHeader("User-Agent")}} or {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).</li>
- <li><em>Representation metadata headers</em> (formerly <em>entity headers</em>), like {{HTTPHeader("Content-Length")}} that describe the encoding and format of the message body (only present if the message has a body).</li>
+ <li>{{glossary("General header", "General headers")}}, like {{HTTPHeader("Via")}}, apply to the message as a whole.</li> 
+ <li>{{glossary("Request header", "Request headers")}}, like {{HTTPHeader("User-Agent")}} or {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).</li>
+ <li>{{glossary("Representation header", "Representation headers")}} like {{HTTPHeader("Content-Type")}} that describe the original format of the message data and any encoding applied (only present if the message has a body).</li>
 </ul>
 
 <p><img alt="Example of headers in an HTTP request" src="http_request_headers3.png"></p>
@@ -103,9 +103,9 @@ tags:
 <p>Many different headers can appear in responses. These can be divided into several groups:</p>
 
 <ul>
- <li><em>General headers</em>, like {{HTTPHeader("Via")}}, apply to the whole message.</li>
- <li><em>Response headers</em>, like {{HTTPHeader("Vary")}} and {{HTTPHeader("Accept-Ranges")}}, give additional information about the server which doesn't fit in the status line.</li>
- <li><em>Representation metadata headers</em> (formerly <em>entity headers</em>), like {{HTTPHeader("Content-Length")}} that describe the encoding and format of the message body (only present if the message has a body).</li>
+ <li>{{glossary("General header", "General headers")}}, like {{HTTPHeader("Via")}}, apply to the whole message.</li> 
+ <li>{{glossary("Response header", "Response headers")}}, like {{HTTPHeader("Vary")}} and {{HTTPHeader("Accept-Ranges")}}, give additional information about the server which doesn't fit in the status line.</li>  
+ <li><{{glossary("Representation header", "Representation headers")}} like {{HTTPHeader("Content-Type")}} that describe the original format of the message data and any encoding applied (only present if the message has a body).</li>
 </ul>
 
 <p><img alt="Example of headers in an HTTP response" src="http_response_headers3.png"></p>

--- a/files/en-us/web/http/messages/index.html
+++ b/files/en-us/web/http/messages/index.html
@@ -105,7 +105,7 @@ tags:
 <ul>
  <li>{{glossary("General header", "General headers")}}, like {{HTTPHeader("Via")}}, apply to the whole message.</li> 
  <li>{{glossary("Response header", "Response headers")}}, like {{HTTPHeader("Vary")}} and {{HTTPHeader("Accept-Ranges")}}, give additional information about the server which doesn't fit in the status line.</li>  
- <li><{{glossary("Representation header", "Representation headers")}} like {{HTTPHeader("Content-Type")}} that describe the original format of the message data and any encoding applied (only present if the message has a body).</li>
+ <li>{{glossary("Representation header", "Representation headers")}} like {{HTTPHeader("Content-Type")}} that describe the original format of the message data and any encoding applied (only present if the message has a body).</li>
 </ul>
 
 <p><img alt="Example of headers in an HTTP response" src="http_response_headers3.png"></p>

--- a/files/en-us/web/http/methods/head/index.html
+++ b/files/en-us/web/http/methods/head/index.html
@@ -8,10 +8,11 @@ tags:
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p><span class="seoSummary">The <strong>HTTP <code>HEAD</code> method</strong> requests the <a href="/en-US/docs/Web/HTTP/Headers">headers</a> that would be returned if the <code>HEAD</code> request's URL was instead requested with the HTTP {{HTTPMethod("GET")}} method.</span> For example, if a URL might produce a large download, a <code>HEAD</code> request could read its {{HTTPHeader("Content-Length")}} header to check the filesize without actually downloading the file.</p>
+<p>The <strong>HTTP <code>HEAD</code> method</strong> requests the <a href="/en-US/docs/Web/HTTP/Headers">headers</a> that would be returned if the <code>HEAD</code> request's URL was instead requested with the HTTP {{HTTPMethod("GET")}} method. For example, if a URL might produce a large download, a <code>HEAD</code> request could read its {{HTTPHeader("Content-Length")}} header to check the filesize without actually downloading the file.</p>
 
 <div class="notecard warning">
-<p>A response to a <code>HEAD</code> method <em>should not</em> have a body. If it has one anyway, that body <strong>must be</strong> ignored: any {{glossary("Entity header", "entity headers")}} that might describe the erroneous body are instead assumed to describe the response which a similar <code>GET</code> request would have received.</p>
+  <h4>Warning</h4>
+  <p>A response to a <code>HEAD</code> method <em>should not</em> have a body. If it has one anyway, that body <strong>must be</strong> ignored: any {{glossary("Representation header", "representation headers")}} that might describe the erroneous body are instead assumed to describe the response which a similar <code>GET</code> request would have received.</p>
 </div>
 
 <p>If the response to a <code>HEAD</code> request shows that a cached URL response is now outdated, the cached copy is invalidated even if no <code>GET</code> request was made.</p>

--- a/files/en-us/web/http/status/200/index.html
+++ b/files/en-us/web/http/status/200/index.html
@@ -14,7 +14,7 @@ tags:
 
 <ul>
  <li>{{HTTPMethod("GET")}}: The resource has been fetched and is transmitted in the message body.</li>
- <li>{{HTTPMethod("HEAD")}}: The entity headers are included in the response without any message body </li>
+ <li>{{HTTPMethod("HEAD")}}: The representation headers are included in the response without any message body </li>
  <li>{{HTTPMethod("POST")}}: The resource describing the result of the action is transmitted in the message body</li>
  <li>{{HTTPMethod("TRACE")}}: The message body contains the request message as received by the server.</li>
 </ul>

--- a/files/en-us/web/http/status/index.html
+++ b/files/en-us/web/http/status/index.html
@@ -47,7 +47,7 @@ tags:
  <dd>The request has succeeded. The meaning of the success depends on the HTTP method:
  <ul>
   <li><code>GET</code>: The resource has been fetched and is transmitted in the message body.</li>
-  <li><code>HEAD</code>: The entity headers are in the message body.</li>
+  <li><code>HEAD</code>: The representation headers are included in the response without any message body.</li>
   <li><code>PUT</code> or <code>POST</code>: The resource describing the result of the action is transmitted in the message body.</li>
   <li><code>TRACE</code>: The message body contains the request message as received by the server.</li>
  </ul>


### PR DESCRIPTION
Follow on work around HTTP Headers - better positioning of general headers, entity headers.