### PR TITLE
Remove nested partial strong in code

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.html
+++ b/files/en-us/web/javascript/data_structures/index.html
@@ -28,7 +28,7 @@ foo     = true;  // foo is now a boolean
  <li>Six <strong>Data Types</strong> that are <a href="/en-US/docs/Glossary/Primitive">primitives</a>, checked by <a href="/en-US/docs/Web/JavaScript/Reference/Operators/typeof">typeof</a> operator:
 
   <ul>
-   <li><a href="/en-US/docs/Glossary/undefined">undefined</a> : <code>typeof instance === "<strong>undefined</strong>"</code></li>
+   <li><a href="/en-US/docs/Glossary/undefined">undefined</a> : <code>typeof instance === "undefined"</code></li>
    <li><a href="/en-US/docs/Glossary/Boolean">Boolean</a> : <code>typeof instance === "boolean"</code></li>
    <li><a href="/en-US/docs/Glossary/Number">Number</a> : <code>typeof instance === "number"</code></li>
    <li><a href="/en-US/docs/Glossary/String">String</a> : <code>typeof instance === "string"</code></li>
@@ -38,13 +38,13 @@ foo     = true;  // foo is now a boolean
  </li>
  <li><strong>Structural</strong> <strong>Types</strong>:
   <ul>
-   <li><a href="/en-US/docs/Glossary/Object">Object</a> : <code>typeof instance === "<strong>object</strong>"</code>. Special non-data but <strong>Structural</strong> <strong>type</strong> for any <a href="/en-US/docs/Learn/JavaScript/Objects#the_constructor">constructed</a> object instance also used as data structures: new {{jsxref("Object")}}, new {{jsxref("Array")}}, new {{jsxref("Map")}}, new {{jsxref("Set")}}, new {{jsxref("WeakMap")}}, new {{jsxref("WeakSet")}}, new {{jsxref("Date")}} and almost everything made with <a href="/en-US/docs/Web/JavaScript/Reference/Operators/new">new keyword</a>;</li>
-   <li><a href="/en-US/docs/Glossary/Function">Function</a> : a non-data structure, though it also answers for <code>typeof</code> operator: <code>typeof instance === "<strong>function</strong>"</code>. This is merely a special shorthand for Functions, though every Function constructor is derived from Object constructor.</li>
+   <li><a href="/en-US/docs/Glossary/Object">Object</a> : <code>typeof instance === "object"</code>. Special non-data but <strong>Structural</strong> <strong>type</strong> for any <a href="/en-US/docs/Learn/JavaScript/Objects#the_constructor">constructed</a> object instance also used as data structures: new {{jsxref("Object")}}, new {{jsxref("Array")}}, new {{jsxref("Map")}}, new {{jsxref("Set")}}, new {{jsxref("WeakMap")}}, new {{jsxref("WeakSet")}}, new {{jsxref("Date")}} and almost everything made with <a href="/en-US/docs/Web/JavaScript/Reference/Operators/new">new keyword</a>;</li>
+   <li><a href="/en-US/docs/Glossary/Function">Function</a> : a non-data structure, though it also answers for <code>typeof</code> operator: <code>typeof instance === "function"</code>. This is merely a special shorthand for Functions, though every Function constructor is derived from Object constructor.</li>
   </ul>
  </li>
  <li><strong>Structural Root</strong> Primitive:
   <ul>
-   <li><strong><a href="/en-US/docs/Glossary/Null">null</a></strong> : <code>typeof instance === "<strong>object</strong>"</code>. Special <a href="/en-US/docs/Glossary/Primitive">primitive</a> type having additional usage for its value: if object is not inherited, then <code>null</code> is shown;</li>
+   <li><strong><a href="/en-US/docs/Glossary/Null">null</a></strong> : <code>typeof instance === "object"</code>. Special <a href="/en-US/docs/Glossary/Primitive">primitive</a> type having additional usage for its value: if object is not inherited, then <code>null</code> is shown;</li>
   </ul>
  </li>
 </ul>

--- a/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
+++ b/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
@@ -162,7 +162,7 @@ tags:
 
 <ul>
  <li>Detection can occur by <code>SimplePropertyRetriever.theGetMethodYouWant(obj).indexOf(prop) &gt; -1</code></li>
