### PR TITLE
Create a new page for CSS `abs()` function

### DIFF
--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -20,6 +20,9 @@ browser-compat: css.types.abs
 
 <h2 id="Syntax">Syntax</h2>
 
+<pre class="brush: css no-line-numbers">/* property: abs(expression) */
+width: abs(20% - 100px);</pre>
+
 <p>The <code>abs()</code> function takes only one expression as its argument.</p>
 
 <h3 id="Formal_syntax">Formal syntax</h3>

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -43,15 +43,13 @@ width: abs(20% - 100px);</pre>
 
 <h3 id="Control_gradient_angle_of_direction">Control gradient angle of direction</h3>
 
-<p>You can also control the gradient direction using <code>abs()</code> function.</p>
+<p>You can also control the gradient direction using <code>abs()</code> function. In the following example, with an angle of -45deg the gradient would start red and transition to blue. By using <code>abs()</code> to make the value positive, the gradient will start blue and transition to red.</p>
 
 <pre class="brush: css;">div {
   --deg: -45deg;
   background-image: linear-gradient( abs( var( --deg ) ), blue, red);
 }
 </pre>
-
-<p>In this example we are making sure the gradient direction is not negetive.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -31,6 +31,8 @@ width: abs(20% - 100px);</pre>
 
 <h2 id="Examples">Examples</h2>
 
+<h3 id="Positive_variables">Positive variables</h3>
+
 <p>A use case for this CSS functions is when you need to use only positive values.</p>
 
 <pre class="brush: css;">h1 {
@@ -38,7 +40,19 @@ width: abs(20% - 100px);</pre>
 }
 </pre>
 
-<p>In this example we can make sure `font-size` value will always be positive even if the `--font-size` variable in negetive.</p>
+<p>In this example we can make sure <code>font-size</code> value will always be positive even if the <code>--font-size</code> variable in negetive.</p>
+
+<h3 id="Control_gradient_angle_of_direction">Control gradient angle of direction</h3>
+
+<p>You can also control the gradient direction using <code>abs()</code> function.</p>
+
+<pre class="brush: css;">div {
+  --deg: -45deg;
+  background-image: linear-gradient( abs( var( --deg ) ), blue, red);
+}
+</pre>
+
+<p>In this example we are making sure the gradient direction is not negetive.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -33,7 +33,7 @@ width: abs(20% - 100px);</pre>
 
 <h3 id="Positive_variables">Positive variables</h3>
 
-<p>The <code>abs()</code> function can be used to ensure that a value is always positive. In the following  example a CSS custom property <code>--font-size</code> is used as the value of {{cssxref("font-size)}}. Wrapping this custom property in <code>abs()</code> will convert a negative value to a positive one.</p>
+<p>The <code>abs()</code> function can be used to ensure that a value is always positive. In the following  example a CSS custom property <code>--font-size</code> is used as the value of {{CSSxRef("font-size")}}. Wrapping this custom property in <code>abs()</code> will convert a negative value to a positive one.</p>
 
 <pre class="brush: css;">h1 {
   font-size: abs( var( --font-size ) );

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -1,0 +1,68 @@
+---
+title: abs()
+slug: Web/CSS/abs()
+tags:
+  - CSS
+  - CSS Function
+  - Sign-Related
+  - Function
+  - Layout
+  - Reference
+  - Web
+  - abs
+browser-compat: css.types.abs
+---
+<div>{{CSSRef}}</div>
+
+<p>The <strong><code>abs()</code></strong> <a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/CSS_Functions">function</a> contains one calculation, and returns the absolute value of the argument, as the same type as the input.</p>
+
+<p>The <code>abs(A)</code> statement will return <code>A</code> if <code>A</code>’s numeric value is positive or 0⁺. Otherwise it will return the value of <code> -1 * A</code>.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<p>The <code>abs()</code> function takes only one expression as its argument.</p>
+
+<h3 id="Formal_syntax">Formal syntax</h3>
+
+{{CSSSyntax}}
+
+<h2 id="Examples">Examples</h2>
+
+<p>A use case for this CSS functions is when you need to use only positive values.</p>
+
+<pre class="brush: css;">h1 {
+  font-size: abs( var( --font-size ) );
+}
+</pre>
+
+<p>The font-size will always be positive.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName("CSS4 Values", "#sign-funcs", "abs()")}}</td>
+   <td>{{Spec2("CSS4 Values")}}</td>
+   <td>Initial definition</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+ <li>{{CSSxRef("sign", "sign()")}}</li>
+ <li><a href="/en-US/docs/Learn/CSS/Introduction_to_CSS/Values_and_units">CSS Values</a></li>
+</ul>

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -33,14 +33,13 @@ width: abs(20% - 100px);</pre>
 
 <h3 id="Positive_variables">Positive variables</h3>
 
-<p>A use case for this CSS functions is when you need to use only positive values.</p>
+<p>The <code>abs()</code> function can be used to ensure that a value is always positive. In the following  example a CSS custom property <code>--font-size</code> is used as the value of {{cssxref("font-size)}}. Wrapping this custom property in <code>abs()</code> will convert a negative value to a positive one.</p>
 
 <pre class="brush: css;">h1 {
   font-size: abs( var( --font-size ) );
 }
 </pre>
 
-<p>In this example we are making sure <code>font-size</code> value will always be positive even if the <code>--font-size</code> variable is negetive.</p>
 
 <h3 id="Control_gradient_angle_of_direction">Control gradient angle of direction</h3>
 

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -40,7 +40,7 @@ width: abs(20% - 100px);</pre>
 }
 </pre>
 
-<p>In this example we can make sure <code>font-size</code> value will always be positive even if the <code>--font-size</code> variable in negetive.</p>
+<p>In this example we are making sure <code>font-size</code> value will always be positive even if the <code>--font-size</code> variable is negetive.</p>
 
 <h3 id="Control_gradient_angle_of_direction">Control gradient angle of direction</h3>
 

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -35,7 +35,7 @@ browser-compat: css.types.abs
 }
 </pre>
 
-<p>The font-size will always be positive.</p>
+<p>In this example we can make sure `font-size` value will always be positive even if the `--font-size` variable in negetive.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/abs()/index.html
+++ b/files/en-us/web/css/abs()/index.html
@@ -64,5 +64,4 @@ browser-compat: css.types.abs
 
 <ul>
  <li>{{CSSxRef("sign", "sign()")}}</li>
- <li><a href="/en-US/docs/Learn/CSS/Introduction_to_CSS/Values_and_units">CSS Values</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Create a new MDN page for a new CSS function.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/abs()

> Issue number (if there is an associated issue)

No.

> Anything else that could help us review it

`abs()` is a functional notation defined in [CSS Values and Units Module Level 4](https://drafts.csswg.org/css-values-4/#sign-funcs).

See also: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions#math_functions