### PR TITLE
Fix up MDN API landing page template for browser-compat

### DIFF
--- a/files/en-us/mdn/structures/compatibility_tables/index.html
+++ b/files/en-us/mdn/structures/compatibility_tables/index.html
@@ -451,14 +451,14 @@ git push</pre>
 
 <p>Once your new compatibility data has been included in the main <a href="https://github.com/mdn/browser-compat-data">browser-compat-data</a> repo, you can start dynamically generating browser compatibility and specification tables based on that data on MDN pages.</p>
 
-<p>First you need to find the "address" for the relevant compatibility data you wish to include. This can be determined by inspecting its source file. For example:</p>
+<p>First you need to find the query string for the relevant compatibility data you wish to include. This can be determined by inspecting its source file. For example:</p>
 <ul>
-  <li>{{domxref("AbortController")}} compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/api/AbortController.json">AbortController.json</a> and has address <code>api.AbortController</code>.</li>
-  <li>{{HTTPHeader("Content-Type")}} HTTP header compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/http/headers/content-type.json">content-type.json</a> and has address <code>http.headers.Content-Type</code>.</li>
-  <li>{{domxref("VRDisplay.capabilities")}} property compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json">VRDisplay.json</a> and has address key is <code>api.VRDisplay.capabilities</code>.</li>
+  <li>{{domxref("AbortController")}} compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/api/AbortController.json">AbortController.json</a> and can be queried using <code>api.AbortController</code>.</li>
+  <li>{{HTTPHeader("Content-Type")}} HTTP header compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/http/headers/content-type.json">content-type.json</a> and the query is <code>http.headers.Content-Type</code>.</li>
+  <li>{{domxref("VRDisplay.capabilities")}} property compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json">VRDisplay.json</a> and its query is <code>api.VRDisplay.capabilities</code>.</li>
 </ul>
 
-<p>The compatibility data address should be specified in the page front-matter using the <code>browser-compat</code> key.
+<p>The compatibility data query should be specified in the page front-matter using the <code>browser-compat</code> key.
   For example, for the {{domxref("AbortController")}} this would be added as shown below:</p>
   
 <pre>---

--- a/files/en-us/mdn/structures/compatibility_tables/index.html
+++ b/files/en-us/mdn/structures/compatibility_tables/index.html
@@ -7,6 +7,7 @@ tags:
   - Structures
   - browser compat
   - compatibility tables
+browser-compat: api.AbortController
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -136,6 +137,7 @@ tags:
 
 <ul>
  <li><code>mdn_url</code>: Contains the URL of the reference page for this feature on MDN. Note that this needs to be written without the locale directory inside, e.g. <code>/docs/...</code> not <code>/en-US/docs/...</code>. This is added in by the macro when the data is put on the page, for localization purposes.</li>
+ <li><code>spec_url</code>: URL or array of URLs to specification(s) in which this feature is defined.</li>
  <li><code>support</code>: Contains members representing the browser support information for this feature in all the different browsers we want to report.</li>
  <li><code>status</code>: Contains members reporting the standards track status of this feature.</li>
 </ul>
