### PR TITLE
There is only one operand for bitwise not (#5210).

### DIFF
--- a/files/en-us/web/javascript/reference/operators/bitwise_not/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_not/index.html
@@ -2,11 +2,11 @@
 title: Bitwise NOT (~)
 slug: Web/JavaScript/Reference/Operators/Bitwise_NOT
 tags:
-- Bitwise operator
-- JavaScript
-- Language feature
-- Operator
-- Reference
+  - Bitwise operator
+  - JavaScript
+  - Language feature
+  - Operator
+  - Reference
 browser-compat: javascript.operators.bitwise_not
 ---
 <div>{{jsSidebar("Operators")}}</div>
@@ -17,24 +17,20 @@ browser-compat: javascript.operators.bitwise_not
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js"><code><var>~a</var></code>
+<pre class="brush: js">~a
 </pre>
 
 <h2 id="Description">Description</h2>
 
-<p>The operands are converted to 32-bit integers and expressed by a series of bits (zeroes
+<p>The operand is converted to a 32-bit integer and expressed as a series of bits (zeroes
   and ones). Numbers with more than 32 bits get their most significant bits discarded. For
-  example, the following integer with more than 32 bits will be converted to a 32 bit
+  example, the following integer, with more than 32 bits, will be converted to a 32 bit
   integer:</p>
 
 <pre class="brush: js">Before: 11100110111110100000000000000110000000000001
 After:              10100000000000000110000000000001</pre>
 
-<p>Each bit in the first operand is paired with the corresponding bit in the second
-  operand: <em>first bit</em> to <em>first bit</em>, <em>second bit</em> to <em>second
-    bit</em>, and so on.</p>
-
-<p>The operator is applied to each pair of bits, and the result is constructed bitwise.
+<p>Each bit in the operand is inverted in the result.
 </p>
 
 <p>The truth table for the <code>NOT</code> operation is:</p>
@@ -89,6 +85,6 @@ After:              10100000000000000110000000000001</pre>
 <h2 id="See_also">See also</h2>
 
 <ul>
-  <li><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Bitwise">Bitwise
+  <li><a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#bitwise">Bitwise
       operators in the JS guide</a></li>
 </ul>


### PR DESCRIPTION
…cted flaws.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The text assumes two operands, but there is only one.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT
> Issue number (if there is an associated issue)

Fix #5210
> Anything else that could help us review it
@iamtheiconoclast: you opened the issue. Do you like the proposed changes?