### PR TITLE
Remove dead link

### DIFF
--- a/files/en-us/web/api/paintworklet/index.html
+++ b/files/en-us/web/api/paintworklet/index.html
@@ -120,5 +120,4 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 <ul>
  <li><a href="/en-US/docs/Web/API/CSS_Painting_API">CSS Painting API</a></li>
  <li><a href="/en-US/docs/Web/Houdini">Houdini APIs</a></li>
- <li><a href="/en-US/docs/Web/Houdini/learn">Houdini overview</a></li>
 </ul>


### PR DESCRIPTION
Removed a dead link (Houdini overview) in https://developer.mozilla.org/en-US/docs/Web/API/PaintWorklet