### PR TITLE
linear-gradient: Fix color stops

### DIFF
--- a/files/en-us/web/css/linear-gradient()/index.html
+++ b/files/en-us/web/css/linear-gradient()/index.html
@@ -99,7 +99,7 @@ linear-gradient(red 0%, orange 25%, yellow 50%, green 75%, blue 100%);</pre>
 
 <p>If two or more color stops are at the same location, the transition will be a hard line between the first and last colors declared at that location. </p>
 
-<p>Color stops should be listed in ascending order. Subsequent color stops of lower value will override the value of the previous color stop creating a hard transition. The following changes from red to yellow at the 30% mark, and then transitions from yellow to blue over 35% of the gradient</p>
+<p>Color stops should be listed in ascending order. Subsequent color stops of lower value will override the value of the previous color stop creating a hard transition. The following changes from red to yellow at the 40% mark, and then transitions from yellow to blue over 25% of the gradient</p>
 
 <pre class="brush: css">linear-gradient(red 40%, yellow 30%, blue 65%);
 </pre>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
The explanation for the example was wrong.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient()

> Issue number (if there is an associated issue)
#4918

> Anything else that could help us review it
