### PR TITLE
Update Tools/Page_Inspector/UI_Tour

### DIFF
--- a/files/en-us/tools/page_inspector/ui_tour/index.html
+++ b/files/en-us/tools/page_inspector/ui_tour/index.html
@@ -68,9 +68,7 @@ tags:
 
 <p><img alt="" src="inspector_layout.png" style="border: 1px solid black; display: block; margin: 0px auto;"></p>
 
-<p>To learn more about the Layout view, see <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_the_box_model">Examine and edit the box model</a>. Note that before Firefox 50, the box model view did not appear in the "Computed view" tab, but had its own tab.</p>
-
-<p>To learn more about the CSS declarations listed in this view, see <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#examine_computed_css">Examine computed CSS</a>.</p>
+<p>To learn more about the Layout view, see <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_the_box_model">Examine and edit the box model</a>. Note that before Firefox 50, the box model view did not appear in the "Layout view" tab, but had its own tab.</p>
 
 <h3 id="Changes_view">Changes view</h3>
 
@@ -83,6 +81,8 @@ tags:
 <p>The Computed view shows you the complete computed CSS for the selected element (The computed values are the same as what <a href="/en-US/docs/Web/API/Window/getComputedStyle">getComputedStyle </a>would return.):</p>
 
 <p><img alt="The Computed view within the Inspector." src="inspector_computed.png" style="border: 1px solid black; display: block; margin-left: auto; margin-right: auto;"></p>
+
+<p>To learn more about the CSS declarations listed in this view, see <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#examine_computed_css">Examine computed CSS</a>.</p>
 
 <h3 id="Compatibility_view">Compatibility view</h3>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

>  Note that before Firefox 50, the box model view did not appear in the "Computed view" tab, but had its own tab.
It should be "Layout view" because it is in the section of "Layout view".

A description about the Computed view is in the section of Layout view.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/UI_Tour

> Issue number (if there is an associated issue)

> Anything else that could help us review it
