### PR TITLE
fix: Broken Link in manifest.json » permissions doc

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
@@ -191,7 +191,7 @@ tags:
 
 <ul>
  <li>Enables extensions to exceed any quota imposed by the {{WebExtAPIRef("storage/local", "storage.local")}} API</li>
- <li>In Firefox, enables extensions to create a {{webextAPIref("IndexedDB_API/Browser_storage_limits_and_eviction_criteria", '"persistent" IndexedDB database')}}, without the browser prompting the user for permission at the time the database is created.</li>
+ <li>In Firefox, enables extensions to create a <a href="/en-US/docs/Web/API/IndexedDB_API">"persistent" IndexedDB database</a> without the browser prompting the user for permission at the time the database is created.</li>
 </ul>
 
 <h2 id="Example">Example</h2>


### PR DESCRIPTION
Now redirects to IndexedDB API



<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
Fix Broken link at `"persistent" IndexedDB database`

> MDN URL of the main page changed


> Issue number (if there is an associated issue)
fix #5134 
> Anything else that could help us review it
