### PR TITLE
Issue#1449

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -92,7 +92,9 @@ tags:
 
 <h2 id="Packets_explained">Packets explained</h2>
 
-<p>Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically, when data is sent across the web, it is sent as thousands of small chunks, so that many different web users can download the same website at the same time. If websites were sent as single big chunks, only one user could download one at a time, which obviously would make the web very inefficient and not much fun to use.</p>
+<p>
+	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent as thousands of small chunks.There are multiple reasons why data is sent in small packets.	They are sometimes dropped or corrupted, and it's easier to replace small packets.   Additionally, the packets will likely be routed along different paths, allowing many different users to download the same website at the same time.   If websites were sent as single big chunks, only one user could download one at a time, which obviously would make the web very inefficient and not much fun to use.
+</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -93,7 +93,7 @@ tags:
 <h2 id="Packets_explained">Packets explained</h2>
 
 <p>
-	Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent as thousands of small chunks.There are multiple reasons why data is sent in small packets.	They are sometimes dropped or corrupted, and it's easier to replace small packets.   Additionally, the packets will likely be routed along different paths, allowing many different users to download the same website at the same time.   If websites were sent as single big chunks, only one user could download one at a time, which obviously would make the web very inefficient and not much fun to use.
+Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
 </p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.html
@@ -92,8 +92,7 @@ tags:
 
 <h2 id="Packets_explained">Packets explained</h2>
 
-<p>
-Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
+<p>Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically,	when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
 </p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.html
+++ b/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.html
@@ -51,7 +51,8 @@ TypeError: Cannot delete property '2' of [object Array] (Chrome)
 <p>The {{jsxref("Object.defineProperty()")}} creates non-configurable properties by
   default if you haven't specified them as configurable.</p>
 
-<pre class="brush: js example-bad">var arr = [];
+<pre class="brush: js example-bad">"use strict"
+var arr = [];
 Object.defineProperty(arr, 0, {value: 0});
 Object.defineProperty(arr, 1, {value: "1"});
 
@@ -62,7 +63,8 @@ arr.length = 1;
 <p>You will need to set the elements as configurable, if you intend to shorten the array.
 </p>
 
-<pre class="brush: js example-good">var arr = [];
+<pre class="brush: js example-good">"use strict"
+var arr = [];
 Object.defineProperty(arr, 0, {value: 0, configurable: true});
 Object.defineProperty(arr, 1, {value: "1", configurable: true});
 
@@ -74,7 +76,8 @@ arr.length = 1;
 <p>The {{jsxref("Object.seal()")}} function marks all existing elements as
   non-configurable.</p>
 
-<pre class="brush: js example-bad">var arr = [1,2,3];
+<pre class="brush: js example-bad">"use strict"
+var arr = [1,2,3];
 Object.seal(arr);
 
 arr.length = 1;
@@ -85,7 +88,8 @@ arr.length = 1;
   In case of a copy, shortening the copy of the array does not modify the original array
   length.</p>
 
-<pre class="brush: js example-good">var arr = [1,2,3];
+<pre class="brush: js example-good">"use strict"
+var arr = [1,2,3];
 Object.seal(arr);
 
 // Copy the initial array to shorten the copy

--- a/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.html
+++ b/files/en-us/web/javascript/reference/errors/non_configurable_array_element/index.html
@@ -51,7 +51,7 @@ TypeError: Cannot delete property '2' of [object Array] (Chrome)
 <p>The {{jsxref("Object.defineProperty()")}} creates non-configurable properties by
   default if you haven't specified them as configurable.</p>
 
-<pre class="brush: js example-bad">"use strict"
+<pre class="brush: js example-bad">"use strict";
 var arr = [];
 Object.defineProperty(arr, 0, {value: 0});
 Object.defineProperty(arr, 1, {value: "1"});
@@ -63,7 +63,7 @@ arr.length = 1;
 <p>You will need to set the elements as configurable, if you intend to shorten the array.
 </p>
 
-<pre class="brush: js example-good">"use strict"
+<pre class="brush: js example-good">"use strict";
 var arr = [];
 Object.defineProperty(arr, 0, {value: 0, configurable: true});
 Object.defineProperty(arr, 1, {value: "1", configurable: true});
@@ -76,7 +76,7 @@ arr.length = 1;
 <p>The {{jsxref("Object.seal()")}} function marks all existing elements as
   non-configurable.</p>
 
-<pre class="brush: js example-bad">"use strict"
+<pre class="brush: js example-bad">"use strict";
 var arr = [1,2,3];
 Object.seal(arr);
 
@@ -88,7 +88,7 @@ arr.length = 1;
   In case of a copy, shortening the copy of the array does not modify the original array
   length.</p>
 
-<pre class="brush: js example-good">"use strict"
+<pre class="brush: js example-good">"use strict";
 var arr = [1,2,3];
 Object.seal(arr);
 

--- a/files/en-us/web/javascript/reference/operators/new/index.html
+++ b/files/en-us/web/javascript/reference/operators/new/index.html
@@ -99,7 +99,7 @@ tags:
   color property with value <code>"original color"</code> to all objects of type
   <code>Car</code>, and then overwrites that value with the string "<code>black</code>"
   only in the instance object <code>car1</code>. For more information, see <a
-    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">prototype</a>.
+    href="/en-US/docs/Learn/JavaScript/Objects/Object_prototypes">prototype</a>.
 </p>
 
 <pre class="brush: js">function Car() {}


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Issue #1449 

The prototype and Function.prototype both had the same link. The link for Function.prototype is acceptable according to me, but for prototype, there is an entire page on MDN which explains it's functionality in JavaScript. So, I replaced the link for prototype with a more comprehensive and detailed link. 


> MDN URL of the main page changed


https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new

> Issue number (if there is an associated issue)
#1449 



> Anything else that could help us review it
PR made on branch named "Issue#1449"

