### PR TITLE
fixed mathjax addon link

### DIFF
--- a/files/en-us/web/mathml/index.html
+++ b/files/en-us/web/mathml/index.html
@@ -45,7 +45,7 @@ tags:
  <li><a href="https://addons.mozilla.org/firefox/collections/fred_wang/mathzilla/">Mathzilla Firefox add-on collection</a></li>
  <li><a href="https://github.com/fred-wang/TeXZilla">TeXZilla</a> — Javascript LaTeX to MathML converter (<a href="https://fred-wang.github.io/TeXZilla/">live demo</a>, <a href="https://r-gaia-cs.github.io/TeXZilla-webapp/">Firefox OS webapp</a>, <a href="https://addons.mozilla.org/en-US/firefox/addon/texzilla/">Firefox add-on</a>, <a href="https://github.com/fred-wang/TeXZilla/wiki/Using-TeXZilla">using in a Web Page, JS program etc</a>)</li>
  <li><a href="https://dlmf.nist.gov/LaTeXML/">LaTeXML</a> - Convert LaTeX documents into HTML+MathML Web pages</li>
- <li><a href="https://www.mathjax.org/">MathJax</a> - Cross-browser JavaScript display engine for mathematics. To force MathJax to use native MathML, try <a href="https://addons.mozilla.org/en-US/firefox/addon/mathjax-native-mathml/">this Mozilla add-on</a>, this <a href="https://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz">Safari extension</a> or this <a href="https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/">GreaseMonkey script</a>.</li>
+ <li><a href="https://www.mathjax.org/">MathJax</a> - Cross-browser JavaScript display engine for mathematics. To force MathJax to use native MathML, try <a href="https://addons.mozilla.org/en-US/firefox/addon/native-mathml/">this Mozilla add-on</a>, this <a href="https://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz">Safari extension</a> or this <a href="https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/">GreaseMonkey script</a>.</li>
 </ul>
 
 <h2 id="Related_topics">Related topics</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

MathJax addon link to firefox addons was broken URL. changed it to the right link.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/MathML
> Issue number (if there is an associated issue)

> Anything else that could help us review it

this is the link section:
https://developer.mozilla.org/en-US/docs/Web/MathML#tools