### PR TITLE
Deprecate SVGPoint

### DIFF
--- a/files/en-us/web/api/svgpoint/index.html
+++ b/files/en-us/web/api/svgpoint/index.html
@@ -7,7 +7,7 @@ tags:
 - NeedsContent
 - SVG
 ---
-<div>{{APIRef("SVG")}}</div>
+<div>{{APIRef("SVG")}}{{Deprecated_header}}</div>
 
 <p>An <code>SVGPoint</code> represents a 2D or 3D point in the SVG coordinate system.</p>
 


### PR DESCRIPTION
SVGPoint is not part of the current SVG spec (SVG2); instead at https://svgwg.org/svg2-draft/single-page.html#changes-types the SVG2 spec specifically says:

> All appearance of SVGPoint were replaced by DOMPoint or DOMPointReadOnly.

Related BCD change:://github.com/mdn/browser-compat-data/pull/10538