### PR TITLE
Update TypeScript popularity information in Svelte Section

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
@@ -74,10 +74,6 @@ tags:
 
 <h2 id="Why_TypeScript">Why TypeScript?</h2>
 
-<p>Recently TypeScript has seen enormous growth. From year 2020's <a href="https://octoverse.github.com/">GitHub octoverse report</a> we can see that TypeScript is rising fast and currently at 4th most used language used on GitHub. According to <a href="https://insights.stackoverflow.com/survey/2020">StackOverflow's 2020 Developer Survey</a> it is one among the top 10 <a href="https://insights.stackoverflow.com/survey/2020#most-popular-technologies">most popular languages</a> and the <a href="https://insights.stackoverflow.com/survey/2020#most-loved-dreaded-and-wanted">2nd most loved language</a>, right behind Rust</p>
-
-<p>So TypeScript is going through a great phase of adoption.</p>
-
 <p>TypeScript's main advantages are:</p>
 
 <ul>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.html
@@ -74,7 +74,7 @@ tags:
 
 <h2 id="Why_TypeScript">Why TypeScript?</h2>
 
-<p>Recently TypeScript has seen enormous growth. From last year's <a href="https://octoverse.github.com/">GitHub octoverse report</a> we can see that TypeScript is the <a href="https://octoverse.github.com/#top-languages-over-time">7th most used</a> and <a href="https://octoverse.github.com/#fastest-growing-languages">5th fastest growing</a> language used on GitHub. According to <a href="https://insights.stackoverflow.com/survey/2019#overview">StackOverflow's 2019 Developer Survey</a> it is the <a href="https://insights.stackoverflow.com/survey/2019#most-loved-dreaded-and-wanted">third most loved language</a>, right behind Rust and Python.</p>
+<p>Recently TypeScript has seen enormous growth. From year 2020's <a href="https://octoverse.github.com/">GitHub octoverse report</a> we can see that TypeScript is rising fast and currently at 4th most used language used on GitHub. According to <a href="https://insights.stackoverflow.com/survey/2020">StackOverflow's 2020 Developer Survey</a> it is one among the top 10 <a href="https://insights.stackoverflow.com/survey/2020#most-popular-technologies">most popular languages</a> and the <a href="https://insights.stackoverflow.com/survey/2020#most-loved-dreaded-and-wanted">2nd most loved language</a>, right behind Rust</p>
 
 <p>So TypeScript is going through a great phase of adoption.</p>
 


### PR DESCRIPTION
What's Updated: The popularity information of TypeScript according to latest reports and statistics, since some of the links are now dead

Content URL: https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_TypeScript#why_typescript

