### PR TITLE
Toolbox doc: Toggle tools removed in FF88

### DIFF
--- a/files/en-us/tools/tools_toolbox/index.html
+++ b/files/en-us/tools/tools_toolbox/index.html
@@ -10,7 +10,7 @@ slug: Tools/Tools_Toolbox
 
 <ul>
     <li>Right-click a mouse on any element in the page, and select <strong>Inspect</strong> from the popup menu.</li>
- <li>Open the Hamburger menu (<img alt="" src="hamburger.png" style="display:inline" width="20px"/>) and select <strong>More tools > Web Developer Tools</strong> (or <strong>Web Developer > Toggle Tools</strong> before Firefox 89).</li>
+ <li>Open the Hamburger menu (<img alt="" src="hamburger.png" style="display:inline" width="20px"/>) and select <strong>More tools > Web Developer Tools</strong> (or <strong>Web Developer > Toggle Tools</strong> before Firefox 88).</li>
  <li>Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> on Windows and Linux, or <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd> on OS X. See also <a href="/en-US/docs/Tools/Keyboard_shortcuts">keyboard shortcuts</a>.</li>
 </ul>
 

--- a/files/en-us/tools/tools_toolbox/index.html
+++ b/files/en-us/tools/tools_toolbox/index.html
@@ -10,7 +10,7 @@ slug: Tools/Tools_Toolbox
 
 <ul>
     <li>Right-click a mouse on any element in the page, and select <strong>Inspect</strong> from the popup menu.</li>
- <li>Open the Hamburger menu (<img alt="" src="hamburger.png" style="display:inline" width="20px"/>) and select <strong>More tools > Web Developer Tools</strong> (or <strong>Web Developer > Toggle Tools</strong> before Firefox 88).</li>
+ <li>Open the Hamburger menu (<img alt="" src="hamburger.png" style="display:inline" width="20px"/>) and select <strong>More tools > Web Developer Tools</strong> (Firefox 88 and earlier use the top level menu <strong>Web Developer</strong> rather than <strong>More tools</strong>).</li>
  <li>Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> on Windows and Linux, or <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd> on OS X. See also <a href="/en-US/docs/Tools/Keyboard_shortcuts">keyboard shortcuts</a>.</li>
 </ul>
 

--- a/files/en-us/tools/tools_toolbox/index.html
+++ b/files/en-us/tools/tools_toolbox/index.html
@@ -10,7 +10,7 @@ slug: Tools/Tools_Toolbox
 
 <ul>
     <li>Right-click a mouse on any element in the page, and select <strong>Inspect</strong> from the popup menu.</li>
- <li>Open the Hamburger menu (<img alt="" src="hamburger.png" style="display:inline" width="20px"/>) and select <strong>More tools > Web Developer Tools</strong> (Firefox 88 and earlier use the top level menu <strong>Web Developer</strong> rather than <strong>More tools</strong>).</li>
+ <li>Open the Hamburger menu (<img alt="" src="hamburger.png" style="display:inline" width="20px"/>) and select <strong>More tools > Web Developer Tools</strong> (Firefox 88 and earlier use the top-level menu <strong>Web Developer</strong> rather than <strong>More tools</strong>).</li>
  <li>Press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> on Windows and Linux, or <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd> on OS X. See also <a href="/en-US/docs/Tools/Keyboard_shortcuts">keyboard shortcuts</a>.</li>
 </ul>
 


### PR DESCRIPTION
Fixes #5242

https://developer.mozilla.org/en-US/docs/Tools/Tools_Toolbox

Some rapid changes in web developer tool location. Text omitted some variants:
- FF89/90: Menu > More Tools > Web Developer Tools
- FF88: Menu > Web Developer > Web Developer Tools
- FF87 (ish): Menu > Web Developer > Toggle Tools

This just makes it clear that before ff88 the top level menu folder might be different.