### PR TITLE
Creating a cross-browser video player: Use getBoundingClientRect

### DIFF
--- a/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.html
+++ b/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.html
@@ -243,7 +243,8 @@ voldec.addEventListener('click', function(e) {
 <p>Another feature of most browser default video control sets is the ability to click on the video's progress bar to "skip ahead" to a different point in the video. This can also be achieved by adding a simple <code>click</code> event listener to the <code>progress</code> element:</p>
 
 <pre class="brush: js">progress.addEventListener('click', function(e) {
-   var pos = (e.pageX  - this.offsetLeft) / this.offsetWidth;
+   var rect = this.getBoundingClientRect();
+   var pos = (e.pageX  - rect.left) / this.offsetWidth;
    video.currentTime = pos * video.duration;
 });
 </pre>


### PR DESCRIPTION
`getBoundingClientRect` should be used to find the left position of the progress bar on the screen instead of `offsetLeft`. Using `offsetLeft` was causing the progress position to not be calculated correctly when absolute positioning the progress bar somewhere on the screen other than the left side. For example, if you right-justify the [live example](https://iandevlin.github.io/mdn/video-player/) This change lets you position the progress bar anywhere on the screen and still have the calculation work as intended.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
offsetLeft does not lead to the correct progress calculation
> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery/cross_browser_video_player
> Issue number (if there is an associated issue)

> Anything else that could help us review it
In the [live example](https://iandevlin.github.io/mdn/video-player/), set the `videoContainer` to `position: absolute` and `right: 0`. Then click on the progress bar to see the issue.