### PR TITLE
Remove hidden bcd paragraph in whole web/html area

### DIFF
--- a/files/en-us/web/html/attributes/crossorigin/index.html
+++ b/files/en-us/web/html/attributes/crossorigin/index.html
@@ -87,19 +87,16 @@ tags:
 
 <h3 id="script_crossorigin">script crossorigin</h3>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.script.crossorigin")}}</p>
 
 <h3 id="video_crossorigin">video crossorigin</h3>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.video.crossorigin")}}</p>
 
 <h3 id="link_crossorigin">link crossorigin</h3>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.link.crossorigin")}}</p>
 

--- a/files/en-us/web/html/attributes/rel/index.html
+++ b/files/en-us/web/html/attributes/rel/index.html
@@ -413,7 +413,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.link.rel")}}</p>
 

--- a/files/en-us/web/html/element/aside/index.html
+++ b/files/en-us/web/html/element/aside/index.html
@@ -112,7 +112,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.aside")}}</p>
 

--- a/files/en-us/web/html/element/bdi/index.html
+++ b/files/en-us/web/html/element/bdi/index.html
@@ -195,7 +195,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.bdi")}}</p>
 

--- a/files/en-us/web/html/element/cite/index.html
+++ b/files/en-us/web/html/element/cite/index.html
@@ -139,7 +139,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you’d like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.cite")}}</p>
 

--- a/files/en-us/web/html/element/embed/index.html
+++ b/files/en-us/web/html/element/embed/index.html
@@ -118,7 +118,6 @@ tags:
 <p><strong>Note</strong>: Prior to version 45, Firefox did not display content of HTML resource, but a generic message saying the content needs a plug-in (see {{Bug("730768")}}).</p>
 </div>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.embed")}}</p>
 

--- a/files/en-us/web/html/element/figure/index.html
+++ b/files/en-us/web/html/element/figure/index.html
@@ -163,7 +163,6 @@ Love is a spirit all compact of fire,
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.figure")}}</p>
 

--- a/files/en-us/web/html/element/form/index.html
+++ b/files/en-us/web/html/element/form/index.html
@@ -198,7 +198,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.form")}}</p>
 

--- a/files/en-us/web/html/element/head/index.html
+++ b/files/en-us/web/html/element/head/index.html
@@ -109,7 +109,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.head")}}</p>
 

--- a/files/en-us/web/html/element/header/index.html
+++ b/files/en-us/web/html/element/header/index.html
@@ -108,7 +108,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.header")}}</p>
 

--- a/files/en-us/web/html/element/heading_elements/index.html
+++ b/files/en-us/web/html/element/heading_elements/index.html
@@ -244,7 +244,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.h1")}}</p>
 

--- a/files/en-us/web/html/element/meta/name/index.html
+++ b/files/en-us/web/html/element/meta/name/index.html
@@ -298,6 +298,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.meta.name")}}</p>

--- a/files/en-us/web/html/element/meta/name/theme-color/index.html
+++ b/files/en-us/web/html/element/meta/name/theme-color/index.html
@@ -39,6 +39,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.meta.name.theme-color")}}</p>

--- a/files/en-us/web/html/element/noframes/index.html
+++ b/files/en-us/web/html/element/noframes/index.html
@@ -64,7 +64,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
 
 <p>{{Compat("html.elements.noframes")}}</p>
 

--- a/files/en-us/web/html/element/noscript/index.html
+++ b/files/en-us/web/html/element/noscript/index.html
@@ -101,6 +101,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.noscript")}}</p>

--- a/files/en-us/web/html/element/section/index.html
+++ b/files/en-us/web/html/element/section/index.html
@@ -163,7 +163,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.section")}}</p>
 

--- a/files/en-us/web/html/element/span/index.html
+++ b/files/en-us/web/html/element/span/index.html
@@ -117,7 +117,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.span")}}</p>
 

--- a/files/en-us/web/html/element/strong/index.html
+++ b/files/en-us/web/html/element/strong/index.html
@@ -130,7 +130,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.strong")}}</p>
 

--- a/files/en-us/web/html/element/sub/index.html
+++ b/files/en-us/web/html/element/sub/index.html
@@ -137,7 +137,6 @@ commonly known as "caffeine."&lt;/p&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.sub")}}</p>
 

--- a/files/en-us/web/html/element/sup/index.html
+++ b/files/en-us/web/html/element/sup/index.html
@@ -132,7 +132,6 @@ languages as follows:&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.sup")}}</p>
 

--- a/files/en-us/web/html/element/time/index.html
+++ b/files/en-us/web/html/element/time/index.html
@@ -163,7 +163,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.time")}}</p>
 

--- a/files/en-us/web/html/element/track/index.html
+++ b/files/en-us/web/html/element/track/index.html
@@ -169,7 +169,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.track")}}</p>
 

--- a/files/en-us/web/html/element/u/index.html
+++ b/files/en-us/web/html/element/u/index.html
@@ -201,7 +201,6 @@ Chicken Noodle Soup With Carrots</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.u")}}</p>
 

--- a/files/en-us/web/html/element/var/index.html
+++ b/files/en-us/web/html/element/var/index.html
@@ -146,6 +146,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.var")}}</p>

--- a/files/en-us/web/html/element/wbr/index.html
+++ b/files/en-us/web/html/element/wbr/index.html
@@ -96,7 +96,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("html.elements.wbr")}}</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There were a paragraph in html (most of the time hidden) saying BCD was coming from structure data. This is now done automatically and was duplicated.

> MDN URL of the main page changed

25 HTML pages
> Issue number (if there is an associated issue)

Fix #2228 for web/html (only)

> Anything else that could help us review it

Before, rg 'The compatibility table' |wc -l , was giving 27 entries (in 25 files)
After, it gives 0 entry left in web/html.

(Still a lot of them elsewhere!)
