### PR TITLE
Fix RTCPeerConnection connectionstatechange event handler xref

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
@@ -4,7 +4,7 @@ slug: Web/API/RTCPeerConnection/connectionstatechange_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
-<p><span class="seoSummary">The <strong><code>connectionstatechange</code></strong> event is sent to the {{domxref("RTCPeerConnection.ontrack", "ontrack")}} event handler on an {{domxref("RTCPeerConnection")}} object after a new track has been added to an {{domxref("RTCRtpReceiver")}} which is part of the connection.</span> The new connection state can be found in {{domxref("RTCPeerConnection.connectionState", "connectionState")}}, and is one of the strings in the {{domxref("RTCPeerConnectionState")}} enumerated type.</p>
+<p><span class="seoSummary">The <strong><code>connectionstatechange</code></strong> event is sent to the {{domxref("RTCPeerConnection.onconnectionstatechange", "onconnectionstatechange")}} event handler on an {{domxref("RTCPeerConnection")}} object after a new track has been added to an {{domxref("RTCRtpReceiver")}} which is part of the connection.</span> The new connection state can be found in {{domxref("RTCPeerConnection.connectionState", "connectionState")}}, and is one of the strings in the {{domxref("RTCPeerConnectionState")}} enumerated type.</p>
 
 <table class="properties">
  <tbody>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The doc currently says that the `connectionstatechange` event is sent to the `ontrack` event handler. It should instead say that it is sent to the `onconnectionstatechange` event handler.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionstatechange_event

> Issue number (if there is an associated issue)

none

> Anything else that could help us review it

n/a