### PR TITLE
Tutorials: speakingjs https link not working

### DIFF
--- a/files/en-us/web/tutorials/index.html
+++ b/files/en-us/web/tutorials/index.html
@@ -166,7 +166,7 @@ tags:
  <dd>A recap of the JavaScript programming language aimed at intermediate-level developers.</dd>
  <dt><strong><a href="https://eloquentjavascript.net/" rel="external">Eloquent JavaScript</a></strong></dt>
  <dd>A comprehensive guide to intermediate and advanced JavaScript methodologies.</dd>
- <dt><strong><a href="https://speakingjs.com/es5/" rel="external">Speaking JavaScript</a> </strong></dt>
+ <dt><strong><a href="http://speakingjs.com/es5/" rel="external">Speaking JavaScript</a> </strong></dt>
  <dd>For programmers who want to learn JavaScript quickly and properly, and for JavaScript programmers who want to deepen their skills and/or look up specific topics.</dd>
  <dt><strong><a href="https://www.addyosmani.com/resources/essentialjsdesignpatterns/book/" rel="external">Essential JavaScript Design Patterns</a> </strong></dt>
  <dd>An introduction to essential JavaScript design patterns.</dd>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

the HTTPS link of `speakingjs.com` not working changed it to HTTP.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Tutorials
> Issue number (if there is an associated issue)

> Anything else that could help us review it

page section contains url.
https://developer.mozilla.org/en-US/docs/Web/Tutorials#intermediate_level_3