### PR TITLE
Remove confusing <code>

### DIFF
--- a/files/en-us/web/html/element/track/index.html
+++ b/files/en-us/web/html/element/track/index.html
@@ -113,7 +113,7 @@ tags:
 
 <p>The type of data that <code>track</code> adds to the media is set in the <code>kind</code> attribute, which can take values of <code>subtitles</code>, <code>captions</code>, <code>descriptions</code>, <code>chapters</code> or <code>metadata</code>. The element points to a source file containing timed text that the browser exposes when the user requests additional data.</p>
 
-<p>A <code>media</code> element cannot have more than one <code>track</code> with the same <code>kind</code>, <code>srclang</code>, and <code>label</code>.</p>
+<p>A media element cannot have more than one <code>track</code> with the same <code>kind</code>, <code>srclang</code>, and <code>label</code>.</p>
 
 <h3 id="Detecting_cue_changes">Detecting cue changes</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The "a media element" is supposed to mean "a `<audio>` or a `<video>` element", not "a `<media>` element".

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track

> Issue number (if there is an associated issue)

🙅‍♀️

> Anything else that could help us review it

🙅‍♀️