### PR TITLE
Remove inline styles from CSS border pages

### DIFF
--- a/files/en-us/web/css/border-bottom-left-radius/index.html
+++ b/files/en-us/web/css/border-bottom-left-radius/index.html
@@ -17,7 +17,7 @@ browser-compat: css.properties.border-bottom-left-radius
 
 <p>The rounding can be a circle or an ellipse, or if one of the value is <code>0</code> no rounding is done and the corner is square.</p>
 
-<div style="text-align: center;"><img alt="border-bottom-left-radius.png" class="default internal" src="border-bottom-left-radius.png"></div>
+<img alt="border-bottom-left-radius.png" class="default internal" src="border-bottom-left-radius.png">
 
 <p>A background, being an image or a color, is clipped at the border, even a rounded one; the exact location of the clipping is defined by the value of the {{cssxref("background-clip")}} property.</p>
 
@@ -76,91 +76,77 @@ border-bottom-left-radius: inherit;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Examples_of_different_border-bottom-left-radius_values">Examples of different border-bottom-left-radius values</h3>
+<h3 id="arc_of_a_circle">Arc of a circle</h3>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th>Live example</th>
-			<th>Code</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-left-radius: 40px 40px; width: 100px; height: 100px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>An arc of circle is used as the border
-			<pre class="brush: css">
-div {
-  border-bottom-left-radius: 40px 40px;
+<p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
+  border-bottom-left-radius: 40px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-left-radius: 40px 20px; width: 100px; height: 100px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>An arc of ellipse is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_a_circle")}}
+
+<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+
+<p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-bottom-left-radius: 40px 20px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-left-radius: 40%; width: 100px; height: 100px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The box is a square: an arc of circle is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_an_ellipse")}}
+
+<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+
+<p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-bottom-left-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-left-radius: 40%; width: 100px; height: 200px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The box is not a square: an arc of ellipse is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("square_element_with_percentage_radius")}}
+
+<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+
+<p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-bottom-left-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 200px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="border: black 3px double; border-bottom-left-radius: 40%; height: 100px; width: 100px; background-color: rgb(250,20,70); background-clip: content-box;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The background color is clipped at the border
-			<pre class="brush: css">
-div {
-  border-bottom-left-radius:40%;
-  border-style: black 3px double;
-  background-color: rgb(250,20,70);
-  background-clip: content-box;
-}
-</pre>
-			</td>
-		</tr>
-	</tbody>
-</table>
+
+{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-bottom-right-radius/index.html
+++ b/files/en-us/web/css/border-bottom-right-radius/index.html
@@ -17,7 +17,7 @@ browser-compat: css.properties.border-bottom-right-radius
 
 <p>The rounding can be a circle or an ellipse, or if one of the value is <code>0</code> no rounding is done and the corner is square.</p>
 
-<div style="text-align: center;"><img alt="border-bottom-right-radius.png" class="default internal" src="border-bottom-right-radius.png"></div>
+<img alt="border-bottom-right-radius.png" class="default internal" src="border-bottom-right-radius.png">
 
 <p>A background, being an image or a color, is clipped at the border, even a rounded one; the exact location of the clipping is defined by the value of the {{cssxref("background-clip")}} property.</p>
 
@@ -70,91 +70,77 @@ border-bottom-right-radius: inherit;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Examples_of_different_border-bottom-right-radius_values">Examples of different border-bottom-right-radius values</h3>
+<h3 id="arc_of_a_circle">Arc of a circle</h3>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th>Live example</th>
-			<th>Code</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-right-radius: 40px 40px; width: 100px; height: 100px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>An arc of circle is used as the border
-			<pre class="brush: css">
-div {
-  border-bottom-right-radius: 40px 40px;
+<p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
+  border-bottom-right-radius: 40px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-right-radius: 40px 20px; width: 100px; height: 100px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>An arc of ellipse is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_a_circle")}}
+
+<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+
+<p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-bottom-right-radius: 40px 20px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-right-radius: 40%; width: 100px; height: 100px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The box is a square: an arc of circle is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_an_ellipse")}}
+
+<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+
+<p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-bottom-right-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-bottom-right-radius: 40%; width: 100px; height: 200px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The box is not a square: an arc of ellipse is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("square_element_with_percentage_radius")}}
+
+<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+
+<p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-bottom-right-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 200px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="border: black 3px double; border-bottom-right-radius: 40%; height: 100px; width: 100px; background-color: rgb(250,20,70); background-clip: content-box;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The background color is clipped at the border
-			<pre class="brush: css">
-div {
-  border-bottom-right-radius:40%;
-  border-style: black 3px double;
-  background-color: rgb(250,20,70);
-  background-clip: content-box;
-}
-</pre>
-			</td>
-		</tr>
-	</tbody>
-</table>
+
+{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-radius/index.html
+++ b/files/en-us/web/css/border-radius/index.html
@@ -80,39 +80,39 @@ border-radius: unset;
 <table>
  <tbody>
   <tr>
-   <td style="vertical-align: top;"><em>radius</em></td>
+   <td><em>radius</em></td>
    <td><img alt="all-corner.png" class="default internal" src="all-corner.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in each corner of the border. It is used only in the one-value syntax.</td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in each corner of the border. It is used only in the one-value syntax.</td>
   </tr>
   <tr>
-   <td style="vertical-align: top;"><em>top-left-and-bottom-right</em></td>
+   <td><em>top-left-and-bottom-right</em></td>
    <td><img alt="top-left-bottom-right.png" class="default internal" src="top-left-bottom-right.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-left and bottom-right corners of the element's box. It is used only in the two-value syntax.</td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-left and bottom-right corners of the element's box. It is used only in the two-value syntax.</td>
   </tr>
   <tr>
-   <td style="vertical-align: top;"><em>top-right-and-bottom-left</em></td>
+   <td><em>top-right-and-bottom-left</em></td>
    <td><img alt="top-right-bottom-left.png" class="default internal" src="top-right-bottom-left.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-right and bottom-left corners of the element's box. It is used only in the two- and three-value syntaxes.</td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-right and bottom-left corners of the element's box. It is used only in the two- and three-value syntaxes.</td>
   </tr>
   <tr>
-   <td style="vertical-align: top;"><em>top-left</em></td>
+   <td><em>top-left</em></td>
    <td><img alt="top-left.png" class="default internal" src="top-left.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-left corner of the element's box. It is used only in the three- and four-value syntaxes.</td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-left corner of the element's box. It is used only in the three- and four-value syntaxes.</td>
   </tr>
   <tr>
-   <td style="vertical-align: top;"><em>top-right</em></td>
-   <td style="margin-left: 2px;"><img alt="top-right.png" class="default internal" src="top-right.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-right corner of the element's box. It is used only in the four-value syntax.</td>
+   <td><em>top-right</em></td>
+   <td><img alt="top-right.png" class="default internal" src="top-right.png"></td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the top-right corner of the element's box. It is used only in the four-value syntax.</td>
   </tr>
   <tr>
-   <td style="vertical-align: top;"><em>bottom-right</em></td>
-   <td style="margin-left: 2px;"><img alt="bottom-rigth.png" class="default internal" src="bottom-rigth.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the bottom-right corner of the element's box. It is used only in the three- and four-value syntaxes.</td>
+   <td><em>bottom-right</em></td>
+   <td><img alt="bottom-rigth.png" class="default internal" src="bottom-rigth.png"></td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the bottom-right corner of the element's box. It is used only in the three- and four-value syntaxes.</td>
   </tr>
   <tr>
-   <td style="vertical-align: top;"><em>bottom-left</em></td>
+   <td><em>bottom-left</em></td>
    <td><img alt="bottom-left.png" class="default internal" src="bottom-left.png"></td>
-   <td style="vertical-align: top;">Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the bottom-left corner of the element's box. It is used only in the four-value syntax.</td>
+   <td>Is a {{cssxref("&lt;length&gt;")}} or a {{cssxref("&lt;percentage&gt;")}} denoting a radius to use for the border in the bottom-left corner of the element's box. It is used only in the four-value syntax.</td>
   </tr>
  </tbody>
 </table>
@@ -152,39 +152,94 @@ border-bottom-left-radius:  3px 4px;
 
 {{csssyntax}}
 
-<h2 id="Examples">Examples</h2>
+<h2 id="examples">Examples</h2>
 
-<pre style="display: inline-block; margin: 10px; border: solid 10px !important; border-radius: 10px 40px 40px 10px; width: 90%;">  border: solid 10px;
-  /* the border will curve into a 'D' */
+<pre class="brush: html hidden">
+  &lt;pre id="example-1"&gt;
+border: solid 10px;
+border-radius: 10px 40px 40px 10px;
+  &lt;/pre&gt;
+  &lt;pre id="example-2"&gt;
+border: groove 1em red;
+border-radius: 2em;
+  &lt;/pre&gt;
+  &lt;pre id="example-3"&gt;
+background: gold;
+border: ridge gold;
+border-radius: 13em/3em;
+  &lt;/pre&gt;
+  &lt;pre id="example-4"&gt;
+border: none;
+border-radius: 40px 10px;
+background: gold;
+  &lt;/pre&gt;
+  &lt;pre id="example-5"&gt;
+border: none;
+border-radius: 50%;
+background: burlywood;
+  &lt;/pre&gt;
+  &lt;pre id="example-6"&gt;
+border: dotted;
+border-width: 10px 4px;
+border-radius: 10px 40px;
+  &lt;/pre&gt;
+  &lt;pre id="example-7"&gt;
+border: dashed;
+border-width: 2px 4px;
+border-radius: 40px;
+  &lt;/pre&gt;
+</pre>
+
+<pre class="brush: css hidden">
+pre {
+  margin: 20px;
+  padding: 20px;
+  width: 80%;
+  height: 80px;
+}
+
+pre#example-1 {
+  border: solid 10px;
   border-radius: 10px 40px 40px 10px;
-</pre>
+}
 
