### PR TITLE
Remove Page macro: Feature-Policy accelerometer et al

### DIFF
--- a/files/en-us/web/http/headers/feature-policy/accelerometer/index.html
+++ b/files/en-us/web/http/headers/feature-policy/accelerometer/index.html
@@ -7,6 +7,7 @@ tags:
   - Feature Policy
   - HTTP
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.accelerometer
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -19,36 +20,17 @@ browser-compat: http.headers.Feature-Policy.accelerometer
 
 <dl>
  <dt>&lt;allowlist&gt;</dt>
- <dd>{{page('Web/HTTP/Feature_Policy/Using_Feature_Policy', 'allowlist')}}</dd>
+ <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default value is <code>'self'</code>.</p>
+<p>The default <code>allowlist</code> value for this feature is: <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Accelerometer','#accelerometer-interface','Accelerometer')}}</td>
-   <td>{{Spec2('Accelerometer')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
+
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/ambient-light-sensor/index.html
+++ b/files/en-us/web/http/headers/feature-policy/ambient-light-sensor/index.html
@@ -5,6 +5,7 @@ tags:
   - Ambient Light Sensor
   - Feature Policy
   - HTTP
+  - Experimental
 browser-compat: http.headers.Feature-Policy.ambient-light-sensor
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -16,32 +17,18 @@ browser-compat: http.headers.Feature-Policy.ambient-light-sensor
 <pre>Feature-Policy: ambient-light-sensor &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page('Web/HTTP/Feature_Policy/Using_Feature_Policy', 'allowlist')}}</dd>
-</dl>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
+ </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default value is <code>'self'</code>.</p>
+<p>Default allow list for <code>ambient-light-sensor</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
+
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/autoplay/index.html
+++ b/files/en-us/web/http/headers/feature-policy/autoplay/index.html
@@ -27,7 +27,7 @@ browser-compat: http.headers.Feature-Policy.autoplay
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: autoplay &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: autoplay &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/autoplay/index.html
+++ b/files/en-us/web/http/headers/feature-policy/autoplay/index.html
@@ -2,12 +2,13 @@
 title: 'Feature-Policy: autoplay'
 slug: Web/HTTP/Headers/Feature-Policy/autoplay
 tags:
-- Directive
-- Feature Policy
-- Feature-Policy
-- HTTP
-- Reference
-- autoplay
+  - Directive
+  - Feature Policy
+  - Feature-Policy
+  - HTTP
+  - Reference
+  - autoplay
+  - Experimental
 browser-compat: http.headers.Feature-Policy.autoplay
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -15,7 +16,7 @@ browser-compat: http.headers.Feature-Policy.autoplay
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header
     <code>autoplay</code> directive controls whether the current document is allowed to
     autoplay media requested through the {{domxref("HTMLMediaElement")}} interface.</span>
