### PR TITLE
Remove <keygen> link from <form> doc

### DIFF
--- a/files/en-us/web/html/element/form/index.html
+++ b/files/en-us/web/html/element/form/index.html
@@ -206,7 +206,7 @@ tags:
 
 <ul>
  <li><a href="/en-US/docs/Learn/Forms">HTML forms guide</a></li>
- <li>Other elements that are used when creating forms: {{HTMLElement("button")}}, {{HTMLElement("datalist")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("input")}},{{HTMLElement("keygen")}}, {{HTMLElement("label")}}, {{HTMLElement("legend")}}, {{HTMLElement("meter")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}}, {{HTMLElement("select")}}, {{HTMLElement("textarea")}}.</li>
+ <li>Other elements that are used when creating forms: {{HTMLElement("button")}}, {{HTMLElement("datalist")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("input")}}, {{HTMLElement("label")}}, {{HTMLElement("legend")}}, {{HTMLElement("meter")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}}, {{HTMLElement("select")}}, {{HTMLElement("textarea")}}.</li>
  <li>Getting a list of the elements in the form: {{domxref("HTMLFormElement.elements")}}</li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Form_Role">ARIA: Form role</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role">ARIA: Search role</a></li>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

`<keygen>` is deprecated.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

None.
