### PR TITLE
SVGPointList

### DIFF
--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -34,7 +34,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, appended to the list.</p>
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, and appended to the list.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;polyline id="example" stroke="black" fill="none"
@@ -74,4 +74,3 @@ console.log(example.points.appendItem(svgpoint));</pre>
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.SVGPointList.appendItem")}}</p>
-

--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -1,0 +1,77 @@
+---
+title: SVGPointList.appendItem()
+slug: Web/API/SVGPointList/appendItem
+tags:
+  - API
+  - Method
+  - Reference
+  - appendItem
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>appendItem()</code></strong> method of the {{domxref("SVGPointList")}} interface adds a {{domxref("SVGPoint","point")}} to the end of the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.appendItem(obj);</pre>
+
+<dl>
+  <dt><code>obj</code></dt>
+  <dd>An {{domxref("SVGPoint")}} object containing the coordinates of the point to be appended.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The {{domxref("SVGPoint")}} object that was appended.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NoModicationAllowedError</code></dt>
+  <dd>Thrown if the list is read-only.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, appended to the list.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+let svgpoint = document.getElementById("svg").createSVGPoint();
+svgpoint.y = 10;
+svgpoint.x = 10;
+console.log(example.points.appendItem(svgpoint));</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__appendItem", "appendItem()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__appendItem", "SVGPointList.appendItem()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.appendItem")}}</p>
+

--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -56,4 +56,4 @@ console.log(example.points.appendItem(svgpoint));</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat(}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -50,25 +50,7 @@ console.log(example.points.appendItem(svgpoint));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__appendItem", "appendItem()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__appendItem", "SVGPointList.appendItem()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/appenditem/index.html
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - appendItem
   - SVGPointList