- <li>Iteration can occur by <code>SimplePropertyRetriever.theGetMethodYouWant(obj).forEach(function (value, prop) {});</code> (or use<code> filter()</code>, <code>map()</code>, etc.)</li>
+ <li>Iteration can occur by <code>SimplePropertyRetriever.theGetMethodYouWant(obj).forEach(function (value, prop) {});</code> (or use <code>filter()</code>, <code>map()</code>, etc.)</li>
 </ul>
 
 <pre class="brush: js">var SimplePropertyRetriever = {

--- a/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
+++ b/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.html
@@ -89,7 +89,7 @@ tags:
       <th>
         Nonenumerable
       </th>
-      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a> </code>– filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
+      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code> – filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
       <td>Not available without extra code</td>
       <td>Not available without extra code</td>
     </tr>
@@ -138,7 +138,7 @@ tags:
       <th>
         Nonenumerable
       </th>
-      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a> </code>– filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
+      <td><code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames">getOwnPropertyNames</a></code>, <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols">getOwnPropertySymbols</a></code> – filtered to exclude enumerables using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable">propertyIsEnumerable</a></code></td>
       <td>Not available without extra code</td>
       <td>Not available without extra code</td>
     </tr>

--- a/files/en-us/web/javascript/guide/index.html
+++ b/files/en-us/web/javascript/guide/index.html
@@ -49,7 +49,8 @@ tags:
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for_statement">for</a></code></li>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#while_statement">while</a></code></li>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#do...while_statement">do...while</a></code></li>
- <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#continue_statement">continue</a>/<a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#break_statement">break</a></code></li>
+ <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#continue_statement">continue</a></code></li>
+ <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#break_statement">break</a></code></li>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...in_statement">for..in</a></code></li>
  <li><code><a href="/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement">for..of</a></code></li>
 </ul>

--- a/files/en-us/web/javascript/reference/errors/illegal_character/index.html
+++ b/files/en-us/web/javascript/reference/errors/illegal_character/index.html
@@ -73,7 +73,7 @@ var foo = 'bar';
 // SyntaxError: illegal character
 </pre>
 
-<p>Add the missing quote for <code><strong>'</strong>#333'</code>.</p>
+<p>Add the missing quote for <code>'#333'</code>.</p>
 
 <pre class="brush: js example-good">var colors = ['#000', '#333', '#666'];</pre>
 

--- a/files/en-us/web/javascript/reference/errors/not_a_function/index.html
+++ b/files/en-us/web/javascript/reference/errors/not_a_function/index.html
@@ -62,7 +62,7 @@ TypeError: "x" is not a function
 // TypeError: document.getElementByID is not a function
 </pre>
 
-<p>The correct function name is <code>getElementByI<strong>d</strong></code>:</p>
+<p>The correct function name is <code>getElementById</code>:</p>
 
 <pre class="brush: js example-good">let x = document.getElementById('foo');
 </pre>

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.html
@@ -59,7 +59,7 @@ browser-compat: javascript.builtins.escape
 
 <p>The hexadecimal form for characters, whose code unit value is <code>0xFF</code> or
   less, is a two-digit escape sequence: <code>%<var>xx</var></code>. For characters with a
-  greater code unit, the four-digit format <code>%<strong>u</strong><var>xxxx</var></code>
+  greater code unit, the four-digit format <code>%u<var>xxxx</var></code>
   is used.</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/javascript/reference/operators/logical_and/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_and/index.html
@@ -28,8 +28,8 @@ browser-compat: javascript.operators.logical_and
 
 <h2 id="Description">Description</h2>
 
-<p>If <code>expr<strong>1</strong></code> can be converted to <code>true</code>, returns
-  <code>expr<strong>2</strong></code>; else, returns <code>expr<strong>1</strong></code>.
+<p>If <code>expr1</code> can be converted to <code>true</code>, returns
+  <code>expr2</code>; else, returns <code>expr1</code>.
 </p>
 
 <p>If a value can be converted to <code>true</code>, the value is so-called

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.html
@@ -28,8 +28,8 @@ browser-compat: javascript.operators.logical_or
 
 <h2 id="Description">Description</h2>
 
-<p>If <code>expr<strong>1</strong></code> can be converted to <code>true</code>, returns
-  <code>expr<strong>1</strong></code>; else, returns <code>expr<strong>2</strong></code>.
+<p>If <code>expr1</code> can be converted to <code>true</code>, returns
+  <code>expr1</code>; else, returns <code>expr2</code>.
 </p>
 
 <p>If a value can be converted to <code>true</code>, the value is so-called


### PR DESCRIPTION
This PR tries to remove all occurrences of the following pattern in the JS docs: where an element is nested in a `<code>` element, but the text content of the nested element is a subset of the `<code>`.

Like this:

`<code>This is a <strong>thing</strong></code>`

In Markdown you can't do this:

```
`This is a **thing**`
```

We can handle it by converting as follows:

```
`This is a `**`thing`**
```

...but you get double-spacing then because the `<code>` adds padding:

> `This is a `**`thing`**

There aren't many places we see this pattern in JS, and nowhere it looks useful, so this PR just removes it from the source content.
