### PR TITLE
AudioWorkletProcessor.parameterDescriptors remove Page macro from example

### DIFF
--- a/files/en-us/web/api/audioworkletnode/parameters/index.html
+++ b/files/en-us/web/api/audioworkletnode/parameters/index.html
@@ -9,6 +9,8 @@ tags:
 - Property
 - Reference
 - Web Audio API
+
+browser-compat: api.AudioWorkletNode.parameters
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -97,25 +99,11 @@ gainParam.linearRampToValueAtTime(0.5, audioContext.currentTime + 0.5)
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>{{SpecName('Web Audio API', '#dom-audioworkletnode-parameters', 'parameters')}}
-      </td>
-      <td>{{Spec2('Web Audio API')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletNode.parameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.html
@@ -2,27 +2,27 @@
 title: AudioWorkletProcessor.parameterDescriptors (static getter)
 slug: Web/API/AudioWorkletProcessor/parameterDescriptors
 tags:
-- API
-- AudioWorkletProcessor
-- Experimental
-- Property
-- Reference
-- parameterDescriptors
+  - API
+  - AudioWorkletProcessor
+  - Experimental
+  - Property
+  - Reference
+  - parameterDescriptors
+
+browser-compat: api.AudioWorkletProcessor.parameterDescriptors
 ---
 <div>{{APIRef("Web Audio API")}}{{SeeCompatTable}}</div>
 
-<p class="summary">The read-only <strong><code>parameterDescriptors</code></strong>
-  property of an {{domxref("AudioWorkletProcessor")}}-derived class is a <em>static
-    getter</em>, which returns an iterable of {{domxref("AudioParamDescriptor")}}-based
-  objects.</p>
+<p>The read-only <strong><code>parameterDescriptors</code></strong> property of an {{domxref("AudioWorkletProcessor")}}-derived class is a <em>static getter</em>,
+  which returns an iterable of {{domxref("AudioParamDescriptor")}}-based objects.</p>
 
-<p class="summary">The property is not a part of the {{domxref("AudioWorkletProcessor")}}
+<p>The property is not a part of the {{domxref("AudioWorkletProcessor")}}
   interface, but, if defined, it is called internally by the
   {{domxref("AudioWorkletProcessor")}} constructor to create a list of custom
   {{domxref("AudioParam")}} objects in the {{domxref("AudioWorkletNode.parameters",
   "parameters")}} property of the associated {{domxref("AudioWorkletNode")}}.</p>
 
-<p class="summary">Defining the getter is optional.</p>
+<p>Defining the getter is optional.</p>
 
 <h2 id="Syntax">Syntax</h2>
 
@@ -49,7 +49,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>{{page("/en-US/docs/Web/API/AudioWorkletNode/parameters", "Examples")}}</p>
+<p>See <a href="/en-US/docs/Web/API/AudioWorkletNode/parameters#examples"><code>AudioWorkletNode.parameters</code></a> for example code showing how to add static <code>parameterDescriptors</code> getter to a custom <code>AudioWorkletProcessor</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
@@ -71,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletProcessor.parameterDescriptors")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
Partial fix to #3196

Removes Page macro from [AudioWorkletProcessor.parameterDescriptors](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor/parameterDescriptors) static getter example, replacing it with a link to the example. 
This is pretty much the agreed approach for removing the Page macro from examples.

This also adds BCD to page frontmatter on affected pages, fixing up compat and spec tables as appropriate. 