### PR TITLE
Clean up SVGLocatable and SVGTransformable references

### DIFF
--- a/files/en-us/web/api/svgforeignobjectelement/index.html
+++ b/files/en-us/web/api/svgforeignobjectelement/index.html
@@ -45,7 +45,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "embedded.html#ForeignObjectElement", "SVGForeignObjectElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}, {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}} by {{domxref("SVGGraphicsElement")}} and {{domxref("SVGURIReference")}}</td>
+   <td>Replaced the inheritance from {{domxref("SVGElement")}}, {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGraphicsElement")}} and {{domxref("SVGURIReference")}}</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "extend.html#InterfaceSVGForeignObjectElement", "SVGForeignObjectElement")}}</td>

--- a/files/en-us/web/api/svggelement/index.html
+++ b/files/en-us/web/api/svggelement/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "struct.html#InterfaceSVGGElement", "SVGGElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}}.</td>
+   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGGElement", "SVGGElement")}}</td>

--- a/files/en-us/web/api/svggraphicselement/index.html
+++ b/files/en-us/web/api/svggraphicselement/index.html
@@ -14,10 +14,6 @@ tags:
 
 <p>{{InheritanceDiagram(600, 120)}}</p>
 
-<div class="note">
-<p><strong>Note:</strong> This interface was introduced in SVG 2 and replaces the {{domxref("SVGLocatable")}} and {{domxref("SVGTransformable")}} interfaces from SVG 1.1.</p>
-</div>
-
 <h2 id="Properties">Properties</h2>
 
 <p><em>This interface also inherits properties from its parent, {{domxref("SVGElement")}}.</em></p>

--- a/files/en-us/web/api/svgimageelement/index.html
+++ b/files/en-us/web/api/svgimageelement/index.html
@@ -59,7 +59,7 @@ tags:
 		<tr>
 			<td>{{SpecName("SVG2", "embedded.html#InterfaceSVGImageElement", "SVGImageElement")}}</td>
 			<td>{{Spec2("SVG2")}}</td>
-			<td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}}, removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}} and added the <code>crossOrigin</code> property.</td>
+			<td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}}, removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> and added the <code>crossOrigin</code> property.</td>
 		</tr>
 		<tr>
 			<td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGImageElement", "SVGImageElement")}}</td>

--- a/files/en-us/web/api/svglineelement/index.html
+++ b/files/en-us/web/api/svglineelement/index.html
@@ -45,7 +45,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGLineElement", "SVGLineElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGeometryElement")}} and removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}}.</td>
+   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGeometryElement")}} and removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGLineElement", "SVGLineElement")}}</td>

--- a/files/en-us/web/api/svgmaskelement/index.html
+++ b/files/en-us/web/api/svgmaskelement/index.html
@@ -49,7 +49,7 @@ tags:
   <tr>
    <td>{{SpecName("CSS Masks", "#InterfaceSVGMaskElement", "SVGMaskElement")}}</td>
    <td>{{Spec2("CSS Masks")}}</td>
-   <td>Removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}}.</td>
+   <td>Removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "masking.html#InterfaceSVGMaskElement", "SVGMaskElement")}}</td>

--- a/files/en-us/web/api/svgpatternelement/index.html
+++ b/files/en-us/web/api/svgpatternelement/index.html
@@ -51,7 +51,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "pservers.html#InterfaceSVGPatternElement", "SVGPatternElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}}.</td>
+   <td>Removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "pservers.html#InterfaceSVGPatternElement", "SVGPatternElement")}}</td>

