### PR TITLE
Update JavaScript for...in syntax block

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for...in/index.html
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.html
@@ -19,8 +19,10 @@ browser-compat: javascript.statements.for_in
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">for (<var>variable</var> in <var>object</var>)
-  statement</pre>
+<pre class="brush: js">for (<var>variable</var> in <var>object</var>) {
+  <var>statement</var>
+}
+</pre>
 
 <dl>
   <dt><code><var>variable</var></code></dt>


### PR DESCRIPTION
Add missing angled brackets (`{ }`) missing from `for...in` syntax example. 

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Angled brackets (`{ }`) were missing from the JavaScript `for...in` syntax example. 

![for-in](https://user-images.githubusercontent.com/3147296/118595295-283b3380-b7ee-11eb-8fc1-b8ffb57f3f89.png)

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

I am matching the HTML and code snippet example of the **for...of** page:

[`for...of` MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)  

`for...of` syntax HTML format:
https://github.com/mdn/content/blob/f9d710480812705f184665a3bd42de55e9ab098f/files/en-us/web/javascript/reference/statements/for...of/index.html#L27-L30
