### PR TITLE
navigator.getBattery() is not deprecated

### DIFF
--- a/files/en-us/web/api/navigator/getbattery/index.html
+++ b/files/en-us/web/api/navigator/getbattery/index.html
@@ -10,7 +10,7 @@ tags:
 - Reference
 - getBattery
 ---
-<div>{{ ApiRef("Battery API") }}{{deprecated_header}}</div>
+<div>{{ ApiRef("Battery API") }}</div>
 
 <p>The <strong><code>getBattery()</code></strong> method provides information about the
   system's battery. It returns a battery promise, which is resolved in a

--- a/files/en-us/web/api/navigator/getbattery/index.html
+++ b/files/en-us/web/api/navigator/getbattery/index.html
@@ -2,13 +2,13 @@
 title: Navigator.getBattery()
 slug: Web/API/Navigator/getBattery
 tags:
-- API
-- Battery API
-- Device API
-- Method
-- Navigator
-- Reference
-- getBattery
+  - API
+  - Battery API
+  - Device API
+  - Method
+  - Navigator
+  - Reference
+  - getBattery
 ---
 <div>{{ ApiRef("Battery API") }}</div>
 
@@ -16,7 +16,7 @@ tags:
   system's battery. It returns a battery promise, which is resolved in a
   {{domxref("BatteryManager")}} object providing also some new events you can handle to
   monitor the battery status. This implements the <a
-    href="/en-US/docs/WebAPI/Battery_Status">Battery Status API</a>; see that
+    href="/en-US/docs/Web/API/Battery_Status_API">Battery Status API</a>; see that
   documentation for additional details, a guide to using the API, and sample code.</p>
 
 <div class="notecard note">
@@ -103,7 +103,7 @@ navigator.getBattery().then(function(battery) {
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/WebAPI/Battery_Status">Battery Status API</a></li>
+  <li><a href="/en-US/docs/Web/API/Battery_Status_API">Battery Status API</a></li>
   <li><code>Feature-Policy</code> {{HTTPHeader("Feature-Policy/battery", "battery")}}
     feature</li>
 </ul>

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -134,6 +134,8 @@ tags:
  <dd>Returns <code>true</code> if a call to <code>Navigator.share()</code> would succeed.</dd>
  <dt>{{domxref("Navigator.clearAppBadge()")}}</dt>
  <dd>Clears a badge on the current app's icon and returns a {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}}.</dd>
+ <dt>{{domxref("Navigator.getBattery()")}}</dt>
+ <dd>Returns a promise that resolves to a {{domxref("BatteryManager")}} object that you can use to get information about the battery charging status.</dd>
  <dt>{{domxref("Navigator.registerProtocolHandler()")}}</dt>
  <dd>Allows web sites to register themselves as a possible handler for a given protocol.</dd>
  <dt>{{domxref("Navigator.requestMediaKeySystemAccess()")}}</dt>

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -135,7 +135,7 @@ tags:
  <dt>{{domxref("Navigator.clearAppBadge()")}}</dt>
  <dd>Clears a badge on the current app's icon and returns a {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}}.</dd>
  <dt>{{domxref("Navigator.getBattery()")}}</dt>
- <dd>Returns a promise that resolves to a {{domxref("BatteryManager")}} object that you can use to get information about the battery charging status.</dd>
+ <dd>Returns a promise that resolves with a {{domxref("BatteryManager")}} object that returns information about the battery charging status.</dd>
  <dt>{{domxref("Navigator.registerProtocolHandler()")}}</dt>
  <dd>Allows web sites to register themselves as a possible handler for a given protocol.</dd>
  <dt>{{domxref("Navigator.requestMediaKeySystemAccess()")}}</dt>


### PR DESCRIPTION
Fixes #5200

This removes the deprecation notice on https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getBattery and also adds a link to this method from the parent (`Navigator`).

The BCD previously also incorrectly marked this as deprecated. That was fixed in https://github.com/mdn/browser-compat-data/pull/9626 : "Don't claim it's deprecated, https://w3c.github.io/battery/ is still a "real" spec and Chromium hasn't deprecated it."
