### PR TITLE
Fix issue #5261, missing parenthesis in image() url() example.

### DIFF
--- a/files/en-us/web/css/url()/index.html
+++ b/files/en-us/web/css/url()/index.html
@@ -46,7 +46,7 @@ border-image: url("/media/diamonds.png") 30 fill / 30px / 30px space;
 
 /* As a parameter in another CSS function */
 background-image: cross-fade(20% url(first.png), url(second.png));
-mask-image: image(url(mask.png), skyblue, linear-gradient(rgba(0, 0, 0, 1.0), transparent);
+mask-image: image(url(mask.png), skyblue, linear-gradient(rgba(0, 0, 0, 1.0), transparent));
 
 /* as part of a non-shorthand multiple value */
 content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
@@ -207,7 +207,7 @@ content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 <ul>
 	<li>{{cssxref("&lt;gradient&gt;")}}</li>
 	<li>{{cssxref("element()")}}</li>
-	<li>{{cssxref("_image","image()")}}</li>
-	<li>{{cssxref("image-set","image-set()")}}</li>
-	<li>{{cssxref("cross-fade")}}</li>
+	<li>{{cssxref("image()")}}</li>
+	<li>{{cssxref("image-set()")}}</li>
+	<li>{{cssxref("cross-fade()")}}</li>
 </ul>


### PR DESCRIPTION
Fix the 3 flawed cssxref macros at the end of the page.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A missing parenthesis in the image(url(…), …) example.
3 cssxref macros were marked as flawed

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/url()

> Issue number (if there is an associated issue)
Fix #5261

> Anything else that could help us review it
