### PR TITLE
Remove adjacent dt elements

### DIFF
--- a/files/en-us/web/accessibility/implementing_msaa_server/index.html
+++ b/files/en-us/web/accessibility/implementing_msaa_server/index.html
@@ -291,22 +291,11 @@ tags:
 <p>Check with our assistive technology partners to find out what object identifiers you need to support. There's a very good chance they won't ask for more than the object identifiers marked <strong>[important]</strong>:</p>
 
 <dl>
- <dt>OBJID_ALERT</dt>
- <dt>OBJID_CARET</dt>
- <dt>OBJID_CLIENT</dt>
+ <dt>OBJID_ALERT, OBJID_CARET, OBJID_CLIENT</dt>
  <dd>[important]</dd>
- <dt>OBJID_CURSOR</dt>
- <dt>OBJID_HSCROLL</dt>
- <dt>OBJID_NATIVEOM</dt>
+ <dt>OBJID_CURSOR, OBJID_HSCROLL, OBJID_NATIVEOM</dt>
  <dd>[important? might be useful for supporting custom interfaces, need to research]</dd>
- <dt>OBJID_MENU</dt>
- <dt>OBJID_QUERYCLASSNAMEIDX</dt>
- <dt>OBJID_SIZEGRIP</dt>
- <dt>OBJID_SOUND</dt>
- <dt>OBJID_SYSMENU</dt>
- <dt>OBJID_TITLEBAR</dt>
- <dt>OBJID_VSCROLL</dt>
- <dt>OBJID_WINDOW</dt>
+ <dt>OBJID_MENU, OBJID_QUERYCLASSNAMEIDX, OBJID_SIZEGRIP, OBJID_SOUND, OBJID_SYSMENU, OBJID_TITLEBAR, OBJID_VSCROLL, OBJID_WINDOW</dt>
  <dd>[important, but implemented automatically by Microsoft Windows. Will return object of type ROLE_WINDOW. See <a href="#windowfromaccessibleobject">WindowFromAccessibleObject quirk explanation</a> below.]</dd>
 </dl>
 

--- a/files/en-us/web/api/file_and_directory_entries_api/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/index.html
@@ -82,8 +82,7 @@ tags:
 <dl>
  <dt>{{domxref("LocalFileSystem")}}</dt>
  <dd>Gives you access to a sandboxed file system.</dd>
- <dt>{{domxref("LocalFileSystemSync")}}</dt>
- <dt>{{domxref("LockedFile")}}</dt>
+ <dt>{{domxref("LocalFileSystemSync")}}, {{domxref("LockedFile")}}</dt>
  <dd>Provides tools to deal with a given file with all the necessary locks.</dd>
  <dt>{{domxref("Metadata")}}{{experimental_inline}}</dt>
  <dd></dd>

--- a/files/en-us/web/api/htmlscriptelement/index.html
+++ b/files/en-us/web/api/htmlscriptelement/index.html
@@ -33,8 +33,7 @@ tags:
  <dt>{{domxref("HTMLScriptElement.charset")}} {{deprecated_inline}}</dt>
  <dd>Is a {{domxref("DOMString")}} representing the character encoding of an external script. It reflects the {{htmlattrxref("charset","script")}} attribute.</dd>
 
- <dt>{{domxref("HTMLScriptElement.async")}}</dt>
- <dt>{{domxref("HTMLScriptElement.defer")}}</dt>
+ <dt>{{domxref("HTMLScriptElement.async")}}, {{domxref("HTMLScriptElement.defer")}}</dt>
  <dd>
   <p>The <code>async</code> and <code>defer</code> attributes are {{domxref("Boolean")}} attributes that control how the script should be executed. <strong>The <code>defer</code> and <code>async</code> attributes must not be specified if the <code>src</code> attribute is absent.</strong></p>
 

--- a/files/en-us/web/css/align-items/index.html
+++ b/files/en-us/web/css/align-items/index.html
@@ -68,9 +68,7 @@ align-items: unset;
  <dd>The items are packed flush to the edge of the alignment container of the start side of the item, in the appropriate axis.</dd>
  <dt><code>self-end</code></dt>
  <dd>The items are packed flush to the edge of the alignment container of the end side of the item, in the appropriate axis.</dd>
