### PR TITLE
Resolved Issue #3197

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -93,7 +93,7 @@ tags:
 <h2 id="Packets_explained">Packets explained</h2>
 
 <p>
-	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent as thousands of small chunks.There are multiple reasons why data is sent in small packets.	They are sometimes dropped or corrupted, and it's easier to replace small packets.   Additionally, the packets will likely be routed along different paths, allowing many different users to download the same website at the same time.   If websites were sent as single big chunks, only one user could download one at a time, which obviously would make the web very inefficient and not much fun to use.
+	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
 </p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -92,7 +92,9 @@ tags:
 
 <h2 id="Packets_explained">Packets explained</h2>
 
-<p>Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically, when data is sent across the web, it is sent as thousands of small chunks, so that many different web users can download the same website at the same time. If websites were sent as single big chunks, only one user could download one at a time, which obviously would make the web very inefficient and not much fun to use.</p>
+<p>
+	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent as thousands of small chunks.There are multiple reasons why data is sent in small packets.	They are sometimes dropped or corrupted, and it's easier to replace small packets.   Additionally, the packets will likely be routed along different paths, allowing many different users to download the same website at the same time.   If websites were sent as single big chunks, only one user could download one at a time, which obviously would make the web very inefficient and not much fun to use.
+</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -93,7 +93,7 @@ tags:
 <h2 id="Packets_explained">Packets explained</h2>
 
 <p>
-	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
+	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
 </p>
 
 <h2 id="See_also">See also</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Fixed Issue #3197 
An analogy explaining why packets are small relies on a TCP feature, the connection between two computers, was incomplete. 
There should also have been a point explaining that small packets are easier to be dropped and replaced. 

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works

> Issue number (if there is an associated issue)
Issue #3197
https://github.com/mdn/content/issues/3197


> Anything else that could help us review it
I have created a new branch Issue#3197 for the Pull Request. 

