### PR TITLE
Remove redundant hidden BCD comments in web/api (262 files, half of a…

### DIFF
--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.html
@@ -82,8 +82,6 @@ ext.drawArraysInstancedANGLE(gl.POINTS, 0, 8, 4);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.ANGLE_instanced_arrays.drawArraysInstancedANGLE")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.html
@@ -94,8 +94,6 @@ ext.drawElementsInstancedANGLE(gl.POINTS, 2, gl.UNSIGNED_SHORT, 0, 4);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.ANGLE_instanced_arrays.drawElementsInstancedANGLE")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/angle_instanced_arrays/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/index.html
@@ -73,8 +73,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.ANGLE_instanced_arrays")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.html
@@ -60,8 +60,6 @@ ext.vertexAttribDivisorANGLE(0, 2);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.ANGLE_instanced_arrays.vertexAttribDivisorANGLE")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
@@ -48,6 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchEvent.BackgroundFetchEvent")}}</p>

--- a/files/en-us/web/api/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/index.html
@@ -70,6 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchEvent")}}</p>

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.html
@@ -46,6 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchEvent.registration")}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
@@ -107,6 +107,4 @@ method.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchManager.fetch")}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.html
@@ -58,6 +58,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchManager.get")}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.html
@@ -58,6 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchManager.getIds")}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/index.html
@@ -64,6 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchManager")}}</p>

--- a/files/en-us/web/api/backgroundfetchrecord/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/index.html
@@ -58,6 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRecord")}}</p>

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.html
@@ -52,6 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRecord.request")}}</p>

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
@@ -52,6 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRecord.responseReady")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.html
@@ -49,6 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.abort")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
@@ -44,6 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.downloaded")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
@@ -40,6 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.downloadTotal")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
@@ -58,6 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.failureReason")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.html
@@ -44,6 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.id")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/index.html
@@ -129,6 +129,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.html
@@ -96,6 +96,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.match")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
@@ -82,6 +82,4 @@ console.log(records); // an array of BackgroundFetchRecord objects
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.matchAll")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
@@ -57,6 +57,4 @@ BackgroundRegistration.addEventListener('progress', function);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.onprogress")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
@@ -42,6 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.recordsAvailable")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/result/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/result/index.html
@@ -53,6 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.result")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
@@ -44,6 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.uploaded")}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
@@ -44,6 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchRegistration.uploadTotal")}}</p>

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
@@ -63,6 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent")}}</p>

--- a/files/en-us/web/api/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/index.html
@@ -74,6 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchUpdateUIEvent")}}</p>

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
@@ -91,6 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.BackgroundFetchUpdateUIEvent.updateUI")}}</p>

--- a/files/en-us/web/api/characterdata/appenddata/index.html
+++ b/files/en-us/web/api/characterdata/appenddata/index.html
@@ -51,5 +51,5 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 <p>{{Compat("api.CharacterData.appendData")}}</p>

--- a/files/en-us/web/api/characterdata/data/index.html
+++ b/files/en-us/web/api/characterdata/data/index.html
@@ -35,5 +35,5 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 <p>{{Compat("api.CharacterData.data")}}</p>

--- a/files/en-us/web/api/characterdata/deletedata/index.html
+++ b/files/en-us/web/api/characterdata/deletedata/index.html
@@ -54,5 +54,5 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 <p>{{Compat("api.CharacterData.deleteData")}}</p>

--- a/files/en-us/web/api/characterdata/insertdata/index.html
+++ b/files/en-us/web/api/characterdata/insertdata/index.html
@@ -55,5 +55,5 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 <p>{{Compat("api.CharacterData.insertData")}}</p>

--- a/files/en-us/web/api/characterdata/replacedata/index.html
+++ b/files/en-us/web/api/characterdata/replacedata/index.html
@@ -56,5 +56,5 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 <p>{{Compat("api.CharacterData.replaceData")}}</p>

--- a/files/en-us/web/api/characterdata/substringdata/index.html
+++ b/files/en-us/web/api/characterdata/substringdata/index.html
@@ -54,5 +54,5 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 <p>{{Compat("api.CharacterData.substringData")}}</p>

--- a/files/en-us/web/api/compressionstream/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.html
@@ -59,6 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CompressionStream.CompressionStream")}}</p>

--- a/files/en-us/web/api/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/index.html
@@ -52,6 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CompressionStream")}}</p>

--- a/files/en-us/web/api/compressionstream/readable/index.html
+++ b/files/en-us/web/api/compressionstream/readable/index.html
@@ -45,6 +45,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CompressionStream.readable")}}</p>

--- a/files/en-us/web/api/compressionstream/writable/index.html
+++ b/files/en-us/web/api/compressionstream/writable/index.html
@@ -43,6 +43,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CompressionStream.writable")}}</p>

--- a/files/en-us/web/api/cookie_store_api/index.html
+++ b/files/en-us/web/api/cookie_store_api/index.html
@@ -56,6 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -86,6 +86,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieChangeEvent.changed")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -55,6 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieChangeEvent.CookieChangeEvent")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -78,6 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieChangeEvent.deleted")}}</p>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -77,6 +77,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieChangeEvent")}}</p>

--- a/files/en-us/web/api/cookiestore/delete/index.html
+++ b/files/en-us/web/api/cookiestore/delete/index.html
@@ -79,6 +79,4 @@ console.log(result);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore.delete")}}</p>

--- a/files/en-us/web/api/cookiestore/get/index.html
+++ b/files/en-us/web/api/cookiestore/get/index.html
@@ -114,6 +114,4 @@ if (cookie) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore.get")}}</p>

--- a/files/en-us/web/api/cookiestore/getall/index.html
+++ b/files/en-us/web/api/cookiestore/getall/index.html
@@ -79,6 +79,4 @@ if (cookies) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore.getAll")}}</p>