- <dt><code>baseline</code></dt>
- <dt><code>first baseline</code></dt>
- <dt><code>last baseline</code></dt>
+ <dt><code>baseline</code>, <code>first baseline</code>, <code>last baseline</code></dt>
  <dd>All flex items are aligned such that their <a href="https://drafts.csswg.org/css-flexbox-1/#flex-baselines" rel="external">flex container baselines</a> align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.</dd>
  <dt><code>stretch</code></dt>
  <dd>Flex items are stretched such that the cross-size of the item's margin box is the same as the line while respecting width and height constraints.</dd>

--- a/files/en-us/web/css/color_value/index.html
+++ b/files/en-us/web/css/color_value/index.html
@@ -1120,8 +1120,7 @@ browser-compat: css.types.color
  <dd>
  <p>Text color for dialog boxes. Should be used with the <code>-moz-Dialog</code> background color.</p>
  </dd>
- <dt>-moz-dragtargetzone</dt>
- <dt>-moz-EvenTreeRow</dt>
+ <dt>-moz-dragtargetzone, -moz-EvenTreeRow</dt>
  <dd>
  <p>Background color for even-numbered rows in a tree. Should be used with the <code>-moz-FieldText</code> foreground color. In Gecko versions prior to 1.9, use <code>-moz-Field</code>. See also <code>-moz-OddTreeRow</code>.</p>
  </dd>
@@ -1133,24 +1132,13 @@ browser-compat: css.types.color
  <dd>
  <p>Text color for highlighted items in HTML {{HTMLElement("select")}}s. Should be used with the <code>-moz-html-CellHighlight</code> background color. Prior to Gecko 1.9, use <code>-moz-CellHighlightText</code>.</p>
  </dd>
- <dt>-moz-mac-accentdarkestshadow</dt>
- <dt>-moz-mac-accentdarkshadow</dt>
- <dt>-moz-mac-accentface</dt>
- <dt>-moz-mac-accentlightesthighlight</dt>
- <dt>-moz-mac-accentlightshadow</dt>
- <dt>-moz-mac-accentregularhighlight</dt>
- <dt>-moz-mac-accentregularshadow</dt>
- <dt>-moz-mac-chrome-active</dt>
+ <dt>-moz-mac-accentdarkestshadow, -moz-mac-accentdarkshadow, -moz-mac-accentface, -moz-mac-accentlightesthighlight, -moz-mac-accentlightshadow, -moz-mac-accentregularhighlight, -moz-mac-accentregularshadow, -moz-mac-chrome-active</dt>
  <dd>
  </dd>
  <dt>-moz-mac-chrome-inactive</dt>
  <dd>
  </dd>
- <dt>-moz-mac-focusring</dt>
- <dt>-moz-mac-menuselect</dt>
- <dt>-moz-mac-menushadow</dt>
- <dt>-moz-mac-menutextselect</dt>
- <dt>-moz-MenuHover</dt>
+ <dt>-moz-mac-focusring, -moz-mac-menuselect, -moz-mac-menushadow, -moz-mac-menutextselect, -moz-MenuHover</dt>
  <dd>
  <p>Background color for hovered menu items. Often similar to <code>Highlight</code>. Should be used with the <code>-moz-MenuHoverText</code> or <code>-moz-MenuBarHoverText</code> foreground color.</p>
  </dd>

--- a/files/en-us/web/css/custom-ident/index.html
+++ b/files/en-us/web/css/custom-ident/index.html
@@ -37,16 +37,11 @@ tags:
 <dl>
  <dt>{{CSSxRef("animation-name")}}</dt>
  <dd>Forbids the global CSS values (<code>unset</code>, <code>initial</code>, and <code>inherit</code>), as well as <code>none</code>.</dd>
- <dt>{{CSSxRef("counter-reset")}}</dt>
- <dt>{{CSSxRef("counter-increment")}}</dt>
+ <dt>{{CSSxRef("counter-reset")}}, {{CSSxRef("counter-increment")}}</dt>
  <dd>Forbids the global CSS values (<code>unset</code>, <code>initial</code>, and <code>inherit</code>), as well as <code>none</code>.</dd>
