### PR TITLE
Fixes #5143

### DIFF
--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.html
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.html
@@ -86,7 +86,7 @@ function multiplyMatrixAndPoint(matrix, point) {
 }
 </pre>
 
-<p>Now using the function above we can multiply a point by the matrix. Using the identity matrix it should return a matrix identical to the original, since a matrix multiplied by the identity matrix is always equal to itself:</p>
+<p>Now using the function above we can multiply a point by the matrix. Using the identity matrix it should return a point identical to the original, since a point (or any other matrix) multiplied by the identity matrix is always equal to itself:</p>
 
 <pre class="brush: js">// sets identityResult to [4,3,2,1]
 let identityResult = multiplyMatrixAndPoint(identityMatrix, [4, 3, 2, 1]);


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
See 5143 that requests referring to a point instead of a matrix to go with the flow in the previous sentence

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Matrix_math_for_the_web

> Issue number (if there is an associated issue)
#5143 
> Anything else that could help us review it
