### PR TITLE
HTML Manifest: Use bcd front-matter + spec macro

### DIFF
--- a/files/en-us/web/manifest/background_color/index.html
+++ b/files/en-us/web/manifest/background_color/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - background_color
+browser-compat: html.manifest.background_color
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -35,25 +36,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Manifest', '#background_color-member', 'background_color')}}</td>
-   <td>{{Spec2('Manifest')}}</td>
-   <td>Initial definition.</td>
-   <td><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.background_color")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/categories/index.html
+++ b/files/en-us/web/manifest/categories/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - categories
+browser-compat: html.manifest.categories
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -38,33 +39,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="fullwidth-table standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#categories-member', 'categories')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.categories")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/description/index.html
+++ b/files/en-us/web/manifest/description/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - description
+browser-compat: html.manifest.description
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -37,33 +38,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#description-member', 'description')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.description")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/dir/index.html
+++ b/files/en-us/web/manifest/dir/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - dir
+browser-compat: html.manifest.dir
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -51,33 +52,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#dir-member', 'dir')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.dir")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/display/index.html
+++ b/files/en-us/web/manifest/display/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - display
+browser-compat: html.manifest.display
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -74,37 +75,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#display-member', 'display')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="notecard note">
-<p><strong>Note:</strong> Firefox version 47 supports only <code>browser</code> value of <code>display</code>; <code>minimal-ui</code>, <code>standalone</code> , and <code>fullscreen</code> were added in Firefox 57.</p>
-</div>
-
-<p>{{Compat("html.manifest.display")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/iarc_rating_id/index.html
+++ b/files/en-us/web/manifest/iarc_rating_id/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - iarc_rating_id
+browser-compat: html.manifest.iarc_rating_id
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -34,36 +35,11 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#iarc_rating_id-member', 'iarc_rating_id')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.iarc_rating_id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/manifest/icons/index.html
+++ b/files/en-us/web/manifest/icons/index.html
@@ -5,6 +5,7 @@ tags:
   - Icons
   - Manifest
   - Web
+browser-compat: html.manifest.icons
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -88,33 +89,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#icons-member', 'icons')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.icons")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/lang/index.html
+++ b/files/en-us/web/manifest/lang/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - lang
+browser-compat: html.manifest.lang
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -29,33 +30,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#lang-member', 'lang')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.lang")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/name/index.html
+++ b/files/en-us/web/manifest/name/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - name
+browser-compat: html.manifest.name
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -37,33 +38,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#name-member', 'name')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/orientation/index.html
+++ b/files/en-us/web/manifest/orientation/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Orientation
   - Web
+browser-compat: html.manifest.orientation
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -52,33 +53,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#orientation-member', 'orientation')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.orientation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/prefer_related_applications/index.html
+++ b/files/en-us/web/manifest/prefer_related_applications/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - prefer_related_applications
+browser-compat: html.manifest.prefer_related_applications
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -32,33 +33,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#prefer_related_applications-member', 'prefer_related_applications')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.prefer_related_applications")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/related_applications/index.html
+++ b/files/en-us/web/manifest/related_applications/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - related_applications
+browser-compat: html.manifest.related_applications
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -69,27 +70,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Manifest', '#related_applications-member', 'related_applications')}}</td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>Initial definition.</td>
-   <td><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.related_applications")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/scope/index.html
+++ b/files/en-us/web/manifest/scope/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - scope
+browser-compat: html.manifest.scope
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -44,33 +45,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#scope-member', 'scope')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.scope")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/screenshots/index.html
+++ b/files/en-us/web/manifest/screenshots/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Screenshots
   - Web
+browser-compat: html.manifest.screenshots
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -40,33 +41,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#screenshots-member', 'screenshots')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.screenshots")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/short_name/index.html
+++ b/files/en-us/web/manifest/short_name/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - short_name
+browser-compat: html.manifest.short_name
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -40,33 +41,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#short_name-member', 'short_name')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.short_name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/shortcuts/index.html
+++ b/files/en-us/web/manifest/shortcuts/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - shortcuts
+browser-compat: html.manifest.shortcuts
 ---
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</p>
 
@@ -80,33 +81,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#shortcuts-member', 'shortcuts')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.shortcuts")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/start_url/index.html
+++ b/files/en-us/web/manifest/start_url/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - start_url
+browser-compat: html.manifest.start_url
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -41,33 +42,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#start_url-member', 'start_url')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.start_url")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/manifest/theme_color/index.html
+++ b/files/en-us/web/manifest/theme_color/index.html
@@ -5,6 +5,7 @@ tags:
   - Manifest
   - Web
   - theme_color
+browser-compat: html.manifest.theme_color
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}</div>
 
@@ -30,33 +31,8 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-   <th scope="col">Feedback</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>
-    <p>{{SpecName('Manifest', '#theme_color-member', 'theme_color')}}</p>
-   </td>
-   <td>
-    <p>{{Spec2('Manifest')}}</p>
-   </td>
-   <td>
-    <p>Initial definition.</p>
-   </td>
-   <td>
-    <p><a href="https://github.com/w3c/manifest/issues/">Web App Manifest Working Group drafts</a></p>
-   </td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.manifest.theme_color")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
The manifest pages should use the bcd front-matter plus the new specifications approach, so that PRs like the following are not needed to provide up-to-date specifications!

Closes https://github.com/mdn/content/pull/5154
Closes https://github.com/mdn/yari/pull/3835