-  When this policy is enabled and there were no user gestures, the {{domxref("Promise")}}
+  When this policy is enabled and there were no user gestures, the {{jsxref("Promise")}}
   returned by {{domxref("HTMLMediaElement.play()")}} will reject with
   a {{domxref("DOMException")}}. The {{htmlattrxref("autoplay", "audio")}} attribute on
   {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements will be ignored.</p>
@@ -30,8 +31,8 @@ browser-compat: http.headers.Feature-Policy.autoplay
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
-  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
-</dl>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
+ </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
@@ -41,22 +42,7 @@ browser-compat: http.headers.Feature-Policy.autoplay
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Feature Policy')}}</td>
-      <td>{{Spec2('Feature Policy')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/battery/index.html
+++ b/files/en-us/web/http/headers/feature-policy/battery/index.html
@@ -1,7 +1,13 @@
 ---
 title: 'Feature-Policy: battery'
 slug: Web/HTTP/Headers/Feature-Policy/battery
+tags:
+  - Battery
+  - Feature Policy
+  - HTTP
+  - Experimental
 browser-compat: http.headers.Feature-Policy.battery
+
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
@@ -12,37 +18,17 @@ browser-compat: http.headers.Feature-Policy.battery
 <pre>Feature-Policy: battery &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy","allowlist")}}</dd>
-</dl>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
+ </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default value is <code>'self'</code>.</p>
+<p>Default allow list for <code>battery</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Feature Policy")}}</td>
-   <td>{{Spec2("Feature Policy")}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("Battery API","#permissions-policy-integration","Permissions Policy integration")}}</td>
-   <td>{{Spec2("Battery API")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/camera/index.html
+++ b/files/en-us/web/http/headers/feature-policy/camera/index.html
@@ -21,7 +21,7 @@ browser-compat: http.headers.Feature-Policy.camera
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: camera &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: camera &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/camera/index.html
+++ b/files/en-us/web/http/headers/feature-policy/camera/index.html
@@ -10,7 +10,7 @@ tags:
 - camera
 browser-compat: http.headers.Feature-Policy.camera
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}} {{SeeCompatTable}} </div>
 
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header
     <code>camera</code> directive controls whether the current document is allowed to use
@@ -24,31 +24,16 @@ browser-compat: http.headers.Feature-Policy.camera
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
-  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
-</dl>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
+ </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default value is <code>'self'</code>.</p>
+<p>Default allow list for <code>camera</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Feature Policy')}}</td>
-      <td>{{Spec2('Feature Policy')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
@@ -59,6 +44,5 @@ browser-compat: http.headers.Feature-Policy.camera
 <ul>
   <li>{{HTTPHeader("Feature-Policy")}} header</li>
   <li><a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a></li>
-  <li><a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature
-      Policy</a></li>
+  <li><a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a></li>
 </ul>

--- a/files/en-us/web/http/headers/feature-policy/camera/index.html
+++ b/files/en-us/web/http/headers/feature-policy/camera/index.html
@@ -8,6 +8,7 @@ tags:
 - HTTP
 - Reference
 - camera
+- Experimental
 browser-compat: http.headers.Feature-Policy.camera
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}} </div>

--- a/files/en-us/web/http/headers/feature-policy/display-capture/index.html
+++ b/files/en-us/web/http/headers/feature-policy/display-capture/index.html
@@ -1,9 +1,16 @@
 ---
 title: 'Feature-Policy: display-capture'
 slug: Web/HTTP/Headers/Feature-Policy/display-capture
+tags:
+  - Directive
+  - Feature Policy
+  - HTTP
+  - Reference
+  - display-capture
+  - Experimental
 browser-compat: http.headers.Feature-Policy.display-capture
 ---
-<div>{{HTTPSidebar}}</div>
+<div>{{HTTPSidebar}} {{SeeCompatTable}} </div>
 
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header <code>display-capture</code> directive controls whether or not the document is permitted to use <a href="/en-US/docs/Web/API/Screen_Capture_API">Screen Capture API</a>, i.e.,{{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} to capture the screen's contents.</span></p>
 
@@ -11,34 +18,21 @@ browser-compat: http.headers.Feature-Policy.display-capture
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: display-capture &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: display-capture &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default alowlist is <code>'self'</code>.</p>
+<p>Default allow list for <code>display-capture</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="https://w3c.github.io/mediacapture-screen-share/#feature-policy-integration">Screen Capture</a></td>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/permissions/#dom-permissionname-display-capture">Permissions</a></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
+
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/document-domain/index.html
+++ b/files/en-us/web/http/headers/feature-policy/document-domain/index.html
@@ -22,7 +22,7 @@ browser-compat: http.headers.Feature-Policy.document-domain
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: document-domain &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: document-domain &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
@@ -31,7 +31,7 @@ browser-compat: http.headers.Feature-Policy.document-domain
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>Default allow list for <code>document-domain</code> is <code>'self'</code>.</p>
+<p>Default allow list for <code>document-domain</code> is <code>*</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/document-domain/index.html
+++ b/files/en-us/web/http/headers/feature-policy/document-domain/index.html
@@ -9,7 +9,7 @@ tags:
 - HTTP
 - Reference
 - document-domain
-- header
+- Header
 browser-compat: http.headers.Feature-Policy.document-domain
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -22,36 +22,20 @@ browser-compat: http.headers.Feature-Policy.document-domain
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre
-  class="brush: html">Feature-Policy: document-domain &lt;allowlist&gt;;</pre>
+<pre class="brush: html">Feature-Policy: document-domain &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
-  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default value is <code>*</code>.</p>
+<p>Default allow list for <code>document-domain</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('HTML WHATWG', '#document-domain-feature', 'document-domain')}}</td>
-      <td>{{Spec2('HTML WHATWG')}}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
@@ -62,6 +46,5 @@ browser-compat: http.headers.Feature-Policy.document-domain
 <ul>
   <li>{{HTTPHeader("Feature-Policy")}} header</li>
   <li><a href="/en-US/docs/Web/HTTP/Feature_Policy">Feature Policy</a></li>
-  <li><a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature
-      Policy</a></li>
+  <li><a href="/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy">Using Feature Policy</a></li>
 </ul>

--- a/files/en-us/web/http/headers/feature-policy/encrypted-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/encrypted-media/index.html
@@ -17,7 +17,7 @@ browser-compat: http.headers.Feature-Policy.encrypted-media
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: encrypted-media &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: encrypted-media &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/encrypted-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/encrypted-media/index.html
@@ -8,6 +8,7 @@ tags:
   - Feature-Policy
   - HTTP
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.encrypted-media
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
@@ -19,37 +20,17 @@ browser-compat: http.headers.Feature-Policy.encrypted-media
 <pre class="brush: html">Feature-Policy: encrypted-media &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The allow list is <code>'self'</code>.</p>
+<p>Default allow list for <code>encrypted-media</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Feature Policy")}}</td>
-   <td>{{Spec2("Feature Policy")}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("EME","#permissions-policy-integration","Permissions Policy integration")}}</td>
-   <td>{{Spec2("EME")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
+++ b/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
@@ -31,7 +31,7 @@ browser-compat: http.headers.Feature-Policy.fullscreen
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>Default allow list for <code>fulscreen</code> is <code>'self'</code>.</p>
+<p>Default allow list for <code>fullscreen</code> is <code>'self'</code>.</p>
 
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
+++ b/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - fullscreen
   - header
+  - Experimental
 browser-compat: http.headers.Feature-Policy.fullscreen
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -24,13 +25,14 @@ browser-compat: http.headers.Feature-Policy.fullscreen
 <pre class="brush: html">Feature-Policy: fullscreen &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
-<p>The default value is <code>'self'</code>.</p>
+<p>Default allow list for <code>fulscreen</code> is <code>'self'</code>.</p>
+
 
 <h2 id="Examples">Examples</h2>
 
@@ -54,27 +56,7 @@ browser-compat: http.headers.Feature-Policy.fullscreen
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Fullscreen','#feature-policy-integration','Fullscreen')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Defines the <code>fullscreen</code> policy.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
+++ b/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
@@ -22,7 +22,7 @@ browser-compat: http.headers.Feature-Policy.fullscreen
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: fullscreen &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: fullscreen &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/geolocation/index.html
+++ b/files/en-us/web/http/headers/feature-policy/geolocation/index.html
@@ -26,7 +26,7 @@ browser-compat: http.headers.Feature-Policy.geolocation
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: geolocation &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: geolocation &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
@@ -60,7 +60,7 @@ browser-compat: http.headers.Feature-Policy.geolocation
   <code>&lt;iframe&gt;</code> element:</p>
 
 <pre
-  class="brush: html">&lt;iframe src="https://other.com/map" allow="geolocation"&gt;&lt;/iframe&gt;</pre>
+  class="brush: http">&lt;iframe src="https://other.com/map" allow="geolocation"&gt;&lt;/iframe&gt;</pre>
 
 <p>iframe attributes can selectively enable features in certain frames, and not in others,
   even if those frames contain documents from the same origin.</p>

--- a/files/en-us/web/http/headers/feature-policy/geolocation/index.html
+++ b/files/en-us/web/http/headers/feature-policy/geolocation/index.html
@@ -3,10 +3,11 @@ title: 'Feature-Policy: geolocation'
 slug: Web/HTTP/Headers/Feature-Policy/geolocation
 tags:
   - Feature Policy
-  - Feature-Policy
   - Geolocation
   - HTTP
   - header
+  - Experimental
+
 browser-compat: http.headers.Feature-Policy.geolocation
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -29,9 +30,12 @@ browser-compat: http.headers.Feature-Policy.geolocation
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
-  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}The default
-    value is <code>'self'</code>.</dd>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>geolocation</code> is <code>'self'</code>.</p>
 
 <h2 id="Examples">Examples</h2>
 
@@ -63,22 +67,7 @@ browser-compat: http.headers.Feature-Policy.geolocation
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Feature Policy')}}</td>
-      <td>{{Spec2('Feature Policy')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/gyroscope/index.html
+++ b/files/en-us/web/http/headers/feature-policy/gyroscope/index.html
@@ -1,6 +1,12 @@
 ---
 title: 'Feature-Policy: gyroscope'
 slug: Web/HTTP/Headers/Feature-Policy/gyroscope
+tags:
+  - Feature Policy
+  - gyroscope
+  - HTTP
+  - header
+  - Experimental
 browser-compat: http.headers.Feature-Policy.gyroscope
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -12,28 +18,17 @@ browser-compat: http.headers.Feature-Policy.gyroscope
 <pre>Feature-Policy: gyroscope &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>gyroscope</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/index.html
+++ b/files/en-us/web/http/headers/feature-policy/index.html
@@ -45,10 +45,27 @@ browser-compat: http.headers.Feature-Policy
 
 <dl>
  <dt><code>&lt;directive&gt;</code></dt>
- <dd>The Feature Policy directive to apply the <code>allowlist</code> to. See {{anch("Directives")}} below for a list of the permitted directive names.</dd>
- <dt><code>&lt;allowlist&gt;</code></dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+ <dd>The Feature Policy directive to apply the <code>allowlist</code> to. See <a href="#directives">Directives</a> below for a list of the permitted directive names.</dd>
+ <dt>&lt;allowlist&gt;</dt>
+ <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
+
+  <ul>
+   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
+   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
+   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
+    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
+   </li>
+   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
+   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
+  </ul>
+  
+  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
+  <p>Features have a <em>default</em> allowlist, which is one of: <code>*</code>, <code>'self'</code>, or <code>'none'</code>.</p>
+</dd>
 </dl>
+
+
+
 
 <h2 id="Directives">Directives</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/index.html
+++ b/files/en-us/web/http/headers/feature-policy/index.html
@@ -41,7 +41,7 @@ browser-compat: http.headers.Feature-Policy
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: &lt;directive&gt; &lt;allowlist&gt;</pre>
+<pre class="brush: http">Feature-Policy: &lt;directive&gt; &lt;allowlist&gt;</pre>
 
 <dl>
  <dt><code>&lt;directive&gt;</code></dt>

--- a/files/en-us/web/http/headers/feature-policy/index.html
+++ b/files/en-us/web/http/headers/feature-policy/index.html
@@ -118,8 +118,14 @@ browser-compat: http.headers.Feature-Policy
  <dd>Controls whether the current document is allowed to use the <a href="/en-US/docs/Web/API/Web_Authentication_API">Web Authentication API</a> to retrieve already stored public-key credentials, i.e. via {{domxref("CredentialsContainer.get","navigator.credentials.get({publicKey: ..., ...})")}}.</dd>
  <dt>{{httpheader('Feature-Policy/sync-xhr', 'sync-xhr')}}</dt>
  <dd>Controls whether the current document is allowed to make synchronous {{DOMxRef("XMLHttpRequest")}} requests.</dd>
+ <dt>{{httpheader('Feature-Policy/unoptimized-images', 'unoptimized-images')}} {{experimental_inline}}{{Non-standard_Inline}}</dt>
+ <dd>Controls whether the current document is allowed to download and display unoptimized images.</dd>
+ <dt>{{httpheader('Feature-Policy/unsized-media', 'unsized-media')}} {{experimental_inline}}{{Non-standard_Inline}}</dt>
+ <dd>Controls whether the current document is allowed to change the size of media elements after the initial layout is complete.</dd>
  <dt>{{httpheader('Feature-Policy/usb', 'usb')}}</dt>
  <dd>Controls whether the current document is allowed to use the <a href="https://wicg.github.io/webusb/">WebUSB API</a>.</dd>
+ <dt>{{httpheader('Feature-Policy/vibrate', 'vibrate')}} {{deprecated_inline}}{{experimental_inline}}{{Non-standard_Inline}}</dt>
+ <dd>Controls whether the current document is  allowed to trigger device vibrations via {{DOMxRef("Navigator.vibrate","Navigator.vibrate()")}} method of <a href="/en-US/docs/Web/API/Vibration_API">Vibration API</a>.</dd>
  <dt>{{httpheader('Feature-Policy/vr', 'vr')}} {{deprecated_inline}}</dt>
  <dd>Controls whether the current document is allowed to use the <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a>. When this policy is disabled, the {{jsxref("Promise")}} returned by {{domxref("Navigator.getVRDisplays","Navigator.getVRDisplays()")}} will reject with a {{domxref("DOMException")}}. Keep in mind that the WebVR standard is in the process of being replaced with <a href="/en-US/docs/Web/API/WebXR_Device_API">WebXR</a>.</dd>
  <dt>{{httpheader('Feature-Policy/screen-wake-lock', 'screen-wake-lock')}}</dt>

--- a/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
+++ b/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
@@ -7,6 +7,8 @@ tags:
   - HTTP
   - Reference
   - layout-animations
+  - Experimental
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.layout-animations
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
@@ -18,9 +20,13 @@ browser-compat: http.headers.Feature-Policy.layout-animations
 <pre>Feature-Policy: layout-animations &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>layout-animations</code> is <code>'self'</code>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
+++ b/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
@@ -7,6 +7,8 @@ tags:
   - HTTP
   - Reference
   - legacy-image-formats
+  - Experimental
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.legacy-image-formats
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}{{Non-standard_header}}</p>
@@ -18,9 +20,13 @@ browser-compat: http.headers.Feature-Policy.legacy-image-formats
 <pre>Feature-Policy: legacy-image-formats &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>legacy-image-formats</code> is <code>'self'</code>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/magnetometer/index.html
+++ b/files/en-us/web/http/headers/feature-policy/magnetometer/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Magnetometer
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.magnetometer
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -18,28 +19,18 @@ browser-compat: http.headers.Feature-Policy.magnetometer
 <pre>Feature-Policy: magnetometer &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>magnetometer</code> is <code>'self'</code>.</p>
+
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/microphone/index.html
+++ b/files/en-us/web/http/headers/feature-policy/microphone/index.html
@@ -20,7 +20,7 @@ browser-compat: http.headers.Feature-Policy.microphone
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: microphone &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: microphone &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/microphone/index.html
+++ b/files/en-us/web/http/headers/feature-policy/microphone/index.html
@@ -7,6 +7,7 @@ tags:
 - HTTP
 - header
 - microphone
+- Experimental
 browser-compat: http.headers.Feature-Policy.microphone
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -23,28 +24,17 @@ browser-compat: http.headers.Feature-Policy.microphone
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>
-  <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default
-    value is <code>'self'</code>.</dd>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>microphone</code> is <code>'self'</code>.</p>
+
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SpecName('Feature Policy')}}</td>
-      <td>{{Spec2('Feature Policy')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/midi/index.html
+++ b/files/en-us/web/http/headers/feature-policy/midi/index.html
@@ -17,7 +17,7 @@ browser-compat: http.headers.Feature-Policy.midi
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: midi &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: midi &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/midi/index.html
+++ b/files/en-us/web/http/headers/feature-policy/midi/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - MIDI
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.midi
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
@@ -19,8 +20,8 @@ browser-compat: http.headers.Feature-Policy.midi
 <pre class="brush: html">Feature-Policy: midi &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
@@ -29,22 +30,7 @@ browser-compat: http.headers.Feature-Policy.midi
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
@@ -6,6 +6,8 @@ tags:
   - Feature-Policy
   - HTTP
   - Reference
+  - Experimental
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.oversized-images
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
@@ -17,8 +19,8 @@ browser-compat: http.headers.Feature-Policy.oversized-images
 <pre>Feature-Policy: oversized-images &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_value">Default value</h2>

--- a/files/en-us/web/http/headers/feature-policy/payment/index.html
+++ b/files/en-us/web/http/headers/feature-policy/payment/index.html
@@ -9,6 +9,7 @@ tags:
   - Payment Request API
   - Payments API
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.payment
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -20,8 +21,8 @@ browser-compat: http.headers.Feature-Policy.payment
 <pre class="brush: html">Feature-Policy: payment &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>

--- a/files/en-us/web/http/headers/feature-policy/payment/index.html
+++ b/files/en-us/web/http/headers/feature-policy/payment/index.html
@@ -18,7 +18,7 @@ browser-compat: http.headers.Feature-Policy.payment
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: payment &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: payment &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/picture-in-picture/index.html
+++ b/files/en-us/web/http/headers/feature-policy/picture-in-picture/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Picture in picture
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.picture-in-picture
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -18,8 +19,8 @@ browser-compat: http.headers.Feature-Policy.picture-in-picture
 <pre>Feature-Policy: picture-in-picture &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>

--- a/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
+++ b/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
@@ -1,6 +1,13 @@
 ---
 title: 'Feature-Policy: publickey-credentials-get'
 slug: Web/HTTP/Headers/Feature-Policy/publickey-credentials-get
+tags:
+  - Directive
+  - Feature-Policy
+  - HTTP
+  - publickey-credentials-get
+  - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.publickey-credentials-get
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -14,8 +21,8 @@ browser-compat: http.headers.Feature-Policy.publickey-credentials-get
 <pre class="brush: html">Feature-Policy: publickey-credentials-get &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy","allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
@@ -24,27 +31,7 @@ browser-compat: http.headers.Feature-Policy.publickey-credentials-get
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Feature Policy")}}</td>
-   <td>{{Spec2("Feature Policy")}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td><a href="https://w3c.github.io/webauthn/#sctn-permissions-policy">Web Authentication Level 2</a></td>
-   <td>Editor's draft.</td>
-   <td>Definition of <code>publickey-credentials-get</code> directive, default allowlist.</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
+++ b/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
@@ -18,7 +18,7 @@ browser-compat: http.headers.Feature-Policy.publickey-credentials-get
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: publickey-credentials-get &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: publickey-credentials-get &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/screen-wake-lock/index.html
+++ b/files/en-us/web/http/headers/feature-policy/screen-wake-lock/index.html
@@ -1,13 +1,17 @@
 ---
 title: 'Feature-Policy: screen-wake-lock'
 slug: Web/HTTP/Headers/Feature-Policy/screen-wake-lock
+tags:
+  - Directive
+  - Feature Policy
+  - Feature-Policy
+  - HTTP
+  - Reference
+  - screen-wake-lock
+  - Experimental
 browser-compat: http.headers.Feature-Policy.screen-wake-lock
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
-
-<div class="hidden">
-<p><strong>Note:</strong> This API is still actively being developed and available only behind a flag on select browsers and platforms.</p>
-</div>
 
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header <strong><code>screen-wake-lock</code></strong> directive controls whether the current document is allowed to use <a href="/en-US/docs/Web/API/Screen_Wake_Lock_API">Screen Wake Lock API</a> to indicate that device should not dim or turn off the screen.</span></p>
 
@@ -20,8 +24,8 @@ browser-compat: http.headers.Feature-Policy.screen-wake-lock
 <pre>Feature-Policy: screen-wake-lock &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page('Web/HTTP/Feature_Policy/Using_Feature_Policy', 'allowlist')}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>

--- a/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - Reference
   - XMLHttpRequest
+  - Experimental
 browser-compat: http.headers.Feature-Policy.sync-xhr
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -19,8 +20,8 @@ browser-compat: http.headers.Feature-Policy.sync-xhr
 <pre>Feature-Policy: sync-xhr &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>

--- a/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
@@ -8,9 +8,10 @@ tags:
   - Image
   - Reference
   - Experimental
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.unoptimized-images
 ---
-<p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
 <p>The HTTP {{HTTPHeader("Feature-Policy")}} header <code>unoptimized-images</code> directive controls whether the current document is allowed to download and display unoptimized images.</p>
 

--- a/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
@@ -7,9 +7,10 @@ tags:
   - HTTP
   - Image
   - Reference
+  - Experimental
 browser-compat: http.headers.Feature-Policy.unoptimized-images
 ---
-<p>{{HTTPSidebar}}{{Non-standard_header}}</p>
+<p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
 <p>The HTTP {{HTTPHeader("Feature-Policy")}} header <code>unoptimized-images</code> directive controls whether the current document is allowed to download and display unoptimized images.</p>
 
@@ -19,7 +20,20 @@ browser-compat: http.headers.Feature-Policy.unoptimized-images
 
 <dl>
  <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}} The default value is <code>'self'</code>.</dd>
