### PR TITLE
Removing mention of W3C HTML spec

### DIFF
--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -127,7 +127,7 @@ tags:
  </div>
  </dd>
  <dt>{{htmlattrdef("type")}} {{deprecated_inline}}</dt>
- <dd>No effect. Browsers ignore it. (The W3C 5.3 fork of the HTML specification defines it as valid, but <a href="https://html.spec.whatwg.org/multipage/#the-area-element">the canonical HTML specification</a> doesn’t, and it has no effect in any user agents.)</dd>
+ <dd>Hint for the type of the referenced resource. Ignored by browsers.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
Fixes #5016 removes mention of the HTML 5.3 spec, as it doesn't add anything and is potentially confusing.