### PR TITLE
Guides landing page

### DIFF
--- a/files/en-us/web/guide/index.html
+++ b/files/en-us/web/guide/index.html
@@ -7,52 +7,96 @@ tags:
   - Landing
   - Web
 ---
-<p><strong>These articles provide how-to information to help make use of specific web technologies and APIs.</strong></p>
+<p>There are a number of guides within MDN docs. These articles aim to add additional usage examples, or teach you how to use an API or feature. This page links to some of the most popular material.</p>
+
+<h2>HTML</h2>
 
 <dl>
- <dt class="landingPageList"><a href="/en-US/docs/Learn/HTML">HTML learning area</a></dt>
- <dd class="landingPageList"><strong>HyperText Markup Language (HTML)</strong> is the core language of nearly all web content. Most of what you see on screen in your browser is described, fundamentally, using HTML.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Learn/CSS">CSS learning area</a></dt>
- <dd class="landingPageList">Cascading Style Sheets (CSS) is a stylesheet language used to define the presentation of a document written in HTML.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Audio_and_video_delivery">Audio and video delivery</a></dt>
- <dd class="landingPageList">We can deliver audio and video on the web in several ways, ranging from 'static' media files to adaptive live streams. This article is intended as a starting point for exploring the various delivery mechanisms of web-based media and compatibility with popular browsers.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Audio_and_video_manipulation">Audio and video manipulation</a></dt>
- <dd class="landingPageList">The beauty of the web is that you can combine technologies to create new forms. Having native audio and video in the browser means we can use these data streams with technologies such as {{htmlelement("canvas")}}, <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> or <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> to modify audio and video directly, for example adding reverb/compression effects to audio, or grayscale/sepia filters to video. This article provides a reference to explain what you need to do.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/AJAX">AJAX</a></dt>
- <dd class="landingPageList">AJAX is a term that defines a group of technologies allowing web applications to make quick, incremental updates to the user interface without reloading the entire browser page. This makes the application faster and more responsive to user actions.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Graphics">Graphics on the web</a></dt>
- <dd class="landingPageList">Modern web sites and applications often need to present graphics of varying sophistication.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/API">Guide to web APIs</a></dt>
- <dd class="landingPageList">A list of all web APIs and what they do.</dd>
- <dt><a href="/en-US/docs/Web/JavaScript">JavaScript</a></dt>
- <dd>JavaScript is the powerful scripting language used to create applications for the Web.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Localizations_and_character_encodings">Localizations and character encodings</a></dt>
- <dd class="landingPageList">Browsers process text as Unicode internally. However, a way of representing characters in terms of bytes (character encoding) is used for transferring text over the network to the browser. The <a class="external external-icon" href="https://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#charset">HTML specification recommends the use of the UTF-8 encoding</a> (which can represent all of Unicode), and regardless of the encoding used requires Web content to declare that encoding.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Mobile">Mobile web development</a></dt>
- <dd class="landingPageList">This article provides an overview of some of the main techniques needed to design web sites that work well on mobile devices. See also <a href="/en-US/docs/Mozilla/Firefox_for_Android">Firefox for Android</a>.</dd>
+  <dt><a href="/en-US/docs/Learn/JavaScript">Structuring the web with HTML</a></dt>
+  <dd>The HTML learning area offers tutorials to help you learn HTML from the ground up.</dd>
+  <dt><a href="/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics">HTML basics</a></dt>
+  <dd>This article will give you a basic understanding of HTML. After following this guide, you can further explore the material in the HTML Learning Area.</dd>
 </dl>
 
+<h2>CSS</h2>
+
 <dl>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Progressive_web_apps#core_pwa_guides">Progressive web apps</a></dt>
