### PR TITLE
Updated example

### DIFF
--- a/files/en-us/web/javascript/reference/statements/with/index.html
+++ b/files/en-us/web/javascript/reference/statements/with/index.html
@@ -116,8 +116,8 @@ browser-compat: javascript.statements.with
   {{jsxref("Math.sin", "sin")}} methods, without specifying an object. JavaScript assumes
   the <code>Math</code> object for these references.</p>
 
-<pre class="brush: js">var a, x, y;
-var r = 10;
+<pre class="brush: js">let a, x, y;
+const r = 10;
 
 with (Math) {
   a = PI * r * r;


### PR DESCRIPTION


> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with#examples

Fixes  #5040 

