### PR TITLE
Tell developers TextTrackCueList an "array-like object" rather than an "interface" (WebIDL-speak)

### DIFF
--- a/files/en-us/web/api/texttrackcuelist/index.html
+++ b/files/en-us/web/api/texttrackcuelist/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
-<p class="summary">The <strong><code>TextTrackCueList</code></strong> interface represents a dynamically updating list of {{domxref("TextTrackCue")}} objects.</p>
+<p class="summary">The <strong><code>TextTrackCueList</code></strong> array-like object represents a dynamically updating list of {{domxref("TextTrackCue")}} objects.</p>
 
 <p>This interface has no constructor. Retrieve an instance of this object with {{domxref('TextTrack.cues')}} which returns all of the cues in a {{domxref("TextTrack")}} object.</p>
 


### PR DESCRIPTION
I suggest replacing word "interface" with "array-like object" in description of TextTrackCueList (the very first paragraph)

Best Regards
Dariusz Dziara

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
