### PR TITLE
Update warning & add links to more info

### DIFF
--- a/files/en-us/web/api/element/innerhtml/index.html
+++ b/files/en-us/web/api/element/innerhtml/index.html
@@ -152,8 +152,7 @@ el.innerHTML = name; // shows the alert</pre>
       href="https://wiki.mozilla.org/Add-ons/Reviewers/Guide/Reviewing#Step_2:_Automatic_validation">if
       you use <code>innerHTML</code></a> in a <a
       href="/en-US/docs/Mozilla/Add-ons/WebExtensions">browser extension</a> and submit
-    the extension to <a href="https://addons.mozilla.org/">addons.mozilla.org</a>, it will
-    not pass the automated review process.</p>
+    the extension to <a href="https://addons.mozilla.org/">addons.mozilla.org</a>, it may be rejected in the review process. Please see <a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page">Safely inserting external content into a page</a> for alternative methods.</p>
 </div>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
Fixes #4908. 

Updates warning note about using Element.innerHTML in extensions and adds link to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page. 

@wagnerand, could you review this? 
