### PR TITLE
404 fixed

### DIFF
--- a/files/en-us/web/accessibility/aria/aria_techniques/using_the_slider_role/index.html
+++ b/files/en-us/web/accessibility/aria/aria_techniques/using_the_slider_role/index.html
@@ -8,7 +8,7 @@ tags:
 ---
 <p id="Description"></p>
 
-<p class="summary"><span class="seoSummary">This technique demonstrates how to use the <a href="https://www.w3.org/TR/wai-aria/roles#slider" rel="external">slider</a> role and describes the effect it has on browsers and assistive technology.</span></p>
+<p class="summary"><span class="seoSummary">This technique demonstrates how to use the <a href="https://www.w3.org/TR/wai-aria-1.0/roles#slider" rel="external">slider</a> role and describes the effect it has on browsers and assistive technology.</span></p>
 
 <p>The <code>slider</code> role is used for markup that allows a user to select a value from within a given range. The slider role is assigned to the "thumb," the control that is adjusted to change the value. As the user interacts with the thumb, the application must programmatically adjust the slider's <code>aria-valuenow</code> (and possible <code>aria-valuetext</code>) attribute to reflect the current value. See the {{ anch("Examples") }} section below for more information.</p>
 


### PR DESCRIPTION
The first link of the [page](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role) "slider" was leading to a 404 page on W3C website.
Page changed to https://www.w3.org/TR/wai-aria-1.0/roles#slider

That's all mates :)