- <dt>{{CSSxRef("@counter-style")}}</dt>
- <dt>{{CSSxRef("list-style-type")}}</dt>
+ <dt>{{CSSxRef("@counter-style")}}, {{CSSxRef("list-style-type")}}</dt>
  <dd>Forbids the global CSS values (<code>unset</code>, <code>initial</code>, and <code>inherit</code>), as well as the values <code>none</code>, <code>inline</code>, and <code>outside</code>. Also, quite a few predefined values are implemented by the different browsers: <code>disc</code>, <code>circle</code>, <code>square</code>, <code>decimal</code>, <code>cjk-decimal</code>, <code>decimal-leading-zero</code>, <code>lower-roman</code>, <code>upper-roman</code>, <code>lower-greek</code>, <code>lower-alpha</code>, <code>lower-latin</code>, <code>upper-alpha</code>, <code>upper-latin</code>, <code>arabic-indic</code>, <code>armenian</code>, <code>bengali</code>, <code>cambodian</code>, <code>cjk-earthly-branch</code>, <code>cjk-heavenly-stem</code>, <code>cjk-ideographic</code>, <code>devanagari</code>, <code>ethiopic-numeric</code>, <code>georgian</code>, <code>gujarati</code>, <code>gurmukhi</code>, <code>hebrew</code>, <code>hiragana</code>, <code>hiragana-iroha</code>, <code>japanese-formal</code>, <code>japanese-informal</code>, <code>kannada</code>, <code>katakana</code>, <code>katakana-iroha</code>, <code>khmer</code>, <code>korean-hangul-formal</code>, <code>korean-hanja-formal</code>, <code>korean-hanja-informal</code>, <code>lao</code>, <code>lower-armenian</code>, <code>malayalam</code>, <code>mongolian</code>, <code>myanmar</code>, <code>oriya</code>, <code>persian</code>, <code>simp-chinese-formal</code>, <code>simp-chinese-informal</code>, <code>tamil</code>, <code>telugu</code>, <code>thai</code>, <code>tibetan</code>, <code>trad-chinese-formal</code>, <code>trad-chinese-informal</code>, <code>upper-armenian</code>, <code>disclosure-open</code>, and <code>disclosure-close</code>.</dd>
- <dt>{{CSSxRef("grid-row-start")}}<br>
- {{CSSxRef("grid-row-end")}}<br>
- {{CSSxRef("grid-column-start")}}<br>
- {{CSSxRef("grid-column-end")}}</dt>
+ <dt>{{CSSxRef("grid-row-start")}}, {{CSSxRef("grid-row-end")}}, {{CSSxRef("grid-column-start")}}, {{CSSxRef("grid-column-end")}}</dt>
  <dd>Forbids the <code>span</code> value.</dd>
  <dt>{{CSSxRef("will-change")}}</dt>
  <dd>Forbids the global CSS values (<code>unset</code>, <code>initial</code>, and <code>inherit</code>), as well as the values <code>will-change</code>, <code>auto</code>, <code>scroll-position</code>, and <code>contents</code>.</dd>

--- a/files/en-us/web/css/list-style-type/index.html
+++ b/files/en-us/web/css/list-style-type/index.html
@@ -134,8 +134,7 @@ list-style-type: unset;
   <li>E.g. α, β, γ…</li>
  </ul>
  </dd>
- <dt><code>lower-alpha</code></dt>
- <dt><code>lower-latin</code></dt>
+ <dt><code>lower-alpha</code>, <code>lower-latin</code></dt>
  <dd>
  <ul style="list-style-type: lower-alpha;">
   <li>Lowercase ASCII letters</li>
@@ -144,8 +143,7 @@ list-style-type: unset;
   <li>See {{anch("Browser compatibility")}} section.</li>
  </ul>
  </dd>
- <dt><code>upper-alpha</code></dt>
- <dt><code>upper-latin</code></dt>
+ <dt><code>upper-alpha</code>, <code>upper-latin</code></dt>
  <dd>
  <ul style="list-style-type: upper-alpha;">
   <li>Uppercase ASCII letters</li>
@@ -153,10 +151,9 @@ list-style-type: unset;
   <li><code>upper-latin</code> is unsupported in IE7 and earlier</li>
  </ul>
  </dd>
- <dt><code>arabic-indic</code></dt>
- <dt><code>-moz-arabic-indic</code></dt>
+ <dt><code>arabic-indic</code>, <code>-moz-arabic-indic</code></dt>
  <dd>
- <ul style="list-style-type: arabic-indic;"> 
+ <ul style="list-style-type: arabic-indic;">
   <li>E.g. ١, ٢, ٣, ٤, ٥, ٦</li>
  </ul>
  </dd>
