### PR TITLE
fixed typo

### DIFF
--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/overview/index.html
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/overview/index.html
@@ -67,7 +67,7 @@ tags:
 
 <h4 id="Linters">Linters</h4>
 
-<p><strong>Linters</strong> are tools that check through your code and tell you about any errors that are present, what error types they are, and what code lines they are present on. Often linters can be configured to not only report errors, but also report any violations of a specified style guide that you team might be using (for example code that is using the wrong number of spaces for indentation, or using <a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a> rather than regular string literals).</p>
+<p><strong>Linters</strong> are tools that check through your code and tell you about any errors that are present, what error types they are, and what code lines they are present on. Often linters can be configured to not only report errors, but also report any violations of a specified style guide that your team might be using (for example code that is using the wrong number of spaces for indentation, or using <a href="/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a> rather than regular string literals).</p>
 
 <p><a href="https://eslint.org/">eslint</a> is the industry standard JavaScript linter — a highly configurable tool for catching potential syntax errors and encouraging "best practices" throughout your code. Some companies and projects have also <a href="https://www.npmjs.com/search?q=keywords:eslintconfig">shared their eslint configs</a>.</p>
 
@@ -127,7 +127,7 @@ tags:
 
 <h4 id="Testing_tools">Testing tools</h4>
 
-<p>These generally take the form of a tool that will automatically run tests against your code to make sure it is correct before you go any further (for example, when you attempt to push changes to a GitHub repo). This can including linting, but also more sophisticated procedures like unit tests, where you run part of your code, making sure they behave as they should.</p>
+<p>These generally take the form of a tool that will automatically run tests against your code to make sure it is correct before you go any further (for example, when you attempt to push changes to a GitHub repo). This can include linting, but also more sophisticated procedures like unit tests, where you run part of your code, making sure they behave as they should.</p>
 
 <ul>
  <li>Frameworks for writing tests include <a href="https://jestjs.io/">Jest</a>, <a href="https://mochajs.org/">Mocha</a>, and <a href="https://jasmine.github.io/">Jasmine</a>.</li>


### PR DESCRIPTION
I found "you team" in the Linters section then changed it to "your team". Also I changed "This code can including linting, ..." statement in the Testing tools section to "This code can include linting, ..."

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
