### PR TITLE
Remove Page macro: ScriptProcessorNode examples

### DIFF
--- a/files/en-us/web/api/audioprocessingevent/index.html
+++ b/files/en-us/web/api/audioprocessingevent/index.html
@@ -8,13 +8,14 @@ tags:
   - Internationalization
   - Reference
   - Web Audio API
+browser-compat: api.AudioProcessingEvent
 ---
 <p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
 
 <p><span class="seoSummary">The <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> <code>AudioProcessingEvent</code> represents events that occur when a {{domxref("ScriptProcessorNode")}} input buffer is ready to be processed.</span></p>
 
-<div class="note">
-<p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by <a href="https://webaudio.github.io/web-audio-api/#audioworklet">AudioWorklet</a>.</p>
+<div class="notecard note">
+  <p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by <a href="https://webaudio.github.io/web-audio-api/#audioworklet">AudioWorklet</a>.</p>
 </div>
 
 <h2 id="Properties">Properties</h2>
@@ -72,11 +73,11 @@ tags:
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createScriptProcessor","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example"><code>BaseAudioContext.createScriptProcessor()</code></a> for example code that uses an <code>AudioProcessingEvent</code>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioProcessingEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.html
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.html
@@ -8,14 +8,15 @@ tags:
   - ScriptProcessorNode
   - Web Audio API
   - bufferSize
+browser-compat: api.ScriptProcessorNode.bufferSize
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
-<div class="note">
-<p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by <a href="/en-US/docs/Web/API/Web_Audio_API#audio_workers">Audio Workers</a>.</p>
+<div class="notecard note">
+  <p><strong>Note</strong>: As of the August 29 2014 Web Audio API spec publication, this feature has been marked as deprecated, and is soon to be replaced by <a href="/en-US/docs/Web/API/Web_Audio_API#audio_workers">Audio Workers</a>.</p>
 </div>
 
-<div>
+
 <p>The <code>bufferSize</code> property of the {{domxref("ScriptProcessorNode")}} interface returns an integer representing both the input and output buffer size, in sample-frames. Its value can be a power of 2 value in the range <code>256</code>–<code>16384</code>.</p>
 
 <h2 id="Syntax">Syntax</h2>
@@ -27,11 +28,10 @@ console.log(scriptNode.bufferSize);</pre>
 <h3 id="Value">Value</h3>
 
 <p>An integer.</p>
-</div>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createScriptProcessor","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example"><code>BaseAudioContext.createScriptProcessor()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -52,7 +52,7 @@ console.log(scriptNode.bufferSize);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ScriptProcessorNode.bufferSize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/index.html
+++ b/files/en-us/web/api/scriptprocessornode/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - ScriptProcessorNode
   - Web Audio API
+browser-compat: api.ScriptProcessorNode
 ---
 <p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createScriptProcessor","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example"><code>BaseAudioContext.createScriptProcessor()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ScriptProcessorNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
+++ b/files/en-us/web/api/scriptprocessornode/onaudioprocess/index.html
@@ -8,6 +8,7 @@ tags:
   - ScriptProcessorNode
   - Web Audio API
   - onaudioprocess
+browser-compat: api.ScriptProcessorNode.onaudioprocess
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -27,7 +28,7 @@ scriptNode.onaudioprocess = function() { ... }</pre>
 
 <h2 id="Example">Example</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioContext.createScriptProcessor","Example")}}</p>
+<p>See <a href="/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example"><code>BaseAudioContext.createScriptProcessor()</code></a> for example code.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -48,7 +49,7 @@ scriptNode.onaudioprocess = function() { ... }</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ScriptProcessorNode.onaudioprocess")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Partial fix to : #3196

Replaces inclusion of example at [BaseAudioContext.createScriptProcessor](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createScriptProcessor#example) with linking for ScriptProcessorNode and a few other pages (e.g.).

Note, as last time we did this @wbamberg I haven't tried to create or find a great example. Merely to remove the unwanted inclusion in a way that is no worse than the current situation. While I was here took the time to import BCD in page frontmatter.