-<pre style="display: inline-block; margin: 10px; border: groove 1em red  !important; border-radius: 2em; width: 90%;">  border: groove 1em red;
+pre#example-2 {
+  border: groove 1em red;
   border-radius: 2em;
-</pre>
+}
 
-<pre style="display: inline-block; margin: 10px; background: gold; border: ridge gold  !important; border-radius: 13em/3em; width: 90%;">  background: gold;
+pre#example-3 {
+  background: gold;
   border: ridge gold;
   border-radius: 13em/3em;
-</pre>
+}
 
-<pre style="display: inline-block; margin: 10px; background: gold; border: none  !important; border-radius: 40px 10px; width: 90%;">  border: none;
+pre#example-4 {
+  border: none;
   border-radius: 40px 10px;
-</pre>
+  background: gold;
+}
 
-<pre style="display: inline-block; margin: 10px; background: burlywood; border: none  !important; border-radius: 50%; width: 90%;">  border: none;
+pre#example-5 {
+  border: none;
   border-radius: 50%;
-</pre>
+  background: burlywood;
+}
 
-<pre style="display: inline-block; margin: 10px; border: dotted; border-width: 10px 4px  !important; border-radius: 10px 40px; width: 90%;">  border: dotted;
+pre#example-6 {
+  border: dotted;
   border-width: 10px 4px;
   border-radius: 10px 40px;
