### PR TITLE
Improve documentation on common macros

### DIFF
--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -48,21 +48,86 @@ tags:
 
 <h3 id="Linking_to_pages_in_references">Linking to pages in references</h3>
 
-<p>There are various macros for linking to pages in specific reference areas of MDN.</p>
+<p>There are macros for locale-independent linking to pages in specific reference areas of MDN: Javascript, CSS, HTML elements, SVG etc.</p>
 
-<ul>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/cssxref.ejs">cssxref</a></code> links to a page in the <a href="/en-US/docs/Web/CSS/Reference">CSS Reference</a>.<br>
-  Example: <code>\{{CSSxRef("cursor")}}</code>, results in: {{CSSxRef("cursor")}}.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/DOMxRef.ejs">domxref</a></code> links to pages in the DOM reference; if you include parentheses at the end, the template knows to display the link to look like a function name. For example, <code>\{{DOMxRef("document.getElementsByName()")}}</code> results in {{DOMxRef("document.getElementsByName()")}} while <code>\{{DOMxRef("Node")}}</code> results in {{DOMxRef("Node")}}.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTMLElement.ejs">HTMLElement</a></code> links to an HTML element in the HTML Reference.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/htmlattrxref.ejs">htmlattrxref</a></code> links to an HTML attribute, either a global attribute description if you only specify the attribute name or an attribute associated with a specific element if you specify an attribute name and an element name. For example, <code>\{{HTMLAttrxRef("lang")}} </code>will create this link: {{HTMLAttrxRef("lang")}}. <code>\{{HTMLAttrxRef("type","input")}}</code> will create this link: {{htmlattrxref("type","input")}}.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/jsxref.ejs">jsxref</a></code> links to a page in the <a href="/en-US/docs/Web/JavaScript/Reference">JavaScript Reference</a>.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGAttr.ejs">SVGAttr</a></code> links to a specific SVG attribute. For example, <code>\{{SVGAttr("d")}}</code> creates this link: {{SVGAttr("d")}}.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGElement.ejs">SVGElement</a></code> links to an SVG element in the SVG Reference.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPHeader.ejs">HTTPHeader</a></code> links to an <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a>.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPMethod.ejs">HTTPMethod</a></code> links to an <a href="/en-US/docs/Web/HTTP/Methods">HTTP request method</a>.</li>
- <li><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPStatus.ejs">HTTPStatus</a></code> links to an <a href="/en-US/docs/Web/HTTP/Status">HTTP response status code</a>.</li>
-</ul>
+<p>The macros are easy to use. Minimally all you need to do is specify the name of the item to link to in the first argument. Most macros will also take a second argument allowing you to change the display text (documentation can be found at the links in the left-most column below).</p>
+
+<table class="standard-table">
+    <caption>Compound assignment operators</caption>
+    <thead>
+      <tr>
+        <th>Macro</th>
+        <th>Links to page under</th>
+        <th>Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/cssxref.ejs">CSSxRef</a></td>
+        <td><a href="/en-US/docs/Web/CSS/Reference">CSS Reference</a> (/Web/CSS/Reference)</td>
+        <td><code>\{{CSSxRef("cursor")}}</code> results in {{CSSxRef("cursor")}}.</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/DOMxRef.ejs">DOMxRef</a></td>
+        <td><a href="/en-US/docs/Web/API">DOM Reference</a> (/Web/API)</td>
+        <td><code>\{{DOMxRef("Document")}}</code> or <code>\{{DOMxRef("document")}}</code> results in {{DOMxRef("Document")}},<br>
+            <code>\{{DOMxRef("document.getElementsByName()")}}</code> result in {{DOMxRef("document.getElementsByName()")}}<br/>
+            <code>\{{DOMxRef("Node")}}</code> result in {{DOMxRef("Node")}}. <br/>
+            You can change the display text using a second parameter: <code>\{{DOMxRef("document.getElementsByName()","getElementsByName()")}}</code> results in {{DOMxRef("document.getElementsByName()","getElementsByName()")}}.</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTMLElement.ejs">HTMLElement</a></code></td>
+        <td><a href="/en-US/docs/Web/HTML/Element">HTML Elements reference</a> (/Web/HTML/Element)</td>
+        <td><code>\{{HTMLElement("select")}}</code> results in {{HTMLElement("select")}}</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/htmlattrxref.ejs">HTMLAttrxRef</a></td>
+        <td><a href="/en-US/docs/Web/HTML/Global_attributes">HTML global attribute description</a> if you only specify the attribute name.<br/>Attribute associated with a specific HTML element if you specify an attribute name and an element name.</td>
+        <td><code>\{{HTMLAttrxRef("lang")}} </code> links to the global attribute description {{HTMLAttrxRef("lang")}}.<br/><code>\{{HTMLAttrxRef("type","input")}}</code> result in a link to the {{htmlattrxref("type","input")}} attribute (on the {{HTMLElement("input")}} element).</td>
+      </tr>
+      <tr>
+        <td> <a href="https://github.com/mdn/yari/tree/master/kumascript/macros/jsxref.ejs">JSxRef</a></td>
+        <td><a href="/en-US/docs/Web/JavaScript/Reference">JavaScript reference</a> (/Web/JavaScript/Reference).</td>
+        <td>\{{("Promise")}}</code> results in {{JSxRef("Promise")}}</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGAttr.ejs">SVGAttr</a></td>
+        <td><a href="/en-US/docs/Web/SVG/Attribute">SVG attribute reference</a> (/Web/SVG/Attribute).</td>
+        <td><code>\{{SVGAttr("d")}}</code> results in {{SVGAttr("d")}}</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/SVGElement.ejs">SVGElement</a></td>
+        <td><a href="/en-US/docs/Web/SVG/Attribute">SVG Element reference</a> (/Web/SVG/Element).</td>
+        <td><code>\{{SVGElement("view")}}</code> results in {{SVGElement("view")}}</td>
+      </tr>
+      <tr>
+        <td><code><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPHeader.ejs">HTTPHeader</a></td>
+        <td><a href="/en-US/docs/Web/HTTP/Headers">HTTP headers</a> (/Web/HTTP/Headers).</td>
+        <td><code>\{{HTTPHeader("ACCEPT")}}</code> results in {{HTTPHeader("ACCEPT")}}</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPMethod.ejs">HTTPMethod</a></td>
+        <td><a href="/en-US/docs/Web/HTTP/Methods">HTTP request methods</a> (/Web/HTTP/Methods).</td>
+        <td><code>\{{HTTPMethod("HEAD")}}</code> results in {{HTTPMethod("HEAD")}}</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/tree/master/kumascript/macros/HTTPStatus.ejs">HTTPStatus</a></td>
+        <td><a href="/en-US/docs/Web/HTTP/Status">HTTP response status codes</a> (/Web/HTTP/Status)</td>
+        <td><code>\{{HTTPStatus("404")}}</code> results in {{HTTPStatus("404")}}</td>
+      </tr>
+      <tr>
+        <td><a href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs">Event</a>.</td>
+        <td><a href="/en-US/docs/Web/Events">Events reference</a> (/Web/Events)</td>
+        <td><code>\{{Event("Event_handlers", "Event handlders")}}</code> results in {{Event("Event_handlers", "Event handlers")}}
+        <div class="notecard note">
+            <h4>Note</h4>
+            <p>This macro is not particularly useful because events are now under their associated DOM element. So to link to the wheel event you would use <code>\{{DOMxRef("Document.wheel_event")}}</code>: {{DOMxRef("Document.wheel_event")}}</p>
+        </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
 
 <h3 id="Linking_to_bugs">Linking to bugs</h3>
 

--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.html
@@ -53,7 +53,6 @@ tags:
 <p>The macros are easy to use. Minimally all you need to do is specify the name of the item to link to in the first argument. Most macros will also take a second argument allowing you to change the display text (documentation can be found at the links in the left-most column below).</p>
 
 <table class="standard-table">
-    <caption>Compound assignment operators</caption>
     <thead>
       <tr>
         <th>Macro</th>


### PR DESCRIPTION
Fixes #5070

The [commonly used macros > linking to pages in reference](https://developer.mozilla.org/en-US/docs/MDN/Structures/Macros/Commonly-used_macros#linking_to_pages_in_references) docs were displayed as a list that was quite hard to parse, and for which some had examples and some did not. It was also missing the (not very useful) event reference.

To make this more useful I have formatted as a table with macro, reference area and examples columns. That makes it very easy to see where these things might be useful, and how they are used. I also added a note to highlight that one benefit is not just the simplicity, but that these are locale aware.

FYI @escattone 