### PR TITLE
Document PAC's alert() (#3782)

### DIFF
--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.html
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.html
@@ -132,7 +132,7 @@ tags:
  </li>
  <li>Logging utility
   <ul>
-   <li>{{domxref("Window/alert", "alert()")}}</li>
+   <li><code><a href="#alert">alert()</a></code></li>
   </ul>
  </li>
  <li>There was one associative array (object) already defined, because at the time JavaScript code was unable to define it by itself:
@@ -538,6 +538,28 @@ timerange(12, "GMT");         // returns true from noon to 1pm, in GMT timezone
 timerange(9, 17);             // returns true from 9am to 5pm
 timerange(8, 30, 17, 00);     // returns true from 8:30am to 5:00pm
 timerange(0, 0, 0, 0, 0, 30); // returns true between midnight and 30 seconds past midnight</pre>
+
+<h3 id="alert">alert()</h3>
+
+<h4 id="Syntax_14">Syntax</h4>
+
+<pre class="brush: html">
+alert(message)
+</pre>
+
+<h4 id="Parameters_15">Parameters</h4>
+
+<dl>
+ <dt>message</dt>
+ <dd>The string to log</dd>
+</dl>
+
+<p>Logs the message in the browser console.</p>
+
+<h4 id="Examples_12">Examples</h4>
+
+<pre class="brush: js">alert(host + " = " + dnsResolve(host));            // logs the host name and its IP address
+alert("Error: shouldn't reach this clause.");      // log a simple message</pre>
 
 <h2 id="Example_1">Example 1</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The alert() function was not documented, but linked to the not-related Window.alert() function

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file

> Issue number (if there is an associated issue)

Fix #3782

> Anything else that could help us review it
