### PR TITLE
Fix links nullish and logical or docs

### DIFF
--- a/files/en-us/web/javascript/reference/operators/logical_or/index.html
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.html
@@ -2,11 +2,11 @@
 title: Logical OR (||)
 slug: Web/JavaScript/Reference/Operators/Logical_OR
 tags:
-- JavaScript
-- Language feature
-- Logical Operator
-- Operator
-- Reference
+  - JavaScript
+  - Language feature
+  - Logical Operator
+  - Operator
+  - Reference
 browser-compat: javascript.operators.logical_or
 ---
 <div>{{jsSidebar("Operators")}}</div>
@@ -49,11 +49,10 @@ browser-compat: javascript.operators.logical_or
 <p>Even though the <code>||</code> operator can be used with operands that are not Boolean
   values, it can still be considered a boolean operator since its return value can always
   be converted to a <a
-    href="/en-US/docs/Web/JavaScript/Data_structures#Boolean_type">boolean primitive</a>.
+    href="/en-US/docs/Web/JavaScript/Data_structures#boolean_type">boolean primitive</a>.
   To explicitly convert its return value (or any expression in general) to the
-  corresponding boolean value, use a double <a
-    href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT">NOT
-    operator</a> or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}}
+  corresponding boolean value, use a double {{JSxRef("Operators/Logical_NOT", "NOT
+  operator")}} or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}}
   constructor.</p>
 
 <h3 id="Short-circuit_evaluation">Short-circuit evaluation</h3>

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.html
@@ -19,10 +19,7 @@ browser-compat: javascript.operators.nullish_coalescing
 <p>This can be contrasted with the <a
     href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR">logical OR
     (<code>||</code>) operator</a>, which returns the right-hand side operand if the left
-  operand is <em>any</em> <a
-    href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Description">falsy</a><em><a
-      href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Description">
-    </a></em>value, not only <code>null</code> or <code>undefined</code>. In other words,
+  operand is <em>any</em> {{Glossary("falsy")}} value, not only <code>null</code> or <code>undefined</code>. In other words,
   if you use <code>||</code> to provide some default value to another variable
   <code>foo</code>, you may encounter unexpected behaviors if you consider some falsy
   values as usable (e.g., <code>''</code> or <code>0</code>). See below for more examples.
@@ -67,7 +64,7 @@ console.log(valC); // 42</pre>
 
 <p>Earlier, when one wanted to assign a default value to a variable, a common pattern was
   to use the logical OR operator
-  (<code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR_2">||</a></code>):
+  (<code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR">||</a></code>):
 </p>
 
 <pre class="brush: js">let foo;
@@ -165,11 +162,7 @@ console.log(foo.someBarProp?.toUpperCase() ?? "not available"); // "not availabl
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining">The
-      optional chaining operator</a></li>
-  <li><a
-      href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR_2">The
-      logical OR (<code>||</code>) operator</a></li>
-  <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters">Default
-      parameters in functions</a></li>
+  <li>The <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining">optional chaining operator</a></li>
+  <li>The <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR">logical OR (<code>||</code>) operator</a></li>
+  <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters">Default parameters in functions</a></li>
 </ul>


### PR DESCRIPTION
Fixes #5253

This fixes link flaws in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR

In particular it links to the falsy glossary entry to fix the linked issue. 

