### PR TITLE
Remove deprecated onkeypress from event guide

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/events/index.html
+++ b/files/en-us/learn/javascript/building_blocks/events/index.html
@@ -134,7 +134,7 @@ btn.onclick = bgChange;</pre>
 <ul>
  <li><code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onfocus">btn.onfocus</a></code> and <code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onblur">btn.onblur</a></code> — The color changes when the button is focused and unfocused; try pressing the tab to focus on the button and press the tab again to focus away from the button. These are often used to display information about filling in form fields when they are focused, or displaying an error message if a form field is filled with an incorrect value.</li>
  <li><code><a href="/en-US/docs/Web/API/GlobalEventHandlers/ondblclick">btn.ondblclick</a></code> — The color changes only when the button is double-clicked.</li>
- <li><code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onkeypress">window.onkeypress</a></code>, <code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onkeydown">window.onkeydown</a></code>, <code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onkeyup">window.onkeyup</a></code> — The color changes when a key is pressed on the keyboard. The <code>keypress</code> event refers to a general press (button down and then up), while <code>keydown</code> and <code>keyup</code> refer to just the key down and key up parts of the keystroke, respectively. Note: It doesn't work if you try to register this event handler on the button itself — we've had to register it on the <a href="/en-US/docs/Web/API/Window">window</a> object, which represents the entire browser window.</li>
+ <li><code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onkeydown">window.onkeydown</a></code>, <code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onkeyup">window.onkeyup</a></code> — The color changes when a key is pressed on the keyboard. The <code>keydown</code> and <code>keyup</code> refer to just the key down and key up parts of the keystroke, respectively. Note: It doesn't work if you try to register this event handler on the button itself — we've had to register it on the <a href="/en-US/docs/Web/API/Window">window</a> object, which represents the entire browser window.</li>
  <li><code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onmouseover">btn.onmouseover</a></code> and <code><a href="/en-US/docs/Web/API/GlobalEventHandlers/onmouseout">btn.onmouseout</a></code> — The color changes when the mouse pointer hovers over the button, or when the pointer moves off the button, respectively.</li>
 </ul>
 
@@ -612,6 +612,6 @@ video.onclick = function() {
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions">Functions — reusable blocks of code</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function">Build your own function</a></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Return_values">Function return values</a></li>
- <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+ <li><strong>Introduction to events</strong></li>
  <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Image_gallery">Image gallery</a></li>
 </ul>

--- a/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
@@ -8,11 +8,12 @@ tags:
   - HTML DOM
   - Property
   - Reference
+  - Deprecated
 ---
 <div>{{ApiRef("HTML DOM")}} {{deprecated_header}}</div>
 
 <p>The <code><strong>onkeypress</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{domxref("EventHandler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an {{event("EventHandler")}} that
   processes {{event("keypress")}} events.</p>
 
 <p>The <code>keypress</code> event <em>should</em> fire when the user presses a key on the

--- a/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
@@ -13,7 +13,7 @@ tags:
 <div>{{ApiRef("HTML DOM")}} {{deprecated_header}}</div>
 
 <p>The <code><strong>onkeypress</strong></code> property of the
-  {{domxref("GlobalEventHandlers")}} mixin is an {{event("EventHandler")}} that
+  {{domxref("GlobalEventHandlers")}} mixin is an <a href="/en-US/docs/Web/Events/Event_handlers">event handler</a> that
   processes {{event("keypress")}} events.</p>
 
 <p>The <code>keypress</code> event <em>should</em> fire when the user presses a key on the


### PR DESCRIPTION
Fixes #4716

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events references deprecated windows keypress handler. This removes the handler from the guide and also marks it as deprecated in the sidebar.