+browser-compat: api.SVGPointList.appendItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -73,4 +74,4 @@ console.log(example.points.appendItem(svgpoint));</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.appendItem")}}</p>
+<p>{{Compat(}}</p>

--- a/files/en-us/web/api/svgpointlist/clear/index.html
+++ b/files/en-us/web/api/svgpointlist/clear/index.html
@@ -29,7 +29,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. Calling <code>clear()</code> empties the list, therefore the polyline no longer displays in the SVG.</p>
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. Calling <code>clear()</code> empties the list. Therefore the polyline no longer displays in the SVG.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;polyline id="example" stroke="black" fill="none"
@@ -66,4 +66,3 @@ example.points.clear();</pre>
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.SVGPointList.clear")}}</p>
-

--- a/files/en-us/web/api/svgpointlist/clear/index.html
+++ b/files/en-us/web/api/svgpointlist/clear/index.html
@@ -1,0 +1,69 @@
+---
+title: SVGPointList.clear()
+slug: Web/API/SVGPointList/clear
+tags:
+  - API
+  - Method
+  - Reference
+  - clear
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>clear()</code></strong> method of the {{domxref("SVGPointList")}} interface removes all items from the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.clear();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NoModicationAllowedError</code></dt>
+  <dd>Thrown if the list is read-only.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. Calling <code>clear()</code> empties the list, therefore the polyline no longer displays in the SVG.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+example.points.clear();</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__clear", "clear()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__clear", "SVGPointList.clear()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.clear")}}</p>
+

--- a/files/en-us/web/api/svgpointlist/clear/index.html
+++ b/files/en-us/web/api/svgpointlist/clear/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - clear
   - SVGPointList
+browser-compat: api.SVGPointList.clear
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -65,4 +66,4 @@ example.points.clear();</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.clear")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/clear/index.html
+++ b/files/en-us/web/api/svgpointlist/clear/index.html
@@ -42,25 +42,7 @@ example.points.clear();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__clear", "clear()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__clear", "SVGPointList.clear()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/getitem/index.html
+++ b/files/en-us/web/api/svgpointlist/getitem/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The {{domxref("SVGPoint")}} at index <code>1</code> (the second item in the list) is returned.</p>
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The {{domxref("SVGPoint")}} at index <code>0</code>.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;polyline id="example" stroke="black" fill="none"
@@ -44,7 +44,7 @@ tags:
 </svg></pre>
 
 <pre class="brush: js">let example = document.getElementById("example");
-console.log(example.points.getItem(1));</pre>
+console.log(example.points.getItem(0));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/api/svgpointlist/getitem/index.html
+++ b/files/en-us/web/api/svgpointlist/getitem/index.html
@@ -1,0 +1,76 @@
+---
+title: SVGPointList.getItem()
+slug: Web/API/SVGPointList/getItem
+tags:
+  - API
+  - Method
+  - Reference
+  - getItem
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>getItem()</code></strong> method of the {{domxref("SVGPointList")}} interface gets one item from the list at the specified index.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.getItem(index);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>index</code></dt>
+  <dd>The index of the item to return.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>An {{domxref("SVGPoint")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>IndexSizeError</code></dt>
+  <dd>Thrown if the index passed in is greater than the number of items in the list.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The {{domxref("SVGPoint")}} at index <code>1</code> (the second item in the list) is returned.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+console.log(example.points.getItem(1));</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__getItem", "getItem()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__getItem", "SVGPointList.getItem()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.getItem")}}</p>
+

--- a/files/en-us/web/api/svgpointlist/getitem/index.html
+++ b/files/en-us/web/api/svgpointlist/getitem/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - getItem
   - SVGPointList
+browser-compat: api.SVGPointList.getItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -72,5 +73,5 @@ console.log(example.points.getItem(0));</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.getItem")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/svgpointlist/getitem/index.html
+++ b/files/en-us/web/api/svgpointlist/getitem/index.html
@@ -49,29 +49,10 @@ console.log(example.points.getItem(0));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__getItem", "getItem()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__getItem", "SVGPointList.getItem()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
-

--- a/files/en-us/web/api/svgpointlist/index.html
+++ b/files/en-us/web/api/svgpointlist/index.html
@@ -1,0 +1,82 @@
+---
+title: SVGPointList
+slug: Web/API/SVGPointList
+tags:
+  - API
+  - Interface
+  - Reference
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>SVGPointList</code></strong> interface represents a list of {{domxref("SVGPoint","points")}}.</p>
+
+<p>An <code>SVGPointList</code> can be designated as read-only, which means that attempts to modify the object will result in an exception being thrown.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<dl>
+  <dt>{{domxref("SVGPointList.length")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the number of points in the list.</dd>
+  <dt>{{domxref("SVGPointList.numberOfItems")}}{{ReadOnlyInline}}</dt>
+  <dd>Returns the number of points in the list.</dd>
+</dl>
+
+<h2 id="Methods">Methods</h2>
+
+<dl>
+  <dt>{{domxref("SVGPointList.clear()")}}</dt>
+  <dd>Removes all items in the list.</dd>
+  <dt>{{domxref("SVGPointList.initialize()")}}</dt>
+  <dd>First removes all items in the list, then adds a single value to the list.</dd>
+  <dt>{{domxref("SVGPointList.getItem()")}}</dt>
+  <dd>Gets an item from the list at a specified position.</dd>
+  <dt>{{domxref("SVGPointList.insertItemBefore()")}}</dt>
+  <dd>Inserts an element into the list at a specified position.</dd>
+  <dt>{{domxref("SVGPointList.replaceItem()")}}</dt>
+  <dd>Replaces an item in the list with a new item.</dd>
+  <dt>{{domxref("SVGPointList.removeItem()")}}</dt>
+  <dd>Removes an item from the list.</dd>
+  <dt>{{domxref("SVGPointList.appendItem()")}}</dt>
+  <dd>Adds an item to the end of the list.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The <code>points</code> property returns an <code>SVGPointList</code>.</p>
+
+<pre class="brush: html">&lt;svg viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+console.log(example.points); //an SVGPointList</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGPointList", "SVGPointList")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#InterfaceSVGPointList", "SVGPointList")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList")}}</p>

--- a/files/en-us/web/api/svgpointlist/index.html
+++ b/files/en-us/web/api/svgpointlist/index.html
@@ -9,7 +9,7 @@ tags:
 ---
 <div>{{APIRef("SVG")}}</div>
 
-<p class="summary">The <strong><code>SVGPointList</code></strong> interface represents a list of {{domxref("SVGPoint","points")}}.</p>
+<p class="summary">The <strong><code>SVGPointList</code></strong> interface represents a list of {{domxref("SVGPoint")}} objects.</p>
 
 <p>An <code>SVGPointList</code> can be designated as read-only, which means that attempts to modify the object will result in an exception being thrown.</p>
 

--- a/files/en-us/web/api/svgpointlist/index.html
+++ b/files/en-us/web/api/svgpointlist/index.html
@@ -56,25 +56,7 @@ console.log(example.points); //an SVGPointList</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "shapes.html#InterfaceSVGPointList", "SVGPointList")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#InterfaceSVGPointList", "SVGPointList")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/index.html
+++ b/files/en-us/web/api/svgpointlist/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - SVGPointList
+browser-compat: api.SVGPointList
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -79,4 +80,4 @@ console.log(example.points); //an SVGPointList</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/initialize/index.html
+++ b/files/en-us/web/api/svgpointlist/initialize/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. Returning {{domxref("SVGPointList.length")}} gives the value <code>5</code>. After calling <code>initialize()</code> returning {{domxref("SVGPointList.length")}} gives the value <code>1</code>.</p>
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. Returning {{domxref("SVGPointList.length")}} gives the value <code>5</code>. After calling <code>initialize()</code>, returning {{domxref("SVGPointList.length")}} gives the value <code>1</code>.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;polyline id="example" stroke="black" fill="none"

--- a/files/en-us/web/api/svgpointlist/initialize/index.html
+++ b/files/en-us/web/api/svgpointlist/initialize/index.html
@@ -1,0 +1,78 @@
+---
+title: SVGPointList.initialize()
+slug: Web/API/SVGPointList/initialize
+tags:
+  - API
+  - Method
+  - Reference
+  - initialize
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>initialize()</code></strong> method of the {{domxref("SVGPointList")}} interface clears the list then adds a single new {{domxref("SVGPoint")}} object to the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.initialize(obj);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>obj</code></dt>
+  <dd>An {{domxref("SVGPoint")}} object containing the coordinates of the point to be added when the list is initialized.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The added {{domxref("SVGPoint")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NoModicationAllowedError</code></dt>
+  <dd>Thrown if the list is read-only.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. Returning {{domxref("SVGPointList.length")}} gives the value <code>5</code>. After calling <code>initialize()</code> returning {{domxref("SVGPointList.length")}} gives the value <code>1</code>.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+console.log(example.points.length) //5;
+let svgpoint = document.getElementById("svg").createSVGPoint();
+example.points.initialize(svgpoint);
+console.log(example.points.length); //1</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__initialize", "initialize()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__initialize", "SVGPointList.initialize()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.initialize")}}</p>

--- a/files/en-us/web/api/svgpointlist/initialize/index.html
+++ b/files/en-us/web/api/svgpointlist/initialize/index.html
@@ -52,25 +52,7 @@ console.log(example.points.length); //1</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__initialize", "initialize()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__initialize", "SVGPointList.initialize()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/initialize/index.html
+++ b/files/en-us/web/api/svgpointlist/initialize/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - initialize
   - SVGPointList
+browser-compat: api.SVGPointList.initialize
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -75,4 +76,4 @@ console.log(example.points.length); //1</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.initialize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -1,0 +1,78 @@
+---
+title: SVGPointList.insertItemBefore()
+slug: Web/API/SVGPointList/insertItemBefore
+tags:
+  - API
+  - Method
+  - Reference
+  - insertItemBefore
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>insertItemBefore()</code></strong> method of the {{domxref("SVGPointList")}} interface inserts a {{domxref("SVGPoint", "point")}} before another item in the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.insertItemBefore(obj,index);</pre>
+
+<dl>
+  <dt><code>obj</code></dt>
+  <dd>An {{domxref("SVGPoint")}} object containing the coordinates of the point to be inserted.</dd>
+  <dt><code>index</code></dt>
+  <dd>The index of the item the object should be inserted before. If the index passed in is greater than the length of the list, then index ill be set to the list length and the item inserted before the last item in the list.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The {{domxref("SVGPoint")}} object that was inserted.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NoModicationAllowedError</code></dt>
+  <dd>Thrown if the list is read-only.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, inserted before the point at index <code>2</code>.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+let svgpoint = document.getElementById("svg").createSVGPoint();
+svgpoint.y = 10;
+svgpoint.x = 10;
+console.log(example.points.insertItemBefore(svgpoint,2));</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__insertItemBefore", "insertItemBefore()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__insertItemBefore", "SVGPointList.insertItemBefore()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.insertItemBefore")}}</p>

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -36,7 +36,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, inserted before the point at index <code>2</code>.</p>
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, and inserted before the point at index <code>2</code>.</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;polyline id="example" stroke="black" fill="none"

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -20,7 +20,7 @@ tags:
   <dt><code>obj</code></dt>
   <dd>An {{domxref("SVGPoint")}} object containing the coordinates of the point to be inserted.</dd>
   <dt><code>index</code></dt>
-  <dd>The index of the item the object should be inserted before. If the index passed in is greater than the length of the list, then index ill be set to the list length and the item inserted before the last item in the list.</dd>
+  <dd>The index of the item the object should be inserted before. If the index passed in is greater than the length of the list, then index will be set to the list length and the item inserted before the last item in the list.</dd>
 </dl>
 
 <h3 id="Returns">Return value</h3>

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -52,25 +52,7 @@ console.log(example.points.insertItemBefore(svgpoint,2));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__insertItemBefore", "insertItemBefore()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__insertItemBefore", "SVGPointList.insertItemBefore()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.html
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - insertItemBefore
   - SVGPointList
+browser-compat: api.SVGPointList.insertItemBefore
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -75,4 +76,4 @@ console.log(example.points.insertItemBefore(svgpoint,2));</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.insertItemBefore")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/length/index.html
+++ b/files/en-us/web/api/svgpointlist/length/index.html
@@ -1,0 +1,55 @@
+---
+title: SVGPointList.length
+slug: Web/API/SVGPointList/length
+tags:
+  - API
+  - Property
+  - Reference
+  - length
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>length</code></strong> read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let length = SVGPointList.length;</pre>
+
+<h3>Value</h3>
+<p>The number of items in the list.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The <code>length</code> property returns <code>5</code>.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+console.log(example.points.length); // 5</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__length", "length")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+  </tbody>
+ </table>
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.length")}}</p>
+

--- a/files/en-us/web/api/svgpointlist/length/index.html
+++ b/files/en-us/web/api/svgpointlist/length/index.html
@@ -34,23 +34,8 @@ console.log(example.points.length); // 5</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__length", "length")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-  </tbody>
- </table>
-<h2 id="Browser_compatibility">Browser compatibility</h2>
+<p>{{Specifications}}</p>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat}}</p>
-

--- a/files/en-us/web/api/svgpointlist/length/index.html
+++ b/files/en-us/web/api/svgpointlist/length/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - length
   - SVGPointList
+browser-compat: api.SVGPointList.length
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -51,5 +52,5 @@ console.log(example.points.length); // 5</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.length")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/svgpointlist/numberofitems/index.html
+++ b/files/en-us/web/api/svgpointlist/numberofitems/index.html
@@ -1,0 +1,60 @@
+---
+title: SVGPointList.numberOfItems
+slug: Web/API/SVGPointList/numberOfItems
+tags:
+  - API
+  - Property
+  - Reference
+  - numberOfItems
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>numberOfItems</code></strong> read-only property of the {{domxref("SVGPointList")}} interface returns the number of items in the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let numberOfItems = SVGPointList.numberOfItems;</pre>
+
+<h3>Value</h3>
+<p>The number of items in the list.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The <code>numberOfItems</code> property returns <code>5</code>.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+console.log(example.points.numberOfItems); // 5</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__numberOfItems", "numberOfItems")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__numberOfItems", "SVGPointList.numberOfItems")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.numberOfItems")}}</p>

--- a/files/en-us/web/api/svgpointlist/numberofitems/index.html
+++ b/files/en-us/web/api/svgpointlist/numberofitems/index.html
@@ -34,25 +34,7 @@ console.log(example.points.numberOfItems); // 5</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__numberOfItems", "numberOfItems")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__numberOfItems", "SVGPointList.numberOfItems")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/numberofitems/index.html
+++ b/files/en-us/web/api/svgpointlist/numberofitems/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - numberOfItems
   - SVGPointList
+browser-compat: api.SVGPointList.numberOfItems
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -57,4 +58,4 @@ console.log(example.points.numberOfItems); // 5</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.numberOfItems")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/removeitem/index.html
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.html
@@ -1,0 +1,75 @@
+---
+title: SVGPointList.removeItem()
+slug: Web/API/SVGPointList/removeItem
+tags:
+  - API
+  - Method
+  - Reference
+  - removeItem
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>removeItem()</code></strong> method of the {{domxref("SVGPointList")}} interface removes a {{domxref("SVGPoint","point")}} from the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.removeItem(index);</pre>
+
+<dl>
+  <dt><code>index</code></dt>
+  <dd>The index of the item to remove.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The removed {{domxref("SVGPoint")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NoModicationAllowedError</code></dt>
+  <dd>Thrown if the list is read-only.</dd>
+  <dt>{{domxref("DOMException")}} <code>IndexSizeError</code></dt>
+  <dd>Thrown if the index passed in is greater than the number of items in the list.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. The item at index <code>2</code> is removed.</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+console.log(example.points.removeItem(2));</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__removeItem", "removeItem()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__removeItem", "SVGPointList.removeItem()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.removeItem")}}</p>

--- a/files/en-us/web/api/svgpointlist/removeitem/index.html
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.html
@@ -49,25 +49,7 @@ console.log(example.points.removeItem(2));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__removeItem", "removeItem()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__removeItem", "SVGPointList.removeItem()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/svgpointlist/removeitem/index.html
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - removeItem
   - SVGPointList
+browser-compat: api.SVGPointList.removeItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -72,4 +73,4 @@ console.log(example.points.removeItem(2));</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.removeItem")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.html
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.html
@@ -1,0 +1,80 @@
+---
+title: SVGPointList.replaceItem()
+slug: Web/API/SVGPointList/replaceItem
+tags:
+  - API
+  - Method
+  - Reference
+  - replaceItem
+  - SVGPointList
+---
+<div>{{APIRef("SVG")}}</div>
+
+<p class="summary">The <strong><code>replaceItem()</code></strong> method of the {{domxref("SVGPointList")}} interface replaces an {{domxref("SVGPoint","point")}} in the list.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">SVGPointList.replaceItem(obj,index);</pre>
+
+<dl>
+  <dt><code>obj</code></dt>
+  <dd>An {{domxref("SVGPoint","point")}} object containing the coordinates of the point to be inserted.</dd>
+  <dt><code>index</code></dt>
+  <dd>The index of the item to replace.</dd>
+</dl>
+
+<h3 id="Returns">Return value</h3>
+
+<p>The new {{domxref("SVGPoint")}} object.</p>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{domxref("DOMException")}} <code>NoModicationAllowedError</code></dt>
+  <dd>Thrown if the list is read-only.</dd>
+  <dt>{{domxref("DOMException")}} <code>IndexSizeError</code></dt>
+  <dd>Thrown if the index passed in is greater than the number of items in the list.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, then replaced the point at index <code>1</code> (the second item in the list).</p>
+
+<pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
+  &lt;polyline id="example" stroke="black" fill="none"
+   points="50,0 21,90 98,35 2,35 79,90"/&gt;
+</svg></pre>
+
+<pre class="brush: js">let example = document.getElementById("example");
+let svgpoint = document.getElementById("svg").createSVGPoint();
+svgpoint.y = 10;
+svgpoint.x = 10;
+console.log(example.points.replaceItem(svgpoint,1));</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__replaceItem", "replaceItem()")}}</td>
+    <td>{{Spec2("SVG2")}}</td>
+    <td></td>
+   </tr>
+   <tr>
+    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__replaceItem", "SVGPointList.replaceItem()")}}</td>
+    <td>{{Spec2("SVG1.1")}}</td>
+    <td>Initial definition</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.SVGPointList.replaceItem")}}</p>

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.html
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.html
@@ -38,7 +38,7 @@ tags:
 
 <h2 id="Examples">Examples</h2>
 
-<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, then replaced the point at index <code>1</code> (the second item in the list).</p>
+<p>The following example shows an SVG which contains a {{SVGElement("polyline")}} with five coordinate pairs. A new {{domxref("SVGPoint")}} is created, then replaces the point at index <code>1</code> (the second item in the list).</p>
 
 <pre class="brush: html">&lt;svg id="svg" viewBox="-10 -10 120 120" xmlns="http://www.w3.org/2000/svg"&gt;
   &lt;polyline id="example" stroke="black" fill="none"

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.html
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - replaceItem
   - SVGPointList
+browser-compat: api.SVGPointList.replaceItem
 ---
 <div>{{APIRef("SVG")}}</div>
 
@@ -77,4 +78,4 @@ console.log(example.points.replaceItem(svgpoint,1));</pre>
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.SVGPointList.replaceItem")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.html
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.html
@@ -54,25 +54,7 @@ console.log(example.points.replaceItem(svgpoint,1));</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG2", "types.html#__svg__SVGNameList__replaceItem", "replaceItem()")}}</td>
-    <td>{{Spec2("SVG2")}}</td>
-    <td></td>
-   </tr>
-   <tr>
-    <td>{{SpecName("SVG1.1", "coords.html#__svg__SVGPointList__replaceItem", "SVGPointList.replaceItem()")}}</td>
-    <td>{{Spec2("SVG1.1")}}</td>
-    <td>Initial definition</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Adds the `SVGPointList` interface.

Reviewer: @jpmedley 

Notes for review: 

This was fun, the [SVG 2 spec](https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGPointList) has redefined each individual point in the list as a DOMPoint, however Chrome and Firefox still return and require an SVGPoint as per the SVG 1 spec.

Had a bit of a poke around and found this: https://github.com/w3c/svgwg/issues/706#issuecomment-544697551 which just appears not to have been edited into the spec.

See also the Chromium bug comment here: https://bugs.chromium.org/p/chromium/issues/detail?id=709001#c12

So ... if these are not being changed, does that mean the deprecation notice MDN has on SVGPoint is actually incorrect https://developer.mozilla.org/en-US/docs/Web/API/SVGPoint ?

Anyhow, I have documented reality. I tested the code of my examples to be correct as to what I have documented. The only real difference is in needing to create an SVGPoint object to insert or replace etc. everything else seems correct as per spec.