### PR TITLE
fix: Change link creating issue and fix typo

### DIFF
--- a/files/en-us/mdn/contribute/index.html
+++ b/files/en-us/mdn/contribute/index.html
@@ -105,7 +105,7 @@ tags:
 </ul>
 
 <div class="notecard note">
-<p><strong>Note</strong>: If you have found something that is incorrect on MDN but you're not sure how to fix it, you can report problems by <a href="https://github.com/mdn/content/issues/new">filing a documentation issue</a>. Please give the issue a descriptive title. (It's not helpful to say "Dead link" without saying where you found the link.</p>
+<p><strong>Note</strong>: If you have found something that is incorrect on MDN but you're not sure how to fix it, you can report problems by <a href="https://github.com/mdn/content/issues/new/choose">filing a documentation issue</a>. Please give the issue a descriptive title. (It's not helpful to say "Dead link" without saying where you found the link).</p>
 </div>
 
 <h2 id="Other_useful_pages">Other useful pages</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

 Create issue with right format.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/MDN/Contribute
