### PR TITLE
Remove buffered from attributes in <video> element doc

### DIFF
--- a/files/en-us/web/html/element/video/index.html
+++ b/files/en-us/web/html/element/video/index.html
@@ -50,8 +50,6 @@ browser-compat: html.elements.video
  </dd>
  <dt>{{htmlattrdef("autopictureinpicture")}} {{experimental_inline}}</dt>
  <dd>A Boolean attribute which if <code>true</code> indicates that the element should automatically toggle picture-in-picture mode when the user switches back and forth between this document and another document or application.</dd>
- <dt>{{htmlattrdef("buffered")}}</dt>
- <dd>An attribute you can read to determine the time ranges of the buffered media. This attribute contains a {{domxref("TimeRanges")}} object.</dd>
  <dt>{{htmlattrdef("controls")}}</dt>
  <dd>If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.</dd>
  <dt>{{htmlattrdef("controlslist")}} {{experimental_inline}}</dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Remove `buffered` from attributes since it is not a content attribute.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

I must have missed it in #5033. 😓 