### PR TITLE
Update API Wikipedia link

### DIFF
--- a/files/en-us/glossary/api/index.html
+++ b/files/en-us/glossary/api/index.html
@@ -24,7 +24,7 @@ tags:
 <h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
- <li>{{Interwiki("wikipedia", "Application_programming_interface", "API")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "API", "API")}} on Wikipedia</li>
 </ul>
 
 <h3 id="Technical_reference">Technical reference</h3>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The link to the API article on Wikipedia is out of date.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Glossary/API

> Issue number (if there is an associated issue)

> Anything else that could help us review it
