### PR TITLE
Remove unrelated or redundant links from @font-face

### DIFF
--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -214,12 +214,7 @@ browser-compat: css.at-rules.font-face
 
 <ul>
  <li><a href="/en-US/docs/Web/Guide/WOFF">About WOFF</a></li>
- <li><a href="https://everythingfonts.com/font-face">Everythingfonts font-face generator</a></li>
  <li><a href="https://www.fontsquirrel.com/fontface/generator">FontSquirrel @font-face generator</a></li>
  <li><a href="https://hacks.mozilla.org/2009/06/beautiful-fonts-with-font-face/">Beautiful fonts with @font-face</a></li>
  <li><a href="https://openfontlibrary.org/">Open Font Library</a></li>
- <li><a href="https://caniuse.com/woff">When can I use WOFF?</a></li>
- <li><a href="https://caniuse.com/svg-fonts">When can I use SVG Fonts?</a></li>
- <li><a href="https://coolfont.org">Free Fancy Cool Fonts</a></li>
- <li><a href="https://nicknames.name/">Best Nicknames</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Remove ~`"svg"` from available formats due to low browser support, along with~ some not-so-relevant or redundant links.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

- _Can I use_ links: In the BCD table.
- `https://everythingfonts.com/font-face`: `http://www.fontsquirrel.com/fontface/generator` outperforms. (Supports WOFF2 and such)
- `https://coolfont.org/` and `https://nicknames.name/`: They are not... _fonts_...