### PR TITLE
Adds a link to the code of separate worker thread. Fixes  #3060

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/concepts/index.html
+++ b/files/en-us/learn/javascript/asynchronous/concepts/index.html
@@ -119,7 +119,7 @@ Thread 2: Task C --&gt; Task D</pre>
 <pre>  Main thread: Task A --&gt; Task C
 Worker thread: Expensive task B</pre>
 
-<p>With this in mind, have a look at <a href="https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/introducing/simple-sync-worker.html">simple-sync-worker.html</a> (<a href="https://mdn.github.io/learning-area/javascript/asynchronous/introducing/simple-sync-worker.html">see it running live</a>), again with your browser's JavaScript console open. This is a rewrite of our previous example that calculates the 10 million dates in a separate worker thread. Now when you click the button, the browser is able to display the paragraph before the dates have finished calculating. The first operation no longer blocks the second.</p>
+<p>With this in mind, have a look at <a href="https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/introducing/simple-sync-worker.html">simple-sync-worker.html</a> (<a href="https://mdn.github.io/learning-area/javascript/asynchronous/introducing/simple-sync-worker.html">see it running live</a>), again with your browser's JavaScript console open. This is a rewrite of our previous example that calculates the 10 million dates in a separate worker thread (See <a href="https://github.com/mdn/learning-area/blob/master/javascript/asynchronous/introducing/worker.js">). Now when you click the button, the browser is able to display the paragraph before the dates have finished calculating. The first operation no longer blocks the second.</p>
 
 <h2 id="Asynchronous_code">Asynchronous code</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The issue #3060 describes missing code for the separate worker thread. Although that is discoverable, the fix adds an explicit link

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Concepts

> Issue number (if there is an associated issue)
#3060 

> Anything else that could help us review it
