### PR TITLE
Link to the glossary entries for QUIC, TCP and TLS

### DIFF
--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.html
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.html
@@ -203,6 +203,6 @@ Server: Apache
 
 <p>{{Draft}}{{SeeCompatTable}}</p>
 
-<p>The next major version of HTTP, HTTP/3, will use QUIC instead TCP/TLS for the transport layer portion.</p>
+<p>The next major version of HTTP, HTTP/3, will use {{Glossary("QUIC")}} instead {{Glossary("TCP")}}/{{Glossary("TLS")}} for the transport layer portion.</p>
 
 <p>See {{bug(1158011)}} for implementation status in Firefox.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We have documentation about QUIC, TCP and TLS but didn't link to it.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP

> Issue number (if there is an associated issue)

> Anything else that could help us review it

(My first content edit of MDN on yari)