+ <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
+
+  <ul>
+   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
+   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
+   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
+    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
+   </li>
+   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
+   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
+  </ul>
+  
+  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
+  </dd>
 </dl>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>

--- a/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
@@ -19,22 +19,13 @@ browser-compat: http.headers.Feature-Policy.unoptimized-images
 <pre>Feature-Policy: unoptimized-images &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
-
-  <ul>
-   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
-   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
-   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
-    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
-   </li>
-   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
-   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
-  </ul>
-  
-  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
-  </dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
+
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>unoptimized-images</code> is <code>'self'</code>.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
@@ -6,6 +6,8 @@ tags:
   - Feature-Policy
   - HTTP
   - Reference
+  - Experimental
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.unsized-media
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
@@ -20,7 +22,20 @@ browser-compat: http.headers.Feature-Policy.unsized-media
 
 <dl>
  <dt>&lt;allowlist&gt;</dt>
- <dd>{{page('Web/HTTP/Feature_Policy/Using_Feature_Policy', 'allowlist')}}</dd>
+ <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
+
+  <ul>
+   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
+   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
+   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
+    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
+   </li>
+   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
+   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
+  </ul>
+  
+  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
+  </dd>
 </dl>
 
 <h2 id="Default_value">Default value</h2>

--- a/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
@@ -21,21 +21,8 @@ browser-compat: http.headers.Feature-Policy.unsized-media
 <pre>Feature-Policy: unsized-media &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
