### PR TITLE
Remove hidden bcd paragraph in whole web/css area

### DIFF
--- a/files/en-us/web/css/@color-profile/index.html
+++ b/files/en-us/web/css/@color-profile/index.html
@@ -78,6 +78,4 @@ browser-compat: css.at-rules.color-profile
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>

--- a/files/en-us/web/css/@font-face/font-variant/index.html
+++ b/files/en-us/web/css/@font-face/font-variant/index.html
@@ -96,10 +96,6 @@ font-variant: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/@keyframes/index.html
+++ b/files/en-us/web/css/@keyframes/index.html
@@ -136,8 +136,6 @@ browser-compat: css.at-rules.keyframes
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/@media/forced-colors/index.html
+++ b/files/en-us/web/css/@media/forced-colors/index.html
@@ -135,10 +135,6 @@ browser-compat: css.at-rules.media.forced-colors
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/@property/index.html
+++ b/files/en-us/web/css/@property/index.html
@@ -99,8 +99,6 @@ browser-compat: css.at-rules.property
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/@property/inherits/index.html
+++ b/files/en-us/web/css/@property/inherits/index.html
@@ -86,8 +86,6 @@ browser-compat: css.at-rules.property.inherits
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/@property/initial-value/index.html
+++ b/files/en-us/web/css/@property/initial-value/index.html
@@ -83,8 +83,6 @@ browser-compat: css.at-rules.property.initial-value
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/@property/syntax/index.html
+++ b/files/en-us/web/css/@property/syntax/index.html
@@ -111,8 +111,6 @@ syntax: '*'; /* any valid token */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_any-link/index.html
+++ b/files/en-us/web/css/_colon_any-link/index.html
@@ -74,8 +74,6 @@ a:-webkit-any-link {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_current/index.html
+++ b/files/en-us/web/css/_colon_current/index.html
@@ -69,8 +69,6 @@ This is the third caption
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_future/index.html
+++ b/files/en-us/web/css/_colon_future/index.html
@@ -69,8 +69,6 @@ This is the third caption
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_host-context()/index.html
+++ b/files/en-us/web/css/_colon_host-context()/index.html
@@ -99,8 +99,6 @@ style.textContent = 'span:hover { text-decoration: underline; }' +
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_last-child/index.html
+++ b/files/en-us/web/css/_colon_last-child/index.html
@@ -115,8 +115,6 @@ ul li:last-child {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_left/index.html
+++ b/files/en-us/web/css/_colon_left/index.html
@@ -65,8 +65,6 @@ browser-compat: css.selectors.left
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_local-link/index.html
+++ b/files/en-us/web/css/_colon_local-link/index.html
@@ -57,8 +57,6 @@ a:local-link {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_nth-col/index.html
+++ b/files/en-us/web/css/_colon_nth-col/index.html
@@ -81,8 +81,6 @@ browser-compat: css.selectors.nth-col
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_nth-last-col/index.html
+++ b/files/en-us/web/css/_colon_nth-last-col/index.html
@@ -81,8 +81,6 @@ browser-compat: css.selectors.nth-last-col
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_past/index.html
+++ b/files/en-us/web/css/_colon_past/index.html
@@ -69,8 +69,6 @@ This is the third caption
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_paused/index.html
+++ b/files/en-us/web/css/_colon_paused/index.html
@@ -52,8 +52,6 @@ browser-compat: css.selectors.paused
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_playing/index.html
+++ b/files/en-us/web/css/_colon_playing/index.html
@@ -52,8 +52,6 @@ browser-compat: css.selectors.playing
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_right/index.html
+++ b/files/en-us/web/css/_colon_right/index.html
@@ -65,8 +65,6 @@ browser-compat: css.selectors.right
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/_colon_scope/index.html
+++ b/files/en-us/web/css/_colon_scope/index.html
@@ -107,8 +107,6 @@ document.getElementById('results').innerHTML = Array.prototype.map.call(selected
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/align-tracks/index.html
+++ b/files/en-us/web/css/align-tracks/index.html
@@ -98,10 +98,6 @@ align-tracks: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background-color/index.html
+++ b/files/en-us/web/css/background-color/index.html
@@ -149,8 +149,6 @@ background-color: transparent;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background-origin/index.html
+++ b/files/en-us/web/css/background-origin/index.html
@@ -120,8 +120,6 @@ background-origin: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background-position-x/index.html
+++ b/files/en-us/web/css/background-position-x/index.html
@@ -119,7 +119,6 @@ background-position-x: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<!-- The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out https://github.com/mdn/browser-compat-data and send us a pull request. -->
 <div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background-position-y/index.html
+++ b/files/en-us/web/css/background-position-y/index.html
@@ -119,7 +119,6 @@ background-position-y: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<!-- The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out https://github.com/mdn/browser-compat-data and send us a pull request. -->
 <div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background-position/index.html
+++ b/files/en-us/web/css/background-position/index.html
@@ -207,8 +207,6 @@ div {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h3 id="Quantum_CSS_notes">Quantum CSS notes</h3>

--- a/files/en-us/web/css/background-repeat/index.html
+++ b/files/en-us/web/css/background-repeat/index.html
@@ -223,8 +223,6 @@ div {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background-size/index.html
+++ b/files/en-us/web/css/background-size/index.html
@@ -204,8 +204,6 @@ background-size: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/background/index.html
+++ b/files/en-us/web/css/background/index.html
@@ -161,8 +161,6 @@ background: no-repeat center/80% url("../img/image.png");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/border-bottom/index.html
+++ b/files/en-us/web/css/border-bottom/index.html
@@ -124,8 +124,6 @@ border-bottom: medium dashed blue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/border-left/index.html
+++ b/files/en-us/web/css/border-left/index.html
@@ -124,8 +124,6 @@ border-left: medium dashed blue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/border-right/index.html
+++ b/files/en-us/web/css/border-right/index.html
@@ -124,8 +124,6 @@ border-right: medium dashed green;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/border-top/index.html
+++ b/files/en-us/web/css/border-top/index.html
@@ -124,8 +124,6 @@ border-top: medium dashed green;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/color-adjust/index.html
+++ b/files/en-us/web/css/color-adjust/index.html
@@ -112,8 +112,6 @@ color-adjust: exact;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/color-scheme/index.html
+++ b/files/en-us/web/css/color-scheme/index.html
@@ -81,8 +81,6 @@ color-scheme: light dark;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/compositing_and_blending/index.html
+++ b/files/en-us/web/css/compositing_and_blending/index.html
@@ -55,23 +55,12 @@ tags:
 
 <h3 id="background-blend-mode_property"><code>background-blend-mode</code> property</h3>
 
-<div>
-
 <p>{{Compat("css.properties.background-blend-mode")}}</p>
-</div>
 
 <h3 id="isolation_property"><code>isolation</code> property</h3>
 
-<div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.isolation")}}</p>
-</div>
 
 <h3 id="mix-blend-mode_property"><code>mix-blend-mode</code> property</h3>
 
-<div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.mix-blend-mode")}}</p>
-</div>

--- a/files/en-us/web/css/css_color/index.html
+++ b/files/en-us/web/css/css_color/index.html
@@ -92,13 +92,9 @@ tags:
 
 <h3 id="color-adjust_property"><code>color-adjust</code> property</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.color-adjust")}}</p>
 
 <h3 id="opacity_property"><code>opacity</code> property</h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.opacity")}}</p>
 

--- a/files/en-us/web/css/css_conditional_rules/index.html
+++ b/files/en-us/web/css/css_conditional_rules/index.html
@@ -52,18 +52,12 @@ tags:
 
 <h3 id="import_rule"><code>@import</code> rule</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.at-rules.import")}}</p>
 
 <h3 id="media_rule"><code>@media</code> rule</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.at-rules.media")}}</p>
 
 <h3 id="supports_rule"><code>@supports</code> rule</h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.at-rules.supports")}}</p>

--- a/files/en-us/web/css/css_containment/index.html
+++ b/files/en-us/web/css/css_containment/index.html
@@ -144,8 +144,6 @@ contain: strict style;</pre>
 
 <p>{{Compat("css.properties.contain")}}</p>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.content-visibility")}}</p>
 
 <h2 id="External_resources">External resources</h2>

--- a/files/en-us/web/css/css_counter_styles/index.html
+++ b/files/en-us/web/css/css_counter_styles/index.html
@@ -79,12 +79,8 @@ tags:
 
 <h3 id="counter-increment_property"><code>counter-increment</code> property</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.counter-increment")}}</p>
 
 <h3 id="counter-reset_property"><code>counter-reset</code> property</h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("css.properties.counter-reset")}}</p>

--- a/files/en-us/web/css/css_display/index.html
+++ b/files/en-us/web/css/css_display/index.html
@@ -114,6 +114,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.display", 10)}}</p>

--- a/files/en-us/web/css/display-box/index.html
+++ b/files/en-us/web/css/display-box/index.html
@@ -104,8 +104,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <h3 id="Support_of_contents">Support of contents</h3>
 
 <p>{{Compat("css.properties.display.contents", 10)}}</p>

--- a/files/en-us/web/css/display-inside/index.html
+++ b/files/en-us/web/css/display-inside/index.html
@@ -92,8 +92,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out https://github.com/mdn/browser-compat-data and send us a pull request.</div>
-
 <h3 id="Support_of_multiple_keyword_values">Support of multiple keyword values</h3>
 
 <p>{{Compat("css.properties.display.multi-keyword_values", 10)}}</p>

--- a/files/en-us/web/css/display-internal/index.html
+++ b/files/en-us/web/css/display-internal/index.html
@@ -101,8 +101,6 @@ label, input {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <h3 id="Support_of_table_values">Support of table values</h3>
 
 <p><code>table</code>, <code>table-cell</code>, <code>table-column</code>, <code>table-column-group</code>, <code>table-footer-group</code>, <code>table-header-group</code>, <code>table-row</code>, and <code>table-row-group</code></p>

--- a/files/en-us/web/css/display-legacy/index.html
+++ b/files/en-us/web/css/display-legacy/index.html
@@ -88,8 +88,6 @@ Not a flex item
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <h3 id="Support_of_inline-block">Support of inline-block</h3>
 
 <p>{{Compat("css.properties.display.inline-block", 10)}}</p>

--- a/files/en-us/web/css/display-listitem/index.html
+++ b/files/en-us/web/css/display-listitem/index.html
@@ -62,8 +62,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <h3 id="Support_of_list-item">Support of <code>list-item</code></h3>
 
 <p>{{Compat("css.properties.display.list-item", 10)}}</p>

--- a/files/en-us/web/css/display-outside/index.html
+++ b/files/en-us/web/css/display-outside/index.html
@@ -67,8 +67,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.display.display-outside", 10)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/display/index.html
+++ b/files/en-us/web/css/display/index.html
@@ -360,8 +360,6 @@ updateDisplay();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.display", 10)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/display/two-value_syntax_of_display/index.html
+++ b/files/en-us/web/css/display/two-value_syntax_of_display/index.html
@@ -150,8 +150,6 @@ tags:
 
 <p>As demonstrated above, there is not a lot of advantage in using the two-value version right now; if you did your page would only work in Firefox! Other browsers do not yet implement the two-value versions. Therefore <code>display: block flex</code> will only get you flex layout in Firefox, and will be ignored as invalid in Chrome. You can see current support in the compat data for the two-value syntax:</p>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.display.multi-keyword_values", 10)}}</p>
 
 <ul>

--- a/files/en-us/web/css/filter_effects/index.html
+++ b/files/en-us/web/css/filter_effects/index.html
@@ -58,6 +58,4 @@ tags:
 
 <h3 id="filter_property"><code>filter</code> property</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.filter")}}</p>

--- a/files/en-us/web/css/flex-direction/index.html
+++ b/files/en-us/web/css/flex-direction/index.html
@@ -144,8 +144,6 @@ flex-direction: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/flex-grow/index.html
+++ b/files/en-us/web/css/flex-grow/index.html
@@ -121,8 +121,6 @@ flex-grow: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/flex-shrink/index.html
+++ b/files/en-us/web/css/flex-shrink/index.html
@@ -115,8 +115,6 @@ flex-shrink: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/flex/index.html
+++ b/files/en-us/web/css/flex/index.html
@@ -282,8 +282,6 @@ flex.addEventListener("click", function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/float/index.html
+++ b/files/en-us/web/css/float/index.html
@@ -215,8 +215,6 @@ div {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/font-optical-sizing/index.html
+++ b/files/en-us/web/css/font-optical-sizing/index.html
@@ -103,8 +103,6 @@ p {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/font-size/index.html
+++ b/files/en-us/web/css/font-size/index.html
@@ -234,8 +234,6 @@ span {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/font-style/index.html
+++ b/files/en-us/web/css/font-style/index.html
@@ -223,8 +223,6 @@ update();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/font-weight/index.html
+++ b/files/en-us/web/css/font-weight/index.html
@@ -391,8 +391,6 @@ span {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See-also">See Also</h2>

--- a/files/en-us/web/css/forced-color-adjust/index.html
+++ b/files/en-us/web/css/forced-color-adjust/index.html
@@ -113,8 +113,6 @@ forced-color-adjust: none;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/inset-block-end/index.html
+++ b/files/en-us/web/css/inset-block-end/index.html
@@ -95,8 +95,6 @@ inset-block-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/inset-block-start/index.html
+++ b/files/en-us/web/css/inset-block-start/index.html
@@ -93,8 +93,6 @@ inset-block-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/inset-inline-end/index.html
+++ b/files/en-us/web/css/inset-inline-end/index.html
@@ -98,8 +98,6 @@ inset-inline-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/inset-inline-start/index.html
+++ b/files/en-us/web/css/inset-inline-start/index.html
@@ -97,8 +97,6 @@ inset-inline-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/justify-tracks/index.html
+++ b/files/en-us/web/css/justify-tracks/index.html
@@ -102,10 +102,6 @@ justify-tracks: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.html
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.html
@@ -50,10 +50,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h4 id="Flexbox">Flexbox</h4>
 
 <p>{{Compat("css.properties.flex")}}</p>

--- a/files/en-us/web/css/layout_cookbook/card/index.html
+++ b/files/en-us/web/css/layout_cookbook/card/index.html
@@ -64,10 +64,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h4 id="grid-template-columns">grid-template-columns</h4>
 
 <p>{{Compat("css.properties.grid-template-columns")}}</p>

--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.html
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.html
@@ -39,10 +39,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h4 id="align-items">align-items</h4>
 
 <p>{{Compat("css.properties.align-items")}}</p>

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.html
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.html
@@ -47,10 +47,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p><em>Include the compat data for key properties you used, as in the example below which includes align-items.</em></p>
 
 <h4 id="align-items">align-items</h4>

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.html
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.html
@@ -67,10 +67,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h4 id="grid-template-columns">grid-template-columns</h4>
 
 <p>{{Compat("css.properties.grid-template-columns")}}</p>

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.html
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.html
@@ -40,10 +40,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h4 id="justify-content">justify-content</h4>
 
 <p>{{Compat("css.properties.justify-content")}}</p>

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.html
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.html
@@ -77,8 +77,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h4 id="grid-template-areas">grid-template-areas</h4>
 
 <p>{{Compat("css.properties.grid-template-areas")}}</p>

--- a/files/en-us/web/css/layout_cookbook/pagination/index.html
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.html
@@ -60,10 +60,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p><em>Include the compat data for key properties you used, as in the example below which includes align-items.</em></p>
 
 <h4 id="justify-content">justify-content</h4>

--- a/files/en-us/web/css/layout_cookbook/split_navigation/index.html
+++ b/files/en-us/web/css/layout_cookbook/split_navigation/index.html
@@ -39,10 +39,6 @@ tags:
 
 <p>The various layout methods have different browser support. See the charts below for details on basic support for the properties used.</p>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h4 id="Flexbox">Flexbox</h4>
 
 <p>{{Compat("css.properties.flex")}}</p>

--- a/files/en-us/web/css/margin-trim/index.html
+++ b/files/en-us/web/css/margin-trim/index.html
@@ -95,8 +95,6 @@ article &gt; span {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/mask/index.html
+++ b/files/en-us/web/css/mask/index.html
@@ -131,8 +131,6 @@ mask: url(masks.svg#star) left / 16px repeat-y,    /* Element within SVG graphic
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/masonry-auto-flow/index.html
+++ b/files/en-us/web/css/masonry-auto-flow/index.html
@@ -153,8 +153,6 @@ selectElem.addEventListener('change', changeMasonryFlow);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/math-style/index.html
+++ b/files/en-us/web/css/math-style/index.html
@@ -74,10 +74,4 @@ property: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p><em>(See <a href="/Project:en/Compatibility_tables" title="Project:en/Compatibility_tables">Compatibility tables</a> for more information)</em></p>
-
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat}}</p>

--- a/files/en-us/web/css/max-content/index.html
+++ b/files/en-us/web/css/max-content/index.html
@@ -116,8 +116,6 @@ grid-template-columns: 200px 1fr max-content;</code>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h3 id="Supported_for_width_and_other_sizing_properties">Supported for width (and other sizing properties)</h3>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/css/max-height/index.html
+++ b/files/en-us/web/css/max-height/index.html
@@ -119,8 +119,6 @@ form { max-height: none; }
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/max-width/index.html
+++ b/files/en-us/web/css/max-width/index.html
@@ -145,8 +145,6 @@ max-width: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/min-content/index.html
+++ b/files/en-us/web/css/min-content/index.html
@@ -108,8 +108,6 @@ grid-template-columns: 200px 1fr min-content;</code>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h3 id="Supported_for_width_and_other_sizing_properties">Supported for width (and other sizing properties)</h3>
 
 <p>{{Compat}}</p>

--- a/files/en-us/web/css/scroll-margin-block-end/index.html
+++ b/files/en-us/web/css/scroll-margin-block-end/index.html
@@ -60,8 +60,6 @@ scroll-margin-block-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-block-start/index.html
+++ b/files/en-us/web/css/scroll-margin-block-start/index.html
@@ -62,8 +62,6 @@ scroll-margin-block-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-block/index.html
+++ b/files/en-us/web/css/scroll-margin-block/index.html
@@ -74,8 +74,6 @@ scroll-margin-block: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-bottom/index.html
+++ b/files/en-us/web/css/scroll-margin-bottom/index.html
@@ -65,8 +65,6 @@ scroll-margin-bottom: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-inline-end/index.html
+++ b/files/en-us/web/css/scroll-margin-inline-end/index.html
@@ -137,8 +137,6 @@ scroll-margin-inline-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-inline-start/index.html
+++ b/files/en-us/web/css/scroll-margin-inline-start/index.html
@@ -140,8 +140,6 @@ scroll-margin-inline-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-inline/index.html
+++ b/files/en-us/web/css/scroll-margin-inline/index.html
@@ -155,8 +155,6 @@ scroll-margin-inline: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-left/index.html
+++ b/files/en-us/web/css/scroll-margin-left/index.html
@@ -66,8 +66,6 @@ scroll-margin-left: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-right/index.html
+++ b/files/en-us/web/css/scroll-margin-right/index.html
@@ -64,8 +64,6 @@ scroll-margin-right: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-margin-top/index.html
+++ b/files/en-us/web/css/scroll-margin-top/index.html
@@ -63,8 +63,6 @@ scroll-margin-top: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-block-start/index.html
+++ b/files/en-us/web/css/scroll-padding-block-start/index.html
@@ -71,8 +71,6 @@ scroll-padding-block-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-block/index.html
+++ b/files/en-us/web/css/scroll-padding-block/index.html
@@ -82,8 +82,6 @@ scroll-padding-block: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-bottom/index.html
+++ b/files/en-us/web/css/scroll-padding-bottom/index.html
@@ -71,8 +71,6 @@ scroll-padding-bottom: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-inline-end/index.html
+++ b/files/en-us/web/css/scroll-padding-inline-end/index.html
@@ -69,8 +69,6 @@ scroll-padding-inline-end: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-inline-start/index.html
+++ b/files/en-us/web/css/scroll-padding-inline-start/index.html
@@ -70,8 +70,6 @@ scroll-padding-inline-start: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-inline/index.html
+++ b/files/en-us/web/css/scroll-padding-inline/index.html
@@ -83,8 +83,6 @@ scroll-padding-inline: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-left/index.html
+++ b/files/en-us/web/css/scroll-padding-left/index.html
@@ -69,8 +69,6 @@ scroll-padding-left: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-right/index.html
+++ b/files/en-us/web/css/scroll-padding-right/index.html
@@ -70,8 +70,6 @@ scroll-padding-right: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding-top/index.html
+++ b/files/en-us/web/css/scroll-padding-top/index.html
@@ -70,8 +70,6 @@ scroll-padding-top: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-padding/index.html
+++ b/files/en-us/web/css/scroll-padding/index.html
@@ -81,8 +81,6 @@ scroll-padding: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-snap-coordinate/index.html
+++ b/files/en-us/web/css/scroll-snap-coordinate/index.html
@@ -140,8 +140,6 @@ scroll-snap-coordinate: unset;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-snap-points-x/index.html
+++ b/files/en-us/web/css/scroll-snap-points-x/index.html
@@ -95,8 +95,6 @@ scroll-snap-points-x: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-snap-points-y/index.html
+++ b/files/en-us/web/css/scroll-snap-points-y/index.html
@@ -96,8 +96,6 @@ scroll-snap-points-y: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-snap-type-x/index.html
+++ b/files/en-us/web/css/scroll-snap-type-x/index.html
@@ -55,8 +55,6 @@ scroll-snap-type-x: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-snap-type-y/index.html
+++ b/files/en-us/web/css/scroll-snap-type-y/index.html
@@ -55,8 +55,6 @@ scroll-snap-type-y: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scroll-snap-type/index.html
+++ b/files/en-us/web/css/scroll-snap-type/index.html
@@ -250,8 +250,6 @@ html, body, .holster {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/scrollbar-color/index.html
+++ b/files/en-us/web/css/scrollbar-color/index.html
@@ -123,8 +123,6 @@ scrollbar-color: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/text-align-last/index.html
+++ b/files/en-us/web/css/text-align-last/index.html
@@ -102,8 +102,6 @@ text-align-last: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/text-emphasis/index.html
+++ b/files/en-us/web/css/text-emphasis/index.html
@@ -133,8 +133,6 @@ text-emphasis: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/css/touch-action/index.html
+++ b/files/en-us/web/css/touch-action/index.html
@@ -143,10 +143,6 @@ touch-action: unset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{compat("css.properties.touch-action")}}</p>
 
 <h2 id="See_also">See also</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There were a paragraph in html (most of the time hidden) saying BCD was coming from structure data. This is now done automatically and was duplicated.

> MDN URL of the main page changed

114 CSS pages

> Issue number (if there is an associated issue)

Fix #2228 for web/css (only)

> Anything else that could help us review it

Before, rg 'The compatibility table' |wc -l , was giving 119 entries   (in 114 files)
After, it gives 0 entry left in web/css.

(Still a lot of them elsewhere!)