- <dd class="landingPageList">Progressive web apps (PWAs) use modern web APIs along with traditional progressive enhancement strategy to create cross-platform web applications. These apps work everywhere and provide several features that give them the same user experience advantages as native apps. This set of guides tells you all you need to know about PWAs.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Performance">Optimization and performance</a></dt>
- <dd class="landingPageList">When building modern web apps and sites, it's important to make your content work quickly and efficiently. This lets it perform effectively for both powerful desktop systems and weaker handheld devices.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Parsing_and_serializing_XML">Parsing and serializing XML</a></dt>
- <dd class="landingPageList">The web platform provides different methods of parsing and serializing XML, each with its pros and cons.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/WOFF">The Web Open Font Format (WOFF)</a></dt>
- <dd class="landingPageList">WOFF (Web Open Font Format) is a font file format that is free for anyone to use on the web.</dd>
+  <dt><a href="/en-US/docs/Learn/CSS">Learn to style HTML using CSS</a></dt>
+  <dd>Our complete CSS tutorial, taking you from first steps through styling text, creating layouts, and more.</dd>
+  <dt><a href="/en-US/docs/Web/Guide/CSS/CSS_Layout">CSS Layout Guides</a></dt>
+  <dd>There are a large number of guides to CSS Layout across MDN, this page collects them all together.</dd>
+  <dt><a href="/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations">Using CSS animations</a></dt>
+  <dd>CSS animations make it possible to animate transitions from one CSS style configuration to another. This guide will help you get started with the animation properties.</dd>
+</dl>
+
+<h2>JavaScript</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Learn/JavaScript">JavaScript learning area</a></dt>
+  <dd>Whether you are a complete beginner, or hoping to refresh your skills, this is the place to start.</dd>
+  <dt><a href="/en-US/docs/Web/Guide/AJAX">AJAX</a></dt>
+  <dd>AJAX is a term that defines a group of technologies allowing web applications to make quick, incremental updates to the user interface without reloading the entire browser page. This makes the application faster and more responsive to user actions.</dd>
+
+</dl>
+
+<h2>Media</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Web/Guide/Graphics">Graphics on the web</a></dt>
+  <dd>Modern web sites and applications often need to present graphics of varying sophistication.</dd>
+  <dt><a href="/en-US/docs/Web/Guide/Audio_and_video_delivery">Audio and video delivery</a></dt>
+  <dd>We can deliver audio and video on the web in several ways, ranging from 'static' media files to adaptive live streams. This article is intended as a starting point for exploring the various delivery mechanisms of web-based media and compatibility with popular browsers.</dd>
+  <dt><a href="/en-US/docs/Web/Guide/Audio_and_video_manipulation">Audio and video manipulation</a></dt>
+  <dd>The beauty of the web is that you can combine technologies to create new forms. Having native audio and video in the browser means we can use these data streams with technologies such as {{htmlelement("canvas")}}, <a href="/en-US/docs/Web/API/WebGL_API">WebGL</a> or <a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a> to modify audio and video directly, for example adding reverb/compression effects to audio, or grayscale/sepia filters to video. This article provides a reference to explain what you need to do.</dd>
+</dl>
+
+<h2>APIs</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Web/API/FormData/Using_FormData_Objects">Using FormData objects</a></dt>
+ <dd class="landingPageList">The <a href="/en-US/docs/Web/API/FormData"><code>FormData</code></a> object lets you compile a set of key/value pairs to send using <code>XMLHttpRequest</code>. It's primarily intended for sending form data, but can be used independently from forms to transmit keyed data. The transmission is in the same format that the form's <code>submit()</code> method would use to send the data if the form's encoding type were set to "multipart/form-data".</dd>
+ <dt><a href="/en-US/docs/Web/Progressive_web_apps#core_pwa_guides">Progressive web apps</a></dt>
+ <dd>Progressive web apps (PWAs) use modern web APIs along with traditional progressive enhancement strategy to create cross-platform web applications. These apps work everywhere and provide several features that give them the same user experience advantages as native apps. This set of guides tells you all you need to know about PWAs.</dd>
+ <dt><a href="/en-US/docs/Web/Guide/Parsing_and_serializing_XML">Parsing and serializing XML</a></dt>
+ <dd>The web platform provides different methods of parsing and serializing XML, each with its pros and cons.</dd>
+</dl>
+
+<h2>Internationalization</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Web/Guide/Localizations_and_character_encodings">Localizations and character encodings</a></dt>
+ <dd>Browsers process text as Unicode internally. However, a way of representing characters in terms of bytes (character encoding) is used for transferring text over the network to the browser. The <a class="external external-icon" href="https://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#charset">HTML specification recommends the use of the UTF-8 encoding</a> (which can represent all of Unicode), and regardless of the encoding used requires Web content to declare that encoding.</dd>
  <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/Unicode_Bidrectional_Text_Algorithm">Unicode Bidirectional Text Algorithm (BiDi)</a></dt>
  <dd class="landingPageList">The Unicode® BiDi algorithm is part of the Unicode text standard. It describes how the browser should order characters while rendering Unicode text. This guide covers the algorithm in general and how it applies to content you create—especially when you build properly localized and internationalized content.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/API/FormData/Using_FormData_Objects">Using FormData objects</a></dt>