-
-  <ul>
-   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
-   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
-   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
-    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
-   </li>
-   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
-   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
-  </ul>
-  
-  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
-  </dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_value">Default value</h2>

--- a/files/en-us/web/http/headers/feature-policy/usb/index.html
+++ b/files/en-us/web/http/headers/feature-policy/usb/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Vibration API
   - Web USB
+  - Experimental
 browser-compat: http.headers.Feature-Policy.usb
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -19,8 +20,8 @@ browser-compat: http.headers.Feature-Policy.usb
 <pre>Feature-Policy: usb &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page('Web/HTTP/Feature_Policy/Using_Feature_Policy', 'allowlist')}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
@@ -29,27 +30,7 @@ browser-compat: http.headers.Feature-Policy.usb
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web USB','#feature-policy','Feature-Policy integration')}}</td>
-   <td>{{Spec2('Web USB')}}</td>
-   <td>Default allow list is <code>'self'</code>.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/vibrate/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vibrate/index.html
@@ -18,7 +18,7 @@ browser-compat: http.headers.Feature-Policy.vibrate
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre>Feature-Policy: vibrate &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: vibrate &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/vibrate/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vibrate/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Reference
   - Vibration API
+  - Experimental
 browser-compat: http.headers.Feature-Policy.vibrate
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
@@ -18,8 +19,21 @@ browser-compat: http.headers.Feature-Policy.vibrate
 <pre>Feature-Policy: vibrate &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;vibrate&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy", "allowlist")}}</dd>
