### PR TITLE
Fix typo in command line crash course

### DIFF
--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/command_line/index.html
@@ -44,7 +44,7 @@ tags:
 
 <p>The terminal originates from around the 1950s-60s and its original form really doesn’t resemble what we use today (for that we should be thankful). You can read a bit of the history on Wikipedia’s entry for <a href="https://en.wikipedia.org/wiki/Computer_terminal">Computer Terminal</a>.</p>
 
-<p>Since then, the terminal has remained a constant feature of all operating systems — from desktop machines, to servers tucked away in the cloud (it’s not really a cloud), to microcomputers like the Raspberry PI Zero, and even to mobile phones. it provides direct access to the computer’s underlying file system and low-level features, and is therefore incredibly useful for performing complex tasks rapidly, if you know what you are doing.</p>
+<p>Since then, the terminal has remained a constant feature of all operating systems — from desktop machines, to servers tucked away in the cloud, to microcomputers like the Raspberry PI Zero, and even to mobile phones. It provides direct access to the computer’s underlying file system and low-level features, and is therefore incredibly useful for performing complex tasks rapidly, if you know what you are doing.</p>
 
 <p>It is also useful for automation — for example to write a command to update the titles of hundreds of files instantly, say from “ch01-xxxx.png”  to “ch02-xxxx.png”. If you updated the file names using your finder or explorer GUI app, it would take you a long time.</p>
 
@@ -471,7 +471,7 @@ printMe(myObj);</pre>
 
 <ul>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">Client-side tooling overview</a></li>
- <li><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line">Command line crash course</a></li>
+ <li><strong>Command line crash course</strong></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management">Package management basics</a></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain">Introducing a complete toolchain</a></li>
  <li><a href="/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Deployment">Deploying our app</a></li>


### PR DESCRIPTION
Fixes #5051

Trivial typo and link-to-self fix. 