--- a/files/en-us/web/api/cookiestore/index.html
+++ b/files/en-us/web/api/cookiestore/index.html
@@ -74,6 +74,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore")}}</p>

--- a/files/en-us/web/api/cookiestore/onchange/index.html
+++ b/files/en-us/web/api/cookiestore/onchange/index.html
@@ -50,6 +50,4 @@ CookieStore.addEventListener('change', function() { ... })</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore.onchange")}}</p>

--- a/files/en-us/web/api/cookiestore/set/index.html
+++ b/files/en-us/web/api/cookiestore/set/index.html
@@ -103,6 +103,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStore.set")}}</p>

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
@@ -52,6 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStoreManager.getSubscriptions")}}</p>

--- a/files/en-us/web/api/cookiestoremanager/index.html
+++ b/files/en-us/web/api/cookiestoremanager/index.html
@@ -56,6 +56,4 @@ await registration.cookies.subscribe(subscriptions);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStoreManager")}}</p>

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.html
@@ -73,6 +73,4 @@ cookieStore.set({name: 'cookie1', value: 'cookie-value', path: '/path/two/'}); /
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStoreManager.subscribe")}}</p>

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
@@ -67,6 +67,4 @@ await registration.cookies.unsubscribe(subscriptions);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CookieStoreManager.unsubscribe")}}</p>

--- a/files/en-us/web/api/cssanimation/index.html
+++ b/files/en-us/web/api/cssanimation/index.html
@@ -70,6 +70,4 @@ console.log(animations[0]);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSAnimation")}}</p>

--- a/files/en-us/web/api/cssfontfacerule/index.html
+++ b/files/en-us/web/api/cssfontfacerule/index.html
@@ -68,6 +68,4 @@ console.log(myRules[0]); //a CSSFontFaceRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSFontFaceRule")}}</p>

--- a/files/en-us/web/api/cssfontfacerule/style/index.html
+++ b/files/en-us/web/api/cssfontfacerule/style/index.html
@@ -61,6 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSFontFaceRule.style")}}</p>

--- a/files/en-us/web/api/cssimportrule/index.html
+++ b/files/en-us/web/api/cssimportrule/index.html
@@ -65,6 +65,4 @@ console.log(myRules[0]); //a CSSImportRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSImportRule")}}</p>

--- a/files/en-us/web/api/csspagerule/selectortext/index.html
+++ b/files/en-us/web/api/csspagerule/selectortext/index.html
@@ -62,6 +62,4 @@ console.log(myRules[1].selectorText); // returns the string ":first"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPageRule.selectorText")}}</p>

--- a/files/en-us/web/api/csspagerule/style/index.html
+++ b/files/en-us/web/api/csspagerule/style/index.html
@@ -68,6 +68,4 @@ console.log(myRules[0].style); // returns a CSSStyleDeclaration object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPageRule.style")}}</p>

--- a/files/en-us/web/api/csspropertyrule/index.html
+++ b/files/en-us/web/api/csspropertyrule/index.html
@@ -68,6 +68,4 @@ console.log(myRules[0]); //a CSSPropertyRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPropertyRule")}}</p>

