### PR TITLE
Replace "positive" with "nonnegative" in :nth-child() doc

### DIFF
--- a/files/en-us/web/css/_colon_nth-child/index.html
+++ b/files/en-us/web/css/_colon_nth-child/index.html
@@ -46,7 +46,7 @@ li:nth-child(2) {
  <dd>Represents elements in a list whose indices match those found in a custom pattern of numbers, defined by <code>An+B</code>, where:<br>
  <code>A</code> is an integer step size,<br>
  <code>B</code> is an integer offset,<br>
- <code>n</code> is all positive integers, starting from 0.</dd>
+ <code>n</code> is all nonnegative integers, starting from 0.</dd>
  <dd>It can be read as the <em>An+B</em>th element of a list.</dd>
 </dl>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

I argue that characterizing `n` as a positive integer here makes less likely the readers' memorization of 0's inclusion.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child
