### PR TITLE
noopener link type - Fix up duplicate BCD table

### DIFF
--- a/files/en-us/web/html/link_types/noopener/index.html
+++ b/files/en-us/web/html/link_types/noopener/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - Link types
   - Reference
+browser-compat: html.elements.a.rel.noopener
 ---
 <p><span class="seoSummary">The <strong><code>noopener</code></strong> keyword for the <code><a href="/en-US/docs/Web/HTML/Attributes/rel">rel</a></code> attribute of the {{HTMLElement("a")}}, {{HTMLElement("area")}}, and {{HTMLElement("form")}} elements instructs the browser to navigate to the target resource without granting the new browsing context access to the document that opened it — by not setting the {{DOMxRef("Window.opener")}} property on the opened window (it returns <code>null</code>).</span></p>
 
@@ -15,7 +16,7 @@ tags:
 
 <div class="notecard note">
  <h4>Note</h4>
- <p>Setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements now implicitly provides the same <code>rel</code> behavior as setting <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> which does not set <code>window.opener</code>. See <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#browser_compatibility">browser compatibility</a> for support status.</p>
+ <p>Setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements now implicitly provides the same <code>rel</code> behavior as setting <code>rel="noopener"</code> (does not set <code>window.opener</code> property on the opened window). See <a href="/en-US/docs/Web/HTML/Element/a#browser_compatibility">browser compatibility</a> for support status.</p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>
@@ -39,5 +40,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.a.rel.noopener")}}</p>
-<p>{{Compat("html.elements.area.rel.noopener")}}</p>
+<p>{{Compat}}</p>
+<!-- This pulls in html.elements.a.rel.noopener from frontmatter. Note that html.elements.area.rel.noopener should also be listed here, but is a duplicate -->


### PR DESCRIPTION
Fixes duplicate compatibility table in https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener

The tables are actually for different elements, but they look exactly the same and have no context to tell them apart. Easiest way is just to delete one. I also took time to move the info on the BCD into front matter, and fix a broken link.

(issue raised here: https://github.com/mdn/content/pull/4673#issuecomment-842728105)