### PR TITLE
Adds InputDeviceInfo

### DIFF
--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
@@ -1,0 +1,105 @@
+---
+title: InputDeviceInfo.getCapabilities()
+slug: Web/API/InputDeviceInfo/getCapabilities
+tags:
+  - API
+  - Method
+  - Reference
+  - getCapabilities
+  - InputDeviceInfo
+---
+{{DefaultAPISidebar("Media Capture and Streams")}}
+
+<p class="summary">The <strong><code>getCapabilities()</code></strong> method of the {{domxref("InputDeviceInfo")}} interface returns a <code>MediaTrackCapabilities</code> object describing the primary audio or video track of the device's {{domxref("MediaStream")}}.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">InputDeviceInfo.getCapabilities();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h3 id="Returns">Return value</h3>
+
+<p>A <code>MediaTrackCapabilities</code> object containing the following members:</p>
+
+<dl>
+  <dt><code>deviceId</code></dt>
+  <dd>A {{domxref("ConstrainDOMString")}} object containing the device ID.</dd>
+  <dt><code>groudId</code></dt>
+  <dd>A {{domxref("ConstrainDOMString")}} object containing a group ID.</dd>
+  <dt><code>autoGainControl</code>></dt>
+  <dd>A {{domxref("ConstrainBoolean")}} object reporting if the source can do auto gain control.
+    If the feature can be controlled by a script the source will report both true and false as possible values.</dd>
+  <dt><code>channelCount</code></dt>
+  <dd>A {{domxref("ConstrainULong")}} containing the channel count or range of channel counts.</dd>
+  <dt><code>echoCancellation</code></dt>
+  <dd>A {{domxref("ConstrainBoolean")}} object reporting if the source can do echo cancellation.
+    If the feature can be controlled by a script the source will report both true and false as possible values.</dd>
+  <dt><code>latency</code></dt>
+  <dd>A {{domxref("ConstrainDouble")}} containing the latency or range of latencies.</dd>
+  <dt><code>noiseSuppression</code></dt>
+  <dd>A {{domxref("ConstrainBoolean")}} object reporting if the source can do noise suppression.
+    If the feature can be controlled by a script the source will report both true and false as possible values.</dd>
+  <dt><code>sampleRate</code></dt>
+  <dd>A {{domxref("ConstrainULong")}} containing the sample rate or range of sample rates.</dd>
+  <dt><code>sampleSize</code></dt>
+  <dd>A {{domxref("ConstrainULong")}} containing the sample size or range of sample sizes.</dd>
+  <dt><code>aspectRatio</code></dt>
+  <dd>A {{domxref("ConstrainDouble")}} containing the video aspect ratio (width in pixels divided by height in pixels) or range of aspect ratios.</dd>
+  <dt><code>facingMode</code></dt>
+  <dd>A {{domxref("ConstrainDOMString")}} object containing the camera facing mode. A camera may report multiple facings, for example "left" and "user".</dd>
+  <dt><code>frameRate</code></dt>
+  <dd>A {{domxref("ConstrainDouble")}} containing the frame rate or range of frame rates which are acceptable.</dd>
+  <dt><code>height</code></dt>
+  <dd>A {{domxref("ConstrainULong")}} containing the video height or range of heights in pixels.</dd>
+  <dt><code>width</code></dt>
+  <dd>A {{domxref("ConstrainULong")}} containing the video width or range of widths in pixels.</dd>
+  <dt><code>resizeMode</code></dt>
+  <dd>A {{domxref("ConstrainDOMString")}} object containing the mode or an array of modes the UA can use to derive the resolution of the video track.</dd>
+</dl>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>If the user has not granted permission to access the input device an empty object will be returned.</p>
+</div>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example we ask for permission to access audio and video devices with {{domxref("mediaDevices.getUserMedia()")}}, as to use <code>getCapabilities()</code> we need permission to access the devices.</p>
+
+<p>If <code>device</code> is an <code>InputDeviceInfo</code> object, then <code>getCapabilities()</code> will return an object with members representing its capbilities. A video stream will not include auto properties such as <code>noiseSuppression</code>, for example.</p>
+
+<pre class="brush: js">// Get permission to access audio or video devices
+navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+
+navigator.mediaDevices.enumerateDevices()
+  .then(function(devices) {
+    devices.forEach(function(device) {
+      console.log(device.getCapabilities()); // a MediaTrackCapabilities object.
+    });
+  })</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Media Capture', '#dom-inputdeviceinfo-getcapabilities', 'InputDeviceInfo.getCapabilities()')}}</td>
+    <td>{{Spec2('Media Capture')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.InputDeviceInfo.getCapabilities")}}</p>

--- a/files/en-us/web/api/inputdeviceinfo/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/index.html
@@ -18,7 +18,7 @@ tags:
 
 <dl>
   <dt>{{domxref("InputDeviceInfo.getCapabilities()")}}</dt>
-  <dd>Returns a <code>MediaTrackCapabilities</code> object describing the primary audio or video track of a device's MediaStream</dd>
+  <dd>Returns a <code>MediaTrackCapabilities</code> object describing the primary audio or video track of a device's <code>MediaStream</code>.</dd>
 </dl>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/api/inputdeviceinfo/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/index.html
@@ -1,0 +1,56 @@
+---
+title: InputDeviceInfo
+slug: Web/API/InputDeviceInfo
+tags:
+  - API
+  - Media Streams API
+  - Interface
+  - Reference
+  - InputDeviceInfo
+---
+{{DefaultAPISidebar("Media Capture and Streams")}}
+
+<p class="summary">The <strong><code>InputDeviceInfo</code></strong> interface of the {{domxref('Media Streams API','','',' ')}} gives access to the capabilities of the input device that it represents.</p>
+
+<p><code>InputDeviceInfo</code> objects are returned by {{domxref("MediaDevices.enumerateDevices()")}} if the returned device is an audio or video input device.</p>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("InputDeviceInfo.getCapabilities()")}}</dt>
+  <dd>Returns a <code>MediaTrackCapabilities</code> object describing the primary audio or video track of a device's MediaStream</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example gets all media devices with {{domxref("MediaDevices.enumerateDevices()")}}. If any of the devices are input devices then <code>console.log(device)</code> will print an <code>InputDeviceInfo</code> object to the console.</p>
+
+<pre class="brush: js">navigator.mediaDevices.enumerateDevices()
+  .then(function(devices) {
+    devices.forEach(function(device) {
+      console.log(device); // an InputDeviceInfo object if the device is an input device, otherwise a MediaDeviceInfo object.
+    });
+  })</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('Media Capture', '#dom-inputdeviceinfo', 'InputDeviceInfo')}}</td>
+    <td>{{Spec2('Media Capture')}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.InputDeviceInfo")}}</p>


### PR DESCRIPTION
Adds InputDeviceInfo.

Reviewer: @jpmedley 

The getCapabilities() method returns a dictionary `MediaTrackCapabilities`. I believe we are documenting these inline now, which is what I have done.

That is listed as an interface on the overview page so if we are leaving it inline I'll remove that https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API

However, an equivalent dictionary  `MediaTrackConstraints` has a page already https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints which I wanted to point out as I don't know if we want to move that one inline or just live with the inconsistency.


