### PR TITLE
Fix grammar error and delete extra space

### DIFF
--- a/files/en-us/learn/javascript/first_steps/math/index.html
+++ b/files/en-us/learn/javascript/first_steps/math/index.html
@@ -200,7 +200,7 @@ num2 + num1 / 8 + 2;</pre>
  </li>
 </ol>
 
-<p>Some of these last sets of calculations might not give you quite the result you were expecting; the section below might well give the answer as to why.</p>
+<p>Parts of this last set of calculations might not give you quite the result you were expecting; the section below might well give the answer as to why.</p>
 
 <h3 id="Operator_precedence">Operator precedence</h3>
 

--- a/files/en-us/learn/javascript/first_steps/math/index.html
+++ b/files/en-us/learn/javascript/first_steps/math/index.html
@@ -200,7 +200,7 @@ num2 + num1 / 8 + 2;</pre>
  </li>
 </ol>
 
-<p>Some of this last set of calculations might not give you quite the result you were expecting; the  section below might well give the answer as to why.</p>
+<p>Some of these last sets of calculations might not give you quite the result you were expecting; the section below might well give the answer as to why.</p>
 
 <h3 id="Operator_precedence">Operator precedence</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There were some grammar errors.

> MDN URL of the main page changed:
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math