--- a/files/en-us/web/api/csstransition/index.html
+++ b/files/en-us/web/api/csstransition/index.html
@@ -72,6 +72,4 @@ item.addEventListener('transitionrun', () => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CSSTransition")}}</p>

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.html
@@ -60,6 +60,4 @@ const decompressedStream = blob.stream().pipeThrough(ds);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.DecompressionStream.DecompressionStream")}}</p>

--- a/files/en-us/web/api/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/index.html
@@ -53,6 +53,4 @@ const decompressedStream = blob.stream().pipeThrough(ds);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.DecompressionStream")}}</p>

--- a/files/en-us/web/api/decompressionstream/readable/index.html
+++ b/files/en-us/web/api/decompressionstream/readable/index.html
@@ -45,6 +45,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.DecompressionStream.readable")}}</p>

--- a/files/en-us/web/api/decompressionstream/writable/index.html
+++ b/files/en-us/web/api/decompressionstream/writable/index.html
@@ -43,6 +43,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.DecompressionStream.writable")}}</p>

--- a/files/en-us/web/api/element/ariaatomic/index.html
+++ b/files/en-us/web/api/element/ariaatomic/index.html
@@ -58,6 +58,4 @@ console.log(el.ariaAtomic); // false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaAtomic")}}</p>

--- a/files/en-us/web/api/element/ariaautocomplete/index.html
+++ b/files/en-us/web/api/element/ariaautocomplete/index.html
@@ -70,6 +70,4 @@ console.log(el.ariaAutoComplete); // inline</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaAutoComplete")}}</p>

--- a/files/en-us/web/api/element/ariabusy/index.html
+++ b/files/en-us/web/api/element/ariabusy/index.html
@@ -59,6 +59,4 @@ console.log(el.ariaBusy); // true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaBusy")}}</p>

--- a/files/en-us/web/api/element/ariachecked/index.html
+++ b/files/en-us/web/api/element/ariachecked/index.html
@@ -69,8 +69,6 @@ console.log(el.ariaChecked); // "true"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaChecked")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariacolcount/index.html
+++ b/files/en-us/web/api/element/ariacolcount/index.html
@@ -78,8 +78,6 @@ console.log(el.ariaColCount); // 3</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaColCount")}}</p>
 
 <ul>

--- a/files/en-us/web/api/element/ariacolindex/index.html
+++ b/files/en-us/web/api/element/ariacolindex/index.html
@@ -78,8 +78,6 @@ console.log(el.ariaColIndex); // 2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaColIndex")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariacolindextext/index.html
+++ b/files/en-us/web/api/element/ariacolindextext/index.html
@@ -78,8 +78,6 @@ console.log(el.ariaColIndexText); // "New column name"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaColIndexText")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariacolspan/index.html
+++ b/files/en-us/web/api/element/ariacolspan/index.html
@@ -62,8 +62,6 @@ console.log(el.ariaColSpan);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaColSpan")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariacurrent/index.html
+++ b/files/en-us/web/api/element/ariacurrent/index.html
@@ -75,8 +75,6 @@ console.log(el.ariaCurrent); // "tab"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaCurrent")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariadescription/index.html
+++ b/files/en-us/web/api/element/ariadescription/index.html
@@ -52,6 +52,4 @@ console.log(el.ariaDescription); // "A different description"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaDescription")}}</p>

--- a/files/en-us/web/api/element/ariadisabled/index.html
+++ b/files/en-us/web/api/element/ariadisabled/index.html
@@ -64,6 +64,4 @@ console.log(el.ariaDisabled); // "false"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaDisabled")}}</p>

--- a/files/en-us/web/api/element/ariaexpanded/index.html
+++ b/files/en-us/web/api/element/ariaexpanded/index.html
@@ -69,6 +69,4 @@ console.log(el.ariaExpanded); // true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaExpanded")}}</p>

--- a/files/en-us/web/api/element/ariahaspopup/index.html
+++ b/files/en-us/web/api/element/ariahaspopup/index.html
@@ -77,6 +77,4 @@ console.log(el.ariaHasPopup); // false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaHasPopup")}}</p>

--- a/files/en-us/web/api/element/ariahidden/index.html
+++ b/files/en-us/web/api/element/ariahidden/index.html
@@ -61,6 +61,4 @@ console.log(el.ariaHidden); // false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaHidden")}}</p>

--- a/files/en-us/web/api/element/ariakeyshortcuts/index.html
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.html
@@ -52,6 +52,4 @@ console.log(el.ariaKeyShortcuts); // "Alt+Shift+M"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaKeyShortcuts")}}</p>

--- a/files/en-us/web/api/element/arialabel/index.html
+++ b/files/en-us/web/api/element/arialabel/index.html
@@ -52,6 +52,4 @@ console.log(el.ariaLabel); // "Close dialog"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaLabel")}}</p>

--- a/files/en-us/web/api/element/arialevel/index.html
+++ b/files/en-us/web/api/element/arialevel/index.html
@@ -58,8 +58,6 @@ console.log(el.ariaLevel); // "2"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaLevel")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/arialive/index.html
+++ b/files/en-us/web/api/element/arialive/index.html
@@ -63,6 +63,4 @@ console.log(el.ariaLive); // assertive</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaLive")}}</p>

--- a/files/en-us/web/api/element/ariamodal/index.html
+++ b/files/en-us/web/api/element/ariamodal/index.html
@@ -60,8 +60,6 @@ console.log(el.ariaModal); // "false"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaModal")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariamultiline/index.html
+++ b/files/en-us/web/api/element/ariamultiline/index.html
@@ -66,8 +66,6 @@ console.log(el.ariaMultiline); // "false"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaMultiline")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariamultiselectable/index.html
+++ b/files/en-us/web/api/element/ariamultiselectable/index.html
@@ -69,8 +69,6 @@ console.log(el.ariaMultiSelectable); // "false"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaMultiSelectable")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariaorientation/index.html
+++ b/files/en-us/web/api/element/ariaorientation/index.html
@@ -68,6 +68,4 @@ console.log(el.ariaOrientation); // "horizontal"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaOrientation")}}</p>

--- a/files/en-us/web/api/element/ariaplaceholder/index.html
+++ b/files/en-us/web/api/element/ariaplaceholder/index.html
@@ -58,8 +58,6 @@ console.log(el.ariaPlaceholder); // "12345"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaPlaceholder")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariaposinset/index.html
+++ b/files/en-us/web/api/element/ariaposinset/index.html
@@ -54,6 +54,4 @@ console.log(el.ariaPosInSet); // "3"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaPosInSet")}}</p>

--- a/files/en-us/web/api/element/ariapressed/index.html
+++ b/files/en-us/web/api/element/ariapressed/index.html
@@ -68,8 +68,6 @@ console.log(el.ariaPressed); // "true"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaPressed")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariareadonly/index.html
+++ b/files/en-us/web/api/element/ariareadonly/index.html
@@ -66,8 +66,6 @@ console.log(el.ariaReadOnly); // "false"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaReadOnly")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariarelevant/index.html
+++ b/files/en-us/web/api/element/ariarelevant/index.html
@@ -46,6 +46,4 @@ console.log(el.ariaRelevant); // text</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRelevant")}}</p>

--- a/files/en-us/web/api/element/ariarequired/index.html
+++ b/files/en-us/web/api/element/ariarequired/index.html
@@ -66,8 +66,6 @@ console.log(el.ariaRequired); // "false"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRequired")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariaroledescription/index.html
+++ b/files/en-us/web/api/element/ariaroledescription/index.html
@@ -52,8 +52,6 @@ console.log(el.ariaRoleDescription); // "an updated description of this widget"<
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRoleDescription")}}</p>
 
 <ul>

--- a/files/en-us/web/api/element/ariarowcount/index.html
+++ b/files/en-us/web/api/element/ariarowcount/index.html
@@ -78,8 +78,6 @@ console.log(el.ariaRowCount); // 101</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRowCount")}}</p>
 
 <ul>

--- a/files/en-us/web/api/element/ariarowindex/index.html
+++ b/files/en-us/web/api/element/ariarowindex/index.html
@@ -78,8 +78,6 @@ console.log(el.ariaRowIndex); // 2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRowIndex")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariarowindextext/index.html
+++ b/files/en-us/web/api/element/ariarowindextext/index.html
@@ -78,8 +78,6 @@ console.log(el.ariaRowIndexText); // "Updated heading row"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRowIndexText")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariarowspan/index.html
+++ b/files/en-us/web/api/element/ariarowspan/index.html
@@ -63,8 +63,6 @@ console.log(el.ariaRowSpan);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaRowSpan")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariaselected/index.html
+++ b/files/en-us/web/api/element/ariaselected/index.html
@@ -61,8 +61,6 @@ console.log(el.ariaSelected); // false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaSelected")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariasetsize/index.html
+++ b/files/en-us/web/api/element/ariasetsize/index.html
@@ -52,8 +52,6 @@ console.log(el.ariaSetSize); // 4</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaSetSize")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariasort/index.html
+++ b/files/en-us/web/api/element/ariasort/index.html
@@ -89,8 +89,6 @@ console.log(el.ariaSort); // ascending</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaSort")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/ariavaluemax/index.html
+++ b/files/en-us/web/api/element/ariavaluemax/index.html
@@ -54,6 +54,4 @@ console.log(el.ariaValueMax); // 6</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaValueMax")}}</p>

--- a/files/en-us/web/api/element/ariavaluemin/index.html
+++ b/files/en-us/web/api/element/ariavaluemin/index.html
@@ -54,6 +54,4 @@ console.log(el.ariaValueMin); // 2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaValueMin")}}</p>

--- a/files/en-us/web/api/element/ariavaluenow/index.html
+++ b/files/en-us/web/api/element/ariavaluenow/index.html
@@ -54,6 +54,4 @@ console.log(el.ariaValueNow); // 2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaValueNow")}}</p>

--- a/files/en-us/web/api/element/ariavaluetext/index.html
+++ b/files/en-us/web/api/element/ariavaluetext/index.html
@@ -54,6 +54,4 @@ console.log(el.ariaValueText); // Monday</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Element.ariaValueText")}}</p>

--- a/files/en-us/web/api/element_timing_api/index.html
+++ b/files/en-us/web/api/element_timing_api/index.html
@@ -64,8 +64,6 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h3>PerformanceElementTiming</h3>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_blend_minmax/index.html
+++ b/files/en-us/web/api/ext_blend_minmax/index.html
@@ -57,8 +57,6 @@ gl.blendEquationSeparate(ext.MIN_EXT, ext.MAX_EXT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_blend_minmax")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_color_buffer_float/index.html
+++ b/files/en-us/web/api/ext_color_buffer_float/index.html
@@ -69,8 +69,6 @@ gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA16F, 256, 256);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_color_buffer_float")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_color_buffer_half_float/index.html
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.html
@@ -66,8 +66,6 @@ gl.renderbufferStorage(gl.RENDERBUFFER, ext.RBGA16F_EXT, 256, 256);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_color_buffer_half_float")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.html
@@ -105,8 +105,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_frag_depth/index.html
+++ b/files/en-us/web/api/ext_frag_depth/index.html
@@ -52,8 +52,6 @@ void main() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_frag_depth")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_shader_texture_lod/index.html
+++ b/files/en-us/web/api/ext_shader_texture_lod/index.html
@@ -72,8 +72,6 @@ void main(){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_shader_texture_lod")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_srgb/index.html
+++ b/files/en-us/web/api/ext_srgb/index.html
@@ -62,8 +62,6 @@ gl.texImage2D(gl.TEXTURE_2D, 0, ext.SRGB_EXT, 512, 512, 0,
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_sRGB")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.html
@@ -61,8 +61,6 @@ if (ext){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_texture_filter_anisotropic")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_texture_norm16/index.html
+++ b/files/en-us/web/api/ext_texture_norm16/index.html
@@ -95,8 +95,6 @@ gl.renderbufferStorage(gl.RENDERBUFFER, ext.RGBA16_EXT, 1, 1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_texture_norm16")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.html
@@ -86,6 +86,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ExtendableCookieChangeEvent.changed")}}</p>

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.html
@@ -78,6 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ExtendableCookieChangeEvent.deleted")}}</p>

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.html
@@ -55,6 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent")}}</p>

--- a/files/en-us/web/api/extendablecookiechangeevent/index.html
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.html
@@ -82,6 +82,4 @@ self.addEventListener('cookiechange', event => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ExtendableCookieChangeEvent")}}</p>

--- a/files/en-us/web/api/htmldocument/index.html
+++ b/files/en-us/web/api/htmldocument/index.html
@@ -42,6 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLDocument")}}</p>

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
@@ -100,6 +100,4 @@ navigator.mediaDevices.enumerateDevices()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.InputDeviceInfo.getCapabilities")}}</p>

--- a/files/en-us/web/api/inputdeviceinfo/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/index.html
@@ -51,6 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.InputDeviceInfo")}}</p>

--- a/files/en-us/web/api/intersectionobserver/index.html
+++ b/files/en-us/web/api/intersectionobserver/index.html
@@ -80,8 +80,6 @@ intersectionObserver.observe(document.querySelector('.scrollerFooter'));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserverentry/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/index.html
@@ -55,6 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry")}}</p>

--- a/files/en-us/web/api/khr_parallel_shader_compile/index.html
+++ b/files/en-us/web/api/khr_parallel_shader_compile/index.html
@@ -77,8 +77,6 @@ function* linkingProgress(programs) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.KHR_parallel_shader_compile")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/navigator/clearappbadge/index.html
+++ b/files/en-us/web/api/navigator/clearappbadge/index.html
@@ -57,8 +57,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Navigator.clearAppBadge")}}</p>
 
 <h2>See also</h2>

--- a/files/en-us/web/api/navigator/serial/index.html
+++ b/files/en-us/web/api/navigator/serial/index.html
@@ -49,8 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Navigator.serial")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/navigator/setappbadge/index.html
+++ b/files/en-us/web/api/navigator/setappbadge/index.html
@@ -61,8 +61,6 @@ navigator.setAppBadge(unread);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Navigator.setAppBadge")}}</p>
 
 <h2>See also</h2>

--- a/files/en-us/web/api/oes_element_index_uint/index.html
+++ b/files/en-us/web/api/oes_element_index_uint/index.html
@@ -51,8 +51,6 @@ gl.drawElements(gl.POINTS, 8, gl.UNSIGNED_INT, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_element_index_uint")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_standard_derivatives/index.html
+++ b/files/en-us/web/api/oes_standard_derivatives/index.html
@@ -76,8 +76,6 @@ void main(){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_standard_derivatives")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_texture_float/index.html
+++ b/files/en-us/web/api/oes_texture_float/index.html
@@ -65,8 +65,6 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, image);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_texture_float")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_texture_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_float_linear/index.html
@@ -54,8 +54,6 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, image);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_texture_float_linear")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_texture_half_float/index.html
+++ b/files/en-us/web/api/oes_texture_half_float/index.html
@@ -71,8 +71,6 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, ext.HALF_FLOAT_OES, image);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_texture_half_float")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_texture_half_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.html
@@ -54,8 +54,6 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, halfFloat.HALF_FLOAT_OES, imag
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_texture_half_float_linear")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_vertex_array_object/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/index.html
@@ -80,8 +80,6 @@ oes_vao_ext.bindVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OES_vertex_array_object")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/performanceelementtiming/element/index.html
+++ b/files/en-us/web/api/performanceelementtiming/element/index.html
@@ -55,6 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.element")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/id/index.html
+++ b/files/en-us/web/api/performanceelementtiming/id/index.html
@@ -55,6 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.id")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.html
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.html
@@ -55,6 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.identifier")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/index.html
+++ b/files/en-us/web/api/performanceelementtiming/index.html
@@ -76,6 +76,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
@@ -57,6 +57,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.intersectionRect")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.html
@@ -55,6 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.loadTime")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
@@ -55,6 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.naturalHeight")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
@@ -54,6 +54,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.naturalWidth")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.html
@@ -59,6 +59,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.renderTime")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.html
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.html
@@ -59,6 +59,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.toJSON")}}</p>

--- a/files/en-us/web/api/performanceelementtiming/url/index.html
+++ b/files/en-us/web/api/performanceelementtiming/url/index.html
@@ -55,6 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PerformanceElementTiming.url")}}</p>

--- a/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
@@ -49,6 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PushSubscriptionOptions.applicationServerKey")}}</p>

--- a/files/en-us/web/api/pushsubscriptionoptions/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.html
@@ -54,6 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PushSubscriptionOptions")}}</p>

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
@@ -49,6 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PushSubscriptionOptions.userVisibleOnly")}}</p>

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.html
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.html
@@ -56,6 +56,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ResizeObserverSize.blockSize")}}</p>

--- a/files/en-us/web/api/resizeobserversize/index.html
+++ b/files/en-us/web/api/resizeobserversize/index.html
@@ -63,6 +63,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ResizeObserverSize")}}</p>

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.html
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.html
@@ -56,6 +56,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ResizeObserverSize.inlineSize")}}</p>

--- a/files/en-us/web/api/serial/getports/index.html
+++ b/files/en-us/web/api/serial/getports/index.html
@@ -54,6 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Serial.getPorts")}}</p>

--- a/files/en-us/web/api/serial/index.html
+++ b/files/en-us/web/api/serial/index.html
@@ -86,6 +86,4 @@ button.addEventListener('click', () => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Serial")}}</p>

--- a/files/en-us/web/api/serial/onconnect/index.html
+++ b/files/en-us/web/api/serial/onconnect/index.html
@@ -46,6 +46,4 @@ Serial.addEventListener('connect', <var>function(event)</var>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Serial.onconnect")}}</p>

--- a/files/en-us/web/api/serial/ondisconnect/index.html
+++ b/files/en-us/web/api/serial/ondisconnect/index.html
@@ -46,6 +46,4 @@ Serial.addEventListener('disconnect', <var>function(event)</var>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Serial.ondisconnect")}}</p>

--- a/files/en-us/web/api/serial/requestport/index.html
+++ b/files/en-us/web/api/serial/requestport/index.html
@@ -78,6 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Serial.requestPort")}}</p>

--- a/files/en-us/web/api/serialport/close/index.html
+++ b/files/en-us/web/api/serialport/close/index.html
@@ -43,6 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.close()")}}</p>

--- a/files/en-us/web/api/serialport/getinfo/index.html
+++ b/files/en-us/web/api/serialport/getinfo/index.html
@@ -50,6 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.getInfo")}}</p>

--- a/files/en-us/web/api/serialport/getsignals/index.html
+++ b/files/en-us/web/api/serialport/getsignals/index.html
@@ -63,6 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.getSignals")}}</p>

--- a/files/en-us/web/api/serialport/index.html
+++ b/files/en-us/web/api/serialport/index.html
@@ -110,6 +110,4 @@ writer.releaseLock();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort")}}</p>

--- a/files/en-us/web/api/serialport/onconnect/index.html
+++ b/files/en-us/web/api/serialport/onconnect/index.html
@@ -37,6 +37,4 @@ SerialPort.addEventListener('connect', <var>function(event)</var>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.onconnect")}}</p>

--- a/files/en-us/web/api/serialport/ondisconnect/index.html
+++ b/files/en-us/web/api/serialport/ondisconnect/index.html
@@ -36,6 +36,4 @@ SerialPort.addEventListener('disconnect', <var>function(event)</var>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.ondisconnect")}}</p>

--- a/files/en-us/web/api/serialport/open/index.html
+++ b/files/en-us/web/api/serialport/open/index.html
@@ -76,6 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.open")}}</p>

--- a/files/en-us/web/api/serialport/readable/index.html
+++ b/files/en-us/web/api/serialport/readable/index.html
@@ -60,6 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.readable")}}</p>

--- a/files/en-us/web/api/serialport/setsignals/index.html
+++ b/files/en-us/web/api/serialport/setsignals/index.html
@@ -66,6 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.setSignals")}}</p>

--- a/files/en-us/web/api/serialport/writable/index.html
+++ b/files/en-us/web/api/serialport/writable/index.html
@@ -47,6 +47,4 @@ writer.releaseLock();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SerialPort.writable")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/index.html
+++ b/files/en-us/web/api/svgmarkerelement/index.html
@@ -121,6 +121,4 @@ console.log(marker.orientAngle.baseVal.value); // new value - 110</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/markerheight/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerheight/index.html
@@ -56,6 +56,4 @@ console.log(marker.markerHeight.baseVal.value); // 6</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.markerHeight")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/markerunits/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerunits/index.html
@@ -66,6 +66,4 @@ console.log(marker.markerUnits.baseVal); // 2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.markerUnits")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
+++ b/files/en-us/web/api/svgmarkerelement/markerwidth/index.html
@@ -56,7 +56,5 @@ console.log(marker.markerWidth.baseVal.value); // 6</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.markerWidth")}}</p>
 

--- a/files/en-us/web/api/svgmarkerelement/orientangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orientangle/index.html
@@ -55,6 +55,4 @@ console.log(marker.orientAngle.baseVal.value); // 180 as .5turn is 180deg.</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.orientAngle")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/orienttype/index.html
+++ b/files/en-us/web/api/svgmarkerelement/orienttype/index.html
@@ -67,6 +67,4 @@ console.log(marker.orientType.baseVal); // 2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.orientType")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
+++ b/files/en-us/web/api/svgmarkerelement/preserveaspectratio/index.html
@@ -97,6 +97,4 @@ console.log(marker.preserveAspectRatio.baseVal.meetOrSlice); // 1 </pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.preserveAspectRatio")}}</p>

--- a/files/en-us/web/api/svgmarkerelement/refx/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refx/index.html
@@ -56,7 +56,5 @@ console.log(marker.refX.baseVal.value); // 5</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.refX")}}</p>
 

--- a/files/en-us/web/api/svgmarkerelement/refy/index.html
+++ b/files/en-us/web/api/svgmarkerelement/refy/index.html
@@ -56,8 +56,6 @@ console.log(marker.refY.baseVal.value); // 5</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.refY")}}</p>
 
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.html
@@ -65,7 +65,5 @@ console.log(marker.orientAngle.baseVal.value); // new value - 110</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.setOrientToAngle")}}</p>
 

--- a/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.html
@@ -59,8 +59,6 @@ console.log(marker.orientAngle.baseVal.value);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.setOrientToAuto")}}</p>
 
 

--- a/files/en-us/web/api/svgmarkerelement/viewbox/index.html
+++ b/files/en-us/web/api/svgmarkerelement/viewbox/index.html
@@ -57,6 +57,4 @@ console.log(marker.viewBox.baseVal.width); //10</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SVGMarkerElement.viewBox")}}</p>

--- a/files/en-us/web/api/textdecoderstream/encoding/index.html
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.html
@@ -46,6 +46,4 @@ console.log(stream.encoding); // returns the default "utf-8"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream.encoding")}}</p>

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -45,6 +45,4 @@ console.log(stream.fatal); // returns false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream.fatal")}}</p>

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.html
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.html
@@ -44,6 +44,4 @@ console.log(stream.ignoreBOM); // returns false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream.ignoreBOM")}}</p>

--- a/files/en-us/web/api/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/index.html
@@ -59,8 +59,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/textdecoderstream/readable/index.html
+++ b/files/en-us/web/api/textdecoderstream/readable/index.html
@@ -45,6 +45,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream.readable")}}</p>

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -55,6 +55,4 @@ const stream = response.body.pipeThrough(new TextDecoderStream());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream.TextDecoderStream")}}</p>

--- a/files/en-us/web/api/textdecoderstream/writable/index.html
+++ b/files/en-us/web/api/textdecoderstream/writable/index.html
@@ -46,6 +46,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextDecoderStream.writable")}}</p>

--- a/files/en-us/web/api/textencoderstream/encoding/index.html
+++ b/files/en-us/web/api/textencoderstream/encoding/index.html
@@ -47,6 +47,4 @@ console.log(stream.encoding);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextEncoderStream.encoding")}}</p>

--- a/files/en-us/web/api/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/index.html
@@ -56,8 +56,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextEncoderStream")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/textencoderstream/readable/index.html
+++ b/files/en-us/web/api/textencoderstream/readable/index.html
@@ -46,6 +46,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextEncoderStream.readable")}}</p>

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.html
@@ -41,6 +41,4 @@ fetch('/dest', { method: 'POST', body, headers: {'Content-Type': 'text/plain; ch
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextEncoderStream.TextEncoderStream")}}</p>

--- a/files/en-us/web/api/textencoderstream/writable/index.html
+++ b/files/en-us/web/api/textencoderstream/writable/index.html
@@ -46,6 +46,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextEncoderStream.writable")}}</p>

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
@@ -68,6 +68,4 @@ video.onplay = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextTrackCueList.getCueById")}}</p>

--- a/files/en-us/web/api/texttrackcuelist/index.html
+++ b/files/en-us/web/api/texttrackcuelist/index.html
@@ -57,6 +57,4 @@ video.onplay = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextTrackCueList")}}</p>

--- a/files/en-us/web/api/texttrackcuelist/length/index.html
+++ b/files/en-us/web/api/texttrackcuelist/length/index.html
@@ -72,6 +72,4 @@ video.onplay = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextTrackCueList.length")}}</p>

--- a/files/en-us/web/api/trustedhtml/index.html
+++ b/files/en-us/web/api/trustedhtml/index.html
@@ -59,8 +59,6 @@ el.innerHTML = escaped;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedHTML")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/trustedhtml/tojson/index.html
+++ b/files/en-us/web/api/trustedhtml/tojson/index.html
@@ -51,6 +51,4 @@ console.log(escaped.toJSON());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedHTML.toJSON")}}</p>

--- a/files/en-us/web/api/trustedhtml/tostring/index.html
+++ b/files/en-us/web/api/trustedhtml/tostring/index.html
@@ -51,6 +51,4 @@ console.log(escaped.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedHTML.toString")}}</p>

--- a/files/en-us/web/api/trustedscript/index.html
+++ b/files/en-us/web/api/trustedscript/index.html
@@ -49,8 +49,6 @@ console.log(sanitized); /* a TrustedScript object */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedScript")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/trustedscript/tojson/index.html
+++ b/files/en-us/web/api/trustedscript/tojson/index.html
@@ -47,6 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedScript.toJSON")}}</p>

--- a/files/en-us/web/api/trustedscript/tostring/index.html
+++ b/files/en-us/web/api/trustedscript/tostring/index.html
@@ -47,6 +47,4 @@ console.log(sanitized.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedScript.toString")}}</p>

--- a/files/en-us/web/api/trustedscripturl/index.html
+++ b/files/en-us/web/api/trustedscripturl/index.html
@@ -49,8 +49,6 @@ console.log(sanitized;) /* a TrustedScriptURL object */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedScriptURL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/trustedscripturl/tojson/index.html
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.html
@@ -47,6 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedScriptURL.toJSON")}}</p>

--- a/files/en-us/web/api/trustedscripturl/tostring/index.html
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.html
@@ -47,6 +47,4 @@ console.log(sanitized.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedScriptURL.toString")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
@@ -61,6 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicy.createHTML")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.html
@@ -61,6 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicy.createScript")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
@@ -61,6 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicy.createScriptURL")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/index.html
@@ -68,6 +68,4 @@ el.innerHTML = escaped;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicy")}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/name/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.html
@@ -48,6 +48,4 @@ console.log(escapeHTMLPolicy.name); /* "myEscapePolicy" */</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicy.name")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -102,6 +102,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.createPolicy")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -51,6 +51,4 @@ console.log(trustedTypes.defaultPolicy); // a TrustedTypePolicy object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.defaultPolicy")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
@@ -46,6 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.emptyHTML")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -49,6 +49,4 @@ eval(supportsTS ? myTrustedScriptObj : myTrustedScriptObj.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.emptyScript")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -65,6 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.getAttributeType")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -63,6 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.getPropertyType")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.html
@@ -74,6 +74,4 @@ console.log(trustedTypes.isHTML(escaped)) // true;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -63,6 +63,4 @@ console.log(trustedTypes.isHTML("&lt;div&gt;plain string&lt;/div&gt;")); // fals
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.isHTML")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -63,6 +63,4 @@ console.log(trustedTypes.isScript("eval('2 + 2')")); // false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.isScript")}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -63,6 +63,4 @@ console.log(trustedTypes.isScriptURL("https://example.com/myscript.js")); // fal
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TrustedTypePolicyFactory.isScriptURL")}}</p>

--- a/files/en-us/web/api/usbconnectionevent/device/index.html
+++ b/files/en-us/web/api/usbconnectionevent/device/index.html
@@ -46,6 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.USBConnectionEvent.device")}}</p>

--- a/files/en-us/web/api/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/index.html
@@ -56,6 +56,4 @@ navigator.usb.addEventListener('disconnect', event => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.USBConnectionEvent")}}</p>

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
@@ -63,6 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.USBConnectionEvent")}}</p>

--- a/files/en-us/web/api/webgl2renderingcontext/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/index.html
@@ -266,8 +266,6 @@ var gl = canvas.getContext('webgl2');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_color_buffer_float/index.html
+++ b/files/en-us/web/api/webgl_color_buffer_float/index.html
@@ -66,8 +66,6 @@ gl.renderbufferStorage(gl.RENDERBUFFER, ext.RGBA32F_EXT, 256, 256);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_color_buffer_float")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.html
@@ -190,8 +190,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_ASTC_12x12_KHR, 51
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_astc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_atc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_atc/index.html
@@ -63,8 +63,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ATC_WEBGL, 512, 512
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_atc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.html
@@ -75,8 +75,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA8_ETC2_EAC, 512, 51
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_etc")}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.html
@@ -57,8 +57,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ETC1_WEBGL, 512, 51
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_etc1")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.html
@@ -67,8 +67,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_pvrtc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc/index.html
@@ -69,8 +69,6 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_s3tc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.html
@@ -65,8 +65,6 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_s3tc_srgb")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_debug_renderer_info/index.html
+++ b/files/en-us/web/api/webgl_debug_renderer_info/index.html
@@ -64,8 +64,6 @@ console.log(renderer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_debug_renderer_info")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_debug_shaders/index.html
+++ b/files/en-us/web/api/webgl_debug_shaders/index.html
@@ -47,8 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_debug_shaders.getTranslatedShaderSource")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_depth_texture/index.html
+++ b/files/en-us/web/api/webgl_depth_texture/index.html
@@ -73,8 +73,6 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 512, 512, 0, gl.DEPTH_COMPON
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_depth_texture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_draw_buffers/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/index.html
@@ -132,8 +132,6 @@ void main(void) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_draw_buffers.drawBuffersWEBGL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_lose_context/index.html
+++ b/files/en-us/web/api/webgl_lose_context/index.html
@@ -61,8 +61,6 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_lose_context.loseContext")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglactiveinfo/index.html
+++ b/files/en-us/web/api/webglactiveinfo/index.html
@@ -55,8 +55,6 @@ WebGLActiveInfo? getTransformFeedbackVarying(WebGLProgram? program, GLuint index
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLActiveInfo")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglactiveinfo/name/index.html
+++ b/files/en-us/web/api/webglactiveinfo/name/index.html
@@ -39,8 +39,6 @@ activeUniform.name;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLActiveInfo.name")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglactiveinfo/size/index.html
+++ b/files/en-us/web/api/webglactiveinfo/size/index.html
@@ -39,8 +39,6 @@ activeUniform.size;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLActiveInfo.size")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglactiveinfo/type/index.html
+++ b/files/en-us/web/api/webglactiveinfo/type/index.html
@@ -39,8 +39,6 @@ activeUniform.type;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLActiveInfo.type")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglbuffer/index.html
+++ b/files/en-us/web/api/webglbuffer/index.html
@@ -49,8 +49,6 @@ var buffer = gl.createBuffer();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLBuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglcontextevent/index.html
+++ b/files/en-us/web/api/webglcontextevent/index.html
@@ -66,8 +66,6 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLContextEvent")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglcontextevent/statusmessage/index.html
+++ b/files/en-us/web/api/webglcontextevent/statusmessage/index.html
@@ -45,8 +45,6 @@ canvas.addEventListener('webglcontextcreationerror', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLContextEvent.statusMessage")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglframebuffer/index.html
+++ b/files/en-us/web/api/webglframebuffer/index.html
@@ -49,8 +49,6 @@ var buffer = gl.createFramebuffer();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglprogram/index.html
+++ b/files/en-us/web/api/webglprogram/index.html
@@ -77,8 +77,6 @@ gl.drawArrays(gl.TRIANGLES, 0, 3);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglquery/index.html
+++ b/files/en-us/web/api/webglquery/index.html
@@ -54,8 +54,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderbuffer/index.html
@@ -49,8 +49,6 @@ var buffer = gl.createRenderbuffer();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderbuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/index.html
@@ -364,8 +364,6 @@ var gl = canvas.getContext('webgl');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglsampler/index.html
+++ b/files/en-us/web/api/webglsampler/index.html
@@ -50,6 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLSampler")}}</p>

--- a/files/en-us/web/api/webglshader/index.html
+++ b/files/en-us/web/api/webglshader/index.html
@@ -76,8 +76,6 @@ var fragmentShader = createShader(gl, fragmentShaderSource, gl.FRAGMENT_SHADER)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglshaderprecisionformat/index.html
+++ b/files/en-us/web/api/webglshaderprecisionformat/index.html
@@ -50,8 +50,6 @@ gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLShaderPrecisionFormat")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglshaderprecisionformat/precision/index.html
+++ b/files/en-us/web/api/webglshaderprecisionformat/precision/index.html
@@ -41,8 +41,6 @@ gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.LOW_INT).precision; // 0
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLShaderPrecisionFormat.precision")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglshaderprecisionformat/rangemax/index.html
+++ b/files/en-us/web/api/webglshaderprecisionformat/rangemax/index.html
@@ -39,8 +39,6 @@ gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.LOW_INT).rangeMax; // 24
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLShaderPrecisionFormat.rangeMax")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglshaderprecisionformat/rangemin/index.html
+++ b/files/en-us/web/api/webglshaderprecisionformat/rangemin/index.html
@@ -39,8 +39,6 @@ gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.LOW_INT).rangeMin; // 24
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLShaderPrecisionFormat.rangeMin")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglsync/index.html
+++ b/files/en-us/web/api/webglsync/index.html
@@ -50,8 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLSync")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgltexture/index.html
+++ b/files/en-us/web/api/webgltexture/index.html
@@ -49,8 +49,6 @@ var texture = gl.createTexture();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLTexture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgltransformfeedback/index.html
+++ b/files/en-us/web/api/webgltransformfeedback/index.html
@@ -54,6 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLTransformFeedback")}}</p>

--- a/files/en-us/web/api/webgluniformlocation/index.html
+++ b/files/en-us/web/api/webgluniformlocation/index.html
@@ -47,8 +47,6 @@ var location = gl.getUniformLocation(WebGLProgram, 'uniformName');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLUniformLocation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglvertexarrayobject/index.html
+++ b/files/en-us/web/api/webglvertexarrayobject/index.html
@@ -53,8 +53,6 @@ gl.bindVertexArray(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLVertexArrayObject")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webusb_api/index.html
+++ b/files/en-us/web/api/webusb_api/index.html
@@ -93,8 +93,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/en-us/web/api/workernavigator/serial/index.html
+++ b/files/en-us/web/api/workernavigator/serial/index.html
@@ -49,8 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.WorkerNavigator.serial")}}</p>
 
 <h2 id="See_also">See also</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There were a paragraph in html (most of the time hidden) saying BCD was coming from structure data. This is now done automatically and was duplicated.

> MDN URL of the main page changed

262 API pages
> Issue number (if there is an associated issue)

#2228 (for half of web/api, more to be done)

> Anything else that could help us review it

I used @peterbe 's  https://gist.github.com/peterbe/d8f34b3d058a7647f03b65e7e98c50c (from #5343 ).
There are more occurences in web/api, but those were the low hanging fruits, and also I don't want the PR to be even larger.
