### PR TITLE
Add deprecated tag/replace obsolete tag

### DIFF
--- a/files/en-us/glossary/xforms/index.html
+++ b/files/en-us/glossary/xforms/index.html
@@ -4,7 +4,7 @@ slug: Glossary/XForms
 tags:
   - CodingScripting
   - Glossary
-  - Obsolete
+  - Deprecated
   - XForms
 ---
 <div>{{QuickLinksWithSubpages("/en-us/docs/Glossary")}}{{deprecated_header}}</div>

--- a/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
@@ -6,7 +6,7 @@ tags:
   - Firefox
   - Guide
   - Mozilla
-  - Obsolete
+  - Deprecated
   - WebExtensions
 ---
 <div>{{AddonSidebar}}</div>

--- a/files/en-us/web/api/animationevent/initanimationevent/index.html
+++ b/files/en-us/web/api/animationevent/initanimationevent/index.html
@@ -6,7 +6,7 @@ tags:
   - AnimationEvent
   - CSSOM
   - Method
-  - Obsolete
+  - Deprecated
   - Web Animations
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{ apiref("Web Animations API") }}</p>

--- a/files/en-us/web/api/audiocontext/createjavascriptnode/index.html
+++ b/files/en-us/web/api/audiocontext/createjavascriptnode/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Audio
   - Method
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
   - createJavaScriptNode

--- a/files/en-us/web/api/battery_status_api/index.html
+++ b/files/en-us/web/api/battery_status_api/index.html
@@ -9,7 +9,7 @@ tags:
   - Battery Status API
   - Guide
   - Mobile
-  - Obsolete
+  - Deprecated
   - Overview
 ---
 <div>{{DefaultAPISidebar("Battery API")}}{{deprecated_header}}</div>

--- a/files/en-us/web/api/batterymanager/index.html
+++ b/files/en-us/web/api/batterymanager/index.html
@@ -6,7 +6,7 @@ tags:
   - Battery API
   - Device API
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <div>{{APIRef}}{{deprecated_header}}</div>

--- a/files/en-us/web/api/blobbuilder/index.html
+++ b/files/en-us/web/api/blobbuilder/index.html
@@ -6,7 +6,7 @@ tags:
   - DOM
   - DOM Reference
   - File API
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("File API")}}{{ deprecated_header}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/appearance/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/appearance/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothAdvertisingData
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - appearance

--- a/files/en-us/web/api/bluetoothadvertisingdata/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/index.html
@@ -7,7 +7,7 @@ tags:
   - BluetoothAdvertisingData
   - Interface
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
   - Web Bluetooth API
 ---

--- a/files/en-us/web/api/bluetoothadvertisingdata/manufacturerdata/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/manufacturerdata/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothAdvertisingData
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - manufacturerData

--- a/files/en-us/web/api/bluetoothadvertisingdata/rssi/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/rssi/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothAdvertisingData
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - rssi

--- a/files/en-us/web/api/bluetoothadvertisingdata/servicedata/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/servicedata/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothAdvertisingData
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - serviceData

--- a/files/en-us/web/api/bluetoothadvertisingdata/txpower/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/txpower/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothAdvertisingData
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - txPower

--- a/files/en-us/web/api/bluetoothdevice/addata/index.html
+++ b/files/en-us/web/api/bluetoothdevice/addata/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/connectgatt/index.html
+++ b/files/en-us/web/api/bluetoothdevice/connectgatt/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Method
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
   - Web Bluetooth API
   - connectGATT

--- a/files/en-us/web/api/bluetoothdevice/deviceclass/index.html
+++ b/files/en-us/web/api/bluetoothdevice/deviceclass/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/gattserver/index.html
+++ b/files/en-us/web/api/bluetoothdevice/gattserver/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/paired/index.html
+++ b/files/en-us/web/api/bluetoothdevice/paired/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/productid/index.html
+++ b/files/en-us/web/api/bluetoothdevice/productid/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/productversion/index.html
+++ b/files/en-us/web/api/bluetoothdevice/productversion/index.html
@@ -6,7 +6,7 @@ tags:
 - Bluetooth
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/vendorid/index.html
+++ b/files/en-us/web/api/bluetoothdevice/vendorid/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/bluetoothdevice/vendoridsource/index.html
+++ b/files/en-us/web/api/bluetoothdevice/vendoridsource/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - BluetoothDevice
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Web Bluetooth API

--- a/files/en-us/web/api/canvasrenderingcontext2d/addhitregion/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/addhitregion/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Method
 - Reference
+- Deprecated
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearhitregions/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearhitregions/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Method
 - Reference
+- Deprecated
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{deprecated_header}}{{non-standard_header}}</div>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Non-standard
 - Reference
+- Deprecated
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/removehitregion/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/removehitregion/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Method
 - Reference
+- Deprecated
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/closeevent/initcloseevent/index.html
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.html
@@ -1,6 +1,13 @@
 ---
 title: CloseEvent.initCloseEvent()
 slug: Web/API/CloseEvent/initCloseEvent
