### PR TITLE
Demos of open web technologies:  fixed broken links and changed http to https

### DIFF
--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -22,22 +22,21 @@ tags:
 <h3 id="Canvas">Canvas</h3>
 
 <ul>
- <li><a href="http://www.blobsallad.se/">Blob Sallad: an interactive blob using JavaScript and canvas</a> (<a href="http://blobsallad.se/article/">code demos)</a></li>
- <li><a href="http://mdn.github.io/canvas-raycaster/index.html">3D RayCaster</a></li>
- <li><a href="http://processingjs.org/exhibition/">processing.js</a></li>
+ <li><a href="https://www.blobsallad.se/">Blob Sallad: an interactive blob using JavaScript and canvas</a> (<a href="http://blobsallad.se/article/">code demos)</a></li>
+ <li><a href="https://mdn.github.io/canvas-raycaster/index.html">3D RayCaster</a></li>
+ <li><a href="https://processingjs.org/exhibition/">processing.js</a></li>
  <li><a href="https://p5js.org/">p5js</a></li>
  <li><a href="http://gyu.que.jp/jscloth/">3D on 2D Canvas</a></li>
  <li><a href="https://viliusle.github.io/miniPaint/">miniPaint: Image editor</a> (<a href="https://github.com/viliusle/miniPaint">source code</a>)</li>
- <li><a href="http://zenphoton.com">Zen Photon Garden </a>(<a href="https://github.com/scanlime/zenphoton">source code</a>)</li>
+ <li><a href="https://zenphoton.com">Zen Photon Garden </a>(<a href="https://github.com/scanlime/zenphoton">source code</a>)</li>
  <li><a href="http://maximumroulette.com/pages/demos/multi-touch-canvas2d-src.html">Multi touch in canvas demo</a> (<a href="https://github.com/zlatnaspirala/multi-touch-canvas-handler">source code</a>)</li>
 </ul>
 
 <h3 id="SVG">SVG</h3>
 
 <ul>
- <li><a href="http://starkravingfinkle.org/projects/demo/svg-bubblemenu-in-html.xml">Bubblemenu</a> (visual effects and interaction)</li>
- <li><a href="http://starkravingfinkle.org/blog/2007/07/firefox-3-svg-foreignobject/">HTML transformations</a> using <code>foreignObject</code> (visual effects and transforms)</li>
- <li><a href="http://svg-whiz.com/svg/linguistics/theCreepyMouth.svg">Phonetics Guide</a> (interactive)</li>
+ <li><a href="https://starkravingfinkle.org/projects/demo/svg-bubblemenu-in-html.xml">Bubblemenu</a> (visual effects and interaction)</li>
+ <li><a href="https://starkravingfinkle.org/blog/2007/07/firefox-3-svg-foreignobject/">HTML transformations</a> using <code>foreignObject</code> (visual effects and transforms)</li>
  <li><a href="http://www.lutanho.net/svgvml3d/platonic.html">3D objects demo</a> (interactive)</li>
  <li><a href="http://www.themaninblue.com/experiment/Blobular/">Blobular</a> (interactive)</li>
  <li><a href="http://www.double.co.nz/video_test/video.svg">Video embedded in SVG</a> (or use the <a href="http://www.double.co.nz/video_test/video_svg.tar.bz2">local download</a>)</li>
@@ -80,11 +79,10 @@ tags:
 
 <ul>
  <li><a href="http://www.csszengarden.com/">CSS Zen Garden</a></li>
- <li><a href="http://codepen.io/SoftwareRVG/pen/OXkOWj/">CSS floating logo "mozilla"</a></li>
- <li><a href="http://felixniklas.com/paperfold/">Paperfold</a></li>
+ <li><a href="https://codepen.io/SoftwareRVG/pen/OXkOWj/">CSS floating logo "mozilla"</a></li>
+ <li><a href="https://felixniklas.com/paperfold/">Paperfold</a></li>
  <li><a href="https://ondras.github.io/blockout/">CSS Blockout</a></li>
