### PR TITLE
Adds a note to fix #2992

### DIFF
--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -136,7 +136,7 @@ function openRequestedPopup() {
   <p><strong>Tip</strong>: Note that in some browsers, users can override the
     <code><var>windowFeatures</var></code> settings and enable (or prevent the disabling
     of) features. Further, control of some window features is available only on some browsers
-    and platforms. For example see <a href="#popup_condition">popup condition</a> section.
+    and platforms (See <a href="#popup_condition">popup condition</a> section)
   </p>
 </div>
 

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -135,7 +135,9 @@ function openRequestedPopup() {
 <div class="note">
   <p><strong>Tip</strong>: Note that in some browsers, users can override the
     <code><var>windowFeatures</var></code> settings and enable (or prevent the disabling
-    of) features</p>
+    of) features. Further, control of some window features is available only on some browsers
+    and platforms. For example see <a href="#popup_condition">popup condition</a> section.
+  </p>
 </div>
 
 <h3 id="Position_and_size_features">Position and size features</h3>


### PR DESCRIPTION
Fixed as suggested in @Rumyra 's comment.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
See issue 2992 which asks to be explicit about unavailable window features

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/Window/open#popup_condition

> Issue number (if there is an associated issue)
2992

> Anything else that could help us review it
I don't have a deep understanding or experience with this.  Please review and feel free to reject.