### PR TITLE
add `url(...)` around font source paths

### DIFF
--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.html
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.html
@@ -178,7 +178,7 @@ font-variation-settings: 'opsz' 36;</pre>
 
 <pre class="brush: css">@font-face {
  font-family: 'MyVariableFontName';
- src: 'path/to/font/file/myvariablefont.woff2' format('woff2-variations');
+ src: url('path/to/font/file/myvariablefont.woff2') format('woff2-variations');
  font-weight: 125 950;
  font-stretch: 75% 125%;
  font-style: normal;
@@ -189,7 +189,7 @@ font-variation-settings: 'opsz' 36;</pre>
 
 <pre class="brush: css">@font-face {
  font-family: 'MyVariableFontName';
- src: 'path/to/font/file/myvariablefont.woff2' format('woff2-variations');
+ src: url('path/to/font/file/myvariablefont.woff2') format('woff2-variations');
  font-weight: 125 950;
  font-stretch: 75% 125%;
  font-style: oblique 0deg 20deg;
@@ -203,7 +203,7 @@ font-variation-settings: 'opsz' 36;</pre>
 
 <pre class="brush: css">@font-face {
  font-family: 'MyVariableFontName';
- src: 'path/to/font/file/myvariablefont.woff2' format('woff2-variations');
+ src: url('path/to/font/file/myvariablefont.woff2') format('woff2-variations');
  font-weight: 125 950;
  font-stretch: 75% 125%;
  font-style: italic;
@@ -213,7 +213,7 @@ font-variation-settings: 'opsz' 36;</pre>
 
 <pre class="brush: css">@font-face {
  font-family: 'MyVariableFontName';
- src: 'path/to/font/file/myvariablefont.woff2' format('woff2-variations');
+ src: url('path/to/font/file/myvariablefont.woff2') format('woff2-variations');
  font-weight: 125 950;
  font-stretch: 75% 125%;
  font-style: oblique 0deg 12deg;


### PR DESCRIPTION
Not having `url(...)` around the font source paths makes it error-prone to copy paste them, as the paths won't work. 

Some authors might be unaware of the correct syntax, and even an experienced author can easily oversee this detail when copy-pasting (speaking from experience 😅 ).

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide