### PR TITLE
add two question marks to FAQ section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ In such situations:
 
 ## Frequently asked questions (FAQ)
 
-### When will my change show up on the production MDN site
+### When will my change show up on the production MDN site?
 
 After your pull request is merged, it may take up to 48 hours before the
 change goes live on the production <https://developer.mozilla.org/> site,
@@ -737,7 +737,7 @@ has been deployed to the production site.
 And use <https://whatsdeployed.io/s/16d/mdn/translated-content> for changes
 to the <https://github.com/mdn/translated-content> repo.
 
-### Can I copy content from other sources to put on MDN
+### Can I copy content from other sources to put on MDN?
 
 In general, we do not approve of copying content from other sources and putting
 it on MDN. MDN should be made up of original content wherever possible. If we


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Two question marks were missing in this repository's [`README.md`](https://github.com/mdn/content/blob/main/README.md).
> MDN URL of the main page changed

https://github.com/mdn/content#frequently-asked-questions-faq
> Issue number (if there is an associated issue)

> Anything else that could help us review it
