### PR TITLE
Expand Security section of web_accessible_resources

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
@@ -84,6 +84,8 @@ tags:
 
 <p>Note that if you make a page web-accessible, any website may link or redirect to that page. The page should then treat any input (POST data, for examples) as if it came from an untrusted source, just as a normal web page should.</p>
 
+<p>Web-accessible extension resources are not blocked by <a href="/en-US/docs/Web/HTTP/CORS">CORS</a> or <a href="/en-US/docs/Web/HTTP/CSP">CSP</a>. Because of this ability to bypass security checks, extensions should avoid the use of web-accessible scripts when possible. A web-accessible extension script can unexpectedly be misused by malcious websites to weaken the security of other websites. Follow the <a href="https://extensionworkshop.com/documentation/develop/build-a-secure-extension/">security best practices</a> by avoiding injection of moz-extension:-URLs in web pages and ensuring that third-party libraries are up to date.</p>
+
 <h2 id="Example">Example</h2>
 
 <pre class="brush: json no-line-numbers">"web_accessible_resources": ["images/my-image.png"]</pre>

--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -78,6 +78,7 @@ tags:
 
 <ul>
   <li><a href="/en-US/docs/Web/JavaScript/Guide/Modules#dynamic_module_loading">Dynamic JS module imports</a> are now working in WebExtension content scripts ({{bug(1536094)}}).</li>
+  <li>Extension resources listed in <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources">web_accessible_resources</a> can be loaded regardless of the request's CORS mode ({{bug(1694679)}}).</li>
 </ul>
 
 <h4 id="removals_webext">Removals</h4>


### PR DESCRIPTION
Added https://bugzilla.mozilla.org/show_bug.cgi?id=1694679 to the release notes of Firefox 89.

And expanded documentation to warn about the security risks of using the `web_accessible_resources` feature and refer to more documentation about security considerations. A concrete example of the fallout of failing to adhere to these recommendations can be found at https://bugzilla.mozilla.org/show_bug.cgi?id=1711361 .