+ <dt>&lt;allowlist&gt;</dt>
+ <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
+
+  <ul>
+   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
+   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
+   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
+    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
+   </li>
+   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
+   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
+  </ul>
+  
+  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
+  </dd>
 </dl>
 
 <p>The default value is <code>'self'</code>.</p>

--- a/files/en-us/web/http/headers/feature-policy/vibrate/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vibrate/index.html
@@ -8,9 +8,11 @@ tags:
   - Reference
   - Vibration API
   - Experimental
+  - Deprecated
+  - Non-standard
 browser-compat: http.headers.Feature-Policy.vibrate
 ---
-<p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
+<p>{{HTTPSidebar}} {{Deprecated_Header}}</p>
 
 <p><span class="seoSummary">The HTTP {{HTTPHeader("Feature-Policy")}} header <code>vibrate</code> {{deprecated_inline}} directive controls whether the current document is allowed to trigger device vibrations via {{DOMxRef("Navigator.vibrate","Navigator.vibrate()")}} method of <a href="/en-US/docs/Web/API/Vibration_API">Vibration API</a>.</span></p>
 
@@ -19,24 +21,13 @@ browser-compat: http.headers.Feature-Policy.vibrate
 <pre>Feature-Policy: vibrate &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd><p>An <code>allowlist</code> is a list of origins that takes one or more of the following values, separated by spaces:</p>
