### PR TITLE
Move some manifests members into Web App Manifest - App Info spec

### DIFF
--- a/files/en-us/web/manifest/categories/index.html
+++ b/files/en-us/web/manifest/categories/index.html
@@ -50,16 +50,16 @@ tags:
  <tbody>
   <tr>
    <td>
-    <p>{{SpecName('Manifest', '#categories-member', 'categories')}}</p>
+    <p>{{SpecName('ManifestAppInfo', '#categories-member', 'categories')}}</p>
    </td>
    <td>
-    <p>{{Spec2('Manifest')}}</p>
+    <p>{{Spec2('ManifestAppInfo')}}</p>
    </td>
    <td>
     <p>Initial definition.</p>
    </td>
    <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
+    <p><a href="https://github.com/w3c/manifest-app-info/issues/">Web App Manifest App Info Working Group drafts</a></p>
    </td>
   </tr>
  </tbody>

--- a/files/en-us/web/manifest/description/index.html
+++ b/files/en-us/web/manifest/description/index.html
@@ -49,16 +49,16 @@ tags:
  <tbody>
   <tr>
    <td>
-    <p>{{SpecName('Manifest', '#description-member', 'description')}}</p>
+    <p>{{SpecName('ManifestAppInfo', '#description-member', 'description')}}</p>
    </td>
    <td>
-    <p>{{Spec2('Manifest')}}</p>
+    <p>{{Spec2('ManifestAppInfo')}}</p>
    </td>
    <td>
     <p>Initial definition.</p>
    </td>
    <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
+     <p><a href="https://github.com/w3c/manifest-app-info/issues/">Web App Manifest App Info Working Group drafts</a></p>
    </td>
   </tr>
  </tbody>

--- a/files/en-us/web/manifest/iarc_rating_id/index.html
+++ b/files/en-us/web/manifest/iarc_rating_id/index.html
@@ -46,16 +46,16 @@ tags:
  <tbody>
   <tr>
    <td>
-    <p>{{SpecName('Manifest', '#iarc_rating_id-member', 'iarc_rating_id')}}</p>
+    <p>{{SpecName('ManifestAppInfo', '#iarc_rating_id-member', 'iarc_rating_id')}}</p>
    </td>
    <td>
-    <p>{{Spec2('Manifest')}}</p>
+    <p>{{Spec2('ManifestAppInfo')}}</p>
    </td>
    <td>
     <p>Initial definition.</p>
    </td>
    <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
+    <<p><a href="https://github.com/w3c/manifest-app-info/issues/">Web App Manifest App Info Working Group drafts</a></p>
    </td>
   </tr>
  </tbody>

--- a/files/en-us/web/manifest/index.html
+++ b/files/en-us/web/manifest/index.html
@@ -104,6 +104,11 @@ It is a {{Glossary("JSON")}}-formatted file, with one exception: it is allowed t
 			<td>{{Spec2("Manifest")}}</td>
 			<td>Initial definition.</td>
 		</tr>
+    <tr>
+      <td>{{SpecName("ManifestAppInfo")}}</td>
+      <td>{{Spec2("ManifestAppInfo")}}</td>
+      <td>Initial definition.</td>
+    </tr>
 	</tbody>
 </table>
 

--- a/files/en-us/web/manifest/screenshots/index.html
+++ b/files/en-us/web/manifest/screenshots/index.html
@@ -52,16 +52,16 @@ tags:
  <tbody>
   <tr>
    <td>
-    <p>{{SpecName('Manifest', '#screenshots-member', 'screenshots')}}</p>
+    <p>{{SpecName('ManifestAppInfo', '#screenshots-member', 'screenshots')}}</p>
    </td>
    <td>
-    <p>{{Spec2('Manifest')}}</p>
+    <p>{{Spec2('ManifestAppInfo')}}</p>
    </td>
    <td>
     <p>Initial definition.</p>
    </td>
    <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
+     <p><a href="https://github.com/w3c/manifest-app-info/issues/">Web App Manifest App Info Working Group drafts</a></p>
    </td>
   </tr>
  </tbody>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The `categories`, `description`, `iarc_rating_id` and `screenshots` members of [Web App Manifest](https://w3c.github.io/manifest/) have been moved into new [Web App Manifest - Application Information](https://w3c.github.io/manifest-app-info/) specification.

> MDN URL of the main page changed

* https://developer.mozilla.org/en-US/docs/Web/Manifest
* https://developer.mozilla.org/en-US/docs/Web/Manifest/categories
* https://developer.mozilla.org/en-US/docs/Web/Manifest/description
* https://developer.mozilla.org/en-US/docs/Web/Manifest/iarc_rating_id
* https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it

This depends on mdn/yari#3835 to add "App Manifest - Application Information" specification to macros.