### PR TITLE
link is broken

### DIFF
--- a/files/en-us/web/api/document/getelementbyid/index.html
+++ b/files/en-us/web/api/document/getelementbyid/index.html
@@ -144,5 +144,5 @@ var el = document.getElementById('testqq'); // el will be null!
 <ul>
  <li>{{domxref("Document")}} reference for other methods and properties you can use to get references to elements in the document.</li>
  <li>{{domxref("Document.querySelector()")}} for selectors via queries like <code>'div.myclass'</code></li>
- <li><a href="/en-US/docs/xml/xml:id">xml:id</a> - has a utility method for allowing <code>getElementById()</code> to obtain 'xml:id' in XML documents (such as returned by Ajax calls)</li>
+ <li><a href="https://www.w3.org/TR/xml-id/">xml:id</a> - has a utility method for allowing <code>getElementById()</code> to obtain 'xml:id' in XML documents (such as returned by Ajax calls)</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`/en-US/docs/xml/xml:id` does not exist, there doesn't seem to be any references to `xml:id` content anywhere on MDN. I figured linking the W3 docs to this would be sufficient.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById

> Issue number (if there is an associated issue)

> Anything else that could help us review it
I would be willing to assist with the contribution to MDN so the W3 link could be to internal(to MDN) documents