### PR TITLE
Add note about unsupported data:-URLs to 77 relnotes

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.html
@@ -74,10 +74,6 @@ tags:
 
 <p>In the listener, you can then return a {{WebExtAPIRef("webRequest.BlockingResponse", "BlockingResponse")}} object, which indicates the modification you need to make: for example, the modified request header you want to send.</p>
 
-<div class="notecard warning">
-<p><strong>Warning</strong>: Non-HTTP(S) protocols do not currently support <code>"blocking"</code> functionality, so modifying these requests is not available at this time. See {{bug(1475832)}} for more details.</p>
-</div>
-
 <h2 id="Accessing_security_information">Accessing security information</h2>
 
 <p>In the {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}} listener you can access the <a href="/en-US/docs/Glossary/TLS">TLS</a> properties of a request by calling {{WebExtAPIRef("webRequest.getSecurityInfo()", "getSecurityInfo()")}}. To do this you must also pass "blocking" in the <code>extraInfoSpec</code> argument to the event's <code>addListener()</code>.</p>

--- a/files/en-us/mozilla/firefox/releases/77/index.html
+++ b/files/en-us/mozilla/firefox/releases/77/index.html
@@ -76,6 +76,7 @@ tags:
  <li>The {{WebExtAPIRef("tabs.duplicate")}} API now supports <code>duplicateProperties</code>, enabling the position and active status of a duplicated tab to be specified. ({{bug(1560218)}})</li>
  <li>The {{WebExtAPIRef("permissions")}} API events {{WebExtAPIRef("permissions.onAdded")}} and {{WebExtAPIRef("permissions.onRemoved")}} are now supported. ({{bug(1444294)}})</li>
  <li>Multiple <code>Content-Security-Policy</code> header changes requested in {{WebExtAPIRef("webRequest.onHeadersReceived")}} are merged. ({{bug(1462989 )}})</li>
+ <li>{{WebExtAPIRef("webRequest")}} events will no longer be triggered for <code>data:</code>-URLs. ({{bug(1631933)}})</li>
 </ul>
 
 <h3 id="Manifest_changes">Manifest changes</h3>


### PR DESCRIPTION
Added https://bugzilla.mozilla.org/show_bug.cgi?id=1475832 to Firefox 77 release notes, instead of just the blog at https://blog.mozilla.org/addons/2020/05/28/extensions-in-firefox-77/

Removed note about lack of support for "blocking" functionality for non-HTTPS URLs. The top of the article mentions that webRequest is for http requests, which excludes data:-URLs. The referenced bug (https://bugzilla.mozilla.org/show_bug.cgi?id=1475832) is closed.