### PR TITLE
Fix typo in DedicatedWorkerGlobalScope.postMessage

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
@@ -11,7 +11,7 @@ tags:
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
-<p>The <code><strong>postMessage()</strong></code> method of the {{domxref("DedicatedWorkerGlobalScope")}} interface sends a message to the main thread that spawned it. This accepts a single parameter, which is the data to send to the worker. The data may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</p>
+<p>The <code><strong>postMessage()</strong></code> method of the {{domxref("DedicatedWorkerGlobalScope")}} interface sends a message to the main thread that spawned it. This accepts a single parameter, which is the data to send from the worker to the main thread. The data may be any value or JavaScript object handled by the <a href="/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm">structured clone</a> algorithm, which includes cyclical references.</p>
 
 <p>The main scope that spawned the worker can send back information to the thread that spawned it using the {{domxref("Worker.postMessage")}} method.</p>
 


### PR DESCRIPTION
This commit fixes a typo in the `postMessage` method of the
`DedicatedWorkerGlobalScope`. The data is sent from the worker to the
main thread, not the reverse.

> What was wrong/why is this fix needed? (quick summary only)
The original formulation states that data is send to the worker, but `postMessage` in `DedicatedWorkerGlobalScope` sends data from the worker to the main thread.

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/postMessage

> Issue number (if there is an associated issue)
Haven't opened one yet - should I?

> Anything else that could help us review it
