### PR TITLE
Fix addEventListener doc note re: call order & “capturing” phase

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -95,11 +95,9 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
   <dd>
     <div class="notecard note">
       <h4>Note</h4>
-      <p>For event listeners attached to the event target, the event is in the target phase, 
+      <p>For event listeners attached to the event target, the event is in the target phase,
         rather than the capturing and bubbling phases.
-        Events in the target phase will trigger all listeners on an element in the
-      order they were registered, regardless of the <var>useCapture</var>
-      parameter.</p>
+        Capturing event listeners should be called before non-capturing ones</p>
     </div>
 
     <div class="notecard note">

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -97,7 +97,7 @@ target.addEventListener(type, listener, useCapture, wantsUntrusted); // wantsUnt
       <h4>Note</h4>
       <p>For event listeners attached to the event target, the event is in the target phase,
         rather than the capturing and bubbling phases.
-        Capturing event listeners should be called before non-capturing ones</p>
+        Event listeners in the “capturing” phase are called before event listeners in any non-capturing phases.</p>
     </div>
 
     <div class="notecard note">


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->
In chrome 89.0.4363.0 and later versions, the sequence of event triggering has been updated.
At target is no longer triggered in the order of registration, but in the order of catching and bubbling first.
detail in 
https://bugs.chromium.org/p/chromium/issues/detail?id=1185799
https://github.com/whatwg/dom/issues/746
https://github.com/whatwg/dom/issues/685
http://w3c-test.org/dom/events/EventTarget-dispatchEvent.html

> What was wrong/why is this fix needed? (quick summary only)
Fix new event trigger order.

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it

