### PR TITLE
Default image accept value Safari includes webp in big sur

### DIFF
--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.html
@@ -86,7 +86,10 @@ tags:
   </tr>
   <tr>
    <td>Safari</td>
-   <td><code>image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5</code></td>
+   <td>
+     <p><code>image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5</code> (since macOS Big Sur)</p>
+     <p><code>image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5</code> (before macOS Big Sur)</p>
+  </td>
    <td></td>
   </tr>
   <tr>


### PR DESCRIPTION
Fixes #5190 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values#values_for_an_image

[macOS Big Sur added support for WebP](https://9to5mac.com/2020/06/24/apple-adds-webp-hdr-support-and-more-to-safari-with-ios-14-and-macos-big-sur/), which changed the default image accept string as per the linked item. 

This adds the new string, and clarifies the different strings in each version.