### PR TITLE
typo: remove second space symbol

### DIFF
--- a/files/en-us/glossary/crud/index.html
+++ b/files/en-us/glossary/crud/index.html
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - Infrastructure
 ---
-<p><strong>CRUD </strong>(Create, Read, Update, Delete) is an acronym for ways one can operate on stored data. It is a mnemonic for the four basic functions of persistent storage.  CRUD typically refers to operations performed in a database or datastore, but it can also apply to higher level functions of an application such as soft deletes where data is not actually deleted but marked as deleted via a status.</p>
+<p><strong>CRUD </strong>(Create, Read, Update, Delete) is an acronym for ways one can operate on stored data. It is a mnemonic for the four basic functions of persistent storage. CRUD typically refers to operations performed in a database or datastore, but it can also apply to higher level functions of an application such as soft deletes where data is not actually deleted but marked as deleted via a status.</p>
 
 <h2 id="Learn_more">Learn more</h2>
 


### PR DESCRIPTION
Remove second space symbol between two sentences.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only) 

There should be consistent use of space symbols after period. \
Also it is nice to use only **one** space after period (or almost after any punctuation mark).

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Glossary/CRUD

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it

None