+tags:
+  - API
+  - CloseEvent
+  - initCloseEvent
+  - Method
+  - Reference
+  - Deprecated
 ---
 <p>{{APIRef("Websockets API")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
@@ -2,13 +2,14 @@
 title: CSSPositionValue.CSSPositionValue()
 slug: Web/API/CSSPositionValue/CSSPositionValue
 tags:
-- API
-- CSS Typed Object Model API
-- CSSPositionValue
-- Constructor
-- Experimental
-- Houdini
-- Reference
+  - API
+  - CSS Typed Object Model API
+  - CSSPositionValue
+  - Constructor
+  - Experimental
+  - Houdini
+  - Reference
+  - Deprecated
 ---
 <div>{{APIRef("CSS Typed Object Model API")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+  - Deprecated
 ---
 <div>{{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}</div>
 

--- a/files/en-us/web/api/csspositionvalue/x/index.html
+++ b/files/en-us/web/api/csspositionvalue/x/index.html
@@ -9,6 +9,7 @@ tags:
 - Houdini
 - Property
 - Reference
+- Deprecated
 - x
 ---
 <div>{{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}</div>

--- a/files/en-us/web/api/csspositionvalue/y/index.html
+++ b/files/en-us/web/api/csspositionvalue/y/index.html
@@ -9,6 +9,7 @@ tags:
 - Houdini
 - Property
 - Reference
+- Deprecated
 - 'y'
 ---
 <div>{{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}</div>

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - NeedsExample
 - getCounterValue
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSPrimitiveValue
 - Method
 - getFloatValue
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSPrimitiveValue
 - Method
 - getRectValue
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSPrimitiveValue
 - Method
 - getRGBColorValue
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSPrimitiveValue
 - Method
 - getStringValue
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -6,8 +6,8 @@ tags:
   - CSSOM
   - CSSPrimitiveValue
   - Interface
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - NeedsExample
 - setFloatValue
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - NeedsExample
   - setStringValue
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - CSSOM
 - Method
-- Obsolete
+- Deprecated
 - Reference
 ---
 <p>{{ APIRef("CSSOM") }} {{deprecated_header}}</p>

--- a/files/en-us/web/api/cssstylesheet/addrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/addrule/index.html
@@ -10,13 +10,13 @@ tags:
 - Layout
 - Method
 - Object Model
-- Obsolete
 - Reference
 - Style
 - StyleSheet
 - addRule
 - legacy
 - rules
+- Deprecated
 ---
 <p>{{APIRef("CSSOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/cssstylesheet/removerule/index.html
+++ b/files/en-us/web/api/cssstylesheet/removerule/index.html
@@ -10,7 +10,6 @@ tags:
 - Layout
 - Method
 - Object Model
-- Obsolete
 - Reference
 - Rule
 - StyleSheet
@@ -18,6 +17,7 @@ tags:
 - legacy
 - remove
 - removeRule
+- Deprecated
 ---
 <p>{{APIRef("CSSOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/cssstylesheet/rules/index.html
+++ b/files/en-us/web/api/cssstylesheet/rules/index.html
@@ -9,13 +9,13 @@ tags:
 - CSSStyleSheet
 - Layout
 - Object Model
-- Obsolete
 - Property
 - Read-only
 - Reference
 - Style
 - StyleSheet
 - legacy
+- Deprecated
 ---
 <p>{{APIRef("CSSOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - cssText
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - cssValueType
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -7,8 +7,8 @@ tags:
   - CSSValue
   - Interface
   - NeedsExample
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssvaluelist/index.html
+++ b/files/en-us/web/api/cssvaluelist/index.html
@@ -6,8 +6,8 @@ tags:
   - CSSOM
   - CSSValueList
   - Interface
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssvaluelist/item/index.html
+++ b/files/en-us/web/api/cssvaluelist/item/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - item
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/cssvaluelist/length/index.html
+++ b/files/en-us/web/api/cssvaluelist/length/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - length
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.html
@@ -7,6 +7,7 @@ tags:
 - Non-standard
 - Reference
 - drag and drop
+- Deprecated
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.html
@@ -7,6 +7,7 @@ tags:
 - Non-standard
 - Reference
 - drag and drop
+- Deprecated
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.html
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+- Deprecated
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.html
@@ -7,6 +7,7 @@ tags:
 - Non-standard
 - Reference
 - drag and drop
+- Deprecated
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 

--- a/files/en-us/web/api/datatransfer/moztypesat/index.html
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.html
@@ -7,6 +7,7 @@ tags:
 - Non-standard
 - Reference
 - drag and drop
+- Deprecated
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 

--- a/files/en-us/web/api/document/createentityreference/index.html
+++ b/files/en-us/web/api/document/createentityreference/index.html
@@ -5,8 +5,8 @@ tags:
   - API
   - DOM
   - Method
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/domain/index.html
+++ b/files/en-us/web/api/document/domain/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+  - Deprecated
 ---
 <div>{{ApiRef}} {{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/document/enablestylesheetsforset/index.html
+++ b/files/en-us/web/api/document/enablestylesheetsforset/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - NeedsSpecTable
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsExample
   - Reference
   - editor
+  - Deprecated
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/getboxobjectfor/index.html
+++ b/files/en-us/web/api/document/getboxobjectfor/index.html
@@ -5,8 +5,8 @@ tags:
 - API
 - DOM
 - Method
-- Obsolete
 - Reference
+- Deprecated
 ---
 <div>{{ApiRef("DOM")}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/height/index.html
+++ b/files/en-us/web/api/document/height/index.html
@@ -7,9 +7,9 @@ tags:
 - HTML DOM
 - NeedsMarkupWork
 - NeedsSpecTable
-- Obsolete
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("DOM")}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/laststylesheetset/index.html
+++ b/files/en-us/web/api/document/laststylesheetset/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Stylesheets
   - lastStyleSheetSet
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/origin/index.html
+++ b/files/en-us/web/api/document/origin/index.html
@@ -9,6 +9,7 @@ tags:
 - Interface
 - Property
 - Read-only
+- Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/preferredstylesheetset/index.html
+++ b/files/en-us/web/api/document/preferredstylesheetset/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Stylesheets
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/querycommandenabled/index.html
+++ b/files/en-us/web/api/document/querycommandenabled/index.html
@@ -6,6 +6,7 @@ tags:
 - Document
 - Method
 - Reference
+- Deprecated
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/querycommandstate/index.html
+++ b/files/en-us/web/api/document/querycommandstate/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - DOM
   - Reference
+  - Deprecated
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/querycommandsupported/index.html
+++ b/files/en-us/web/api/document/querycommandsupported/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - editor
+- Deprecated
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/rootelement/index.html
+++ b/files/en-us/web/api/document/rootelement/index.html
@@ -6,7 +6,6 @@ tags:
 - DOM
 - Deprecated
 - Document
-- Obsolete
 - Property
 - Reference
 - SVG

--- a/files/en-us/web/api/document/selectedstylesheetset/index.html
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Stylesheets
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/stylesheetsets/index.html
+++ b/files/en-us/web/api/document/stylesheetsets/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Stylesheets
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/width/index.html
+++ b/files/en-us/web/api/document/width/index.html
@@ -7,9 +7,9 @@ tags:
 - HTML DOM
 - NeedsBrowserAgnosticism
 - NeedsSpecTable
-- Obsolete
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("DOM")}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/document/xmlencoding/index.html
+++ b/files/en-us/web/api/document/xmlencoding/index.html
@@ -6,8 +6,8 @@ tags:
   - DOM
   - Document.xmlEncoding
   - MakeBrowserAgnostic
-  - Obsolete
   - Property
+  - Deprecated
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/document/xmlversion/index.html
+++ b/files/en-us/web/api/document/xmlversion/index.html
@@ -5,9 +5,9 @@ tags:
   - API
   - DOM
   - DOM Reference
-  - Obsolete
   - Property
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/documenttouch/index.html
+++ b/files/en-us/web/api/documenttouch/index.html
@@ -6,9 +6,9 @@ tags:
   - DOM
   - DocumentTouch
   - Mobile
-  - Obsolete
   - TouchList
   - touch
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/domlocator/index.html
+++ b/files/en-us/web/api/domlocator/index.html
@@ -5,8 +5,8 @@ tags:
   - API
   - DOM
   - DOM Reference
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/domobject/index.html
+++ b/files/en-us/web/api/domobject/index.html
@@ -7,8 +7,8 @@ tags:
   - DOM Reference
   - DOMObject
   - Object
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/domuserdata/index.html
+++ b/files/en-us/web/api/domuserdata/index.html
@@ -6,8 +6,8 @@ tags:
   - DOM
   - Interface
   - NeedsCompatTable
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <p>{{ ApiRef("DOM") }}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/element/keypress_event/index.html
+++ b/files/en-us/web/api/element/keypress_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Event
   - Reference
   - keypress
+  - Deprecated
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/element/mozmousepixelscroll/index.html
+++ b/files/en-us/web/api/element/mozmousepixelscroll/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - mouse
   - wheel
+  - Deprecated
 ---
 <p>{{APIRef}}{{deprecated_header}}{{ Non-standard_header() }}</p>
 

--- a/files/en-us/web/api/element/setcapture/index.html
+++ b/files/en-us/web/api/element/setcapture/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Non-standard
   - Reference
+  - Deprecated
 ---
 <div>{{Deprecated_Header}}{{non-standard_header}}{{ APIRef("DOM") }}</div>
 

--- a/files/en-us/web/api/element/tabstop/index.html
+++ b/files/en-us/web/api/element/tabstop/index.html
@@ -7,9 +7,9 @@ tags:
   - Element
   - NeedsExample
   - Non-standard
-  - Obsolete
   - Property
   - Reference
+  - Deprecated
 ---
 <p>{{APIRef("DOM")}}{{non-standard_header}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/event/returnvalue/index.html
+++ b/files/en-us/web/api/event/returnvalue/index.html
@@ -10,6 +10,7 @@ tags:
 - action
 - default
 - returnValue
+- Deprecated
 ---
 <div>{{APIRef("DOM Events")}}{{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/fetchevent/isreload/index.html
+++ b/files/en-us/web/api/fetchevent/isreload/index.html
@@ -11,6 +11,7 @@ tags:
   - Service Workers
   - Workers
   - isReload
+  - Deprecated
 ---
 <div>{{APIRef("Service Workers API")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/file/filename/index.html
+++ b/files/en-us/web/api/file/filename/index.html
@@ -7,9 +7,9 @@ tags:
 - File API
 - Files
 - Non-standard
-- Obsolete
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("File API")}}{{non-standard_header}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/file/filesize/index.html
+++ b/files/en-us/web/api/file/filesize/index.html
@@ -7,9 +7,9 @@ tags:
 - File API
 - Files
 - Non-standard
-- Obsolete
 - Property
 - Reference
+- Deprecated
 ---
 <p>{{APIRef("File API") }}{{non-standard_header}} {{Deprecated_Header}}</p>
 

--- a/files/en-us/web/api/file/getasbinary/index.html
+++ b/files/en-us/web/api/file/getasbinary/index.html
@@ -7,8 +7,8 @@ tags:
   - Files
   - Method
   - Non-standard
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <p>{{APIRef("File API")}}{{non-standard_header}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/file/getasdataurl/index.html
+++ b/files/en-us/web/api/file/getasdataurl/index.html
@@ -7,8 +7,8 @@ tags:
   - Files
   - Method
   - Non-standard
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("File API") }}</div>
 

--- a/files/en-us/web/api/file/getastext/index.html
+++ b/files/en-us/web/api/file/getastext/index.html
@@ -7,8 +7,8 @@ tags:
   - Files
   - Method
   - Non-standard
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("File API")}}{{non-standard_header}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/fileerror/index.html
+++ b/files/en-us/web/api/fileerror/index.html
@@ -5,8 +5,8 @@ tags:
   - API
   - File API
   - Files
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("File System API")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/fileexception/index.html
+++ b/files/en-us/web/api/fileexception/index.html
@@ -6,10 +6,10 @@ tags:
   - File API
   - File System API
   - Non-standard
-  - Obsolete
   - Offline
   - Reference
   - filesystem
+  - Deprecated
 ---
 <div>{{APIRef("File System API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.html
@@ -1,6 +1,9 @@
 ---
 title: FileReaderSync.readAsBinaryString()
 slug: Web/API/FileReaderSync/readAsBinaryString
+tags:
+  - Reference
+  - Deprecated
 ---
 <div>{{APIRef("File API")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.html
@@ -9,9 +9,9 @@ tags:
 - Files
 - Method
 - Non-standard
-- Obsolete
 - Reference
 - removeRecursively
+- Deprecated
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}{{SeeCompatTable}}</p>
 

--- a/files/en-us/web/api/filesystemdirectoryreader/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/index.html
@@ -11,6 +11,7 @@ tags:
   - Non-standard
   - Offline
   - Reference
+  - Deprecated
 ---
 <p>{{APIRef("File System API")}}{{Deprecated_Header}}{{Non-standard_header}}</p>
 

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
@@ -12,6 +12,7 @@ tags:
 - Non-standard
 - Reference
 - readEntries
+- Deprecated
 ---
 <div>{{APIRef("File System API")}}</div>
 

--- a/files/en-us/web/api/filesystementry/copyto/index.html
+++ b/files/en-us/web/api/filesystementry/copyto/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - copyTo
+- Deprecated
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/filesystementry/getmetadata/index.html
+++ b/files/en-us/web/api/filesystementry/getmetadata/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - getMetadata
+- Deprecated
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/filesystementry/moveto/index.html
+++ b/files/en-us/web/api/filesystementry/moveto/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - moveTo
+- Deprecated
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/filesystementry/remove/index.html
+++ b/files/en-us/web/api/filesystementry/remove/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - delete
 - remove
+- Deprecated
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/filesystemfileentry/createwriter/index.html
+++ b/files/en-us/web/api/filesystemfileentry/createwriter/index.html
@@ -9,9 +9,9 @@ tags:
 - Files
 - Method
 - Non-standard
-- Obsolete
 - Reference
 - createWriter
+- Deprecated
 ---
 <p>{{APIRef("File System
   API")}}{{SeeCompatTable}}{{deprecated_header}}{{Non-standard_header}}</p>

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - displayId
+  - Deprecated
 ---
 <p>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</p>
 

--- a/files/en-us/web/api/getcandidatewindowclientrect/index.html
+++ b/files/en-us/web/api/getcandidatewindowclientrect/index.html
@@ -1,5 +1,8 @@
 ---
 title: getCandidateWindowClientRect
 slug: Web/API/getCandidateWindowClientRect
+tags:
+  - Reference
+  - Deprecated
 ---
 <div>{{deprecated_header}}</div>

--- a/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+  - Deprecated
 ---
 <div>{{ApiRef("HTML DOM")}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousewheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousewheel/index.html
@@ -1,6 +1,8 @@
 ---
 title: GlobalEventHandlers.onmousewheel
 slug: Web/API/GlobalEventHandlers/onmousewheel
+tags:
+  - Deprecated
 ---
 <p>{{ ApiRef("HTML DOM") }}{{Deprecated_Header}}{{ Non-standard_header() }}</p>
 

--- a/files/en-us/web/api/headers/getall/index.html
+++ b/files/en-us/web/api/headers/getall/index.html
@@ -7,9 +7,9 @@ tags:
   - Fetch
   - Headers
   - Method
-  - Obsolete
   - Reference
   - getAll
+  - Deprecated
 ---
 <p>{{deprecated_header}}{{APIRef("Fetch")}}{{ SeeCompatTable() }}</p>
 

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.html
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.html
@@ -6,11 +6,11 @@ tags:
   - Experimental
   - HMDVRDevice
   - Method
-  - Obsolete
   - Reference
   - VR
   - Virtual Reality
   - WebVR
+  - Deprecated
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 

--- a/files/en-us/web/api/hmdvrdevice/index.html
+++ b/files/en-us/web/api/hmdvrdevice/index.html
@@ -6,11 +6,11 @@ tags:
   - Experimental
   - HMDVRDevice
   - Interface
-  - Obsolete
   - Reference
   - VR
   - Virtual Reality
   - WebVR
+  - Deprecated
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.html
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.html
@@ -6,11 +6,11 @@ tags:
   - Experimental
   - HMDVRDevice
   - Method
-  - Obsolete
   - Reference
   - VR
   - Virtual Reality
   - WebVR
+  - Deprecated
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 

--- a/files/en-us/web/api/htmlbasefontelement/index.html
+++ b/files/en-us/web/api/htmlbasefontelement/index.html
@@ -5,8 +5,8 @@ tags:
   - API
   - HTML DOM
   - Interface
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("HTML DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.html
@@ -6,8 +6,8 @@ tags:
 - Canvas
 - HTMLCanvasElement
 - Method
-- Obsolete
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("Canvas API")}} {{deprecated_header}}</div>
 

--- a/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.html
@@ -9,9 +9,9 @@ tags:
 - Method
 - Mozilla
 - Non-standard
-- Obsolete
 - Reference
 - mozGetAsFile
+- Deprecated
 ---
 <div>{{APIRef("Canvas API")}} {{Deprecated_Header}} {{non-standard_header}}</div>
 

--- a/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.html
+++ b/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - Web Components
+- Deprecated
 ---
 <p>{{ APIRef("Web Components") }}{{Deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlcontentelement/select/index.html
+++ b/files/en-us/web/api/htmlcontentelement/select/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - Web Components
+- Deprecated
 ---
 <p>{{ APIRef("Web Components") }}{{Deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlfontelement/color/index.html
+++ b/files/en-us/web/api/htmlfontelement/color/index.html
@@ -7,6 +7,7 @@ tags:
 - HTMLFontElement
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{deprecated_header}}{{APIRef("HTML DOM")}}</div>
 

--- a/files/en-us/web/api/htmlfontelement/face/index.html
+++ b/files/en-us/web/api/htmlfontelement/face/index.html
@@ -7,6 +7,7 @@ tags:
 - HTMLFontElement
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/htmlfontelement/index.html
+++ b/files/en-us/web/api/htmlfontelement/index.html
@@ -5,8 +5,8 @@ tags:
   - API
   - HTML DOM
   - Interface
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{deprecated_header}}{{APIRef("HTML DOM")}}</div>
 

--- a/files/en-us/web/api/htmlfontelement/size/index.html
+++ b/files/en-us/web/api/htmlfontelement/size/index.html
@@ -7,9 +7,9 @@ tags:
 - HTMLFontElement
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{deprecated_header}}</div>
-
 
 <div>{{ APIRef("HTML DOM") }}</div>
 

--- a/files/en-us/web/api/htmlframesetelement/index.html
+++ b/files/en-us/web/api/htmlframesetelement/index.html
@@ -6,8 +6,8 @@ tags:
   - HTML-DOM
   - HTMLFrameSetElement
   - Interface
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("HTML DOM")}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Reference HTMLIFrameElement
 - allowPaymentRequest
+- Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}{{non-standard_header}}</p>
 

--- a/files/en-us/web/api/htmlimageelement/align/index.html
+++ b/files/en-us/web/api/htmlimageelement/align/index.html
@@ -8,12 +8,12 @@ tags:
 - HTML DOM
 - HTMLImageElement
 - Image
-- Obsolete
 - Property
 - Reference
 - alignment
 - float
 - img
+- Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlimageelement/border/index.html
+++ b/files/en-us/web/api/htmlimageelement/border/index.html
@@ -7,11 +7,11 @@ tags:
 - HTML DOM
 - HTMLImageElement
 - Image
-- Obsolete
 - Property
 - Reference
 - border
 - img
+- Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlimageelement/hspace/index.html
+++ b/files/en-us/web/api/htmlimageelement/hspace/index.html
@@ -9,7 +9,6 @@ tags:
 - Horizontal
 - Image
 - Layout
-- Obsolete
 - Property
 - Reference
 - hspace
@@ -18,6 +17,7 @@ tags:
 - margin
 - right
 - spacing
+- Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.html
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.html
@@ -7,12 +7,12 @@ tags:
   - HTML DOM
   - HTMLImageElement
   - Long description
-  - Obsolete
   - Property
   - Reference
   - description
   - img
   - longDesc
+  - Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlimageelement/lowsrc/index.html
+++ b/files/en-us/web/api/htmlimageelement/lowsrc/index.html
@@ -7,7 +7,6 @@ tags:
 - HTML DOM
 - HTMLImageElement
 - Image
-- Obsolete
 - Performance
 - Property
 - Quality
@@ -15,6 +14,7 @@ tags:
 - img
 - lowSrc
 - speed
+- Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}{{non-standard_header}}</p>
 

--- a/files/en-us/web/api/htmlimageelement/vspace/index.html
+++ b/files/en-us/web/api/htmlimageelement/vspace/index.html
@@ -7,7 +7,6 @@ tags:
 - HTML DOM
 - HTMLImageElement
 - Image
-- Obsolete
 - Property
 - Reference
 - Vertical
@@ -18,6 +17,7 @@ tags:
 - spacing
 - top
 - vspace
+- Deprecated
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/htmlkeygenelement/index.html
+++ b/files/en-us/web/api/htmlkeygenelement/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - NeedsNewLayout
   - Reference
+  - Deprecated
 ---
 <div>{{deprecated_header}} {{ APIRef("HTML DOM") }}</div>
 

--- a/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.html
+++ b/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - Web Components
+- Deprecated
 ---
 <div>{{APIRef("Web Components")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/htmlshadowelement/index.html
+++ b/files/en-us/web/api/htmlshadowelement/index.html
@@ -5,8 +5,8 @@ tags:
   - API
   - HTML DOM
   - Interface
-  - Obsolete
   - Reference
+  - Deprecated
 ---
 <div>{{APIRef("Web Components")}}{{Deprecated_header}}</div>
 

--- a/files/en-us/web/api/htmlstyleelement/scoped/index.html
+++ b/files/en-us/web/api/htmlstyleelement/scoped/index.html
@@ -6,10 +6,10 @@ tags:
 - HTML DOM
 - HTMLStyleElement
 - Non-standard
-- Obsolete
 - Property
 - Reference
 - scoped
+- Deprecated
 ---
 <div>
   <div>{{APIRef("HTML DOM")}}</div>

--- a/files/en-us/web/api/htmlstyleelement/type/index.html
+++ b/files/en-us/web/api/htmlstyleelement/type/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Read-only
+- Deprecated
 ---
 <div>
   <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>

--- a/files/en-us/web/api/htmltableelement/cellpadding/index.html
+++ b/files/en-us/web/api/htmltableelement/cellpadding/index.html
@@ -7,6 +7,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/htmltableelement/cellspacing/index.html
+++ b/files/en-us/web/api/htmltableelement/cellspacing/index.html
@@ -6,10 +6,10 @@ tags:
 - HTML DOM
 - HTMLTableElement
 - NeedsSpecTable
-- Obsolete
 - Property
 - Reference
 - cellSpacing
+- Deprecated
 ---
 <div>
   <div>

--- a/files/en-us/web/api/htmltableelement/frame/index.html
+++ b/files/en-us/web/api/htmltableelement/frame/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Tables
+- Deprecated
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/htmltableelement/rules/index.html
+++ b/files/en-us/web/api/htmltableelement/rules/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+- Deprecated
 ---
 <div>
   <div>

--- a/files/en-us/web/api/htmltableelement/summary/index.html
+++ b/files/en-us/web/api/htmltableelement/summary/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/htmltableelement/width/index.html
+++ b/files/en-us/web/api/htmltableelement/width/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+- Deprecated
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 

--- a/files/en-us/web/api/idbcursorsync/index.html
+++ b/files/en-us/web/api/idbcursorsync/index.html
@@ -7,7 +7,7 @@ tags:
   - IndexedDB
   - Interface
   - NeedsMarkupWork
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("IndexedDB")}} {{ draft() }}</p>

--- a/files/en-us/web/api/idbdatabaseexception/index.html
+++ b/files/en-us/web/api/idbdatabaseexception/index.html
@@ -3,7 +3,7 @@ title: IDBDatabaseException
 slug: Web/API/IDBDatabaseException
 tags:
   - API
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 

--- a/files/en-us/web/api/idbdatabasesync/index.html
+++ b/files/en-us/web/api/idbdatabasesync/index.html
@@ -6,7 +6,7 @@ tags:
   - Experimental
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("IndexedDB")}} {{ draft() }}</p>

--- a/files/en-us/web/api/idbenvironment/index.html
+++ b/files/en-us/web/api/idbenvironment/index.html
@@ -8,7 +8,7 @@ tags:
   - IDBEnvironment
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
   - Storage
   - access

--- a/files/en-us/web/api/idbenvironmentsync/index.html
+++ b/files/en-us/web/api/idbenvironmentsync/index.html
@@ -6,7 +6,7 @@ tags:
   - Experimental
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("IndexedDB")}} {{ draft() }}</p>

--- a/files/en-us/web/api/idbfactorysync/index.html
+++ b/files/en-us/web/api/idbfactorysync/index.html
@@ -6,7 +6,7 @@ tags:
   - Experimental
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("IndexedDB")}} {{ draft() }}</p>

--- a/files/en-us/web/api/idbindexsync/index.html
+++ b/files/en-us/web/api/idbindexsync/index.html
@@ -6,7 +6,7 @@ tags:
   - Experimental
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("IndexedDB")}} {{ draft() }}</p>

--- a/files/en-us/web/api/idbobjectstoresync/index.html
+++ b/files/en-us/web/api/idbobjectstoresync/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{ APIRef("IndexedDB") }}</p>

--- a/files/en-us/web/api/idbtransactionsync/index.html
+++ b/files/en-us/web/api/idbtransactionsync/index.html
@@ -6,7 +6,7 @@ tags:
   - Experimental
   - IndexedDB
   - Interface
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <p>{{APIRef("IndexedDB")}}{{ draft() }}</p>

--- a/files/en-us/web/api/localmediastream/index.html
+++ b/files/en-us/web/api/localmediastream/index.html
@@ -10,7 +10,7 @@ tags:
   - Media
   - Media Capture and Streams API
   - Media Stream API
-  - Obsolete
+  - Deprecated
   - Reference
   - WebRTC
 ---

--- a/files/en-us/web/api/mediastream/ended/index.html
+++ b/files/en-us/web/api/mediastream/ended/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - Media Streams API
 - MediaStream
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - ended

--- a/files/en-us/web/api/navigator/mozislocallyavailable/index.html
+++ b/files/en-us/web/api/navigator/mozislocallyavailable/index.html
@@ -6,7 +6,7 @@ tags:
 - Method
 - Navigator
 - Non-standard
-- Obsolete
+- Deprecated
 ---
 <div>{{APIRef("HTML DOM")}} {{non-standard_header}}{{deprecated_header}}</div>
 

--- a/files/en-us/web/api/navigator/registercontenthandler/index.html
+++ b/files/en-us/web/api/navigator/registercontenthandler/index.html
@@ -6,7 +6,7 @@ tags:
   - MIME
   - Method
   - Navigator
-  - Obsolete
+  - Deprecated
   - Web-Based Protocol Handlers
   - registerContentHandler
 ---

--- a/files/en-us/web/api/node/getuserdata/index.html
+++ b/files/en-us/web/api/node/getuserdata/index.html
@@ -6,7 +6,7 @@ tags:
 - DOM
 - Method
 - Node
-- Obsolete
+- Deprecated
 - Reference
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>

--- a/files/en-us/web/api/node/issupported/index.html
+++ b/files/en-us/web/api/node/issupported/index.html
@@ -8,7 +8,7 @@ tags:
 - NeedsBrowserCompatibility
 - NeedsMobileBrowserCompatibility
 - Node
-- Obsolete
+- Deprecated
 - Reference
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>

--- a/files/en-us/web/api/node/setuserdata/index.html
+++ b/files/en-us/web/api/node/setuserdata/index.html
@@ -6,7 +6,7 @@ tags:
 - DOM
 - Method
 - Node
-- Obsolete
+- Deprecated
 - Reference
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>

--- a/files/en-us/web/api/nodeiterator/detach/index.html
+++ b/files/en-us/web/api/nodeiterator/detach/index.html
@@ -6,7 +6,7 @@ tags:
 - DOM
 - Method
 - NodeIterator
-- Obsolete
+- Deprecated
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
@@ -7,7 +7,7 @@ tags:
 - Currency
 - Currency System
 - Money
-- Obsolete
+- Deprecated
 - Payment Request
 - Payment Request API
 - PaymentCurrencyAmount

--- a/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Experimental
   - Method
-  - Obsolete
+  - Deprecated
   - PositionSensorVRDevice
   - Reference
   - VR

--- a/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Experimental
   - Method
-  - Obsolete
+  - Deprecated
   - PositionSensorVRDevice
   - Reference
   - VR

--- a/files/en-us/web/api/positionsensorvrdevice/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Experimental
   - Interface
-  - Obsolete
+  - Deprecated
   - PositionSensorVRDevice
   - Reference
   - VR

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Experimental
   - Method
-  - Obsolete
+  - Deprecated
   - PositionSensorVRDevice
   - Reference
   - VR

--- a/files/en-us/web/api/range/comparenode/index.html
+++ b/files/en-us/web/api/range/comparenode/index.html
@@ -7,7 +7,7 @@ tags:
   - DOM Reference
   - Method
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Range
   - Reference
   - compareNode

--- a/files/en-us/web/api/rtcdatachannel/reliable/index.html
+++ b/files/en-us/web/api/rtcdatachannel/reliable/index.html
@@ -3,7 +3,7 @@ title: RTCDataChannel.reliable
 slug: Web/API/RTCDataChannel/reliable
 tags:
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - RTCDataChannel
   - Read-only

--- a/files/en-us/web/api/rtcdatachannel/stream/index.html
+++ b/files/en-us/web/api/rtcdatachannel/stream/index.html
@@ -3,7 +3,7 @@ title: RTCDataChannel.stream
 slug: Web/API/RTCDataChannel/stream
 tags:
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Property
   - RTCDataChannel
   - Read-only

--- a/files/en-us/web/api/rtcicecandidatepairstats/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/priority/index.html
@@ -4,7 +4,7 @@ slug: Web/API/RTCIceCandidatePairStats/priority
 tags:
 - API
 - ICE
-- Obsolete
+- Deprecated
 - Property
 - RTCIceCandidatePairStats
 - Reference

--- a/files/en-us/web/api/rtcicecandidatepairstats/readable/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/readable/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - Candidate
 - ICE
-- Obsolete
+- Deprecated
 - Property
 - RTCIceCandidatePairStats
 - Reference

--- a/files/en-us/web/api/rtcicecandidatepairstats/writable/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/writable/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - Candidate
 - ICE
-- Obsolete
+- Deprecated
 - Property
 - RTCIceCandidatePairStats
 - Reference

--- a/files/en-us/web/api/rtcicecandidatestats/mozlocaltransport/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/mozlocaltransport/index.html
@@ -7,7 +7,7 @@ tags:
 - ICE
 - Media
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Protocol
 - RTCIceCandidate

--- a/files/en-us/web/api/rtciceserver/url/index.html
+++ b/files/en-us/web/api/rtciceserver/url/index.html
@@ -3,7 +3,7 @@ title: RTCIceServer.url
 slug: Web/API/RTCIceServer/url
 tags:
 - Experimental
-- Obsolete
+- Deprecated
 - Property
 - RTCIceServer
 - Reference

--- a/files/en-us/web/api/rtcnetworktype/index.html
+++ b/files/en-us/web/api/rtcnetworktype/index.html
@@ -16,7 +16,7 @@ tags:
   - WebRTC
   - WebRTC API
   - networkType
-  - Obsolete
+  - Deprecated
 ---
 <p>{{deprecated_header}}{{APIRef("WebRTC")}}</p>
 

--- a/files/en-us/web/api/rtcpeerconnection/addstream_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addstream_event/index.html
@@ -5,7 +5,7 @@ tags:
   - Event
   - Media
   - MediaStream
-  - Obsolete
+  - Deprecated
   - RTCPeerConnection
   - Reference
   - Streams

--- a/files/en-us/web/api/rtcpeerconnection/identityresult_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/identityresult_event/index.html
@@ -6,7 +6,7 @@ tags:
   - Authentication
   - Event
   - Identity
-  - Obsolete
+  - Deprecated
   - RTCPeerConnection
   - Reference
   - WebRTC

--- a/files/en-us/web/api/rtcpeerconnection/idpassertionerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/idpassertionerror_event/index.html
@@ -7,7 +7,7 @@ tags:
   - Error
   - IdP
   - Identity
-  - Obsolete
+  - Deprecated
   - Reference
   - WebRTC
   - WebRTC API

--- a/files/en-us/web/api/rtcpeerconnection/idpvalidationerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/idpvalidationerror_event/index.html
@@ -7,7 +7,7 @@ tags:
   - Error
   - IdP
   - Identity
-  - Obsolete
+  - Deprecated
   - Reference
   - Validation
   - WebRTC

--- a/files/en-us/web/api/rtcpeerconnection/onidpassertionerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onidpassertionerror/index.html
@@ -6,7 +6,7 @@ tags:
 - Event Handler
 - IdP
 - Identity
-- Obsolete
+- Deprecated
 - Property
 - RTCPeerConnection
 - Reference

--- a/files/en-us/web/api/rtcpeerconnection/onidpvalidationerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onidpvalidationerror/index.html
@@ -7,7 +7,7 @@ tags:
 - Event Handler
 - IdP
 - Identity
-- Obsolete
+- Deprecated
 - Property
 - RTCPeerConnection
 - Reference

--- a/files/en-us/web/api/rtcpeerconnection/onpeeridentity/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onpeeridentity/index.html
@@ -7,7 +7,7 @@ tags:
 - Event Handler
 - IdP
 - Identity
-- Obsolete
+- Deprecated
 - Peer
 - Property
 - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity_event/index.html
@@ -4,7 +4,7 @@ slug: Web/API/RTCPeerConnection/peeridentity_event
 tags:
   - Authentication
   - Identity
-  - Obsolete
+  - Deprecated
   - Reference
   - WebRTC
   - WebRTC API

--- a/files/en-us/web/api/rtcpeerconnection_idpvalidationerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection_idpvalidationerror_event/index.html
@@ -7,7 +7,7 @@ tags:
   - IdP
   - Identification
   - Identity
-  - Obsolete
+  - Deprecated
   - Reference
   - Validation
   - WebRTC

--- a/files/en-us/web/api/text/iselementcontentwhitespace/index.html
+++ b/files/en-us/web/api/text/iselementcontentwhitespace/index.html
@@ -4,7 +4,7 @@ slug: Web/API/Text/isElementContentWhitespace
 tags:
   - API
   - DOM
-  - Obsolete
+  - Deprecated
   - Property
   - Text
 ---

--- a/files/en-us/web/api/text/replacewholetext/index.html
+++ b/files/en-us/web/api/text/replacewholetext/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - DOM
 - Method
-- Obsolete
+- Deprecated
 - Text
 ---
 <p>{{ApiRef("DOM")}}{{deprecated_header}}</p>

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -4,7 +4,7 @@ slug: Web/API/TreeWalker/expandEntityReferences
 tags:
 - API
 - DOM
-- Obsolete
+- Deprecated
 - Property
 - TreeWalker
 ---

--- a/files/en-us/web/api/typeinfo/index.html
+++ b/files/en-us/web/api/typeinfo/index.html
@@ -7,7 +7,7 @@ tags:
   - DOM Reference
   - Interface
   - NeedsContent
-  - Obsolete
+  - Deprecated
   - Reference
   - TypeInfo
   - Web

--- a/files/en-us/web/api/uievent/ischar/index.html
+++ b/files/en-us/web/api/uievent/ischar/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - DOM
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Read-only
 - Reference

--- a/files/en-us/web/api/uievent/pagex/index.html
+++ b/files/en-us/web/api/uievent/pagex/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - DOM
 - Non-standard
-- Obsolete
+- Deprecated
 - Property
 - Read-only
 - Reference

--- a/files/en-us/web/api/userdatahandler/index.html
+++ b/files/en-us/web/api/userdatahandler/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - DOM
   - NeedsMarkupWork
-  - Obsolete
+  - Deprecated
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 

--- a/files/en-us/web/api/videoplaybackquality/totalframedelay/index.html
+++ b/files/en-us/web/api/videoplaybackquality/totalframedelay/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - Experimental
 - Media Source Extensions
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Video

--- a/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
+++ b/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Experimental
   - Method
-  - Obsolete
+  - Deprecated
   - Reference
   - VR
   - VRDisplay

--- a/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
+++ b/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VRDisplay/hardwareUnitId
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VREyeParameters/maximumFieldOfView
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VREyeParameters/minimumFieldOfView
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VREyeParameters/recommendedFieldOfView
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vreyeparameters/renderrect/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderrect/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VREyeParameters/renderRect
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VRFieldOfView/VRFieldOfView
 tags:
   - API
   - Constructor
-  - Obsolete
+  - Deprecated
   - Reference
   - VR
   - VRFieldOfView

--- a/files/en-us/web/api/vrpose/hasorientation/index.html
+++ b/files/en-us/web/api/vrpose/hasorientation/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VRPose/hasOrientation
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vrpose/hasposition/index.html
+++ b/files/en-us/web/api/vrpose/hasposition/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VRPose/hasPosition
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/vrpose/timestamp/index.html
+++ b/files/en-us/web/api/vrpose/timestamp/index.html
@@ -4,7 +4,7 @@ slug: Web/API/VRPose/timeStamp
 tags:
   - API
   - Experimental
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/webvr_api/index.html
+++ b/files/en-us/web/api/webvr_api/index.html
@@ -6,7 +6,7 @@ tags:
   - Deprecated
   - Experimental
   - Landing
-  - Obsolete
+  - Deprecated
   - Reference
   - VR
   - Virtual Reality

--- a/files/en-us/web/api/window/back/index.html
+++ b/files/en-us/web/api/window/back/index.html
@@ -8,7 +8,7 @@ tags:
 - HTML DOM
 - Method
 - Non-standard
-- Obsolete
+- Deprecated
 - Window
 - back
 ---

--- a/files/en-us/web/api/window/defaultstatus/index.html
+++ b/files/en-us/web/api/window/defaultstatus/index.html
@@ -8,7 +8,7 @@ tags:
   - NeedsExample
   - NeedsMarkupWork
   - NeedsSpecTable
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - Window

--- a/files/en-us/web/api/window/directories/index.html
+++ b/files/en-us/web/api/window/directories/index.html
@@ -8,7 +8,7 @@ tags:
   - NeedsExample
   - NeedsMarkupWork
   - NeedsSpecTable
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - Window

--- a/files/en-us/web/api/window/forward/index.html
+++ b/files/en-us/web/api/window/forward/index.html
@@ -8,7 +8,7 @@ tags:
   - HTML DOM
   - Method
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Window
   - forward
 ---

--- a/files/en-us/web/api/window/home/index.html
+++ b/files/en-us/web/api/window/home/index.html
@@ -6,7 +6,7 @@ tags:
 - Gecko
 - HTML DOM
 - Method
-- Obsolete
+- Deprecated
 - Reference
 - Window
 ---

--- a/files/en-us/web/api/window/mozanimationstarttime/index.html
+++ b/files/en-us/web/api/window/mozanimationstarttime/index.html
@@ -4,7 +4,7 @@ slug: Web/API/Window/mozAnimationStartTime
 tags:
   - API
   - HTML DOM
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - Window

--- a/files/en-us/web/api/window/onappinstalled/index.html
+++ b/files/en-us/web/api/window/onappinstalled/index.html
@@ -5,7 +5,7 @@ tags:
 - API
 - Event Handler
 - Manifest
-- Obsolete
+- Deprecated
 - Property
 - Reference
 - Window

--- a/files/en-us/web/api/window/ondragdrop/index.html
+++ b/files/en-us/web/api/window/ondragdrop/index.html
@@ -4,7 +4,7 @@ slug: Web/API/Window/ondragdrop
 tags:
   - API
   - HTML DOM
-  - Obsolete
+  - Deprecated
   - Property
   - Window
   - ondragdrop

--- a/files/en-us/web/api/window/onmozbeforepaint/index.html
+++ b/files/en-us/web/api/window/onmozbeforepaint/index.html
@@ -6,7 +6,7 @@ tags:
   - Event Handler
   - Mozilla
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Property
   - Window
   - onmozbeforepaint

--- a/files/en-us/web/api/window/pkcs11/index.html
+++ b/files/en-us/web/api/window/pkcs11/index.html
@@ -7,7 +7,7 @@ tags:
   - NeedsExample
   - NeedsMarkupWork
   - NeedsSpecTable
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - Window

--- a/files/en-us/web/api/window/routeevent/index.html
+++ b/files/en-us/web/api/window/routeevent/index.html
@@ -4,7 +4,7 @@ slug: Web/API/Window/routeEvent
 tags:
   - API
   - Method
-  - Obsolete
+  - Deprecated
   - Reference
   - Window
   - routeEvent

--- a/files/en-us/web/api/workerglobalscope/onclose/index.html
+++ b/files/en-us/web/api/workerglobalscope/onclose/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Event Handler
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - Web Workers

--- a/files/en-us/web/api/xdomainrequest/abort/index.html
+++ b/files/en-us/web/api/xdomainrequest/abort/index.html
@@ -7,7 +7,7 @@ tags:
 - IE
 - Method
 - Microsoft
-- Obsolete
+- Deprecated
 - Reference
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>

--- a/files/en-us/web/api/xdomainrequest/index.html
+++ b/files/en-us/web/api/xdomainrequest/index.html
@@ -7,7 +7,7 @@ tags:
 - IE
 - JavaScript
 - Microsoft
-- Obsolete
+- Deprecated
 - Web
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>

--- a/files/en-us/web/api/xdomainrequest/onerror/index.html
+++ b/files/en-us/web/api/xdomainrequest/onerror/index.html
@@ -7,7 +7,7 @@ tags:
 - DOM
 - IE
 - Microsoft
-- Obsolete
+- Deprecated
 - Property
 - Reference
 ---

--- a/files/en-us/web/api/xdomainrequest/onload/index.html
+++ b/files/en-us/web/api/xdomainrequest/onload/index.html
@@ -7,7 +7,7 @@ tags:
 - DOM
 - IE
 - Microsoft
-- Obsolete
+- Deprecated
 - Property
 - Reference
 ---

--- a/files/en-us/web/api/xdomainrequest/onprogress/index.html
+++ b/files/en-us/web/api/xdomainrequest/onprogress/index.html
@@ -8,7 +8,7 @@ tags:
 - Event
 - IE
 - Microsoft
-- Obsolete
+- Deprecated
 - Property
 - Reference
 ---

--- a/files/en-us/web/api/xdomainrequest/ontimeout/index.html
+++ b/files/en-us/web/api/xdomainrequest/ontimeout/index.html
@@ -7,7 +7,7 @@ tags:
 - DOM
 - IE
 - Microsoft
-- Obsolete
+- Deprecated
 - Property
 - Reference
 ---

--- a/files/en-us/web/api/xdomainrequest/open/index.html
+++ b/files/en-us/web/api/xdomainrequest/open/index.html
@@ -7,7 +7,7 @@ tags:
 - JavaScript
 - Method
 - Microsoft
-- Obsolete
+- Deprecated
 - Reference
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>

--- a/files/en-us/web/api/xdomainrequest/responsetext/index.html
+++ b/files/en-us/web/api/xdomainrequest/responsetext/index.html
@@ -5,7 +5,7 @@ tags:
 - AJAX
 - IE
 - Microsoft
-- Obsolete
+- Deprecated
 - Property
 - Reference
 ---

--- a/files/en-us/web/api/xdomainrequest/send/index.html
+++ b/files/en-us/web/api/xdomainrequest/send/index.html
@@ -7,7 +7,7 @@ tags:
 - IE
 - Method
 - Microsoft
-- Obsolete
+- Deprecated
 - Reference
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>

--- a/files/en-us/web/api/xdomainrequest/timeout/index.html
+++ b/files/en-us/web/api/xdomainrequest/timeout/index.html
@@ -5,7 +5,7 @@ tags:
   - AJAX
   - IE
   - Microsoft
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
 ---

--- a/files/en-us/web/api/xmlhttprequest/multipart/index.html
+++ b/files/en-us/web/api/xmlhttprequest/multipart/index.html
@@ -6,7 +6,7 @@ tags:
   - Gecko
   - Mozilla
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Property
   - Reference
   - XMLHttpRequest

--- a/files/en-us/web/css/image-orientation/index.html
+++ b/files/en-us/web/css/image-orientation/index.html
@@ -9,7 +9,7 @@ tags:
   - Experimental
   - Image Correction
   - Image Orientation
-  - Obsolete
+  - Deprecated
   - Orientation
   - Reference
   - image-orientation

--- a/files/en-us/web/html/element/acronym/index.html
+++ b/files/en-us/web/html/element/acronym/index.html
@@ -5,7 +5,7 @@ tags:
   - Element
   - HTML
   - 'HTML:Flow content'
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/applet/index.html
+++ b/files/en-us/web/html/element/applet/index.html
@@ -5,7 +5,7 @@ tags:
   - Element
   - HTML
   - Java
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
   - applet

--- a/files/en-us/web/html/element/basefont/index.html
+++ b/files/en-us/web/html/element/basefont/index.html
@@ -6,7 +6,7 @@ tags:
   - Fonts
   - HTML
   - Layout
-  - Obsolete
+  - Deprecated
   - Reference
   - Style
   - Web

--- a/files/en-us/web/html/element/bgsound/index.html
+++ b/files/en-us/web/html/element/bgsound/index.html
@@ -8,7 +8,7 @@ tags:
   - HTML
   - Internet Explorer
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/big/index.html
+++ b/files/en-us/web/html/element/big/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/big
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/blink/index.html
+++ b/files/en-us/web/html/element/blink/index.html
@@ -5,7 +5,7 @@ tags:
   - Blink
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/center/index.html
+++ b/files/en-us/web/html/element/center/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/center
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Text
   - Text Alignment

--- a/files/en-us/web/html/element/dir/index.html
+++ b/files/en-us/web/html/element/dir/index.html
@@ -6,7 +6,7 @@ tags:
   - Element
   - HTML
   - HTML Lists
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
   - dir

--- a/files/en-us/web/html/element/font/index.html
+++ b/files/en-us/web/html/element/font/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/font
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/image/index.html
+++ b/files/en-us/web/html/element/image/index.html
@@ -8,7 +8,7 @@ tags:
   - HTML Reference
   - HTML element
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
 ---
 <div>{{deprecated_header}}</div>

--- a/files/en-us/web/html/element/input/datetime/index.html
+++ b/files/en-us/web/html/element/input/datetime/index.html
@@ -8,7 +8,7 @@ tags:
   - Input
   - Input Element
   - Input Type
-  - Obsolete
+  - Deprecated
   - Reference
   - datetime
 ---

--- a/files/en-us/web/html/element/keygen/index.html
+++ b/files/en-us/web/html/element/keygen/index.html
@@ -6,7 +6,7 @@ tags:
   - Element
   - HTML
   - HTML5
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/listing/index.html
+++ b/files/en-us/web/html/element/listing/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/listing
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/marquee/index.html
+++ b/files/en-us/web/html/element/marquee/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/marquee
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
   - marquee

--- a/files/en-us/web/html/element/multicol/index.html
+++ b/files/en-us/web/html/element/multicol/index.html
@@ -5,7 +5,7 @@ tags:
   - Element
   - HTML
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
   - multicol
 ---

--- a/files/en-us/web/html/element/nextid/index.html
+++ b/files/en-us/web/html/element/nextid/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/nextid
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/nobr/index.html
+++ b/files/en-us/web/html/element/nobr/index.html
@@ -5,7 +5,7 @@ tags:
   - Element
   - HTML
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
   - nobr

--- a/files/en-us/web/html/element/noembed/index.html
+++ b/files/en-us/web/html/element/noembed/index.html
@@ -7,7 +7,7 @@ tags:
   - Embedding
   - HTML
   - Non-standard
-  - Obsolete
+  - Deprecated
   - Reference
   - noembed
 ---

--- a/files/en-us/web/html/element/noframes/index.html
+++ b/files/en-us/web/html/element/noframes/index.html
@@ -6,7 +6,7 @@ tags:
   - Frames
   - HTML
   - HTML frames
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
   - noframes

--- a/files/en-us/web/html/element/plaintext/index.html
+++ b/files/en-us/web/html/element/plaintext/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/plaintext
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Plain text
   - Reference
   - Web

--- a/files/en-us/web/html/element/spacer/index.html
+++ b/files/en-us/web/html/element/spacer/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/spacer
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/strike/index.html
+++ b/files/en-us/web/html/element/strike/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/strike
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/html/element/tt/index.html
+++ b/files/en-us/web/html/element/tt/index.html
@@ -7,7 +7,7 @@ tags:
   - Monospace
   - Monotype
   - Non-proportional Type
-  - Obsolete
+  - Deprecated
   - Reference
   - Teletype
   - Teletype Text

--- a/files/en-us/web/html/element/xmp/index.html
+++ b/files/en-us/web/html/element/xmp/index.html
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/xmp
 tags:
   - Element
   - HTML
-  - Obsolete
+  - Deprecated
   - Reference
   - Web
 ---

--- a/files/en-us/web/http/headers/content-security-policy/referrer/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/referrer/index.html
@@ -6,7 +6,7 @@ tags:
 - Content-Security-Policy
 - Directive
 - HTTP
-- Obsolete
+- Deprecated
 - Reference
 - Security
 - referrer

--- a/files/en-us/web/http/headers/cookie2/index.html
+++ b/files/en-us/web/http/headers/cookie2/index.html
@@ -3,7 +3,7 @@ title: Cookie2
 slug: Web/HTTP/Headers/Cookie2
 tags:
   - HTTP
-  - Obsolete
+  - Deprecated
   - Reference
   - header
   - request

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -5,7 +5,7 @@ tags:
   - Client hints
   - HTTP
   - HTTP Header
-  - Obsolete
+  - Deprecated
   - Non-standard
 ---
 <div>{{deprecated_header}}{{Non-standard_header}}</div>

--- a/files/en-us/web/http/headers/public-key-pins-report-only/index.html
+++ b/files/en-us/web/http/headers/public-key-pins-report-only/index.html
@@ -5,7 +5,7 @@ tags:
 - Deprecated
 - HPKP
 - HTTP
-- Obsolete
+- Deprecated
 - Security
 - header
 ---

--- a/files/en-us/web/http/headers/public-key-pins/index.html
+++ b/files/en-us/web/http/headers/public-key-pins/index.html
@@ -5,7 +5,7 @@ tags:
 - Deprecated
 - HPKP
 - HTTP
-- Obsolete
+- Deprecated
 - Reference
 - Security
 - header

--- a/files/en-us/web/http/headers/set-cookie2/index.html
+++ b/files/en-us/web/http/headers/set-cookie2/index.html
@@ -4,7 +4,7 @@ slug: Web/HTTP/Headers/Set-Cookie2
 tags:
 - Cookies
 - HTTP
-- Obsolete
+- Deprecated
 - Reference
 - header
 ---

--- a/files/en-us/web/http/public_key_pinning/index.html
+++ b/files/en-us/web/http/public_key_pinning/index.html
@@ -6,7 +6,7 @@ tags:
   - Guide
   - HPKP
   - HTTP
-  - Obsolete
+  - Deprecated
   - Security
 ---
 <p>{{HTTPSidebar}}{{deprecated_header}}</p>

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.html
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.html
@@ -5,7 +5,7 @@ tags:
   - Deprecated
   - Guide
   - JavaScript
-  - Obsolete
+  - Deprecated
 ---
 <p>{{JsSidebar("More")}}</p>
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/tosource/index.html
@@ -7,7 +7,7 @@ tags:
 - JavaScript
 - Method
 - Non-standard
-- Obsolete
+- Deprecated
 - Prototype
 browser-compat: javascript.builtins.Boolean.toSource
 ---

--- a/files/en-us/web/javascript/reference/global_objects/function/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/function/tosource/index.html
@@ -6,7 +6,7 @@ tags:
 - JavaScript
 - Method
 - Non-standard
-- Obsolete
+- Deprecated
 browser-compat: javascript.builtins.Function.toSource
 ---
 <div>{{JSRef}} {{deprecated_header}}</div>

--- a/files/en-us/web/javascript/reference/global_objects/number/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/number/tosource/index.html
@@ -5,7 +5,7 @@ tags:
 - JavaScript
 - Method
 - Number
-- Obsolete
+- Deprecated
 - Prototype
 browser-compat: javascript.builtins.Number.toSource
 ---

--- a/files/en-us/web/javascript/reference/global_objects/object/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/object/tosource/index.html
@@ -6,7 +6,7 @@ tags:
 - Method
 - Non-standard
 - Object
-- Obsolete
+- Deprecated
 - Prototype
 browser-compat: javascript.builtins.Object.toSource
 ---

--- a/files/en-us/web/javascript/reference/global_objects/regexp/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/tosource/index.html
@@ -5,7 +5,7 @@ tags:
 - JavaScript
 - Method
 - Non-standard
-- Obsolete
+- Deprecated
 - Prototype
 - Reference
 - RegExp

--- a/files/en-us/web/javascript/reference/global_objects/string/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/tosource/index.html
@@ -5,7 +5,7 @@ tags:
 - JavaScript
 - Method
 - Non-standard
-- Obsolete
+- Deprecated
 - Prototype
 - Reference
 - String

--- a/files/en-us/web/javascript/reference/global_objects/symbol/tosource/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/tosource/index.html
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Symbol/toSource
 tags:
 - JavaScript
 - Method
-- Obsolete
+- Deprecated
 - Prototype
 - Symbol
 browser-compat: javascript.builtins.Symbol.toSource

--- a/files/en-us/web/javascript/reference/global_objects/uneval/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/uneval/index.html
@@ -6,7 +6,7 @@ tags:
 - JavaScript
 - Method
 - Non-standard
-- Obsolete
+- Deprecated
 - Reference
 - uneval
 browser-compat: javascript.builtins.uneval

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/clear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/clear/index.html
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Global_Objects/WeakMap/clear
 tags:
 - JavaScript
 - Method
-- Obsolete
+- Deprecated
 - Prototype
 - WeakMap
 browser-compat: javascript.builtins.WeakMap.clear

--- a/files/en-us/web/xml/xml_colon_base/index.html
+++ b/files/en-us/web/xml/xml_colon_base/index.html
@@ -3,7 +3,7 @@ title: 'xml:base'
 slug: 'Web/XML/xml:base'
 tags:
   - Attribute
-  - Obsolete
+  - Deprecated
   - Reference
   - SVG
   - XML


### PR DESCRIPTION
The tags like "Deprecated" are used to add status icons to the sidebar. 
- As we no longer use the term Obsolete this replaces all those tags with `- Deprecated`. 
- Add a whole bunch of deprecated tags to the pages that already have deprecated header macro. This was not exhaustive. I think I need to script it. A good start though. 