@@ -163,6 +165,7 @@ tags:
 
 <pre class="brush: json">"__compat": {
   "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-width",
+  "spec_url": "https://drafts.csswg.org/css-backgrounds/#the-border-width",
   "support": {
     "chrome": {
       "version_added": "1"
@@ -446,15 +449,38 @@ git push</pre>
 
 <h2 id="Inserting_the_data_into_MDN_pages">Inserting the data into MDN pages</h2>
 
-<p>Once your new data has been included in the main repo, you can start dynamically generating browser compat tables based on that data on MDN pages using the {{TemplateLink("Compat")}} macro. This takes a single parameter, the dot notation required to walk down the JSON data and find the object representing the feature you want to generate the compat table for.</p>
+<p>Once your new compatibility data has been included in the main <a href="https://github.com/mdn/browser-compat-data">browser-compat-data</a> repo, you can start dynamically generating browser compatibility and specification tables based on that data on MDN pages.</p>
 
-<p>As an example, on the {{HTTPHeader("Content-Type")}} HTTP header page, the macro call looks like this: <code>\{{Compat("http.headers.Content-Type")}}</code>. If you look at the <a href="https://github.com/mdn/browser-compat-data/blob/main/http/headers/content-type.json">content-type.json</a> file in the repo, you'll see how this is reflected in the JSON data.</p>
+<p>First you need to find the "address" for the relevant compatibility data you wish to include. This can be determined by inspecting its source file. For example:</p>
+<ul>
+  <li>{{domxref("AbortController")}} compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/api/AbortController.json">AbortController.json</a> and has address <code>api.AbortController</code>.</li>
+  <li>{{HTTPHeader("Content-Type")}} HTTP header compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/http/headers/content-type.json">content-type.json</a> and has address <code>http.headers.Content-Type</code>.</li>
+  <li>{{domxref("VRDisplay.capabilities")}} property compatibility data is defined in <a href="https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json">VRDisplay.json</a> and has address key is <code>api.VRDisplay.capabilities</code>.</li>
+</ul>
 
-<p>As another example, The compat table for the {{domxref("VRDisplay.capabilities")}} property is generated using <code>\{{Compat("api.VRDisplay.capabilities")}}</code>. The macro call generates the following table (and corresponding set of notes):</p>
+<p>The compatibility data address should be specified in the page front-matter using the <code>browser-compat</code> key.
+  For example, for the {{domxref("AbortController")}} this would be added as shown below:</p>
+  
+<pre>---
+title: AbortController
+slug: Web/API/AbortController
 
-<hr>
-<p>{{Compat("api.VRDisplay.capabilities")}}</p>
+...
 
-<div class="notecard note">
-<p><strong>Note:</strong> The filenames often match the labels given to the interfaces inside the JSON structures, but it is not always the case. When the macro calls generate the tables, they walk through all the files until they find the relevant JSON to use, so the filenames are not critical. Saying that, you should always name them as intuitively as possible.</p>
-</div>
+browser-compat: api.AbortController
+---</pre>
+
+<p>The compatibility and specification tables corresponding to the key are then automatically rendered in place of the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros in the source.</p>
+
+<p>You can also specify the desired API as the first argument to the macro as shown: <code>\{{Compat("api.AbortController")}}</code>. This can be useful if multiple compatibility tables are required on the same page.</p>
+
+<p>The macro calls generate the following tables (and corresponding set of notes):</p>
+
+
+<h4 id="Compatibility_table_example">Compatibility table example</h4>
+
+<p>{{Compat}}</p>
+
+<h4 id="Specifications_table_example">Specifications table examples</h4>
+
+<p>{{Specifications}}</p>

--- a/files/en-us/mdn/structures/compatibility_tables/index.html
+++ b/files/en-us/mdn/structures/compatibility_tables/index.html
@@ -12,7 +12,7 @@ tags:
 
 <p><span class="seoSummary">MDN has a standard format for compatibility tables for our open web documentation; that is, documentation of technologies such as the DOM, HTML, CSS, JavaScript, SVG, and so forth, that are shared across all browsers.</span> This article is a "getting started" guide to how to add to and maintain the database from which the compatibility tables are generated, as well as how to integrate the tables into articles.</p>
 
-<p>For more advanced documentation, as well as the very latest changes to the processes and JSON schemas used to represent the data, take a look at the data repository's <a href="https://github.com/mdn/browser-compat-data/blob/master/docs/contributing.md">contributor guide</a> as well as the <a href="https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md">data guidelines guide</a>.</p>
+<p>For more advanced documentation, as well as the very latest changes to the processes and JSON schemas used to represent the data, take a look at the data repository's <a href="https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md">contributor guide</a> as well as the <a href="https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md">data guidelines guide</a>.</p>
 
 <p>If you have questions or discover problems, you are welcome to <a href="/en-US/docs/MDN/Contribute/Getting_started#step_4_ask_for_help">ask for help</a>.</p>
 
@@ -42,9 +42,9 @@ tags:
 
 <ol>
  <li>
-  <p>Making sure you are in the master branch:</p>
+  <p>Making sure you are in the main branch:</p>
 
-  <pre class="brush: bash">git checkout master</pre>
+  <pre class="brush: bash">git checkout main</pre>
  </li>
  <li>
   <p>fetching the up-to-date repo contents using the following:</p>
@@ -52,9 +52,9 @@ tags:
   <pre class="brush: bash">git fetch upstream</pre>
  </li>
  <li>
-  <p>rebasing the contents of your master with the main repo's contents:</p>
+  <p>rebasing the contents of your main branch with the official repo's contents:</p>
 
-  <pre class="brush: bash">git rebase upstream/master</pre>
+  <pre class="brush: bash">git rebase upstream/main</pre>
  </li>
  <li>
   <p>pushing these updates back to your remote fork using this:</p>
@@ -68,9 +68,9 @@ tags:
 <p>Next, go to your remote fork (it will be at <code>https://github.com/<em>your-username</em>/browser-compat-data</code>) and create a new branch to store your changes for this data addition. This can be done by:</p>
 
 <ol>
- <li>Clicking on the "Branch: Master" button.</li>
+ <li>Clicking on the "Branch: Main" button.</li>
  <li>Entering a new branch name into the "Find or create a branch..." text field.</li>
- <li>Pressing the resulting "Create branch <em>name-of-branch</em> from Master" button.</li>
+ <li>Pressing the resulting "Create branch <em>name-of-branch</em> from Main" button.</li>
 </ol>
 
 <p>For example, if you were wanting to add data for the WebVR API, you'd create a branch called something like "webvr".</p>
@@ -92,13 +92,13 @@ tags:
 <p>To add the data, you need to create a new file or files to store your compat data in. The files you need to create differ, depending on what technology you are working on:</p>
 
 <ul>
- <li><strong><a href="/en-US/docs/Web/HTML">HTML</a>:</strong> One file per HTML element, contained in <a href="https://github.com/mdn/browser-compat-data/tree/master/html/elements">browser-compat-data/html/elements</a>. The file should be called the name of the element, all in lower case, e.g. <code>div.json</code>.</li>
- <li><strong><a href="/en-US/docs/Web/CSS">CSS</a>:</strong> One file per CSS property or selector, contained in the appropriate directory (see <a href="https://github.com/mdn/browser-compat-data/tree/master/css">browser-compat-data/css</a>). The file should be called the name of the feature, all in lower case, e.g. <code>background-color.json</code>, or <code>hover.json</code>.</li>
- <li><strong><a href="/en-US/docs/Web/JavaScript">JS</a>:</strong> One file per JS object, contained in <a href="https://github.com/mdn/browser-compat-data/tree/master/javascript/builtins">browser-compat-data/javascript/builtins</a>. The file should be called the exact name of the object, with the casing preserved, e.g. <code>Date.json</code> or <code>InternalError.json</code>.</li>
- <li><strong><a href="/en-US/docs/Web/API">APIs</a>:</strong> One file per interface contained in the API, put in <a href="https://github.com/mdn/browser-compat-data/tree/master/api">browser-compat-data/api</a>. Each file should be called the exact name of the interface, with the casing preserved, e.g. The WebVR API has <code>VRDisplay.json</code>, <code>VRDisplayCapabilities.json</code>, etc.</li>
+ <li><strong><a href="/en-US/docs/Web/HTML">HTML</a>:</strong> One file per HTML element, contained in <a href="https://github.com/mdn/browser-compat-data/tree/main/html/elements">browser-compat-data/html/elements</a>. The file should be called the name of the element, all in lower case, e.g. <code>div.json</code>.</li>
+ <li><strong><a href="/en-US/docs/Web/CSS">CSS</a>:</strong> One file per CSS property or selector, contained in the appropriate directory (see <a href="https://github.com/mdn/browser-compat-data/tree/main/css">browser-compat-data/css</a>). The file should be called the name of the feature, all in lower case, e.g. <code>background-color.json</code>, or <code>hover.json</code>.</li>
+ <li><strong><a href="/en-US/docs/Web/JavaScript">JS</a>:</strong> One file per JS object, contained in <a href="https://github.com/mdn/browser-compat-data/tree/main/javascript/builtins">browser-compat-data/javascript/builtins</a>. The file should be called the exact name of the object, with the casing preserved, e.g. <code>Date.json</code> or <code>InternalError.json</code>.</li>
+ <li><strong><a href="/en-US/docs/Web/API">APIs</a>:</strong> One file per interface contained in the API, put in <a href="https://github.com/mdn/browser-compat-data/tree/main/api">browser-compat-data/api</a>. Each file should be called the exact name of the interface, with the casing preserved, e.g. The WebVR API has <code>VRDisplay.json</code>, <code>VRDisplayCapabilities.json</code>, etc.</li>
 </ul>
 
-<p>Each file you create has to follow the pattern defined in the schema contained within our repo; you can see the <a href="https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md">detailed schema description here</a>.</p>
+<p>Each file you create has to follow the pattern defined in the schema contained within our repo; you can see the <a href="https://github.com/mdn/browser-compat-data/blob/main/schemas/compat-data-schema.md">detailed schema description here</a>.</p>
 
 <h3 id="Basic_compat_data_structure">Basic compat data structure</h3>
 
@@ -118,14 +118,14 @@ tags:
 
 <p>You have the <code>css</code> object, inside of which is a <code>properties</code> object. Inside the <code>properties</code> object, you need one member for each of the specific features you want to define the compat data for. Each of these members has a <code>__compat</code> member, inside of which the actual data goes.</p>
 
-<p>The above data is found in the <a href="https://github.com/mdn/browser-compat-data/blob/master/css/properties/border-width.json">border-width.json</a> file — compare this to the <a href="/en-US/docs/Web/CSS/border-width#browser_compatibility">rendered border-width support table on MDN</a>.</p>
+<p>The above data is found in the <a href="https://github.com/mdn/browser-compat-data/blob/main/css/properties/border-width.json">border-width.json</a> file — compare this to the <a href="/en-US/docs/Web/CSS/border-width#browser_compatibility">rendered border-width support table on MDN</a>.</p>
 
 <p>Other types of features work in the same way, but with different object names:</p>
 
 <ul>
- <li>CSS selectors work in basically the same way as CSS properties, except that the top-level object structure is <code>css.selectors</code> instead of <code>css.properties</code>. See <a href="https://github.com/mdn/browser-compat-data/blob/master/css/selectors/cue.json">cue.json</a> for an example.</li>
- <li>HTML data works in basically the same way, except that the top-level object structure is <code>html.elements</code>. See <a href="https://github.com/mdn/browser-compat-data/blob/master/html/elements/article.json">article.json</a> for an example.</li>
- <li>The top level object structure for JS built-in objects is <code>javascript.builtins</code>; see <a href="https://github.com/mdn/browser-compat-data/blob/master/javascript/builtins/Array.json">Array.json</a> for an example.</li>
+ <li>CSS selectors work in basically the same way as CSS properties, except that the top-level object structure is <code>css.selectors</code> instead of <code>css.properties</code>. See <a href="https://github.com/mdn/browser-compat-data/blob/main/css/selectors/cue.json">cue.json</a> for an example.</li>
+ <li>HTML data works in basically the same way, except that the top-level object structure is <code>html.elements</code>. See <a href="https://github.com/mdn/browser-compat-data/blob/main/html/elements/article.json">article.json</a> for an example.</li>
+ <li>The top level object structure for JS built-in objects is <code>javascript.builtins</code>; see <a href="https://github.com/mdn/browser-compat-data/blob/main/javascript/builtins/Array.json">Array.json</a> for an example.</li>
 </ul>
 
 <p>In HTML, CSS, and JS pages, you'll normally only need one feature. API interfaces work slightly differently — they always have multiple sub-features (see {{anch("Sub-features")}}, below).</p>
@@ -140,7 +140,7 @@ tags:
  <li><code>status</code>: Contains members reporting the standards track status of this feature.</li>
 </ul>
 
-<p>The names of the browser members are defined in the schema (see <a href="https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#browser-identifiers">Browser identifiers</a>). You should use the full list of currently defined identifiers. If you wish to add another browser, talk to us first, as this could have a wide-ranging impact and should not be done without careful thought.</p>
+<p>The names of the browser members are defined in the schema (see <a href="https://github.com/mdn/browser-compat-data/blob/main/schemas/compat-data-schema.md#browser-identifiers">Browser identifiers</a>). You should use the full list of currently defined identifiers. If you wish to add another browser, talk to us first, as this could have a wide-ranging impact and should not be done without careful thought.</p>
 
 <p>In a basic browser compat data file, you'll only need to include "version_added" inside the browser identifier members (we'll cover {{anch("Adding_data_Advanced_cases", "Adding data: Advanced cases")}} later on). The different values you might want to include are as follows:</p>
 
@@ -159,7 +159,7 @@ tags:
  <li><code>deprecated</code>: This should be set to <code>true</code> if the feature is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>, or <code>false</code> otherwise.</li>
 </ul>
 
-<p>The feature data for <a href="/en-US/docs/Web/CSS/border-width#browser_compatibility">border-width</a> (also see <a href="https://github.com/mdn/browser-compat-data/blob/master/css/properties/border-width.json">border-width.json</a>) is shown below as an example:</p>
+<p>The feature data for <a href="/en-US/docs/Web/CSS/border-width#browser_compatibility">border-width</a> (also see <a href="https://github.com/mdn/browser-compat-data/blob/main/css/properties/border-width.json">border-width.json</a>) is shown below as an example:</p>
 
 <pre class="brush: json">"__compat": {
   "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-width",
@@ -237,7 +237,7 @@ tags:
 
 <p>In a page where the compat table has more than one row, you'll need multiple subfeatures inside each feature to define the information for each row. This can happen, for example, when you've got the basic support for a feature stored in one row, but then the feature also has a new property or value type that was addded much later in the specification's life and is only supported in a couple of browsers.</p>
 
-<p>As an example, see the <a href="https://github.com/mdn/browser-compat-data/blob/master/css/properties/background-color.json">compat data</a> and <a href="/en-US/docs/Web/CSS/background-color">corresponding MDN page</a> for the <code>background-color</code> property. The basic support exists inside the <code>__compat</code> object as explained above, then you have an additional row for browsers' support for "alpha channel for hex values", which contains its own <code>__compat</code> object.</p>
+<p>As an example, see the <a href="https://github.com/mdn/browser-compat-data/blob/main/css/properties/background-color.json">compat data</a> and <a href="/en-US/docs/Web/CSS/background-color">corresponding MDN page</a> for the <code>background-color</code> property. The basic support exists inside the <code>__compat</code> object as explained above, then you have an additional row for browsers' support for "alpha channel for hex values", which contains its own <code>__compat</code> object.</p>
 
 <pre class="brush: json">{
   "css": {
@@ -281,7 +281,7 @@ tags:
   }
 }</pre>
 
-<p>See <a href="https://github.com/mdn/browser-compat-data/blob/master/api/VRDisplay.json">VRDisplay.json</a> for a full example.</p>
+<p>See <a href="https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json">VRDisplay.json</a> for a full example.</p>
 
 <h2 id="Adding_data_Advanced_cases">Adding data: Advanced cases</h2>
 
@@ -289,7 +289,7 @@ tags:
 
 <h3 id="Including_a_footnote">Including a footnote</h3>
 
-<p>Often compat tables will include footnotes related to certain entries that explain useful details or strange behavior that developers will find useful. As an example, the Chrome Android entry for {{domxref("VRDisplay.capabilities")}} (see also <a href="https://github.com/mdn/browser-compat-data/blob/master/api/VRDisplay.json">VRDisplay.json</a>) (at the time of writing) had a footnote "Currently supported only by Google Daydream." To include this in the capabilities data, we added a "notes" submember inside the relevant "chrome_android" submember; it would look like this:</p>
+<p>Often compat tables will include footnotes related to certain entries that explain useful details or strange behavior that developers will find useful. As an example, the Chrome Android entry for {{domxref("VRDisplay.capabilities")}} (see also <a href="https://github.com/mdn/browser-compat-data/blob/main/api/VRDisplay.json">VRDisplay.json</a>) (at the time of writing) had a footnote "Currently supported only by Google Daydream." To include this in the capabilities data, we added a "notes" submember inside the relevant "chrome_android" submember; it would look like this:</p>
 
 <pre class="brush: json">"chrome_android": {
   "version_added": true,
@@ -361,7 +361,7 @@ tags:
 
 <p>Sometimes you'll want to add multiple support data points for the same browser inside the same feature.</p>
 
-<p>As an example, the {{cssxref("text-align-last")}} property (see also <a href="https://github.com/mdn/browser-compat-data/blob/master/css/properties/text-align-last.json">text-align-last.json</a>) was added to Chrome in version 35, supported behind a pref.</p>
+<p>As an example, the {{cssxref("text-align-last")}} property (see also <a href="https://github.com/mdn/browser-compat-data/blob/main/css/properties/text-align-last.json">text-align-last.json</a>) was added to Chrome in version 35, supported behind a pref.</p>
 
 <p>The support mentioned above was then removed in version 47; also in version 47, support was added for <code>text-align-last</code> enabled by default.</p>
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -9,7 +9,8 @@ browser-compat: path.to.feature.NameOfAPI
 ---
 <div>{{MDNSidebar}}</div>
 
-<div class="note">
+<div class="notecard note">
+
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
 <h3 id="Title_and_slug">Title and slug</h3>
@@ -41,7 +42,14 @@ browser-compat: path.to.feature.NameOfAPI
 <p>To fill in the browser compatibility section, you may first need to create/update an entry for the API in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
 
 <p>Then replace the value of the page front-matter section's <code>browser-compat</code> key (at the top of the page) with the path to the API in the browser compatibility data.
-	The toolchain automatically inserts the data in the browser compatibility section (replacing the <code>\{{Compat}}</code> macro).</p>
+	The toolchain automatically inserts the specified compatibility data into the page, replacing the <code>\{{Compat}}</code> macro.</p>
+
+<h3 id="Specifications">Specifications</h3>
+
+<p>Specification data for the API should be included in its <a href="https://github.com/mdn/browser-compat-data">browser-compat-data</a> as part of creating/updating the entry (see <a href="#browser_compatibility">previous section</a>).</p>
+
+<p>Ensure that the page front-matter section's <code>browser-compat</code> key (at the top of the page) has the correct path to the API in the browser compatibility data. 
+	The toolchain automatically inserts the specification data associated with the key into the page, replacing the <code>\{{Specifications}}</code> macro.</p>
 </div>
 
 <div>{{draft}}{{securecontext_header}}{{APIRef("GroupDataName")}}</div>
@@ -101,27 +109,7 @@ browser-compat: path.to.feature.NameOfAPI
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("NameOfOtherSpecificationfromSpecName")}}</td>
-			<td>{{Spec2("NameOfOtherSpecificationFromSpec2")}}</td>
-			<td>Defines blah blah feature. If no other specs define extensions of this API, you can delete this table row.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('NameOfSpecificationFromSpecName')}}</td>
-			<td>{{Spec2('NameOfSpecificationFromSpec2')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -38,9 +38,10 @@ browser-compat: path.to.feature.NameOfAPI
 
 <h3 id="Browser_compatibility">Browser compatibility</h3>
 
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
+<p>To fill in the browser compatibility section, you may first need to create/update an entry for the API in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
 
-<p>Once that is done, you can show the compat data for the API with a \{{Compat}} macro call.</p>
+<p>Then replace the value of the page front-matter section's <code>browser-compat</code> key (at the top of the page) with the path to the API in the browser compatibility data.
+	The toolchain automatically inserts the data in the browser compatibility section (replacing the <code>\{{Compat}}</code> macro).</p>
 </div>
 
 <div>{{draft}}{{securecontext_header}}{{APIRef("GroupDataName")}}</div>

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -39,7 +39,7 @@ browser-compat: path.to.feature.NameOfAPI
 
 <h3 id="Browser_compatibility">Browser compatibility</h3>
 
-<p>To fill in the browser compatibility section, you may first need to create/update an entry for the API in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
+<p>To fill in the browser compatibility section, you may first need to create/update an entry for the API in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
 
 <p>Then replace the value of the page front-matter section's <code>browser-compat</code> key (at the top of the page) with the path to the API in the browser compatibility data.
 	The toolchain automatically inserts the specified compatibility data into the page, replacing the <code>\{{Compat}}</code> macro.</p>

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -54,9 +54,20 @@ tags:
 
 <h3 id="Browser_compatibility">Browser compatibility</h3>
 
-<p>To fill in the browser compatibility section, you may first need to create/update an entry for the API in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
+<p>API landing pages optionally have a browser compatibility section that shows compatibility tables for one or more of the most important interfaces in the API. If the compatibility is similar for most interfaces in the API then often just one compatibility table is needed. If compatibility across the API is complicated/impossible to capture in a few tables, this sections should be omitted.</p>
 
-<p>Insert the query string key for the API (the path to the API in the browser compatibility data) as an argument into the <code>\{{Compat("path.to.feature.NameOfAPI")}}</code> macro.</p>
+<p>To fill in the browser compatibility section, you may first need to create/update entries for the API interfaces in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
+
+<p>Add the <code>\{{Compat("path.to.feature.Interface")}}</code> macro for each interface for which compatibility information is required, replacing the "path.to.feature.Interface" argument with the path to the desired interface in the browser compatibility data.</p>
+
+<h3 id="Specifications">Specifications</h3>
+
+<p>API landing pages optionally have a specifications section that lists the relevant specification(s) for each interface. Often there is just one specification covering all interfaces in the API.</p>
+
+<p>To fill in the specifications section, you may first need to create/update entries for interfaces in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> to include specification data — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
+
+<p>Use the <code>\{{specifications("path.to.feature.Interface")}}</code> macro to add tables for the main specifications.</p>
+
 </div>
 
 <div>{{draft}}{{securecontext_header}}{{APIRef("GroupDataName")}}</div>
@@ -116,31 +127,16 @@ tags:
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-	<thead>
-		<tr>
-			<th scope="col">Specification</th>
-			<th scope="col">Status</th>
-			<th scope="col">Comment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>{{SpecName("NameOfOtherSpecificationfromSpecName")}}</td>
-			<td>{{Spec2("NameOfOtherSpecificationFromSpec2")}}</td>
-			<td>Defines blah blah feature. If no other specs define extensions of this API, you can delete this table row.</td>
-		</tr>
-		<tr>
-			<td>{{SpecName('NameOfSpecificationFromSpecName')}}</td>
-			<td>{{Spec2('NameOfSpecificationFromSpec2')}}</td>
-			<td>Initial definition.</td>
-		</tr>
-	</tbody>
-</table>
+<p>{{Specifications("path.to.feature.Interface_1")}}</p>
+
+<p>{{Specifications("path.to.feature.Interface_2")}}</p>
+
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfAPI")}}</p>
+<p>{{Compat("path.to.feature.Interface_1")}}</p>
+
+<p>{{Compat("path.to.feature.Interface_2")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -5,7 +5,7 @@ tags:
   - API
   - Landing
   - Template
-browser-compat: path.to.feature.NameOfAPI
+
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -13,43 +13,50 @@ browser-compat: path.to.feature.NameOfAPI
 
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
-<h3 id="Title_and_slug">Title and slug</h3>
+<h3 id="Page_front_matter">Page front matter</h3>
 
-<p>An API landing page should have a <em>Title</em> of <em>Name of the API</em> + "API". For example, <a href="/en-US/docs/Web/API/WebVR_API">WebVR</a> has a title of <em>WebVR API</em>, <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> has a title of <em>Fetch API</em>.</p>
+<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.</p>
 
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>Name of the API</em> + "_API". For example, <a href="/en-US/docs/Web/API/WebVR_API">WebVR</a>'s slug is <em>WebVR API</em>. This is usually filled in for you automatically.</p>
+<pre>---
+title: NameOfTheAPI API
+slug: Web/API/NameOfTheAPI_API
+tags:
+  - API
+  - NameOfTheAPI API
+  - Reference
+  - Experimental
+---</pre>
+
+<dl>
+<dt><strong>Title</strong></dt>
+<dd>Title heading displayed at top of page. This is the name of the API followed by the text "API". For example, <a href="/en-US/docs/Web/API/WebVR_API">WebVR</a> has a title of <em>WebVR API</em>, <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> has a title of <em>Fetch API</em>.</dd>
+<dt>slug</dt>
+<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheAPI_API</code></strong>. For example, <a href="/en-US/docs/Web/API/WebVR_API">WebVR</a>'s slug is <code>Web/API/WebVR_API</code>.</dd>
+<dt>tags</dt>
+<dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Landing</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only).</p>
+
+  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
+</dl>
+
 
 <h3 id="Top_macros">Top macros</h3>
 
 <p>There are three macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
 
 <ul>
-	<li>\{{draft}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
-	<li>\{{securecontext_header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
+	<li><code>\{{draft}}</code> — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+	<li><code>\{{securecontext_header}}</code> — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
 	<li>
-	<div>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
+	<div><code>\{{APIRef("<em>GroupDataName</em>")}}</code> — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</div>
 	</li>
 </ul>
 
-<h3 id="Tags">Tags</h3>
-
-<p>In an API landing page, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Landing</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only).</p>
-
-<p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on the WebVR page we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
 
 <h3 id="Browser_compatibility">Browser compatibility</h3>
 
 <p>To fill in the browser compatibility section, you may first need to create/update an entry for the API in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
 
-<p>Then replace the value of the page front-matter section's <code>browser-compat</code> key (at the top of the page) with the path to the API in the browser compatibility data.
-	The toolchain automatically inserts the specified compatibility data into the page, replacing the <code>\{{Compat}}</code> macro.</p>
-
-<h3 id="Specifications">Specifications</h3>
-
-<p>Specification data for the API should be included in its <a href="https://github.com/mdn/browser-compat-data">browser-compat-data</a> as part of creating/updating the entry (see <a href="#browser_compatibility">previous section</a>).</p>
-
-<p>Ensure that the page front-matter section's <code>browser-compat</code> key (at the top of the page) has the correct path to the API in the browser compatibility data. 
-	The toolchain automatically inserts the specification data associated with the key into the page, replacing the <code>\{{Specifications}}</code> macro.</p>
+<p>Insert the query string key for the API (the path to the API in the browser compatibility data) as an argument into the <code>\{{Compat("path.to.feature.NameOfAPI")}}</code> macro.</p>
 </div>
 
 <div>{{draft}}{{securecontext_header}}{{APIRef("GroupDataName")}}</div>
@@ -109,11 +116,31 @@ browser-compat: path.to.feature.NameOfAPI
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Specifications}}</p>
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">Specification</th>
+			<th scope="col">Status</th>
+			<th scope="col">Comment</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName("NameOfOtherSpecificationfromSpecName")}}</td>
+			<td>{{Spec2("NameOfOtherSpecificationFromSpec2")}}</td>
+			<td>Defines blah blah feature. If no other specs define extensions of this API, you can delete this table row.</td>
+		</tr>
+		<tr>
+			<td>{{SpecName('NameOfSpecificationFromSpecName')}}</td>
+			<td>{{Spec2('NameOfSpecificationFromSpec2')}}</td>
+			<td>Initial definition.</td>
+		</tr>
+	</tbody>
+</table>
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat}}</p>
+<p>{{Compat("path.to.feature.NameOfAPI")}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
@@ -14,11 +14,38 @@ browser-compat: path.to.feature.NameOfTheMethod
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
-<h3 id="Title_and_slug">Title and slug</h3>
+<h3 id="Page_front_matter">Page front matter</h3>
 
-<p>An API method subpage should have a <em>title</em> of <em>NameOfTheParentInterface</em> + "." + <em>NameOfTheMethod</em> + "()". For example, the <a href="/en-US/docs/Web/API/IDBIndex/count">count()</a> method of the <a href="/en-US/docs/Web/API/IDBIndex">IDBIndex</a> interface has a <em>title</em> of "IDBIndex.count()".</p>
+<p>The page frontmatter at the top of the page is where page metadata is defined. The values should be updated appropriately for the particular method.</p>
 
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheMethod</em> without the parentheses, so the slug for <code>count()</code> ends with "count".</p>
+<pre>---
+title: NameOfTheParentInterface.NameOfTheMethod()
+slug: Web/API/NameOfTheParentInterface/NameOfTheMethod
+tags:
+  - API
+  - NameOfTheMethod
+  - Method
+  - Reference
+  - Experimental
+
+browser-compat: path.to.feature.NameOfTheMethod
+---</pre>
+
+<dl>
+<dt><strong>Title</strong></dt>
+<dd>Title heading displayed at top of page. Format as <em>NameOfTheParentInterface</em><strong>.</strong><em>NameOfTheMethod</em><strong>()</strong>. For example, the <a href="/en-US/docs/Web/API/IDBIndex/count">count()</a> method of the <a href="/en-US/docs/Web/API/IDBIndex">IDBIndex</a> interface has a <em>title</em> of "IDBIndex.count()".</dd>
+<dt>slug</dt>
+<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface/NameOfTheMethod</code>. Note that the name of the method in the slug omits the parenthesis (it ends in "NameOfTheMethod" not "NameOfTheMethod()").</dd>
+<dt>tags</dt>
+<dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Method</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>IDBIndex</strong>), the name of the method (e.g. <strong>count()</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+
+  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
+<dt>browser-compat</dt>
+<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheMethod</code> with the query string for the method in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+  
+  <p>Note that you may first need to create/update an entry for the API method in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+</dl>
+
 
 <h3 id="Top_macros">Top macros</h3>
 
@@ -32,24 +59,6 @@ browser-compat: path.to.feature.NameOfTheMethod
  <li><code>\{{Deprecated_Header}}</code> — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
 </ul>
 
-<h3 id="Tags">Tags</h3>
-
-<p>In an API method subpage, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Method</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the parent interface (e.g. <strong>IDBIndex</strong>), the name of the method (e.g. <strong>count()</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
-
-<h3 id="Browser_compatibility_frontmatter">Browser compatibility frontmatter</h3>
-
-<p>Update the page front-matter section's <code>browser-compat</code> key (at the top of the page), replacing the placeholder value "path.to.feature.NameOfTheMethod" with the query string for the method in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically inserts the compatibility data for the specified string into the page, in place of the <code>\{{Compat}}</code> macro.</p>
-  
-<p>Note that you may first need to create/update an entry for the API method (or the whole API) in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
-
-<h3 id="Specifications">Specifications</h3>
-
-<p>Ensure that the page front-matter section's <code>browser-compat</code> key has the correct query string for the method in the browser compatibility data (as discussed in th section above).
-	The toolchain automatically inserts the specification data associated with the key into the page, replacing the <code>\{{Specifications}}</code> macro.</p>
-
-<p>Note that this assumes that specification data for the method's API is included in its <a href="https://github.com/mdn/browser-compat-data">browser-compat-data</a>. If not, see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to add specification infomration to compatibility tables</a>.</p>
 </div>
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_header}}{{Deprecated_Header}}</p>

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
@@ -18,18 +18,18 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 <p>An API method subpage should have a <em>title</em> of <em>NameOfTheParentInterface</em> + "." + <em>NameOfTheMethod</em> + "()". For example, the <a href="/en-US/docs/Web/API/IDBIndex/count">count()</a> method of the <a href="/en-US/docs/Web/API/IDBIndex">IDBIndex</a> interface has a <em>title</em> of "IDBIndex.count()".</p>
 
