### PR TITLE
Update options type

### DIFF
--- a/files/en-us/web/api/credentialscontainer/create/index.html
+++ b/files/en-us/web/api/credentialscontainer/create/index.html
@@ -30,7 +30,7 @@ tags:
 
 <dl>
   <dt>options</dt>
-  <dd>An object of type {{domxref("CredentialCreationOptions")}} that contains options for
+  <dd>An object of type {{domxref("PublicKeyCredentialCreationOptions")}} that contains options for
     the requested new <code>Credentials</code> object. It must include one of the options
     "password", "federated", or "publicKey". The options are:
     <ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Fix bad reference:

CredentialCreationOptions => PublicKeyCredentialCreationOptions

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create

> Issue number (if there is an associated issue)

> Anything else that could help us review it
