### PR TITLE
Remove use of Page macro NSS functions

### DIFF
--- a/files/en-us/mozilla/projects/nss/reference/nss_functions/index.html
+++ b/files/en-us/mozilla/projects/nss/reference/nss_functions/index.html
@@ -4,34 +4,22 @@ slug: Mozilla/Projects/NSS/Reference/NSS_functions
 tags:
   - NSS
 ---
-<p>This page lists all exported functions in NSS 3.11.7 It was ported from <a href="http://www-archive.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html">here</a>.</p>
-<p>This is a <a href="http://meta.wikimedia.org/wiki/Help:Template#Composite_pages">composite page</a>. Section headings are links to the individual pages where you can edit them.</p>
-<p>Keywords:</p>
+<p>This page links all exported functions in NSS 3.11.7 (it was ported from <a href="https://www-archive.mozilla.org/projects/security/pki/nss/ref/nssfunctions.html">here</a>).</p>
+
+
+
 <ul>
-  <li>Deprecated - function should no longer be used.</li>
-  <li>Updated - function has new arguments such as new flag or addition to structure.</li>
+  <li><a id="SSL_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/SSL_functions">SSL functions</a></li>
+  <li><a id="Deprecated_SSL_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/Deprecated_SSL_functions">Deprecated SSL functions</a></li>
+  <li><a id="Certificate_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/Certificate_functions">Certificate functions</a></li>
+  <li><a id="Cryptography_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/Cryptography_functions">Cryptography functions</a></li>
+  <li><a id="Utility_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/Utility_functions">Utility functions</a></li>
+  <li><a id="S.2FMIME_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/S_MIME_functions">S/MIME functions</a></li>
+  <li><a id="PKCS_.237_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/PKCS_7_functions">PKCS #7 functions</a></li>
+  <li><a id="PKCS_.2312_functions"></a> <a href="/en-US/docs/Mozilla/Projects/NSS/PKCS_12_functions">PKCS #12 functions</a></li>
 </ul>
-<h2 id="SSL_functions"><a href="/en-US/docs/NSS/SSL_functions">SSL functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/SSL_functions")}}</div>
-<h2 id="Deprecated_SSL_functions"><a href="/en-US/docs/NSS/Deprecated_SSL_functions">Deprecated SSL functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/Deprecated_SSL_functions")}}</div>
-<h2 id="Certificate_functions"><a href="/en-US/docs/NSS/Certificate_functions">Certificate functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/Certificate_functions")}}</div>
-<h2 id="Cryptography_functions"><a href="/en-US/docs/NSS/Cryptography_functions">Cryptography functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/Cryptography_functions")}}</div>
-<h2 id="Utility_functions"><a href="/en-US/docs/NSS/Utility_functions">Utility functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/Utility_functions")}}</div>
-<h2 id="S.2FMIME_functions"><a href="/en-US/docs/NSS/S_MIME_functions">S/MIME functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/S//MIME_functions")}}</div>
-<h2 id="PKCS_.237_functions"><a href="/en-US/docs/NSS/PKCS_7_functions">PKCS #7 functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/PKCS_7_functions")}}</div>
-<h2 id="PKCS_.2312_functions"><a href="/en-US/docs/NSS/PKCS_12_functions">PKCS #12 functions</a></h2>
-<div>
-  {{page("/en-US/docs/NSS/PKCS_12_functions")}}</div>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>Deprecated functions should no longer be used. Updated functions have new arguments such as new flag or addition to structure.</p>
+</div>


### PR DESCRIPTION
Part of fixing #3196

Removes the (broken) page macro links in https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Reference/NSS_functions and replaces with a flat list of links to the desired pages.