### PR TITLE
Demos of open web technologies: codepen broken link

### DIFF
--- a/files/en-us/web/demos_of_open_web_technologies/index.html
+++ b/files/en-us/web/demos_of_open_web_technologies/index.html
@@ -88,7 +88,6 @@ tags:
  <li>Planetarium (<a href="https://github.com/littleworkshop/planetarium">source code</a>)</li>
  <li><a href="https://codepen.io/equinusocio/full/qjyXPP/">Loader with blend modes</a></li>
  <li><a href="https://codepen.io/equinusocio/full/KNYOxJ/">Text reveal with clip-path</a></li>
- <li><a href="https://codepen.io/equinusocio/full/GvyvWd/">Ambient shadow with custom properties</a></li>
  <li><a href="https://codepen.io/equinusocio/full/jEVNeJ/">Luminiscent vial</a></li>
  <li><a href="https://dmytsv.github.io/sass-spa/index.html#home">CSS-based single page application</a> (<a href="https://github.com/dmytsv/sass-spa">source code</a>)</li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

there is a snippet link to codepen that does not exist anymore.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Demos_of_open_web_technologies
> Issue number (if there is an associated issue)

> Anything else that could help us review it