-<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheMethod</em> without the parentheses, so <code>count()</code>'s slug is "count".</p>
+<p>The <em>Slug</em> (the last segment at the end of the URL) should be filled in as <em>NameOfTheMethod</em> without the parentheses, so the slug for <code>count()</code> ends with "count".</p>
 
 <h3 id="Top_macros">Top macros</h3>
 
 <p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
 
 <ul>
- <li>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
- <li>\{{Draft}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
- <li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
- <li>\{{SecureContext_Header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
- <li>\{{Deprecated_Header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
+ <li><code>\{{APIRef("<em>GroupDataName</em>")}}</code> — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
+ <li><code>\{{Draft}}</code> — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+ <li><code>\{{SeeCompatTable}}</code> — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
+ <li><code>\{{SecureContext_Header}}</code> — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
+ <li><code>\{{Deprecated_Header}}</code> — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
 </ul>
 
 <h3 id="Tags">Tags</h3>
@@ -38,11 +38,18 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 <p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
 
-<h3 id="Browser_compatibility">Browser compatibility</h3>
+<h3 id="Browser_compatibility_frontmatter">Browser compatibility frontmatter</h3>
 
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
+<p>Update the page front-matter section's <code>browser-compat</code> key (at the top of the page), replacing the placeholder value "path.to.feature.NameOfTheMethod" with the query string for the method in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically inserts the compatibility data for the specified string into the page, in place of the <code>\{{Compat}}</code> macro.</p>
+  
+<p>Note that you may first need to create/update an entry for the API method (or the whole API) in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p>
 
-<p>Once that is done, you can show the compat data for the method with a \{{Compat()}} macro call.</p>
+<h3 id="Specifications">Specifications</h3>
+
+<p>Ensure that the page front-matter section's <code>browser-compat</code> key has the correct query string for the method in the browser compatibility data (as discussed in th section above).
+	The toolchain automatically inserts the specification data associated with the key into the page, replacing the <code>\{{Specifications}}</code> macro.</p>
+
+<p>Note that this assumes that specification data for the method's API is included in its <a href="https://github.com/mdn/browser-compat-data">browser-compat-data</a>. If not, see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to add specification infomration to compatibility tables</a>.</p>
 </div>
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_header}}{{Deprecated_Header}}</p>
@@ -91,24 +98,9 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("NameOfSpecificationFromSpecName", "#document-fragment-linking-directly-to-method-definition", "NameOfTheMethod")}}</td>
-   <td>{{Spec2("NameOfSpecificationFromSpec2")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
-<h2 id="Browser_compatibility_2">Browser compatibility</h2>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat}}</p>
 

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
@@ -16,7 +16,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 <h3 id="Page_front_matter">Page front matter</h3>
 
-<p>The page frontmatter at the top of the page is where page metadata is defined. The values should be updated appropriately for the particular method.</p>
+<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular method.</p>
 
 <pre>---
 title: NameOfTheParentInterface.NameOfTheMethod()
@@ -27,7 +27,6 @@ tags:
   - Method
   - Reference
   - Experimental
-
 browser-compat: path.to.feature.NameOfTheMethod
 ---</pre>
 

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.html
@@ -4,7 +4,7 @@ slug: MDN/Structures/Page_types/API_reference_page_template
 tags:
   - API
   - Template
-  - reference page
+  - Reference
 browser-compat: path.to.feature.NameOfTheInterface
 ---
 <p>{{MDNSidebar}}</p>
@@ -12,36 +12,50 @@ browser-compat: path.to.feature.NameOfTheInterface
 <div class="notecard note">
 <h2 id="Remove_before_publishing">Remove before publishing</h2>
 
-<h3 id="Title_and_slug">Title and slug</h3>
+<h3 id="Page_front_matter">Page front matter</h3>
 
-<p>An API reference page should have a <em>Title</em> of <em>Name of the interface the page is about</em>. For example, the <a href="/en-US/docs/Web/API/Request">Request</a> interface page has a <em>title</em> of <em>Request</em>.</p>
+<p>The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.</p>
 
-<p>The <em>Slug</em> (the last segment at the end of the URL) should also be filled in as <em>Name of the interface the page is about</em>, so <code>Request</code>'s slug is <em>Request</em>. This is usually filled in for you automatically.</p>
+<pre>---
+title: NameOfTheInterface
+slug: Web/API/NameOfTheInterface
+tags:
+  - API
+  - NameOfTheInterface
+  - NameOfTheAPI
+  - Reference
+  - Experimental
+
+browser-compat: path.to.feature.NameOfTheInterface
+---</pre>
+
+<dl>
+<dt><strong>Title</strong></dt>
+<dd>Title heading displayed at top of page. This is just the name of the interface. For example, the <a href="/en-US/docs/Web/API/Request">Request</a> interface page has a <em>title</em> of <em>Request</em>.</dd>
+<dt>slug</dt>
+<dd>The end of the URL path after <code>https://developer.mozilla.org/en-US/docs/</code>). This will be formatted like <code>Web/API/NameOfTheParentInterface</code>. For example, <a href="/en-US/docs/Web/API/Request">Request</a> slug is "Web/API/Request".</dd>
+<dt>tags</dt>
+<dd><p>Include the following tags: <strong>API</strong>, <strong>Reference</strong>, <strong>Interface</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the interface (e.g. <strong>Request</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
+
+  <p>Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p></dd>
+<dt>browser-compat</dt>
+<dd><p>Replace the placeholder value <code>path.to.feature.NameOfTheMethod</code> with the query string for the method in the <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>. The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the <code>\{{Compat}}</code> and <code>\{{Specifications}}</code> macros).</p>
+  
+  <p>Note that you may first need to create/update an entry for the API method in our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a>, and the entry for the API will need to include specification information. See our <a href="/en-US/docs/MDN/Structures/Compatibility_tables">guide on how to do this</a>.</p></dd>
+</dl>
 
 <h3 id="Top_macros">Top macros</h3>
 
 <p>There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:</p>
 
 <ul>
- <li>\{{APIRef("<em>GroupDataName</em>")}} — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
- <li>\{{Draft}} — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
- <li>\{{SeeCompatTable}} — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
- <li>\{{SecureContext_Header}} — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
- <li>\{{Deprecated_Header}} — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
- <li>\{{Interface_Overview("<em>GroupDataName</em>")}} {{Experimental_Inline}} — this generates the main body of the page (Constructor, Properties, Methods and Events).</li>
+ <li><code>\{{APIRef("<em>GroupDataName</em>")}}</code> — this generates the left hand reference sidebar showing quick reference links related to the current page. For example, every page in the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of <em>GroupDataName</em>. See our <a href="/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars">API reference sidebars</a> guide for information on how to do this.</li>
+ <li><code>\{{Draft}}</code> — this generates a <strong>Draft</strong> banner that indicates that the page is not yet complete, and should only be removed when the first draft of the page is completely finished. After it is ready to be published, you can remove this.</li>
+ <li><code>\{{SeeCompatTable}}</code> — this generates a <strong>This is an experimental technology</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the <a href="/en-US/docs/Mozilla/Firefox/Experimental_features">Experimental features in Firefox</a> page.</li>
+ <li><code>\{{SecureContext_Header}}</code> — this generates a <strong>Secure context</strong> banner that indicates the technology is only available in a <a href="/en-US/docs/Web/Security/Secure_Contexts">secure context</a>. If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the <a href="/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts">Features restricted to secure contexts</a> page.</li>
+ <li><code>\{{Deprecated_Header}}</code> — this generates a <strong>Deprecated</strong> banner that indicates the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>. If it isn't, then you can remove the macro call.</li>
+ <li><code>\{{Interface_Overview("<em>GroupDataName</em>")}} {{Experimental_Inline}}</code> — this generates the main body of the page (Constructor, Properties, Methods and Events).</li>
 </ul>
-
-<h3 id="Tags">Tags</h3>
-
-<p>In an API reference page, you need to include the following tags (see the <em>Tags</em> section at the bottom of the editor UI): <strong>API</strong>, <strong>Reference</strong>, <strong>Interface</strong>, <em>the name of the API</em> (e.g. <strong>WebVR</strong>), the name of the interface (e.g. <strong>Request</strong>), <strong>Experimental</strong> (if the technology is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental">experimental</a>), <strong>Secure context</strong> (if it is available in a secure context only), and <strong>Deprecated</strong> (if it is <a href="/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete">deprecated</a>).</p>
-
-<p>Optionally, you can elect to include some other tags that effective represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include <strong>VR</strong> and <strong>Virtual reality</strong>.</p>
-
-<h3 id="Browser_compatibility">Browser compatibility</h3>
-
-<p>To fill in the browser compat data, you first need to fill in an entry for the API into our <a href="https://github.com/mdn/browser-compat-data">Browser compat data repo</a> — see our <a href="/en-US/docs/MDN/Structures/Compatibility_tables#the_new_way_the_browser_compat_data_repo_and_dynamic_tables">guide on how to do this</a>.</p>
-
-<p>Once that is done, you can show the compat data for the interface with a \{{Compat(…)}} macro call.</p>
 </div>
 
 <p>{{APIRef("GroupDataName")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_Header}}{{Deprecated_Header}}</p>
@@ -110,27 +124,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("NameOfOtherSpecification", "#document-fragment-linking-directly-to-feature-definition", "NameOfTheFeature")}}</td>
-   <td>{{Spec2("NameOfOtherSpecification")}}</td>
-   <td>Defines blah blah feature. If no other specs define specific subfeatures of this interface, you can delete this table row.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("NameOfSpecification", "#document-fragment-linking-directly-to-interface-definition", "NameOfTheInterface")}}</td>
-   <td>{{Spec2("NameOfSpecification")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 

--- a/files/en-us/web/api/abortcontroller/index.html
+++ b/files/en-us/web/api/abortcontroller/index.html
@@ -66,7 +66,7 @@ function fetchVideo() {
   })
 }</pre>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note</strong>: When <code>abort()</code> is called, the <code>fetch()</code> promise rejects with a <code>DOMException</code> named <code>AbortError</code>.</p>
 </div>
 
@@ -74,20 +74,7 @@ function fetchVideo() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-abortcontroller', 'AbortController')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
The new way of doing browser compatibility sections is to list the BCD path in the page frontmatter `browser-compat` key and just use `{{Compat}}` as a placeholder. Also we no longer have hidden sections.

This fixes just one template: https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_landing_page_template. If this is merged I'll do the other MDN instructional docs/templates - e.g. https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/SVG_element_page_template

This follows follows on naturally from https://github.com/mdn/content/pull/4398 and https://github.com/mdn/content/issues/2228

@wbamberg @Elchi3 Sanity check would be good :-)