### PR TITLE
fixed broken link

### DIFF
--- a/files/en-us/web/api/websockets_api/index.html
+++ b/files/en-us/web/api/websockets_api/index.html
@@ -56,7 +56,7 @@ tags:
  <li><a href="https://www.totaljs.com">Total.js</a>: Web application framework for <a href="https://www.nodejs.org">Node.js</a> (Example: <a href="https://github.com/totaljs/examples/tree/master/websocket">WebSocket chat</a>)</li>
  <li><a href="https://www.npmjs.com/package/faye-websocket">Faye</a>: A {{DOMxRef("WebSocket")}} (two-ways connections) and <a href="/en-US/docs/Web/API/EventSource">EventSource</a> (one-way connections) for <a href="https://nodejs.org">Node.js</a> Server and Client.</li>
  <li><a href="https://signalr.net/">SignalR</a>: SignalR will use WebSockets under the covers when it's available, and gracefully fallback to other techniques and technologies when it isn't, while your application code stays the same.</li>
- <li><a href="https://caddyserver.com/docs/websocket">Caddy</a>: A web server capable of proxying arbitrary commands (stdin/stdout) as a websocket.</li>
+ <li><a href="https://caddyserver.com/">Caddy</a>: A web server capable of proxying arbitrary commands (stdin/stdout) as a websocket.</li>
  <li><a href="https://github.com/websockets/ws">ws</a>: a popular WebSocket client &amp; server library for <a href="https://nodejs.org/">Node.js</a>.</li>
  <li><a href="https://github.com/bigstepinc/jsonrpc-bidirectional">jsonrpc-bidirectional</a>: Asynchronous RPC which, on a single connection, may have functions exported on the server and, and the same time, on the client (client may call server, server may also call client).</li>
  <li><a href="https://github.com/ninenines/cowboy">cowboy</a>: Cowboy is a small, fast and modern HTTP server for Erlang/OTP with WebSocket support.</li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

there is a broken link on this page check.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
> Issue number (if there is an associated issue)

#5281
> Anything else that could help us review it

as mentioned in the issue by @teoli2003 latest version(v2) of API enable Websocket by default. so changed the link to the main page of api.