### PR TITLE
Flexbox gap example

### DIFF
--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.html
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.html
@@ -68,9 +68,11 @@ tags:
 
 <h3 id="Creating_fixed_size_gaps_between_items">Creating fixed size gaps between items</h3>
 
-<p>On the main axis, the <code>column-gap</code> property will create fixed size gaps between adjacent items.</p>
+<p>On the main axis, the <code>column-gap</code> property creates fixed size gaps between adjacent items.</p>
 
-<p>On the cross axis the <code>row-gap</code> property will create spacing between adjacent flex lines, therefore <code>flex-wrap</code> must also be set to <code>wrap</code> for this to have any effect.</p>
+<p>On the cross axis the <code>row-gap</code> property creates spacing between adjacent flex lines, therefore <code>flex-wrap</code> must also be set to <code>wrap</code> for this to have any effect.</p>
+
+<p>{{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 500)}}</p>
 
 <h2 id="Reference">Reference</h2>
 

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.html
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_flexbox/index.html
@@ -72,7 +72,7 @@ tags:
 
 <p>On the cross axis the <code>row-gap</code> property creates spacing between adjacent flex lines, therefore <code>flex-wrap</code> must also be set to <code>wrap</code> for this to have any effect.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 500)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 700)}}</p>
 
 <h2 id="Reference">Reference</h2>
 

--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.html
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.html
@@ -35,13 +35,10 @@ tags:
  <li>{{cssxref("align-items")}} — controls alignment of all items on the cross axis.</li>
  <li>{{cssxref("align-self")}} — controls alignment of an individual flex item on the cross axis.</li>
  <li>{{cssxref("align-content")}} — described in the spec as for “packing flex lines”; controls space between flex lines on the cross axis.</li>
+ <li>{{cssxref("gap")}}, {{cssxref("column-gap")}}, and {{cssxref("row-gap")}} — used to create gaps or gutters between flex items.</li>
 </ul>
 
 <p>We will also discover how auto margins can be used for alignment in flexbox.</p>
-
-<div class="note">
-<p><strong>Note</strong>: The alignment properties in Flexbox have been placed into their own specification — <a href="https://www.w3.org/TR/css-align-3/">CSS Box Alignment Level 3</a>. It is expected that this spec will ultimately supersede the properties as defined in Flexbox Level One.</p>
-</div>
 
 <h2 id="The_Cross_Axis">The Cross Axis</h2>
 
@@ -182,7 +179,7 @@ tags:
 
 <p><img alt="Diagram showing start at the top and end at the bottom." src="align10.png"></p>
 
-<p>If you change flex-direction to one of the reverse values, then they will lay themselves out from the end axis and in the reverse order to the way words are written in the language of your document. <code>flex-start</code> will then change to the end of that axis — so to the location where your lines would wrap if working in rows, or at the end of your last paragraph of text in the block direction.</p>
+<p>If you change <code>flex-direction</code> to one of the reverse values, then they will lay themselves out from the end axis and in the reverse order to the way words are written in the language of your document. <code>flex-start</code> will then change to the end of that axis — so to the location where your lines would wrap if working in rows, or at the end of your last paragraph of text in the block direction.</p>
 
 <p><img alt="Diagram showing start on the right and end on the left." src="align9.png"></p>
 
@@ -202,13 +199,11 @@ tags:
 
 <p>{{EmbedGHLiveSample("css-examples/flexbox/alignment/auto-margins.html", '100%', 470)}} </p>
 
-<h2 id="Future_alignment_features_for_Flexbox">Future alignment features for Flexbox</h2>
+<h2 id="Creating_gaps_between_items">Creating gaps between items</h2>
 
-<p>At the beginning of this article I explained that the alignment properties currently contained in the Level 1 flexbox specification are also included in Box Alignment Level 3, which may well extend these properties and values in the future. We have already seen one place where this has happened, with the introduction of the <code>space-evenly</code> value for <code>align-content</code> and <code>justify-content</code> properties.</p>
+<p>To create a gap between flex items, use the {{cssxref("gap")}}, {{cssxref("column-gap")}}, and {{cssxref("row-gap")}} properties. The {{cssxref("column-gap")}} property creates gaps between items on the main axis. The {{cssxref("row-gap")}} property creates gaps between flex lines, when you have {{cssxref("flex-wrap")}}</code> set to <code>wrap</code>. The {{cssxref("gap")}} property is a shorthand that sets both together.</p>
 
