### PR TITLE
Fix parameter name in RTCPeerConnection.removeTrack()

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
@@ -37,7 +37,7 @@ tags:
 <h3 id="Parameters">Parameters</h3>
 
 <dl>
-  <dt><code>mediaTrack</code></dt>
+  <dt><code>sender</code></dt>
   <dd>A {{domxref("RTCRtpSender")}} specifying the sender to remove from the connection.
   </dd>
 </dl>


### PR DESCRIPTION
> What is wrong/why is this fix needed? (quick summary only)

The Syntax section uses `sender` for the parameter name but the Parameters section uses `mediaTrack`.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeTrack

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

n/a