### PR TITLE
fix an image to appear inline in Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.html
@@ -204,7 +204,7 @@ chrome.runtime.onMessage.addListener(notify);
 <p><img alt="" src="disable-autohide.png" style="display: block; margin-left: auto; margin-right: auto;">Now, when you open a panel in Firefox, it will stay open until you press Escape.</p>
 
 <div class="notecard note">
-<p>Note that this change applies to <a href="/en-US/docs/Tools/Browser_Toolbox#debugging_popups">built-in browser popups</a>, like the Hamburger menu (<img alt="" src="hamburger.png">), as well as extension popups.</p>
+<p>Note that this change applies to <a href="/en-US/docs/Tools/Browser_Toolbox#debugging_popups">built-in browser popups</a>, like the Hamburger menu (<img alt="" src="hamburger.png" style="display: inline-block; vertical-align: middle;">), as well as extension popups.</p>
 
 <p>Also note that the change is persistent, even across browser restarts. We're working on addressing this in <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1251658">bug 1251658</a>, but until then you may prefer to re-enable autohide by clicking the button again before you close the Browser Toolbox.</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

An icon image of a humberger menu is appearing as a block. However it should be as a inline.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)
