### PR TITLE
Remove {{anch}} from image format table

### DIFF
--- a/files/en-us/web/media/formats/image_types/index.html
+++ b/files/en-us/web/media/formats/image_types/index.html
@@ -46,53 +46,53 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row">{{anch("APNG")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#apng">APNG</a></th>
    <th scope="row">Animated Portable Network Graphics</th>
    <td><code>image/apng</code></td>
    <td><code>.apng</code></td>
-   <td>Good choice for lossless animation sequences (GIF is less performant). {{anch("AVIF")}} and {{anch("WebP")}} have better performance but less broad browser support.<br>
+   <td>Good choice for lossless animation sequences (GIF is less performant). AVIF and WebP have better performance but less broad browser support.<br>
     <strong>Supported</strong>: Chrome, Edge, Firefox, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("AVIF")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#avif">AVIF</a></th>
    <th scope="row">AV1 Image File Format</th>
    <td><code>image/avif</code></td>
    <td><code>.avif</code></td>
    <td>
-    <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than {{anch("PNG")}} or {{anch("JPEG")}} with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
+    <p>Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&lt;picture&gt;</a></code> element). <br>
      <strong>Supported:</strong> Chrome, Opera, Firefox (behind a <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_av1_image_file_format_support">preference</a>. Basic support only; advanced features like animated images and colorspace support yet to the implemented).</p>
    </td>
   </tr>
   <tr>
-   <th scope="row">{{anch("GIF")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#gif">GIF</a></th>
    <th scope="row">Graphics Interchange Format</th>
    <td><code>image/gif</code></td>
    <td><code>.gif</code></td>
-   <td>Good choice for simple images and animations. Prefer {{anch("PNG")}} for lossless <em>and</em> indexed still images, and consider {{anch("WebP")}}, {{anch("AVIF")}} or {{anch("APNG")}} for animation sequences.<br>
+   <td>Good choice for simple images and animations. Prefer PNG for lossless <em>and</em> indexed still images, and consider WebP, AVIF or APNG for animation sequences.<br>
     <strong>Supported:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("JPEG")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#jpeg">JPEG</a></th>
    <th scope="row">Joint Photographic Expert Group image</th>
    <td><code>image/jpeg</code></td>
    <td><code>.jpg</code>, <code>.jpeg</code>, <code>.jfif</code>, <code>.pjpeg</code>, <code>.pjp</code></td>
    <td>
-    <p>Good choice for lossy compression of still images (currently the most popular). Prefer {{anch("PNG")}} when more precise reproduction of the image is required, or {{anch("WebP")}}/{{anch("AVIF")}} if both better reproduction and higher compression are required.<br>
+    <p>Good choice for lossy compression of still images (currently the most popular). Prefer PNG when more precise reproduction of the image is required, or WebP/AVIF if both better reproduction and higher compression are required.<br>
      <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</p>
    </td>
   </tr>
   <tr>
-   <th scope="row">{{anch("PNG")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#png">PNG</a></th>
    <th scope="row">Portable Network Graphics</th>
    <td><code>image/png</code></td>
    <td><code>.png</code></td>
    <td>
-    <p>PNG is preferred over JPEG for more precise reproduction of source images, or when transparency is needed. {{anch("WebP")}}/{{anch("AVIF")}} provide even better compression and reproduction, but browser support is more limited.<br>
+    <p>PNG is preferred over JPEG for more precise reproduction of source images, or when transparency is needed. WebP/AVIF provide even better compression and reproduction, but browser support is more limited.<br>
      <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</p>
    </td>
   </tr>
   <tr>
-   <th scope="row">{{anch("SVG")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#svg">SVG</a></th>
    <th scope="row">Scalable Vector Graphics</th>
    <td><code>image/svg+xml</code></td>
    <td><code>.svg</code></td>
@@ -100,11 +100,11 @@ tags:
     <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("WebP")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#webp">WebP</a></th>
    <th scope="row">Web Picture format</th>
    <td><code>image/webp</code></td>
    <td><code>.webp</code></td>
-   <td>Excellent choice for both images and animated images. WebP offers much better compression than {{anch("PNG")}} or {{anch("JPEG")}} with support for higher color depths, animated frames, transparency etc. {{anch("AVIF")}} offers slightly better compression, but is not quite as well-supported in browsers and does not support progressive rendering.<br>
+   <td>Excellent choice for both images and animated images. WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc. AVIF offers slightly better compression, but is not quite as well-supported in browsers and does not support progressive rendering.<br>
     <strong>Support:</strong> Chrome, Edge, Firefox, Opera, Safari</td>
   </tr>
  </tbody>
@@ -131,21 +131,21 @@ tags:
  </thead>
  <tbody>
   <tr>
-   <th scope="row">{{anch("BMP")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#bmp">BMP</a></th>
    <th scope="row">Bitmap file</th>
    <td><code>image/bmp</code></td>
    <td><code>.bmp</code></td>
    <td>Chrome, Edge, Firefox, IE, Opera, Safari</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("ICO")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#ico">ICO</a></th>
    <th scope="row">Microsoft Icon</th>
    <td><code>image/x-icon</code></td>
    <td><code>.ico</code>, <code>.cur</code></td>
    <td>Chrome, Edge, Firefox, IE, Opera, Safari</td>
   </tr>
   <tr>
-   <th scope="row">{{anch("TIFF")}}</th>
+   <th scope="row"><a href="/en-US/docs/Web/Media/Formats/Image_types#tiff">TIFF</a></th>
    <th scope="row">Tagged Image File Format</th>
    <td><code>image/tiff</code></td>
    <td><code>.tif</code>, <code>.tiff</code></td>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Do not use `{{anch}}` within a section that can be embedded in other pages.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types

> Issue number (if there is an associated issue)

Fixes #5052.

> Anything else that could help us review it

Also removes `{{anch}}`s in its summary column, since I thought the table is short enough.