- <dd class="landingPageList">The <a href="/en-US/docs/Web/API/FormData"><code>FormData</code></a> object lets you compile a set of key/value pairs to send using <code>XMLHttpRequest</code>. It's primarily intended for sending form data, but can be used independently from forms to transmit keyed data. The transmission is in the same format that the form's <code>submit()</code> method would use to send the data if the form's encoding type were set to "multipart/form-data".</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/User_input_methods">User input and controls</a></dt>
- <dd class="landingPageList">Modern web user input goes beyond simple mouse and keyboard: think of touchscreens for example. This article provides recommendations for managing user input and implementing controls in open web apps, along with FAQs, real-world examples, and links to further information for anyone needing more detailed information on the underlying technologies.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Glossary">Glossary</a></dt>
- <dd class="landingPageList">Defines numerous technical terms related to the Web and the Internet.</dd>
 </dl>
 
-<h2 id="See_also">See also</h2>
+<h2>Performance</h2>
 
-<ul>
- <li><a href="/en-US/docs/Web/Reference">Web developer reference</a></li>
-</ul>
+<dl>
+  <dt><a href="/en-US/docs/Web/Guide/Performance">Optimization and performance</a></dt>
+ <dd>When building modern web apps and sites, it's important to make your content work quickly and efficiently. This lets it perform effectively for both powerful desktop systems and weaker handheld devices.</dd>
+</dl>
+
+<h2>Mobile web development</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Web/Guide/Mobile">Mobile web development</a></dt>
+  <dd>This article provides an overview of some of the main techniques needed to design web sites that work well on mobile devices.</dd>
+</dl>
+
+<h2>Fonts</h2>
+
+<dl>
+<dt><a href="/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide">Variable fonts guide</a></dt>
+<dd>Find out how to use variable fonts in your designs.</dd>
+ <dt><a href="/en-US/docs/Web/Guide/WOFF">The Web Open Font Format (WOFF)</a></dt>
+ <dd>WOFF (Web Open Font Format) is a font file format that is free for anyone to use on the web.</dd>
+</dl>
+
+
+<h2>User interface development</h2>
+
+<dl>
+  <dt><a href="/en-US/docs/Web/Guide/User_input_methods">User input and controls</a></dt>
+  <dd>Modern web user input goes beyond simple mouse and keyboard: think of touchscreens for example. This article provides recommendations for managing user input and implementing controls in open web apps, along with FAQs, real-world examples, and links to further information for anyone needing more detailed information on the underlying technologies.</dd>
+</dl>


### PR DESCRIPTION
Working on #5105 this is an initial tidy up of the main guides page. I have:

- Split it into sections
- Added some guides from around MDN
- Removed things that were not guides, such as links to main reference pages.

I'm sure we can do more to this, and I've not delved into all the links, as many of the pages are to collections of guides themselves, but this is a start.