- <li><a href="http://ondras.zarovi.cz/demos/rubik/">Rubik's cube</a></li>
- <li><a href="http://ondras.zarovi.cz/demos/nojs/">Pure CSS Slides</a></li>
+ <li><a href="https://ondras.zarovi.cz/demos/rubik/">Rubik's cube</a></li>
  <li>Planetarium (<a href="https://github.com/littleworkshop/planetarium">source code</a>)</li>
  <li><a href="https://codepen.io/equinusocio/full/qjyXPP/">Loader with blend modes</a></li>
  <li><a href="https://codepen.io/equinusocio/full/KNYOxJ/">Text reveal with clip-path</a></li>
@@ -119,9 +117,9 @@ tags:
 <ul>
  <li><a href="https://ondras.github.io/fireworks-webgl/">Web Audio Fireworks</a></li>
  <li><a href="https://ondras.github.io/oscope/">oscope.js - JavaScript oscilloscope</a></li>
- <li><a href="http://nipe-systems.de/webapps/html5-web-audio/">HTML5 Web Audio Showcase</a> (<a href="https://github.com/NIPE-SYSTEMS/html5-web-audio-showcase">source code</a>)</li>
+ <li><a href="https://h3ndrk.github.io/html5-web-audio-showcase/">HTML5 Web Audio Showcase</a> (<a href="https://github.com/NIPE-SYSTEMS/html5-web-audio-showcase">source code</a>)</li>
  <li><a href="https://wayou.github.io/HTML5_Audio_Visualizer/">HTML5 Audio Visualizer</a> (<a href="https://github.com/Wayou/HTML5_Audio_Visualizer">source code</a>)</li>
- <li><a href="http://carlosrafaelgn.com.br/GraphicalFilterEditor/">Graphical Filter Editor and Visualizer</a> (<a href="https://github.com/carlosrafaelgn/GraphicalFilterEditor">source code</a>)</li>
+ <li><a href="https://carlosrafaelgn.com.br/GraphicalFilterEditor/">Graphical Filter Editor and Visualizer</a> (<a href="https://github.com/carlosrafaelgn/GraphicalFilterEditor">source code</a>)</li>
 </ul>
 
 <h3 id="File_API">File API</h3>
@@ -136,6 +134,6 @@ tags:
  <li><a href="https://ondras.github.io/fractal/">Web Worker Fractals</a></li>
  <li><a href="https://ondras.github.io/photo/">Photo editor</a></li>
  <li><a href="https://ondras.github.io/coral/">Coral generator</a></li>
- <li><a href="http://nerget.com/rayjs-mt/rayjs.html">Raytracer</a></li>
+ <li><a href="https://nerget.com/rayjs-mt/rayjs.html">Raytracer</a></li>
  <li><a href="https://palerdot.github.io/hotcold/">HotCold Touch Typing</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

there were several broken links on the page.
change the HTTP links to HTTPS in case it was possible.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Demos_of_open_web_technologies
> Issue number (if there is an associated issue)

> Anything else that could help us review it

<!--StartFragment--> &lt;li&gt;&lt;a href="http://svg-whiz.com/svg/linguistics/theCreepyMouth.svg"&gt;Phonetics Guide&lt;/a&gt; (interactive)&lt;/li&gt;<br class="Apple-interchange-newline"><!--EndFragment-->
`this link dont work anymore`

<!--StartFragment--> &lt;li&gt;&lt;a href="http://ondras.zarovi.cz/demos/nojs/"&gt;Pure CSS Slides&lt;/a&gt;&lt;/li&gt;<br class="Apple-interchange-newline"><!--EndFragment-->
`this link dont work anymore`

<!--StartFragment--> &lt;li&gt;&lt;a href="http://nipe-systems.de/webapps/html5-web-audio/"&gt;HTML5 Web Audio Showcase&lt;/a&gt; (&lt;a href="https://github.com/NIPE-SYSTEMS/html5-web-audio-showcase"&gt;source code&lt;/a&gt;)&lt;/li&gt;<br class="Apple-interchange-newline"><!--EndFragment-->

this url is redirected to [here](https://h3ndrk.github.io/html5-web-audio-showcase/) check [this](https://github.com/NIPE-SYSTEMS/html5-web-audio-showcase)