@@ -167,8 +164,7 @@ list-style-type: unset;
   <li>(ayb/ayp, ben/pen, gim/keem…</li>
  </ul>
  </dd>
- <dt><code>bengali</code></dt>
- <dt><code>-moz-bengali</code></dt>
+ <dt><code>bengali</code>, <code>-moz-bengali</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -181,15 +177,13 @@ list-style-type: unset;
   <li>Is a synonym for <code>khmer</code></li>
  </ul>
  </dd>
- <dt><code>cjk-earthly-branch</code></dt>
- <dt><code>-moz-cjk-earthly-branch</code></dt>
+ <dt><code>cjk-earthly-branch</code>, <code>-moz-cjk-earthly-branch</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>cjk-heavenly-stem</code></dt>
- <dt><code>-moz-cjk-heavenly-stem</code></dt>
+ <dt><code>cjk-heavenly-stem</code>, <code>-moz-cjk-heavenly-stem</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -202,8 +196,7 @@ list-style-type: unset;
   <li>E.g. 一萬一千一百一十一</li>
  </ul>
  </dd>
- <dt><code>devanagari</code></dt>
- <dt><code>-moz-devanagari</code></dt>
+ <dt><code>devanagari</code>, <code>-moz-devanagari</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -222,15 +215,13 @@ list-style-type: unset;
   <li>E.g. an, ban, gan, … he, tan, in…</li>
  </ul>
  </dd>
- <dt><code>gujarati</code></dt>
- <dt><code>-moz-gujarati</code></dt>
+ <dt><code>gujarati</code>, <code>-moz-gujarati</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>gurmukhi</code></dt>
- <dt><code>-moz-gurmukhi</code></dt>
+ <dt><code>gurmukhi</code>, <code>-moz-gurmukhi</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -270,8 +261,7 @@ list-style-type: unset;
   <li>Japanese informal numbering</li>
  </ul>
  </dd>
- <dt><code>kannada</code></dt>
- <dt><code>-moz-kannada</code></dt>
+ <dt><code>kannada</code>, <code>-moz-kannada</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -291,8 +281,7 @@ list-style-type: unset;
   <li>{{interwiki('wikipedia', 'Iroha')}} is the old japanese ordering of syllabs.</li>
  </ul>
  </dd>
- <dt><code>khmer</code></dt>
- <dt><code>-moz-khmer</code></dt>
+ <dt><code>khmer</code>, <code>-moz-khmer</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -319,8 +308,7 @@ list-style-type: unset;
   <li>E.g., 萬 一千百十一</li>
  </ul>
  </dd>
- <dt><code>lao</code></dt>
- <dt><code>-moz-lao</code></dt>
+ <dt><code>lao</code>, <code>-moz-lao</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -332,8 +320,7 @@ list-style-type: unset;
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>malayalam</code></dt>
- <dt><code>-moz-malayalam</code></dt>
+ <dt><code>malayalam</code>, <code>-moz-malayalam</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -345,24 +332,21 @@ list-style-type: unset;
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>myanmar</code></dt>
- <dt><code>-moz-myanmar</code></dt>
+ <dt><code>myanmar</code>, <code>-moz-myanmar</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>oriya</code></dt>
- <dt><code>-moz-oriya</code></dt>
+ <dt><code>oriya</code>, <code>-moz-oriya</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>persian</code> {{experimental_inline}}</dt>
- <dt><code>-moz-persian</code></dt>
+ <dt><code>persian</code> {{experimental_inline}}, <code>-moz-persian</code></dt>
  <dd>
- <ul style="list-style-type: persian;"> 
+ <ul style="list-style-type: persian;">
   <li>E.g. ۱, ۲, ۳, ۴, ۵, ۶</li>
  </ul>
  </dd>
@@ -380,22 +364,19 @@ list-style-type: unset;
   <li>E.g. 一万一千一百一十一</li>
  </ul>
  </dd>
- <dt><code>tamil</code> {{experimental_inline}}</dt>
- <dt><code>-moz-tamil</code></dt>
+ <dt><code>tamil</code> {{experimental_inline}}, <code>-moz-tamil</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>telugu</code></dt>
- <dt><code>-moz-telugu</code></dt>
+ <dt><code>telugu</code>, <code>-moz-telugu</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>thai</code></dt>
- <dt><code>-moz-thai</code></dt>
+ <dt><code>thai</code>, <code>-moz-thai</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -458,31 +439,19 @@ list-style-type: unset;
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>ethiopic-halehame-ti-er</code></dt>
- <dt><code>-moz-ethiopic-halehame-ti-er</code></dt>
+ <dt><code>ethiopic-halehame-ti-er</code>, <code>-moz-ethiopic-halehame-ti-er</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>ethiopic-halehame-ti-et</code></dt>
- <dt><code>-moz-ethiopic-halehame-ti-et</code></dt>
+ <dt><code>ethiopic-halehame-ti-et</code>, <code>-moz-ethiopic-halehame-ti-et</code></dt>
  <dd>
  <ul>
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>hangul</code></dt>
- <dt><code>-moz-hangul</code></dt>
- <dd>
- <ul>
-  <li>Example</li>
-  <li>Example</li>
-  <li>Example</li>
- </ul>
- </dd>
- <dt><code>hangul-consonant</code></dt>
- <dt><code>-moz-hangul-consonant</code></dt>
+ <dt><code>hangul</code>, <code>-moz-hangul</code></dt>
  <dd>
  <ul>
   <li>Example</li>
@@ -490,8 +459,15 @@ list-style-type: unset;
   <li>Example</li>
  </ul>
  </dd>
- <dt><code>urdu</code></dt>
- <dt><code>-moz-urdu</code></dt>
+ <dt><code>hangul-consonant</code>, <code>-moz-hangul-consonant</code></dt>
+ <dd>
+ <ul>
+  <li>Example</li>
+  <li>Example</li>
+  <li>Example</li>
+ </ul>
+ </dd>
+ <dt><code>urdu</code>, <code>-moz-urdu</code></dt>
  <dd>
  <ul>
   <li>Example</li>

--- a/files/en-us/web/html/inline_elements/index.html
+++ b/files/en-us/web/html/inline_elements/index.html
@@ -99,66 +99,64 @@ the block-level element's influence.&lt;/div&gt;</pre>
 
 <p>The following elements are inline by default (although block and inline elements are no longer defined in HTML 5, use <a href="/en-US/docs/Web/Guide/HTML/Content_categories">content categories</a> instead):</p>
 
-<div class="threecolumns">
-<dl>
- <dt>{{ HTMLElement("a") }}</dt>
- <dt>{{ HTMLElement("abbr") }}</dt>
- <dt>{{ HTMLElement("acronym") }}</dt>
- <dt>{{ HTMLElement("audio") }} (if it has visible controls)</dt>
- <dt>{{ HTMLElement("b") }}</dt>
- <dt>{{ HTMLElement("bdi") }}</dt>
- <dt>{{ HTMLElement("bdo") }}</dt>
- <dt>{{ HTMLElement("big") }}</dt>
- <dt>{{ HTMLElement("br") }}</dt>
- <dt>{{ HTMLElement("button") }}</dt>
- <dt>{{ HTMLElement("canvas") }}</dt>
- <dt>{{ HTMLElement("cite") }}</dt>
- <dt>{{ HTMLElement("code") }}</dt>
- <dt>{{ HTMLElement("data") }}</dt>
- <dt>{{ HTMLElement("datalist") }}</dt>
- <dt>{{ HTMLElement("del") }}</dt>
- <dt>{{ HTMLElement("dfn") }}</dt>
- <dt>{{ HTMLElement("em") }}</dt>
- <dt>{{ HTMLElement("embed") }}</dt>
- <dt>{{ HTMLElement("i") }}</dt>
- <dt>{{ HTMLElement("iframe") }}</dt>
- <dt>{{ HTMLElement("img") }}</dt>
- <dt>{{ HTMLElement("input") }}</dt>
- <dt>{{ HTMLElement("ins") }}</dt>
- <dt>{{ HTMLElement("kbd") }}</dt>
- <dt>{{ HTMLElement("label") }}</dt>
- <dt>{{ HTMLElement("map") }}</dt>
- <dt>{{ HTMLElement("mark") }}</dt>
- <dt>{{ HTMLElement("meter") }}</dt>
- <dt>{{ HTMLElement("noscript") }}</dt>
- <dt>{{ HTMLElement("object") }}</dt>
- <dt>{{ HTMLElement("output") }}</dt>
- <dt>{{ HTMLElement("picture") }}</dt>
- <dt>{{ HTMLElement("progress") }}</dt>
- <dt>{{ HTMLElement("q") }}</dt>
- <dt>{{ HTMLElement("ruby") }}</dt>
- <dt>{{ HTMLElement("s") }}</dt>
- <dt>{{ HTMLElement("samp") }}</dt>
- <dt>{{ HTMLElement("script") }}</dt>
- <dt>{{ HTMLElement("select") }}</dt>
- <dt>{{ HTMLElement("slot") }}</dt>
- <dt>{{ HTMLElement("small") }}</dt>
- <dt>{{ HTMLElement("span") }}</dt>
- <dt>{{ HTMLElement("strong") }}</dt>
- <dt>{{ HTMLElement("sub") }}</dt>
- <dt>{{ HTMLElement("sup") }}</dt>
- <dt>{{ HTMLElement("svg") }}</dt>
- <dt>{{ HTMLElement("template") }}</dt>
- <dt>{{ HTMLElement("textarea") }}</dt>
- <dt>{{ HTMLElement("time") }}</dt>
- <dt>{{ HTMLElement("u") }}</dt>
- <dt>{{ HTMLElement("tt") }}</dt>
- <dt>{{ HTMLElement("var") }}</dt>
- <dt>{{ HTMLElement("video") }}</dt>
- <dt>{{ HTMLElement("wbr") }}</dt>
+<ul>
+ <li>{{ HTMLElement("a") }}</li>
+ <li>{{ HTMLElement("abbr") }}</li>
+ <li>{{ HTMLElement("acronym") }}</li>
+ <li>{{ HTMLElement("audio") }} (if it has visible controls)</li>
+ <li>{{ HTMLElement("b") }}</li>
+ <li>{{ HTMLElement("bdi") }}</li>
+ <li>{{ HTMLElement("bdo") }}</li>
+ <li>{{ HTMLElement("big") }}</li>
+ <li>{{ HTMLElement("br") }}</li>
+ <li>{{ HTMLElement("button") }}</li>
+ <li>{{ HTMLElement("canvas") }}</li>
+ <li>{{ HTMLElement("cite") }}</li>
+ <li>{{ HTMLElement("code") }}</li>
+ <li>{{ HTMLElement("data") }}</li>
+ <li>{{ HTMLElement("datalist") }}</li>
+ <li>{{ HTMLElement("del") }}</li>
+ <li>{{ HTMLElement("dfn") }}</li>
+ <li>{{ HTMLElement("em") }}</li>
+ <li>{{ HTMLElement("embed") }}</li>
+ <li>{{ HTMLElement("i") }}</li>
+ <li>{{ HTMLElement("iframe") }}</li>
+ <li>{{ HTMLElement("img") }}</li>
+ <li>{{ HTMLElement("input") }}</li>
+ <li>{{ HTMLElement("ins") }}</li>
+ <li>{{ HTMLElement("kbd") }}</li>
+ <li>{{ HTMLElement("label") }}</li>
+ <li>{{ HTMLElement("map") }}</li>
+ <li>{{ HTMLElement("mark") }}</li>
+ <li>{{ HTMLElement("meter") }}</li>
+ <li>{{ HTMLElement("noscript") }}</li>
+ <li>{{ HTMLElement("object") }}</li>
+ <li>{{ HTMLElement("output") }}</li>
+ <li>{{ HTMLElement("picture") }}</li>
+ <li>{{ HTMLElement("progress") }}</li>
+ <li>{{ HTMLElement("q") }}</li>
+ <li>{{ HTMLElement("ruby") }}</li>
+ <li>{{ HTMLElement("s") }}</li>
+ <li>{{ HTMLElement("samp") }}</li>
+ <li>{{ HTMLElement("script") }}</li>
+ <li>{{ HTMLElement("select") }}</li>
+ <li>{{ HTMLElement("slot") }}</li>
+ <li>{{ HTMLElement("small") }}</li>
+ <li>{{ HTMLElement("span") }}</li>
+ <li>{{ HTMLElement("strong") }}</li>
+ <li>{{ HTMLElement("sub") }}</li>
+ <li>{{ HTMLElement("sup") }}</li>
+ <li>{{ HTMLElement("svg") }}</li>
+ <li>{{ HTMLElement("template") }}</li>
+ <li>{{ HTMLElement("textarea") }}</li>
+ <li>{{ HTMLElement("time") }}</li>
+ <li>{{ HTMLElement("u") }}</li>
+ <li>{{ HTMLElement("tt") }}</li>
+ <li>{{ HTMLElement("var") }}</li>
+ <li>{{ HTMLElement("video") }}</li>
+ <li>{{ HTMLElement("wbr") }}</li>
  <dd></dd>
-</dl>
-</div>
+</ul>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.html
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.html
@@ -56,8 +56,7 @@ tags:
  <dd>The specified proxy should be used</dd>
  <dt><code>HTTPS <em>host:port</em></code></dt>
  <dd>The specified HTTPS proxy should be used</dd>
- <dt><code>SOCKS4 <em>host:port</em></code></dt>
- <dt><code>SOCKS5 <em>host:port</em></code></dt>
+ <dt><code>SOCKS4 <em>host:port</em></code>, <code>SOCKS5 <em>host:port</em></code></dt>
  <dd>The specified SOCKS server (with the specified SOCK version) should be used</dd>
 </dl>
 

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.html
@@ -490,21 +490,11 @@ function attemptMutation(v) {
 </dl>
 
 <dl>
- <dt>{{jsxref("Math.atan2")}}</dt>
- <dt>{{jsxref("Math.ceil")}}</dt>
- <dt>{{jsxref("Math.pow")}}</dt>
- <dt>{{jsxref("Math.round")}}</dt>
+ <dt>{{jsxref("Math.atan2")}}, {{jsxref("Math.ceil")}}, {{jsxref("Math.pow")}}, {{jsxref("Math.round")}}</dt>
  <dd>In some cases,it's possible for a <code>-0</code> to be introduced into an expression as a return value of these methods even when no <code>-0</code> exists as one of the parameters. For example, using {{jsxref("Math.pow")}} to raise {{jsxref("Infinity", "-Infinity")}} to the power of any negative, odd exponent evaluates to <code>-0</code>. Refer to the documentation for the individual methods.</dd>
- <dt>{{jsxref("Math.floor")}}</dt>
- <dt>{{jsxref("Math.max")}}</dt>
- <dt>{{jsxref("Math.min")}}</dt>
- <dt>{{jsxref("Math.sin")}}</dt>
- <dt>{{jsxref("Math.sqrt")}}</dt>
- <dt>{{jsxref("Math.tan")}}</dt>
+ <dt>{{jsxref("Math.floor")}}, {{jsxref("Math.max")}}, {{jsxref("Math.min")}}, {{jsxref("Math.sin")}}, {{jsxref("Math.sqrt")}}, {{jsxref("Math.tan")}}</dt>
  <dd>It's possible to get a <code>-0</code> return value out of these methods in some cases where a <code>-0</code> exists as one of the parameters. E.g., <code>Math.min(-0, +0)</code> evaluates to <code>-0</code>. Refer to the documentation for the individual methods.</dd>
- <dt><code><a href="/en-US/docs/Web/JavaScript/Reference/Operators">~</a></code></dt>
- <dt><code><a href="/en-US/docs/Web/JavaScript/Reference/Operators">&lt;&lt;</a></code></dt>
- <dt><code><a href="/en-US/docs/Web/JavaScript/Reference/Operators">&gt;&gt;</a></code></dt>
+ <dt><code><a href="/en-US/docs/Web/JavaScript/Reference/Operators">~</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators">&lt;&lt;</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators">&gt;&gt;</a></code></dt>
  <dd>Each of these operators uses the ToInt32 algorithm internally. Since there is only one representation for 0 in the internal 32-bit integer type, <code>-0</code> will not survive a round trip after an inverse operation. E.g., both <code>Object.is(~~(-0), -0)</code> and <code>Object.is(-0 &lt;&lt; 2 &gt;&gt; 2, -0)</code> evaluate to <code>false</code>.</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/compare/index.html
@@ -27,8 +27,7 @@ browser-compat: javascript.builtins.Intl.Collator.compare
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-	<dt><code><var>string1</var></code></dt>
-	<dt><code><var>string2</var></code></dt>
+	<dt><code><var>string1</var></code>, <code><var>string2</var></code></dt>
 	<dd>The strings to compare against each other.</dd>
 </dl>
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/resolvedoptions/index.html
@@ -41,16 +41,13 @@ browser-compat: javascript.builtins.Intl.Collator.resolvedOptions
 		values were requested in the input BCP 47 language tag that led to this locale,
 		the key-value pairs that were requested and are supported for this locale are
 		included in <code>locale</code>.</dd>
-	<dt><code>usage</code></dt>
-	<dt><code>sensitivity</code></dt>
-	<dt><code>ignorePunctuation</code></dt>
+	<dt><code>usage</code>, <code>sensitivity</code>, <code>ignorePunctuation</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults.</dd>
 	<dt><code>collation</code></dt>
 	<dd>The value requested using the Unicode extension key "<code>co</code>", if it is
 		supported for <code>locale</code>, or "<code>default</code>".</dd>
-	<dt><code>numeric</code></dt>
-	<dt><code>caseFirst</code></dt>
+	<dt><code>numeric</code>, <code>caseFirst</code></dt>
 	<dd>The values requested for these properties in the <code>options</code> argument or
 		using the Unicode extension keys "<code>kn</code>" and "<code>kf</code>" or filled
 		in as defaults. If the implementation does not support these properties, they are

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
@@ -58,15 +58,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.resolvedOptions
 	<dt><code>hour12</code></dt>
 	<dd>The value provided for this property in the <code>options</code> argument or
 		filled in as a default.</dd>
-	<dt><code>weekday</code></dt>
-	<dt><code>era</code></dt>
-	<dt><code>year</code></dt>
-	<dt><code>month</code></dt>
-	<dt><code>day</code></dt>
-	<dt><code>hour</code></dt>
-	<dt><code>minute</code></dt>
-	<dt><code>second</code></dt>
-	<dt><code>timeZoneName</code></dt>
+	<dt><code>weekday</code>, <code>era</code>, <code>year</code>, <code>month</code>, <code>day</code>, <code>hour</code>, <code>minute</code>, <code>second</code>, <code>timeZoneName</code></dt>
 	<dd>The values resulting from format matching between the corresponding properties in
 		the <code>options</code> argument and the available combinations and
 		representations for date-time formatting in the selected locale. Some of these

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.html
@@ -61,8 +61,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.resolvedOptions
 	<dt><code>useGrouping</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults.</dd>
-	<dt><code>currency</code></dt>
-	<dt><code>currencyDisplay</code></dt>
+	<dt><code>currency</code>, <code>currencyDisplay</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults. These properties are only present if <code>style</code> is
 		"<code>currency</code>".</dd>
@@ -71,15 +70,12 @@ browser-compat: javascript.builtins.Intl.NumberFormat.resolvedOptions
 <p>Only one of the following two groups of properties is included:</p>
 
 <dl>
-	<dt><code>minimumIntegerDigits</code></dt>
-	<dt><code>minimumFractionDigits</code></dt>
-	<dt><code>maximumFractionDigits</code></dt>
+	<dt><code>minimumIntegerDigits</code>, <code>minimumFractionDigits</code>, <code>maximumFractionDigits</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults. These properties are present only if neither
 		<code>minimumSignificantDigits</code> nor <code>maximumSignificantDigits</code>
 		was provided in the <code>options</code> argument.</dd>
-	<dt><code>minimumSignificantDigits</code></dt>
-	<dt><code>maximumSignificantDigits</code></dt>
+	<dt><code>minimumSignificantDigits</code>, <code>maximumSignificantDigits</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults. These properties are present only if at least one of them
 		was provided in the <code>options</code> argument.</dd>

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.html
@@ -48,15 +48,12 @@ browser-compat: javascript.builtins.Intl.PluralRules.resolvedOptions
 <p>Only one of the following two groups of properties is included:</p>
 
 <dl>
-	<dt><code>minimumIntegerDigits</code></dt>
-	<dt><code>minimumFractionDigits</code></dt>
-	<dt><code>maximumFractionDigits</code></dt>
+	<dt><code>minimumIntegerDigits</code>, <code>minimumFractionDigits</code>, <code>maximumFractionDigits</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults. These properties are present only if neither
 		<code>minimumSignificantDigits</code> nor <code>maximumSignificantDigits</code>
 		was provided in the <code>options</code> argument.</dd>
-	<dt><code>minimumSignificantDigits</code></dt>
-	<dt><code>maximumSignificantDigits</code></dt>
+	<dt><code>minimumSignificantDigits</code>, <code>maximumSignificantDigits</code></dt>
 	<dd>The values provided for these properties in the <code>options</code> argument or
 		filled in as defaults. These properties are present only if at least one of them
 		was provided in the <code>options</code> argument.</dd>


### PR DESCRIPTION
This PR removes adjacent `<dt>` elements, as discussed in https://github.com/mdn/content/issues/4367#issuecomment-834966916, replacing them with a single `<dt>` containing multiple terms, except in one case where it replaces them with a  `<ul>`.
