### PR TITLE
Web Security: remove old mailing list link

### DIFF
--- a/files/en-us/web/security/index.html
+++ b/files/en-us/web/security/index.html
@@ -227,7 +227,6 @@ tags:
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="https://lists.mozilla.org/listinfo/dev-security">Mozilla security mailing list</a></li>
  <li><a href="https://blog.mozilla.com/security/">Security Blog</a></li>
  <li><a href="https://twitter.com/mozsec">@mozsec on Twitter</a></li>
 </ul>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

remove a broken link to the Mozilla mailing list at https://lists.mozilla.org/listinfo/dev-security
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Security
> Issue number (if there is an associated issue)

> Anything else that could help us review it

I found lots of these links to lists.mozilla.org and none of them work correctly. is there an alternative to them or should I change them with another link, or just remove them?