### PR TITLE
fix grid-template-columns typo

### DIFF
--- a/files/en-us/web/css/grid-template-columns/index.html
+++ b/files/en-us/web/css/grid-template-columns/index.html
@@ -71,7 +71,7 @@ grid-template-columns: unset;
  <dt id="auto"><code>auto</code></dt>
  <dd><p>As a maximum represents the largest {{cssxref("max-content")}} size of the items in that track.</p>
   <p>As a minimum represents the largest minimum size of items in that track (specified by the {{cssxref("min-width")}}/{{cssxref("min-height")}} of the items). This is often, though not always, the {{cssxref("min-content")}} size.</p>
-  <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maxium described above. This behaves similarly to <code>min-content(min-content,max-content)</code> in most cases.</p>
+  <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maxium described above. This behaves similarly to <code>minmax(min-content,max-content)</code> in most cases.</p>
 
  <div class="notecard note">
    <h4>Note:</h4>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

I strongly suspect the description of `auto` as a track size for `grid-template-columns` meant to reference the `minmax` function since that matches the same description on the page for `grid-template-rows` and I don't think `min-content` is a function.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns

> Issue number (if there is an associated issue)

NA

> Anything else that could help us review it

NA