-</pre>
+}
 
-<pre style="display: inline-block; margin: 10px; border: dashed; border-width: 2px 4px  !important; border-radius: 40px; width: 90%;">  border: dashed;
+pre#example-7 {
+  border: dashed;
   border-width: 2px 4px;
   border-radius: 40px;
+}
 </pre>
+
+{{EmbedLiveSample("examples", "200", "1150")}}
 
 <h3 id="Live_Samples">Live Samples</h3>
 

--- a/files/en-us/web/css/border-style/index.html
+++ b/files/en-us/web/css/border-style/index.html
@@ -70,84 +70,30 @@ border-style: unset;
 
 <dl>
 	<dt><code>&lt;line-style&gt;</code></dt>
-	<dd>Describes the style of the border. It can have the following values:
-	<table class="standard-table">
-		<tbody>
-			<tr>
-				<td style="vertical-align: middle;"><code>none</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-style: none; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Like the <code>hidden</code> keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the computed value of the same side's {{cssxref("border-width")}} will be <code>0</code>, even if the specified value is something else. In the case of table cell and border collapsing, the <code>none</code> value has the <em>lowest</em> priority: if any other conflicting border is set, it will be displayed.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>hidden</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: hidden; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Like the <code>none</code> keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the computed value of the same side's {{cssxref("border-width")}} will be <code>0</code>, even if the specified value is something else. In the case of table cell and border collapsing, the <code>hidden</code> value has the <em>highest</em> priority: if any other conflicting border is set, it won't be displayed.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>dotted</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: dotted; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays a series of rounded dots. The spacing of the dots is not defined by the specification and is implementation-specific. The radius of the dots is half the computed value of the same side's {{cssxref("border-width")}}.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>dashed</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: dashed; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays a series of short square-ended dashes or line segments. The exact size and length of the segments are not defined by the specification and are implementation-specific.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>solid</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: solid; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays a single, straight, solid line.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>double</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: double; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays two straight lines that add up to the pixel size defined by {{cssxref("border-width")}}.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>groove</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: groove; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays a border with a carved appearance. It is the opposite of <code>ridge</code>.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>ridge</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: ridge; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays a border with an extruded appearance. It is the opposite of <code>groove</code>.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>inset</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: inset; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">Displays a border that makes the element appear embedded. It is the opposite of <code>outset</code>. When applied to a table cell with {{cssxref("border-collapse")}} set to <code>collapsed</code>, this value behaves like <code>groove</code>.</td>
-			</tr>
-			<tr>
-				<td style="vertical-align: middle;"><code>outset</code></td>
-				<td style="vertical-align: middle;">
-				<div style="margin: 0.5em; width: 3em; height: 3em; border-width: 3px; border-style: outset; background-color: palegreen;"></div>
-				</td>
-				<td style="vertical-align: middle;">
-				<p>Displays a border that makes the element appear embossed. It is the opposite of <code>inset</code>. When applied to a table cell with {{cssxref("border-collapse")}} set to <code>collapsed</code>, this value behaves like <code>ridge</code>.</p>
-				</td>
-			</tr>
-		</tbody>
-	</table>
-	</dd>
+	<dd><p>Describes the style of the border. It can have the following values:</p>
+    <dl>
+      <dt><code>none</code></dt>
+      <dd>Like the <code>hidden</code> keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the computed value of the same side's {{cssxref("border-width")}} will be <code>0</code>, even if the specified value is something else. In the case of table cell and border collapsing, the <code>none</code> value has the <em>lowest</em> priority: if any other conflicting border is set, it will be displayed.</dd>
+      <dt><code>hidden</code></dt>
+      <dd>Like the <code>none</code> keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the computed value of the same side's {{cssxref("border-width")}} will be <code>0</code>, even if the specified value is something else. In the case of table cell and border collapsing, the <code>hidden</code> value has the <em>highest</em> priority: if any other conflicting border is set, it won't be displayed.</dd>
+      <dt><code>dotted</code></dt>
+      <dd>Displays a series of rounded dots. The spacing of the dots is not defined by the specification and is implementation-specific. The radius of the dots is half the computed value of the same side's {{cssxref("border-width")}}.</dd>
+      <dt><code>dashed</code></dt>
+      <dd>Displays a series of short square-ended dashes or line segments. The exact size and length of the segments are not defined by the specification and are implementation-specific.</dd>
+      <dt><code>solid</code></dt>
+      <dd>Displays a single, straight, solid line.</dd>
+      <dt><code>double</code></dt>
+      <dd>Displays two straight lines that add up to the pixel size defined by {{cssxref("border-width")}}.</dd>
+      <dt><code>groove</code></dt>
+      <dd>Displays a border with a carved appearance. It is the opposite of <code>ridge</code>.</dd>
+      <dt><code>ridge</code></dt>
+      <dd>Displays a border with an extruded appearance. It is the opposite of <code>groove</code>.</dd>
+      <dt><code>inset</code></dt>
+      <dd>Displays a border that makes the element appear embedded. It is the opposite of <code>outset</code>. When applied to a table cell with {{cssxref("border-collapse")}} set to <code>collapsed</code>, this value behaves like <code>groove</code>.</dd>
+      <dt><code>outset</code></dt>
+      <dd>Displays a border that makes the element appear embossed. It is the opposite of <code>inset</code>. When applied to a table cell with {{cssxref("border-collapse")}} set to <code>collapsed</code>, this value behaves like <code>ridge</code>.</dd>
+    </dl>
+  </dd>
 </dl>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -160,57 +106,83 @@ border-style: unset;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Table_with_all_property_values">Table with all property values</h3>
