### PR TITLE
Remove "compatibility caseless"

### DIFF
--- a/files/en-us/web/html/element/map/index.html
+++ b/files/en-us/web/html/element/map/index.html
@@ -56,7 +56,7 @@ tags:
 
 <dl>
  <dt>{{htmlattrdef("name")}}</dt>
- <dd>The <code>name</code> attribute gives the map a name so that it can be referenced. The attribute must be present and must have a non-empty value with no space characters. The value of the <code>name</code> attribute must not be a compatibility-caseless match for the value of the <code>name</code> attribute of another <code>&lt;map&gt;</code> element in the same document. If the {{htmlattrxref("id")}} attribute is also specified, both attributes must have the same value.</dd>
+ <dd>The <code>name</code> attribute gives the map a name so that it can be referenced. The attribute must be present and must have a non-empty value with no space characters. The value of the <code>name</code> attribute must not be equal to the value of the <code>name</code> attribute of another <code>&lt;map&gt;</code> element in the same document. If the {{htmlattrxref("id")}} attribute is also specified, both attributes must have the same value.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`<map>`'s `name` is supposed to be case-sensitive now.

> MDN URL of the main page changed

https://developer.mozilla.org/ko/docs/Web/HTML/Element/map

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

https://www.chromestatus.com/feature/5760965337415680