-
-  <ul>
-   <li><code>*</code>: The feature will be allowed in this document, and all nested browsing contexts (iframes) regardless of their origin.</li>
-   <li><code>'self'</code>: The feature will be allowed in this document, and in all nested browsing contexts (iframes) in the same origin. The feature is not allowed in cross-origin documents in nested browsing contexts.</li>
-   <li><code>'src'</code>: (In an iframe <code>allow</code> attribute only) The feature will be allowed in this iframe, as long as the document loaded into it comes from the same origin as the URL in the iframe's {{HTMLElement('iframe','src','#Attributes')}} attribute.
-    <div class="note">The <code>'src'</code> origin is used in the iframe <code>allow</code> attribute only, and is the <em>default</em> <code>allowlist</code> value. </div>
-   </li>
-   <li><code>'none'</code>: The feature is disabled in top-level and nested browsing contexts.</li>
-   <li>&lt;origin(s)&gt;: The feature is allowed for specific origins (for example, https://example.com). Origins should be separated by a space.</li>
-  </ul>
-  
-  <p>The values <code>*</code> (enable for all origins) or <code>'none'</code> (disable for all origins) may only be used alone, while <code>'self'</code> and <code>'src'</code> may be used with one or more origins.</p>
-  </dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
-<p>The default value is <code>'self'</code>.</p>
+<h2 id="Default_policy">Default policy</h2>
+
+<p>Default allow list for <code>vibrate</code> is <code>'self'</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/vr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vr/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - Reference
   - WebVR
+  - Experimental
 browser-compat: http.headers.Feature-Policy.vr
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
@@ -21,8 +22,8 @@ browser-compat: http.headers.Feature-Policy.vr
 <pre class="brush: html">Feature-Policy: vr &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy","allowlist")}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>

--- a/files/en-us/web/http/headers/feature-policy/vr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vr/index.html
@@ -19,7 +19,7 @@ browser-compat: http.headers.Feature-Policy.vr
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: vr &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: vr &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/web-share/index.html
+++ b/files/en-us/web/http/headers/feature-policy/web-share/index.html
@@ -5,6 +5,7 @@ tags:
   - Feature-Policy
   - HTTP
   - Web Share
+  - Experimental
 browser-compat: http.headers.Feature-Policy.web-share
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
@@ -16,8 +17,8 @@ browser-compat: http.headers.Feature-Policy.web-share
 <pre>Feature-Policy: web-share &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page('Web/HTTP/Feature_Policy/Using_Feature_Policy', 'allowlist')}}</dd>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
 </dl>
 
 <h2 id="Default_policy">Default policy</h2>
