### PR TITLE
change Sourceforge URL to HTTPS

### DIFF
--- a/files/en-us/web/xpath/index.html
+++ b/files/en-us/web/xpath/index.html
@@ -21,7 +21,7 @@ tags:
 
 <div class="notecard note">
   <h4>Note</h4>
-  <p>Support for XPath varies widely; it's supported reasonably well in Firefox (although there are no plans to improve support further), while other browsers implement it to a lesser extent, if at all. If you need a polyfill, you may consider <a href="http://nchc.dl.sourceforge.net/project/js-xpath/js-xpath/1.0.0/xpath.js">js-xpath</a> or <a href="https://github.com/google/wicked-good-xpath">wicked-good-xpath</a>.</p>
+  <p>Support for XPath varies widely; it's supported reasonably well in Firefox (although there are no plans to improve support further), while other browsers implement it to a lesser extent, if at all. If you need a polyfill, you may consider <a href="https://nchc.dl.sourceforge.net/project/js-xpath/js-xpath/1.0.0/xpath.js">js-xpath</a> or <a href="https://github.com/google/wicked-good-xpath">wicked-good-xpath</a>.</p>
 </div>
 
 <h2 id="Documentation">Documentation</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

change HTTP URL to HTTPS.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/XPath
> Issue number (if there is an associated issue)

> Anything else that could help us review it

there is another HTTP URL to `http://qutoric.com/xmlquire/`.
what should I do with HTTP links that are not accessible throw HTTPS? should I remove them or let them be?