### PR TITLE
Fix formatting for KS example in Markdown spec

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.html
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.html
@@ -378,10 +378,14 @@ cell 4    | cell 5    | cell 6
 
 <pre>
 
-The **`margin`** [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) property sets the [margin area](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model) on all four sides of an element. It is a shorthand for {{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}.
+The **`margin`** [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) property
+sets the margin area on all four sides of an element. It is a shorthand for
+\{{cssxref("margin-top")}}, \{{cssxref("margin-right")}}, \{{cssxref("margin-bottom")}},
+and \{{cssxref("margin-left")}}.
 
 \{{EmbedInteractiveExample("pages/css/margin.html")}}
 
-The top and bottom margins have no effect on replaced inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.
+The top and bottom margins have no effect on replaced inline elements, such as
+\{{HTMLElement("span")}} or \{{HTMLElement("code")}}.
 
 </pre>


### PR DESCRIPTION
This fixes the formatting for the KS example in https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#kumascript, adding linebreaks and escaping KS macro calls.