+<h3 id="all_property_values">All property values</h3>
 
 <p>Here is an example of all the property values.</p>
 
 <h4 id="HTML">HTML</h4>
 
-<pre class="brush: html">&lt;table&gt;
-  &lt;tr&gt;
-    &lt;td class="b1"&gt;none&lt;/td&gt;
-    &lt;td class="b2"&gt;hidden&lt;/td&gt;
-    &lt;td class="b3"&gt;dotted&lt;/td&gt;
-    &lt;td class="b4"&gt;dashed&lt;/td&gt;
-  &lt;/tr&gt;
-  &lt;tr&gt;
-    &lt;td class="b5"&gt;solid&lt;/td&gt;
-    &lt;td class="b6"&gt;double&lt;/td&gt;
-    &lt;td class="b7"&gt;groove&lt;/td&gt;
-    &lt;td class="b8"&gt;ridge&lt;/td&gt;
-  &lt;/tr&gt;
-  &lt;tr&gt;
-    &lt;td class="b9"&gt;inset&lt;/td&gt;
-    &lt;td class="b10"&gt;outset&lt;/td&gt;
-  &lt;/tr&gt;
-&lt;/table&gt;</pre>
+<pre class="brush: html">
+&lt;pre class="b1"&gt;none&lt;/pre&gt;
+&lt;pre class="b2"&gt;hidden&lt;/pre&gt;
+&lt;pre class="b3"&gt;dotted&lt;/pre&gt;
+&lt;pre class="b4"&gt;dashed&lt;/pre&gt;
+&lt;pre class="b5"&gt;solid&lt;/pre&gt;
+&lt;pre class="b6"&gt;double&lt;/pre&gt;
+&lt;pre class="b7"&gt;groove&lt;/pre&gt;
+&lt;pre class="b8"&gt;ridge&lt;/pre&gt;
+&lt;pre class="b9"&gt;inset&lt;/pre&gt;
+&lt;pre class="b10"&gt;outset&lt;/pre&gt;
+</pre>
 
 <h4 id="CSS">CSS</h4>
 
