### PR TITLE
AudioNode.ChannelInterpretation: remove page macro

### DIFF
--- a/files/en-us/web/api/audionode/channelinterpretation/index.html
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.html
@@ -8,25 +8,36 @@ tags:
   - Reference
   - Web Audio API
   - channelInterpretation
+browser-compat: api.AudioNode.channelInterpretation
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<p>The <strong><code>channelInterpretation</code></strong> property of the {{ domxref("AudioNode") }} interface represents an enumerated value describing the meaning of the channels. This interpretation will define how audio <a href="/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing">up-mixing and down-mixing</a> will happen.</p>
+<p>The <strong><code>channelInterpretation</code></strong> property of the {{domxref("AudioNode")}} interface represents an enumerated value describing how input channels are mapped to output channels when the number of inputs/outputs is different. For example, this setting defines how a mono input will be up-mixed to a stereo or 5.1 channel output, or how a quad channel input will be down-mixed to a stereo or mono output.</p>
 
-<p>{{page("/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API","Up-mixing and down-mixing")}}</p>
+<p>The property has two options: <code>speakers</code> and <code>discrete</code>. These are documented in <a href="/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing">Basic concepts behind Web Audio API > up-mixing and down-mixing</a>.</p>
+
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js;highlight[2]">var oscillator = audioCtx.createOscillator();
+<pre class="brush: js">var oscillator = audioCtx.createOscillator();
 oscillator.channelInterpretation = 'discrete';</pre>
 
 <h3 id="Value">Value</h3>
 
-<p>An enumerated value representing a <a href="https://webaudio.github.io/web-audio-api/#idl-def-ChannelInterpretation">channelInterpretation</a>.</p>
+<p>The values are documented in <a href="/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing">Basic concepts behind Web Audio API > up-mixing and down-mixing</a>.</p>
+
+<p>In summary:</p>
+<dl>
+  <dt><code>speakers</code></dt>
+  <dd>Use set of "standard" mappings for combinations of common speaker input and outputs setups (mono, stereo, quad, 5.1). For example, with this setting a mono channel input will output to both channels of a stereo output.</dd>
+  <dt><code>discrete</code></dt>
+  <dd>Input channels are mapped to output channels in order. If there are more inputs that outputs the additional inputs are dropped; if there are fewer then the unused outputs are silent.</dd>
+</dl>
+
 
 <h2 id="Example">Example</h2>
 
-<pre class="brush: js;highlight[11]">var AudioContext = window.AudioContext || window.webkitAudioContext;
+<pre class="brush: js">var AudioContext = window.AudioContext || window.webkitAudioContext;
 
 var audioCtx = new AudioContext();
 
@@ -41,24 +52,11 @@ oscillator.channelInterpretation = 'discrete';
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-audionode-channelinterpretation', 'channelInterpretation')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.channelInterpretation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.html
@@ -311,13 +311,13 @@ var buffer = context.createBuffer(1, 22050, 22050);</pre>
 
 <dl>
  <dt>{{domxref("AnalyserNode.getFloatFrequencyData()")}}</dt>
- <dd>Copies the current frequency data into a {{domxref("Float32Array")}} array passed into it.</dd>
+ <dd>Copies the current frequency data into a {{jsxref("Float32Array")}} array passed into it.</dd>
  <dt>{{domxref("AnalyserNode.getByteFrequencyData()")}}</dt>
- <dd>Copies the current frequency data into a {{domxref("Uint8Array")}} (unsigned byte array) passed into it.</dd>
+ <dd>Copies the current frequency data into a {{jsxref("Uint8Array")}} (unsigned byte array) passed into it.</dd>
  <dt>{{domxref("AnalyserNode.getFloatTimeDomainData()")}}</dt>
- <dd>Copies the current waveform, or time-domain, data into a {{domxref("Float32Array")}} array passed into it.</dd>
+ <dd>Copies the current waveform, or time-domain, data into a {{jsxref("Float32Array")}} array passed into it.</dd>
  <dt>{{domxref("AnalyserNode.getByteTimeDomainData()")}}</dt>
- <dd>Copies the current waveform, or time-domain, data into a {{domxref("Uint8Array")}} (unsigned byte array) passed into it.</dd>
+ <dd>Copies the current waveform, or time-domain, data into a {{jsxref("Uint8Array")}} (unsigned byte array) passed into it.</dd>
 </dl>
 
 <div class="note">


### PR DESCRIPTION
Partial fix to #3196

[AudioNode.ChannelInterpretation](https://developer.mozilla.org/en-US/docs/Web/API/AudioNode/channelInterpretation) was pulling in the table of values for that method from https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing

Again, the values would be useful alongside this method. However not worth including. What I have done though is improved the description here/summary of what the values actually *mean* because without the table the description is insufficient.

I also took the time to link to BCD for the compatibility table and spec. 