@@ -26,27 +27,7 @@ browser-compat: http.headers.Feature-Policy.web-share
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Feature Policy')}}</td>
-   <td>{{Spec2('Feature Policy')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Share API','#permissions-policy','')}}</td>
-   <td>{{Spec2('Web Share API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.html
+++ b/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.html
@@ -17,7 +17,7 @@ browser-compat: http.headers.Feature-Policy.xr-spatial-tracking
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: html">Feature-Policy: xr-spatial-tracking &lt;allowlist&gt;;</pre>
+<pre class="brush: http">Feature-Policy: xr-spatial-tracking &lt;allowlist&gt;;</pre>
 
 <dl>
   <dt>&lt;allowlist&gt;</dt>

--- a/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.html
+++ b/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.html
@@ -1,6 +1,14 @@
 ---
 title: 'Feature-Policy: xr-spatial-tracking'
 slug: Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking
+tags:
+  - Directive
+  - Feature Policy
+  - Feature-Policy
+  - HTTP
+  - Reference
+  - xr-spatial-tracking
+  - Experimental
 browser-compat: http.headers.Feature-Policy.xr-spatial-tracking
 ---
 <div>{{HTTPSidebar}}{{Draft}}{{SeeCompatTable}}</div>
@@ -12,9 +20,9 @@ browser-compat: http.headers.Feature-Policy.xr-spatial-tracking
 <pre class="brush: html">Feature-Policy: xr-spatial-tracking &lt;allowlist&gt;;</pre>
 
 <dl>
- <dt>&lt;allowlist&gt;</dt>
- <dd>{{page("Web/HTTP/Feature_Policy/Using_Feature_Policy","allowlist")}}</dd>
-</dl>
+  <dt>&lt;allowlist&gt;</dt>
+  <dd>A list of origins for which the feature is allowed. See <a href="/en-US/docs/Web/HTTP/Headers/Feature-Policy#syntax"><code>Feature-Policy</code></a>.</dd>
+ </dl>
 
 <h2 id="Default_policy">Default policy</h2>
 
@@ -22,22 +30,7 @@ browser-compat: http.headers.Feature-Policy.xr-spatial-tracking
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("WebXR","#permissions-policy","Permissions Policy")}}</td>
-   <td>{{Spec2("WebXR")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/xr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/xr/index.html
@@ -1,7 +1,11 @@
 ---
 title: 'Feature-Policy: xr'
 slug: Web/HTTP/Headers/Feature-Policy/xr
+tags:
+  - Deprecated
+  - Experimental
+
 ---
-<p>{{HTTPSidebar}}</p>
+<p>{{HTTPSidebar}} {{Deprecated_Header}}</p>
 
 <p>This Feature Policy directive was at one point defined as <code>xr</code> (but implemented in Chrome as {{httpheader("Feature-Policy/vr", "vr")}}), use {{httpheader("Feature-Policy/xr-spatial-tracking", "xr-spatial-tracking")}} instead.</p>


### PR DESCRIPTION
Partial fix for #3196

Feature policies like [Feature-Policy: accelerometer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/accelerometer) previously imported the standard definition of `allowlist` from [Using Feature Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#allowlist).

My take on this is that the `allowlist` is important to have in each of the policies, and it should be duplicated rather than linked. This is partially based on the fact that Feature-Policy is "soon" to be replaced by Permission-Policy (on MDN) so there will be no further modification of the content - ie duplication creates no maintenance issue. 

This duplicates the same text for allowlist in each policy. This test is a minor modification of the original. In particular it does not mention the generic "all features have a default value" as that is not necessary to mention here. 

Further this fixes up the tags for Experimental, and uses browser-compat for compatibility and specs, where supported by BCD.