-<pre class="brush: css">/* Define look of the table */
-table {
-  border-width: 3px;
-  background-color: #52E396;
-}
-tr, td {
-  padding: 2px;
+<pre class="brush: css">
+pre {
+  height: 80px;
+  width: 120px;
+  margin: 20px;
+  padding: 20px;
+  display: inline-block;
+  background-color: palegreen;
+  border-width: 5px;
+  box-sizing: border-box;
 }
 
 /* border-style example classes */
-.b1 {border-style:none;}
-.b2 {border-style:hidden;}
-.b3 {border-style:dotted;}
-.b4 {border-style:dashed;}
-.b5 {border-style:solid;}
-.b6 {border-style:double;}
-.b7 {border-style:groove;}
-.b8 {border-style:ridge;}
-.b9 {border-style:inset;}
-.b10 {border-style:outset;}</pre>
+.b1 {
+  border-style: none;
+}
+
+.b2 {
+  border-style: hidden;
+}
+
+.b3 {
+  border-style: dotted;
+}
+
+.b4 {
+  border-style: dashed;
+}
+
+.b5 {
+  border-style: solid;
+}
+
+.b6 {
+  border-style: double;
+}
+
+.b7 {
+  border-style: groove;
+}
+
+.b8 {
+  border-style: ridge;
+}
+
+.b9 {
+  border-style: inset;
+}
+
+.b10 {
+  border-style: outset;
+}</pre>
 
 <h4 id="Result">Result</h4>
 
-<p>{{EmbedLiveSample('Table_with_all_property_values', 300, 200)}}</p>
+<div>{{EmbedLiveSample('all_property_values', "1200", 450)}}</div>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-top-left-radius/index.html
+++ b/files/en-us/web/css/border-top-left-radius/index.html
@@ -17,7 +17,7 @@ browser-compat: css.properties.border-top-left-radius
 
 <p>The rounding can be a circle or an ellipse, or if one of the value is <code>0,</code>no rounding is done and the corner is square.</p>
 
-<div style="text-align: center;"><img alt="border-radius.png" class="default internal" src="border-radius.png"></div>
+<img alt="border-radius.png" class="default internal" src="border-radius.png">
 
 <p>A background, being an image or a color, is clipped at the border, even a rounded one; the exact location of the clipping is defined by the value of the {{cssxref("background-clip")}} property.</p>
 
@@ -66,81 +66,77 @@ border-top-left-radius: inherit;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Examples_of_different_border-top-left-radius_values">Examples of different border-top-left-radius values</h3>
+<h3 id="arc_of_a_circle">Arc of a circle</h3>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th>Live example</th>
-   <th>Code</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td style="padding: 1.5em;">
-    <div id="circle-arc" style="background-color: lightgreen; border: solid 1px black; border-top-left-radius: 40px 40px; width: 100px; height: 100px;"></div>
-   </td>
-   <td>An arc of ellipse is used as the border
-    <pre class="brush:css">
-div {
-  border-top-left-radius: 40px 40px;
+<p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
+  border-top-left-radius: 40px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-   </td>
-  </tr>
-  <tr>
-   <td style="padding: 1.5em;">
-    <div id="ellipse-arc" style="background-color: lightgreen; border: solid 1px black; border-top-left-radius: 40px 20px; width: 100px; height: 100px;"></div>
-   </td>
-   <td>An arc of ellipse is used as the border
-    <pre class="brush:css">
-div {
+
+{{EmbedLiveSample("arc_of_a_circle")}}
+
+<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+
+<p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-top-left-radius: 40px 20px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-   </td>
-  </tr>
-  <tr>
-   <td style="padding: 1.5em;">
-    <div id="square-box-circle-arc" style="background-color: lightgreen; border: solid 1px black; border-top-left-radius: 40%; width: 100px; height: 100px;"></div>
-   </td>
-   <td>The box is a square: an arc of circle is used as the border
-    <pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_an_ellipse")}}
+
+<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+
+<p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-top-left-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-   </td>
-  </tr>
-  <tr>
-   <td style="padding: 1.5em;">
-    <div id="not-square-ellipse-arc" style="background-color: lightgreen; border: solid 1px black; border-top-left-radius: 40%; width: 100px; height: 200px;"></div>
-   </td>
-   <td>The box is not a square: an arc of ellipse is used as the border
-    <pre class="brush: css">
-div {
+
+{{EmbedLiveSample("square_element_with_percentage_radius")}}
+
+<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+
+<p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-top-left-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 200px;
+  height: 100px;
 }
 </pre>
-   </td>
-  </tr>
-  <tr>
-   <td style="padding: 1.5em;">
-    <div id="clipped-border" style="background-color: rgb(250,20,70); background-clip: content-box; border: double 3px black; border-top-left-radius: 40%; width: 100px; height: 100px;"></div>
-   </td>
-   <td>The background color is clipped at the border
-    <pre class="brush: css">
-div {
-  border-top-left-radius:40%;
-  border: 3px double black;
-  background-color: rgb(250,20,70);
-  background-clip: content-box;
-}
-</pre>
-   </td>
-  </tr>
- </tbody>
-</table>
+
+{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/css/border-top-right-radius/index.html
+++ b/files/en-us/web/css/border-top-right-radius/index.html
@@ -17,7 +17,7 @@ browser-compat: css.properties.border-top-right-radius
 
 <p>The rounding can be a circle or an ellipse, or if one of the value is <code>0</code> no rounding is done and the corner is square.</p>
 
-<div style="text-align: center;"><img alt="border-top-right-radius.png" class="default internal" src="border-top-right-radius.png"></div>
+<img alt="border-top-right-radius.png" class="default internal" src="border-top-right-radius.png">
 
 <p>A background, being an image or a color, is clipped at the border, even a rounded one; the exact location of the clipping is defined by the value of the {{cssxref("background-clip")}} property.</p>
 
@@ -66,83 +66,77 @@ border-top-right-radius: inherit;
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="Examples_of_different_border-top-right-radius_values">Examples of different border-top-right-radius values</h3>
+<h3 id="arc_of_a_circle">Arc of a circle</h3>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th>Live example</th>
-			<th>Code</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-top-right-radius: 40px 40px; width: 100px; height: 100px;"></div>
-			</td>
-			<td>An arc of circle is used as the border
-			<pre class="brush: css">
-div {
-  border-top-right-radius: 40px 40px;
+<p>A single <code>&lt;length&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
+  border-top-right-radius: 40px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-top-right-radius: 40px 20px; width: 100px; height: 100px;"></div>
-			</td>
-			<td>An arc of ellipse is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_a_circle")}}
+
+<h3 id="arc_of_an_ellipse">Arc of an ellipse</h3>
+
+<p>Two different <code>&lt;length&gt;</code> values produce an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-top-right-radius: 40px 20px;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-top-right-radius: 40%; width: 100px; height: 100px;"></div>
-			</td>
-			<td>The box is a square: an arc of circle is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("arc_of_an_ellipse")}}
+
+<h3 id="square_element_with_percentage_radius">Square element with percentage radius</h3>
+
+<p>A square element with a single <code>&lt;percentage&gt;</code> value produces an arc of a circle.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-top-right-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 100px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="background-color: lightgreen; border: solid 1px black; border-top-right-radius: 40%; width: 100px; height: 200px;">
-			<div style="display: none;">.</div>
-			</div>
-			</td>
-			<td>The box is not a square: an arc of ellipse is used as the border
-			<pre class="brush: css">
-div {
+
+{{EmbedLiveSample("square_element_with_percentage_radius")}}
+
+<h3 id="non_square_element_with_percentage_radius">Non-square element with percentage radius</h3>
+
+<p>A non-square element with a single <code>&lt;percentage&gt;</code> value produces an arc of an ellipse.</p>
+
+<pre class="brush: html hidden">&lt;div&gt;&lt;/div&gt;
+</pre>
+
+<pre class="brush: css">div {
   border-top-right-radius: 40%;
+  background-color: lightgreen;
+  border: solid 1px black;
+  width: 200px;
+  height: 100px;
 }
 </pre>
-			</td>
-		</tr>
-		<tr>
-			<td style="padding: 1.5em;">
-			<div style="border: black 3px double; border-top-right-radius: 40%; height: 100px; width: 100px; background-color: rgb(250,20,70); background-clip: content-box;"></div>
-			</td>
-			<td>The background color is clipped at the border
-			<pre class="brush: css">
-div {
-  border-top-right-radius:40%;
-  border-style: black 3px double;
-  background-color: rgb(250,20,70);
-  background-clip: content-box;
-}
-</pre>
-			</td>
-		</tr>
-	</tbody>
-</table>
+
+{{EmbedLiveSample("non_square_element_with_percentage_radius")}}
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
To help with the move to Markdown we'd like to get rid of as many inline styles as possible. I've previously filed https://github.com/mdn/content/pull/4806 and https://github.com/mdn/content/pull/4829 to remove a lot of the inline styles in the CSS docs, and we're down to the ones that are a bit more work.

This PR removes inline styles from the `border-*` pages that have them. The general theme of it is that inline styles are used as examples of the properties, and the PR replaces that method with live samples. I think this is better in a couple of ways:
* it's logically clearer (I think) to separate the page content that talks about the feature, from examples showing it
* it's better to present examples consistently in our docs
* inline styles of course inherit the page styles, which can make them behave in unexpected ways.

The four `border-*-radius` all follow the same pattern and I have done the same thing with them. Apart from live-samplizing them I dropped the last example that didn't seem very relevant to border radius.

For the `border-radius` page I went with a very close copy of the original.

For the `border-style` page I removed the examples from the "Values" section, and replaced it with a much more conventional approach, more consistent with the other pages. I then updated the "Examples" section to make it more readable.

I hope these choices seem reasonable!

After this there will still be 7 more pages to go in CSS, but that will be for another PR.

