### PR TITLE
Demos of open web technologies: broken link

### DIFF
--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -26,7 +26,6 @@ tags:
  <li><a href="http://mdn.github.io/canvas-raycaster/index.html">3D RayCaster</a></li>
  <li><a href="http://processingjs.org/exhibition/">processing.js</a></li>
  <li><a href="https://p5js.org/">p5js</a></li>
- <li><a href="http://gyu.que.jp/jscloth/">3D on 2D Canvas</a></li>
  <li><a href="https://viliusle.github.io/miniPaint/">miniPaint: Image editor</a> (<a href="https://github.com/viliusle/miniPaint">source code</a>)</li>
  <li><a href="http://zenphoton.com">Zen Photon Garden </a>(<a href="https://github.com/scanlime/zenphoton">source code</a>)</li>
  <li><a href="http://maximumroulette.com/pages/demos/multi-touch-canvas2d-src.html">Multi touch in canvas demo</a> (<a href="https://github.com/zlatnaspirala/multi-touch-canvas-handler">source code</a>)</li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

a broken link at http://gyu.que.jp/jscloth/
the whole link not working.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Demos_of_open_web_technologies
> Issue number (if there is an associated issue)

> Anything else that could help us review it

the broken link is in the following section:
https://developer.mozilla.org/en-US/docs/Web/Demos_of_open_web_technologies#2d_graphics