### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/api/url/createobjecturl/index.html
+++ b/files/en-us/web/api/url/createobjecturl/index.html
@@ -15,7 +15,7 @@ tags:
 <div>{{APIRef("URL API")}}</div>
 
 <p><span class="seoSummary">The <strong><code>URL.createObjectURL()</code></strong> static
-    method creates a {{domxref("DOMString")}} containing a URL representing the object
+    method creates a {{domxref("DOMString")}} containing an URL representing the object
     given in the parameter.</span> The URL lifetime is tied to the {{domxref("document")}}
   in the window on which it was created. The new object URL represents the specified
   {{domxref("File")}} object or {{domxref("Blob")}} object.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Typo/grammar... "a URL" => "an URL"

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL

> Issue number (if there is an associated issue)

> Anything else that could help us review it
