### PR TITLE
Fix a few broken links (http->https) + reorder to match alphabetical order

### DIFF
--- a/files/en-us/web/css/@font-face/index.html
+++ b/files/en-us/web/css/@font-face/index.html
@@ -49,6 +49,8 @@ browser-compat: css.at-rules.font-face
  <dd>Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values.</dd>
  <dt>{{cssxref("@font-face/line-gap-override", "line-gap-override")}}</dt>
  <dd>Defines the line gap metric for the font.</dd>
+ <dt>{{cssxref("@font-face/size-adjust", "size-adjust")}}{{experimental_inline}}</dt>
+ <dd>Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.</dd>
  <dt>{{cssxref("@font-face/src", "src")}}</dt>
  <dd>
  <p>Specifies the resource containing the font data. This can be a URL to a remote font file location or the name of a font on the user's computer.</p>
@@ -60,8 +62,6 @@ browser-compat: css.at-rules.font-face
 
  <p>The available types are: <code>"woff"</code>, <code>"woff2"</code>, <code>"truetype"</code>, <code>"opentype"</code>, <code>"embedded-opentype"</code>, and <code>"svg"</code>.</p>
  </dd>
- <dt>{{cssxref("@font-face/size-adjust", "size-adjust")}}{{experimental_inline}}</dt>
- <dd>Defines a multiplier for glyph outlines and metrics associated with this font. This makes it easier to harmonize the designs of various fonts when rendered at the same font size.</dd>
  <dt>{{cssxref("@font-face/unicode-range", "unicode-range")}}</dt>
  <dd>The range of Unicode code points to be used from the font.</dd>
 </dl>
@@ -215,9 +215,9 @@ browser-compat: css.at-rules.font-face
 <ul>
  <li><a href="/en-US/docs/Web/Guide/WOFF">About WOFF</a></li>
  <li><a href="https://everythingfonts.com/font-face">Everythingfonts font-face generator</a></li>
- <li><a href="http://www.fontsquirrel.com/fontface/generator">FontSquirrel @font-face generator</a></li>
- <li><a href="http://hacks.mozilla.org/2009/06/beautiful-fonts-with-font-face/">Beautiful fonts with @font-face</a></li>
- <li><a href="http://openfontlibrary.org/">Open Font Library</a></li>
+ <li><a href="https://www.fontsquirrel.com/fontface/generator">FontSquirrel @font-face generator</a></li>
+ <li><a href="https://hacks.mozilla.org/2009/06/beautiful-fonts-with-font-face/">Beautiful fonts with @font-face</a></li>
+ <li><a href="https://openfontlibrary.org/">Open Font Library</a></li>
  <li><a href="https://caniuse.com/woff">When can I use WOFF?</a></li>
  <li><a href="https://caniuse.com/svg-fonts">When can I use SVG Fonts?</a></li>
  <li><a href="https://coolfont.org">Free Fancy Cool Fonts</a></li>

--- a/files/en-us/web/css/font-feature-settings/index.html
+++ b/files/en-us/web/css/font-feature-settings/index.html
@@ -42,7 +42,7 @@ These lead to more effective, predictable, understandable results than <code>fon
  <dd>Text is laid out using default settings.</dd>
  <dt><code>&lt;feature-tag-value&gt;</code></dt>
  <dd>When rendering text, the list of OpenType feature tag value is passed to the text layout engine to enable or disable font features. The tag is always a {{cssxref("&lt;string&gt;")}} of 4 ASCII characters. If it has more or less characters, or if it contains characters outside the <code>U+20</code> – <code>U+7E</code> codepoint range, the whole property is invalid.<br>
- The value is a positive integer. The two keywords <code>on</code> and <code>off</code> are synonyms for <code>1</code> and <code>0</code> respectively. If no value is set, the default is <code>1</code>. For non-Boolean OpenType features (e.g. <a href="http://www.microsoft.com/typography/otspec/features_pt.htm#salt">stylistic alternates</a>), the value implies a particular glyph to be selected; for Boolean values, it is a switch.</dd>
+ The value is a positive integer. The two keywords <code>on</code> and <code>off</code> are synonyms for <code>1</code> and <code>0</code> respectively. If no value is set, the default is <code>1</code>. For non-Boolean OpenType features (e.g. <a href="https://www.microsoft.com/typography/otspec/features_pt.htm#salt">stylistic alternates</a>), the value implies a particular glyph to be selected; for Boolean values, it is a switch.</dd>
 </dl>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -124,7 +124,6 @@ td.tabular { font-feature-settings: "tnum"; }
  <li>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</li>
  <li>{{cssxref("@font-face/src", "src")}}</li>
  <li>{{cssxref("@font-face/unicode-range", "unicode-range")}}</li>
- <li><a href="http://www.microsoft.com/typography/otspec/featurelist.htm">OpenType Feature Tags</a> list</li>
- <li><a href="http://blogs.msdn.com/b/ie/archive/2012/01/09/css-corner-using-the-whole-font.aspx">Using the whole font</a><br>
-  <em>(<strong>Note:</strong> The <code>-moz</code> syntax is the old one. On Gecko, use the <code>-ms</code> syntax but with <code>-moz</code>.)</em></li>
+ <li><a href="https://www.microsoft.com/typography/otspec/featurelist.htm">OpenType Feature Tags</a> list</li>
+
 </ul>


### PR DESCRIPTION
Remove one broken link that doesn't exist anymore (and was commented as an outdated syntax)
Reordered a list to match the alphabetical order

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A few broken links + a list not sorted

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face

> Issue number (if there is an associated issue)

None

> Anything else that could help us review it