-<p>The Box Alignment module also includes other methods of creating space between items, such as the <code>column-gap</code> and <code>row-gap</code> feature as seen in <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a>. The inclusion of these properties in Box Alignment means that in future we should be able to use <code>column-gap</code> and <code>row-gap</code> in flex layouts too, and in Firefox 63 you will find the first browser implementation of the gap properties in flex layout.</p>
-
-<p>My suggestion when exploring flexbox alignment in depth is to do so alongside looking at alignment in Grid Layout. Both specifications use the alignment properties as detailed in the Box Alignment specification. You can see how these properties behave when working with a grid in the MDN article <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box Alignment in Grid Layout</a>, and I have also compared how alignment works in these specifications in my <a href="https://rachelandrew.co.uk/css/cheatsheets/box-alignment">Box Alignment Cheatsheet</a>.</p>
+<p>{{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 500)}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.html
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.html
@@ -203,7 +203,7 @@ tags:
 
 <p>To create a gap between flex items, use the {{cssxref("gap")}}, {{cssxref("column-gap")}}, and {{cssxref("row-gap")}} properties. The {{cssxref("column-gap")}} property creates gaps between items on the main axis. The {{cssxref("row-gap")}} property creates gaps between flex lines, when you have {{cssxref("flex-wrap")}}</code> set to <code>wrap</code>. The {{cssxref("gap")}} property is a shorthand that sets both together.</p>
 
-<p>{{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 500)}}</p>
+<p>{{EmbedGHLiveSample("css-examples/box-alignment/flexbox/gap.html", '100%', 700)}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.html
+++ b/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.html
@@ -24,7 +24,7 @@ tags:
 
 <p>For many people the first reason they start to look at flexbox is because of the ability to properly align flex items inside a flex container. Flexbox provides access to properties that allow the alignment of items on their cross axis and justification of items on the main axis.</p>
 
-<p>These properties started life in the flexbox specification, but are now also part of the <a href="https://www.w3.org/TR/css-align-3/">Box Alignment Specification</a>. This specification details how alignment works in all layout — not just flexbox. Box alignment deals with alignment and justification, and also distribution of space along an axis.</p>
+<p>These properties started life in the flexbox specification, but are now also part of the <a href="https://www.w3.org/TR/css-align-3/">Box Alignment Specification</a>. This specification details how alignment works in all layout — not just flexbox. Box alignment deals with alignment and justification, including creating gaps or gutters between flex items.</p>
 
 <p>The reason that the Box alignment properties remain detailed in the flexbox specification as well as being in box alignment is to ensure that completion of the flexbox spec is not held up by box alignment, which has to detail these methods for all layout types. There is a note in the flexbox spec stating that in the future, once it is completed, the definitions in Box Alignment Level 3 will supersede those of flexbox:</p>
 
@@ -32,11 +32,7 @@ tags:
 <p>"Note: While the alignment properties are defined in CSS Box Alignment [CSS-ALIGN-3], Flexible Box Layout reproduces the definitions of the relevant ones here so as to not create a normative dependency that may slow down advancement of the spec. These properties apply only to flex layout until CSS Box Alignment Level 3 is finished and defines their effect for other layout modes. Additionally, any new values defined in the Box Alignment module will apply to Flexible Box Layout; in other words, the Box Alignment module, once completed, will supersede the definitions here."</p>
 </blockquote>
 
-<p>In a later article in this series — Aligning items in a flex container — we will take a thorough look at how the Box Alignment properties apply to flex items.</p>
-
-<h3 id="The_gap_properties">The gap properties</h3>
-
-<p>A recent addition to the Box Alignment specification has been the {{cssxref("row-gap")}} and {{cssxref("column-gap")}} properties, along with the shorthand {{cssxref("gap")}}. These properties were initially defined in the CSS Grid specification and named <code>grid-row-gap</code>, <code>grid-column-gap</code> and <code>grid-gap</code>. They have been renamed and moved to Box Alignment in order that they can be used in all layout methods — this will ultimately include flexbox. Until browsers implement the <code>gap</code> properties for flexbox, {{cssxref("margin")}}s have to be used to create gaps between items.</p>
+<p>In a later article in this series — <a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a> — we will take a thorough look at how the Box Alignment properties apply to flex items.</p>
 
 <h2 id="Writing_Modes">Writing Modes</h2>
 


### PR DESCRIPTION
Fixes #4573 by updating both the Box Alignment and Flexbox alignment guide to add some up to date info and a new example, also removed some outdated info re gaps.