### PR TITLE
Added Destructuring example to “Destructuring assignment” doc

### DIFF
--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -91,6 +91,16 @@ console.log(a); // 1
 console.log(b); // 2
 </pre>
 
+<p>If there are fewer items in the array than the variables specified during assignment, then destructuring automatically assigns default value(<code>undefined</code>) to the extra variables:</p>
+<pre class="brush: js">const foo = ['one', 'two'];
+
+const [red, yellow, green,blue] = foo;
+console.log(red); // "one"
+console.log(yellow); // "two"
+console.log(green); // undefined
+console.log(blue);  //undefined
+</pre>
+
 <h4 id="Default_values">Default values</h4>
 
 <p>A variable can be assigned a default, in the case that the value unpacked from the array is <code>undefined</code>.</p>

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -91,7 +91,7 @@ console.log(a); // 1
 console.log(b); // 2
 </pre>
 
-<p>If there are fewer items in the array than the variables specified during assignment, then destructuring automatically assigns default value(<code>undefined</code>) to the extra variables:</p>
+<p>In an array destructuring from an array of length <var>N</var> specified on the right-hand side of the assignment, if the number of variables specified on the left-hand side of the assignment is greater than <var>N</var>, only the first <var>N</var> variables are assigned values. The values of the remaining variables will be undefined.</p>
 <pre class="brush: js">const foo = ['one', 'two'];
 
 const [red, yellow, green,blue] = foo;

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -94,7 +94,7 @@ console.log(b); // 2
 <p>In an array destructuring from an array of length <var>N</var> specified on the right-hand side of the assignment, if the number of variables specified on the left-hand side of the assignment is greater than <var>N</var>, only the first <var>N</var> variables are assigned values. The values of the remaining variables will be undefined.</p>
 <pre class="brush: js">const foo = ['one', 'two'];
 
-const [red, yellow, green,blue] = foo;
+const [red, yellow, green, blue] = foo;
 console.log(red); // "one"
 console.log(yellow); // "two"
 console.log(green); // undefined


### PR DESCRIPTION
This commit adds an example to the file.

FIxes #4682 

Now:

![Screenshot from 2021-05-20 15-56-12](https://user-images.githubusercontent.com/55234838/118963429-0ecbf000-b984-11eb-9208-005f5f525530.png)

