### PR TITLE
Where possible, avoid redirects

### DIFF
--- a/files/en-us/web/css/css_functions/index.html
+++ b/files/en-us/web/css/css_functions/index.html
@@ -79,48 +79,48 @@ tags:
 <p>The math functions allow CSS numeric values to be written as mathematical expressions.</p>
 
 <dl>
-  <dt>{{cssxref("calc")}}</dt>
+  <dt>{{cssxref("calc()")}}</dt>
   <dd>A math function that allows basic arithmetic to be performed on numerical CSS values.</dd>
-  <dt>{{cssxref("clamp")}}</dt>
+  <dt>{{cssxref("clamp()")}}</dt>
   <dd>A comparison function that takes a minimum, central, and maximum value and represents its central calculation.</dd>
-  <dt>{{cssxref("max")}}</dt>
+  <dt>{{cssxref("max()")}}</dt>
   <dd>A comparison function that represents the largest of a list of values.</dd>
-  <dt>{{cssxref("min")}}</dt>
+  <dt>{{cssxref("min()")}}</dt>
   <dd>A comparison function that represents the smallest of a list of values.</dd>
-  <dt>{{cssxref("abs","abs()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("abs()")}} {{Experimental_Inline}}</dt>
   <dd>Takes a calculation and returns the absolute value.</dd>
-  <dt>{{cssxref("acos","acos()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("acos()")}} {{Experimental_Inline}}</dt>
   <dd>An inverse trigonometric function the angle returned must be normalized to the range [0deg, 180deg];.</dd>
-  <dt>{{cssxref("asin","asin()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("asin()")}} {{Experimental_Inline}}</dt>
   <dd>An inverse trigonometric function  the angle returned must be normalized to the range [-90deg, 90deg].</dd>
-  <dt>{{cssxref("atan","atan()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("atan()")}} {{Experimental_Inline}}</dt>
   <dd>An inverse trigonometric function the angle returned must be normalized to the range [-90deg, 90deg].</dd>
-  <dt>{{cssxref("atan2","atan2()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("atan2()")}} {{Experimental_Inline}}</dt>
   <dd>Contains two comma-separated calculations, A and B. A and B can resolve to any {{cssxref("&lt;number&gt;")}}, {{cssxref("&lt;dimension&gt;")}}, or {{cssxref("&lt;percentage&gt;")}}, but must have the same type, or else the function is invalid.</dd>
-  <dt>{{cssxref("cos","cos()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("cos()")}} {{Experimental_Inline}}</dt>
   <dd>Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.</dd>
-  <dt>{{cssxref("exp","exp()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("exp()")}} {{Experimental_Inline}}</dt>
   <dd>Contains one calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the same value as pow(e, A) as a {{cssxref("&lt;number&gt;")}}.</dd>
-  <dt>{{cssxref("hypot","hypot()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("hypot()")}} {{Experimental_Inline}}</dt>
   <dd>Contains one or more comma-separated calculations, and returns the length of an N-dimensional vector with components equal to each of the calculations. </dd>
-  <dt>{{cssxref("log","log()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("log()")}} {{Experimental_Inline}}</dt>
   <dd>Contains one or two calculations (representing the value to be logarithmed, and the base of the logarithm, defaulting to e), which must both resolve as a {{cssxref("&lt;number&gt;")}}, and returns the logarithm base B of the value A, as a {{cssxref("&lt;number&gt;")}}.</dd>
-  <dt>{{cssxref("mod","mod()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("mod()")}} {{Experimental_Inline}}</dt>
   <dd>A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.</dd>
-  <dt>{{cssxref("pow","pow()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("pow()")}} {{Experimental_Inline}}</dt>
   <dd>Contains two comma-separated calculations A and B, both of which must resolve as a {{cssxref("&lt;number&gt;")}}, and returns the result of raising A to the power of B, returning the value as a {{cssxref("&lt;number&gt;")}}.</dd>
-  <dt>{{cssxref("rem","rem()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("rem()")}} {{Experimental_Inline}}</dt>
   <dd>A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.</dd>
-  <dt>{{cssxref("round","round()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("round()")}} {{Experimental_Inline}}</dt>
   <dd>Contains an optional rounding strategy, and two calculations A and B, and returns the value of A, rounded according to the rounding strategy, to the nearest integer multiple of B either above or below A. </dd>
-  <dt>{{cssxref("sign","sign()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("sign()")}} {{Experimental_Inline}}</dt>
   <dd>Takes a calculation and returns -1 if the numeric value is negative,
     +1 if the numeric value is positive, 0⁺ if the numeric value is 0⁺, and 0⁻ if the numeric value is 0⁻.</dd>
-  <dt>{{cssxref("sin","sin()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("sin()")}} {{Experimental_Inline}}</dt>
   <dd>Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.</dd>
-  <dt>{{cssxref("sqrt","sqrt()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("sqrt()")}} {{Experimental_Inline}}</dt>
   <dd>Contains a single calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the square root of the value as a {{cssxref("&lt;number&gt;")}}.</dd>
-  <dt>{{cssxref("tan","tan()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("tan()")}} {{Experimental_Inline}}</dt>
   <dd>Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.</dd>
 </dl>
 
@@ -187,19 +187,19 @@ tags:
 <dl>
   <dt>{{cssxref("conic-gradient()", "conic-gradient()")}} </dt>
   <dd>Conic gradients transition colors progressively around a circle. </dd>
-  <dt>{{cssxref("image()", "image()")}} {{Experimental_Inline}}</dt>
+  <dt>{{cssxref("image()")}} {{Experimental_Inline}}</dt>
   <dd>Defines an {{cssxref("&lt;image&gt;")}} in a similar fashion to the {{cssxref("url")}} function, but with added functionality including specifying the image's directionality, specifying fallback images for when the preferred image is not supported</dd>
-	<dt>{{cssxref("image-set()", "image-set()")}} {{Experimental_Inline}}</dt>
+	<dt>{{cssxref("image-set()")}} {{Experimental_Inline}}</dt>
   <dd>A method of letting the browser pick the most appropriate CSS image from a given set, primarily for high pixel density screens.</dd>
-  <dt>{{cssxref("linear-gradient()", "linear-gradient()")}} </dt>
+  <dt>{{cssxref("linear-gradient()")}} </dt>
   <dd>Linear gradients transition colors progressively along an imaginary line.</dd>
-  <dt>{{cssxref("radial-gradient()", "radial-gradient()")}} </dt>
+  <dt>{{cssxref("radial-gradient()")}} </dt>
   <dd>Radial gradients transition colors progressively from a center point (origin).</dd>
-  <dt>{{cssxref("repeating-linear-gradient()", "repeating-linear-gradient()")}} </dt>
+  <dt>{{cssxref("repeating-linear-gradient()")}} </dt>
   <dd>Is similar to <code>linear-gradient()</code> and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container.</dd>
-  <dt>{{cssxref("repeating-radial-gradient()", "repeating-radial-gradient()")}} </dt>
+  <dt>{{cssxref("repeating-radial-gradient()")}} </dt>
   <dd>Is similar to <code>radial-gradient()</code> and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container.</dd>
-  <dt>{{cssxref("repeating-conic-gradient()", "repeating-conic-gradient()")}} </dt>
+  <dt>{{cssxref("repeating-conic-gradient()")}} </dt>
   <dd>Is similar to <code>conic-gradient()</code> and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container.</dd>
 </dl>
 
@@ -208,9 +208,9 @@ tags:
 <p>The counter functions are generally used with the {{cssxref("content")}} property, although in theory may be used wherever a {{cssxref("&lt;string&gt;")}} is supported.</p>
 
 <dl>
-  <dt>{{cssxref("counter()", "counter()")}}</dt>
+  <dt>{{cssxref("counter()")}}</dt>
   <dd>Returns a string representing the current value of the named counter, if there is one.</dd>
-	<dt>{{cssxref("counters()", "counters()")}}</dt>
+	<dt>{{cssxref("counters()")}}</dt>
   <dd>Enables nested counters, returning a concatenated string representing the current values of the named counters, if there are any.</dd>
 </dl>
 


### PR DESCRIPTION
So, links like that: `{{cssxref("abs","abs()")}}` will display `abs()` but link to `abs`.  BUT... css functional notations URLs have `()` in their URL. All the functions without the `()` are redirected back to URLs with `()`.

This PR fixes some links to avoid redirects.