--- a/files/en-us/web/api/svgpolygonelement/index.html
+++ b/files/en-us/web/api/svgpolygonelement/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGPolygonElement", "SVGPolygonElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}{{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}} by {{domxref("SVGGeometryElement")}}</td>
+   <td>Replaced the inheritance from {{domxref("SVGElement")}}{{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGPolygonElement", "SVGPolygonElement")}}</td>

--- a/files/en-us/web/api/svgpolylineelement/index.html
+++ b/files/en-us/web/api/svgpolylineelement/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGPolylineElement", "SVGPolylineElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}{{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}} by {{domxref("SVGGeometryElement")}}</td>
+   <td>Replaced the inheritance from {{domxref("SVGElement")}}{{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGPolylineElement", "SVGPolylineElement")}}</td>

--- a/files/en-us/web/api/svgrectelement/index.html
+++ b/files/en-us/web/api/svgrectelement/index.html
@@ -78,7 +78,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGRectElement", "SVGRectElement")}}</td>
    <td>{{Spec2('SVG2')}}</td>
-   <td>Replaced the inheritance from {{domxref("SVGElement")}}{{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}} by {{domxref("SVGGeometryElement")}}</td>
+   <td>Replaced the inheritance from {{domxref("SVGElement")}}{{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code> by {{domxref("SVGGeometryElement")}}</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "shapes.html#InterfaceSVGRectElement", "SVGRectElement")}}</td>

--- a/files/en-us/web/api/svgsvgelement/index.html
+++ b/files/en-us/web/api/svgsvgelement/index.html
@@ -156,7 +156,7 @@ tags:
 		<tr>
 			<td>{{SpecName("SVG2", "struct.html#InterfaceSVGSVGElement", "SVGSVGElement")}}</td>
 			<td>{{Spec2("SVG2")}}</td>
-			<td>Replaced the inheritance from {{domxref("SVGElement")}} by {{domxref("SVGGraphicsElement")}}, removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, {{domxref("SVGLocatable")}}, {{domxref("DocumentEvent")}}, {{domxref("ViewCSS")}}, and {{domxref("DocumentCSS")}} and added implemented interface {{domxref("WindowEventHandlers")}}.</td>
+			<td>Replaced the inheritance from {{domxref("SVGElement")}} by {{domxref("SVGGraphicsElement")}}, removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, <code>SVGLocatable</code>, {{domxref("DocumentEvent")}}, {{domxref("ViewCSS")}}, and {{domxref("DocumentCSS")}} and added implemented interface {{domxref("WindowEventHandlers")}}.</td>
 		</tr>
 		<tr>
 			<td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGSVGElement", "SVGSVGElement")}}</td>

--- a/files/en-us/web/api/svgswitchelement/index.html
+++ b/files/en-us/web/api/svgswitchelement/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "struct.html#InterfaceSVGSwitchElement", "SVGSwitchElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and {{domxref("SVGTransformable")}}.</td>
+   <td>Changed the inheritance from {{domxref("SVGElement")}} to {{domxref("SVGGraphicsElement")}} and removed the implemented interfaces {{domxref("SVGTests")}}, <code>SVGLangSpace</code>, <code>SVGExternalResourcesRequired</code>, <code>SVGStylable</code>, and <code>SVGTransformable</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "struct.html#InterfaceSVGSwitchElement", "SVGSwitchElement")}}</td>

--- a/files/en-us/web/api/svgtextelement/index.html
+++ b/files/en-us/web/api/svgtextelement/index.html
@@ -34,7 +34,7 @@ tags:
   <tr>
    <td>{{SpecName("SVG2", "text.html#InterfaceSVGTextElement", "SVGTextElement")}}</td>
    <td>{{Spec2("SVG2")}}</td>
-   <td>Removed the implemented interface {{domxref("SVGTransformable")}}.</td>
+   <td>Removed the implemented interface <code>SVGTransformable</code>.</td>
   </tr>
   <tr>
    <td>{{SpecName("SVG1.1", "text.html#InterfaceSVGTextElement", "SVGTextElement")}}</td>

--- a/files/en-us/web/svg/svg_2_support_in_mozilla/index.html
+++ b/files/en-us/web/svg/svg_2_support_in_mozilla/index.html
@@ -92,7 +92,7 @@ tags:
    <td>Implementation status unknown</td>
   </tr>
   <tr style="color: black; background-color: #cccccc;">
-   <td>{{domxref("SVGGraphicsElement")}} instead of {{domxref("SVGLocatable")}} and {{domxref("SVGTransformable")}}</td>
+   <td>{{domxref("SVGGraphicsElement")}} instead of <code>SVGLocatable</code> and <code>SVGTransformable</code></td>
    <td>Implementation status unknown</td>
   </tr>
   <tr style="color: black; background-color: khaki;">


### PR DESCRIPTION
These were mixin-like interfaces in SVG 1.1:
https://www.w3.org/TR/SVG11/types.html#InterfaceSVGLocatable
https://www.w3.org/TR/SVG11/types.html#InterfaceSVGTransformable

Happily, there were no separate pages, the related bits are mostly
already documented on SVGGraphicsElement:
https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement

All that remains of these is now in the specifications tables.