### PR TITLE
docs: add AsyncAPI to list of tools for WebSocket

### DIFF
--- a/files/en-us/web/api/websockets_api/index.html
+++ b/files/en-us/web/api/websockets_api/index.html
@@ -45,6 +45,7 @@ tags:
 <h2 id="Tools">Tools</h2>
 
 <ul>
+ <li><a href="https://www.asyncapi.com/">AsyncAPI</a>: A specification for describing event-driven architectures like WebSocket. Use it to describe your WebSocket API just as you would do the same with OpenAPI specification for your REST API. Learn [why use AsyncAPI with WebSocket](https://www.asyncapi.com/blog/websocket-part1) and [how to do it](https://www.asyncapi.com/blog/websocket-part2).</li>
  <li><a href="https://hacks.mozilla.org/2017/06/introducing-humblenet-a-cross-platform-networking-library-that-works-in-the-browser/">HumbleNet</a>: A cross-platform networking library that works in the browser. It consists of a C wrapper around WebSockets and WebRTC that abstracts away cross-browser differences, facilitating the creation of multi-user networking functionality for games and other apps.</li>
  <li><a href="https://github.com/uWebSockets/uWebSockets">µWebSockets</a>: Highly scalable WebSocket server and client implementation for <a href="https://isocpp.org/">C++11</a> and <a href="https://nodejs.org">Node.js</a>.</li>
  <li><a href="https://github.com/ClusterWS/ClusterWS">ClusterWS</a>:  Lightweight, fast and powerful framework for building scalable WebSocket applications in <a href="https://nodejs.org">Node.js</a>.</li>

--- a/files/en-us/web/api/websockets_api/index.html
+++ b/files/en-us/web/api/websockets_api/index.html
@@ -45,7 +45,7 @@ tags:
 <h2 id="Tools">Tools</h2>
 
 <ul>
- <li><a href="https://www.asyncapi.com/">AsyncAPI</a>: A specification for describing event-driven architectures like WebSocket. Use it to describe your WebSocket API just as you would do the same with OpenAPI specification for your REST API. Learn [why use AsyncAPI with WebSocket](https://www.asyncapi.com/blog/websocket-part1) and [how to do it](https://www.asyncapi.com/blog/websocket-part2).</li>
+ <li><a href="https://www.asyncapi.com/">AsyncAPI</a>: A specification for describing event-driven architectures like WebSocket. You can use it to describe WebSocket-based APIs just as you would describe REST APIs with the OpenAPI specification. Learn <a href="https://www.asyncapi.com/blog/websocket-part1">why you should consider using AsyncAPI with WebSocket</a> and <a href="https://www.asyncapi.com/blog/websocket-part2">how to do so</a>.</li>
  <li><a href="https://hacks.mozilla.org/2017/06/introducing-humblenet-a-cross-platform-networking-library-that-works-in-the-browser/">HumbleNet</a>: A cross-platform networking library that works in the browser. It consists of a C wrapper around WebSockets and WebRTC that abstracts away cross-browser differences, facilitating the creation of multi-user networking functionality for games and other apps.</li>
  <li><a href="https://github.com/uWebSockets/uWebSockets">µWebSockets</a>: Highly scalable WebSocket server and client implementation for <a href="https://isocpp.org/">C++11</a> and <a href="https://nodejs.org">Node.js</a>.</li>
  <li><a href="https://github.com/ClusterWS/ClusterWS">ClusterWS</a>:  Lightweight, fast and powerful framework for building scalable WebSocket applications in <a href="https://nodejs.org">Node.js</a>.</li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The list of tools was missing a specification that is a standard for event-driven architectures.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API

> Issue number (if there is an associated issue)

no

> Anything else that could help us review it

It is just a reference to AsyncAPI website and guides that explain how to use AsyncAPI spec with the WebSocket standard
