### PR TITLE
Remove redundant BCD comment from web/http, /security, /web_components, /events and /exslt

### DIFF
--- a/files/en-us/web/events/detecting_device_orientation/index.html
+++ b/files/en-us/web/events/detecting_device_orientation/index.html
@@ -202,8 +202,6 @@ window.addEventListener('deviceorientation', handleOrientation);
 
 <h3 id="DeviceOrientationEvent"><code>DeviceOrientationEvent</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.DeviceOrientationEvent")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/exslt/math/min/index.html
+++ b/files/en-us/web/exslt/math/min/index.html
@@ -35,8 +35,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("xslt.exslt.math.min")}}</p>

--- a/files/en-us/web/http/csp/index.html
+++ b/files/en-us/web/http/csp/index.html
@@ -277,11 +277,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp")}}</p>
 
 <p>A specific incompatibility exists in some versions of the Safari web browser, whereby

--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.html
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.html
@@ -45,11 +45,6 @@ Accept-CH-Lifetime: 86400
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Accept-CH-Lifetime")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/accept-ch/index.html
+++ b/files/en-us/web/http/headers/accept-ch/index.html
@@ -52,11 +52,6 @@ Vary: Viewport-Width, Width
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Accept-CH")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/accept-language/index.html
+++ b/files/en-us/web/http/headers/accept-language/index.html
@@ -110,10 +110,6 @@ Accept-Language: en-US,en;q=0.5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("http.headers.Accept-Language")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/accept-ranges/index.html
+++ b/files/en-us/web/http/headers/accept-ranges/index.html
@@ -75,11 +75,6 @@ Accept-Ranges: none</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Accept-Ranges")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/access-control-allow-credentials/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-credentials/index.html
@@ -105,11 +105,6 @@ xhr.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Allow-Credentials")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.html
@@ -116,8 +116,6 @@ Access-Control-Max-Age: 86400</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("http.headers.Access-Control-Allow-Headers")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.html
@@ -73,11 +73,6 @@ Access-Control-Allow-Methods: *
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Allow-Methods")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/access-control-request-method/index.html
+++ b/files/en-us/web/http/headers/access-control-request-method/index.html
@@ -66,11 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Request-Method")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/age/index.html
+++ b/files/en-us/web/http/headers/age/index.html
@@ -66,11 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Age")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/alt-svc/index.html
+++ b/files/en-us/web/http/headers/alt-svc/index.html
@@ -71,12 +71,6 @@ Alt-Svc: h3-25=":443"; ma=3600, h2=":443"; ma=3600</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    class="external external-icon" href="https://github.com/mdn/browser-compat-data"
-    rel="noopener">https://github.com/mdn/browser-compat-data</a> and send us a pull
-  request.</div>
-
 <p>{{Compat("http.headers.Alt-Svc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/connection/index.html
+++ b/files/en-us/web/http/headers/connection/index.html
@@ -68,9 +68,4 @@ Connection: close
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Connection")}}</p>

--- a/files/en-us/web/http/headers/content-location/index.html
+++ b/files/en-us/web/http/headers/content-location/index.html
@@ -181,11 +181,6 @@ Content-Location: /my-receipts/38
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Content-Location")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-range/index.html
+++ b/files/en-us/web/http/headers/content-range/index.html
@@ -72,11 +72,6 @@ Content-Range: &lt;unit&gt; */&lt;size&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Content-Range")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.html
@@ -91,11 +91,6 @@ Content-Security-Policy: child-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.child-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.html
@@ -91,11 +91,6 @@ Content-Security-Policy: font-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.font-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.html
@@ -89,11 +89,6 @@ Content-Security-Policy: frame-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.frame-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.html
@@ -87,11 +87,6 @@ Content-Security-Policy: img-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.img-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/index.html
@@ -357,11 +357,6 @@ Content-Security-Policy: default-src https:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.html
@@ -83,11 +83,6 @@ Content-Security-Policy: manifest-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.manifest-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.html
@@ -91,11 +91,6 @@ Content-Security-Policy: media-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.media-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/navigate-to/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/navigate-to/index.html
@@ -94,11 +94,6 @@ Content-Security-Policy: navigate-to &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.navigate-to")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.html
@@ -101,11 +101,6 @@ Content-Security-Policy: object-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.object-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
@@ -114,11 +114,6 @@ Content-Security-Policy: plugin-types &lt;type&gt;/&lt;subtype&gt; &lt;type&gt;/
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.plugin-types")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.html
@@ -72,13 +72,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.report-to")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.html
@@ -132,11 +132,6 @@ if ($json_data = json_decode($json_data)) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.report-uri")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.html
@@ -114,8 +114,6 @@ Content-Security-Policy: sandbox &lt;value&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<!-- The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out https://github.com/mdn/browser-compat-data and send us a pull request. -->
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.sandbox")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
@@ -91,11 +91,6 @@ Content-Security-Policy: script-src-attr &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.script-src-attr")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
@@ -88,11 +88,6 @@ Content-Security-Policy: <code>style</code>-src-attr &lt;source&gt;;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.style-src-attr")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
@@ -89,11 +89,6 @@ Content-Security-Policy: <code>style</code>-src-elem &lt;source&gt;;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.style-src-elem")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.html
@@ -99,11 +99,6 @@ Content-Security-Policy-Report-Only: default-src https:; report-uri /endpoint</p
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.upgrade-insecure-requests")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
@@ -94,11 +94,6 @@ Content-Security-Policy: worker-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy.worker-src")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/date/index.html
+++ b/files/en-us/web/http/headers/date/index.html
@@ -96,11 +96,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Date")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/digest/index.html
+++ b/files/en-us/web/http/headers/digest/index.html
@@ -99,11 +99,6 @@ Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,unixsum=30637</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Digest")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/dnt/index.html
+++ b/files/en-us/web/http/headers/dnt/index.html
@@ -74,11 +74,6 @@ DNT: null
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.DNT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/etag/index.html
+++ b/files/en-us/web/http/headers/etag/index.html
@@ -120,10 +120,6 @@ ETag: W/"0815"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("http.headers.ETag")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/expires/index.html
+++ b/files/en-us/web/http/headers/expires/index.html
@@ -73,11 +73,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Expires")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/accelerometer/index.html
+++ b/files/en-us/web/http/headers/feature-policy/accelerometer/index.html
@@ -51,10 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat('http.headers.Feature-Policy.accelerometer')}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/ambient-light-sensor/index.html
+++ b/files/en-us/web/http/headers/feature-policy/ambient-light-sensor/index.html
@@ -44,10 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat('http.headers.Feature-Policy.ambient-light-sensor')}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/gyroscope/index.html
+++ b/files/en-us/web/http/headers/feature-policy/gyroscope/index.html
@@ -36,10 +36,6 @@ slug: Web/HTTP/Headers/Feature-Policy/gyroscope
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.gyroscope")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
+++ b/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
@@ -23,10 +23,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.layout-animations")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
+++ b/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
@@ -23,8 +23,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Feature-Policy.legacy-image-formats")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/magnetometer/index.html
+++ b/files/en-us/web/http/headers/feature-policy/magnetometer/index.html
@@ -42,10 +42,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.magnetometer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
@@ -26,10 +26,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.oversized-images")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/picture-in-picture/index.html
+++ b/files/en-us/web/http/headers/feature-policy/picture-in-picture/index.html
@@ -46,10 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.picture-in-picture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
+++ b/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
@@ -47,10 +47,6 @@ slug: Web/HTTP/Headers/Feature-Policy/publickey-credentials-get
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.publickey-credentials-get")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/screen-wake-lock/index.html
+++ b/files/en-us/web/http/headers/feature-policy/screen-wake-lock/index.html
@@ -53,10 +53,6 @@ slug: Web/HTTP/Headers/Feature-Policy/screen-wake-lock
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.screen-wake-lock")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
@@ -28,10 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.sync-xhr")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
@@ -23,10 +23,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.unoptimized-images")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
@@ -28,10 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat('http.headers.Feature-Policy.unsized-media')}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/usb/index.html
+++ b/files/en-us/web/http/headers/feature-policy/usb/index.html
@@ -52,10 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat('http.headers.Feature-Policy.usb')}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/vibrate/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vibrate/index.html
@@ -44,10 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("http.headers.Feature-Policy.vibrate")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/feature-policy/web-share/index.html
+++ b/files/en-us/web/http/headers/feature-policy/web-share/index.html
@@ -49,10 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat('http.headers.Feature-Policy.web-share')}}</p>
 
 <p>Browser implementation is being discussed in <a href="https://github.com/w3c/web-share/issues/169">https://github.com/w3c/web-share/issues/169</a>.</p>

--- a/files/en-us/web/http/headers/from/index.html
+++ b/files/en-us/web/http/headers/from/index.html
@@ -66,11 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.From")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/if-match/index.html
+++ b/files/en-us/web/http/headers/if-match/index.html
@@ -97,11 +97,6 @@ If-Match: *
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.If-Match")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/if-modified-since/index.html
+++ b/files/en-us/web/http/headers/if-modified-since/index.html
@@ -92,11 +92,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.If-Modified-Since")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/if-range/index.html
+++ b/files/en-us/web/http/headers/if-range/index.html
@@ -93,11 +93,6 @@ If-Range: &lt;etag&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.If-Range")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/if-unmodified-since/index.html
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.html
@@ -96,11 +96,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.If-Unmodified-Since")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/large-allocation/index.html
+++ b/files/en-us/web/http/headers/large-allocation/index.html
@@ -132,11 +132,6 @@ Large-Allocation: 500
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Large-Allocation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/last-modified/index.html
+++ b/files/en-us/web/http/headers/last-modified/index.html
@@ -87,11 +87,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Last-Modified")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/location/index.html
+++ b/files/en-us/web/http/headers/location/index.html
@@ -86,11 +86,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Location")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/pragma/index.html
+++ b/files/en-us/web/http/headers/pragma/index.html
@@ -78,11 +78,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Pragma")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/public-key-pins-report-only/index.html
+++ b/files/en-us/web/http/headers/public-key-pins-report-only/index.html
@@ -101,11 +101,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Public-Key-Pins-Report-Only")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/public-key-pins/index.html
+++ b/files/en-us/web/http/headers/public-key-pins/index.html
@@ -109,11 +109,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Public-Key-Pins")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -247,8 +247,6 @@ Referrer-Policy: unsafe-url
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("http.headers.Referrer-Policy")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/retry-after/index.html
+++ b/files/en-us/web/http/headers/retry-after/index.html
@@ -85,11 +85,6 @@ Retry-After: 120
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Retry-After")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/save-data/index.html
+++ b/files/en-us/web/http/headers/save-data/index.html
@@ -102,11 +102,6 @@ Content-Type: image/jpeg
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Save-Data")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/set-cookie2/index.html
+++ b/files/en-us/web/http/headers/set-cookie2/index.html
@@ -65,11 +65,6 @@ Set-Cookie2: &lt;cookie-name&gt;=&lt;cookie-value&gt;, &lt;cookie-name&gt;=&lt;c
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Set-Cookie2")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/strict-transport-security/index.html
+++ b/files/en-us/web/http/headers/strict-transport-security/index.html
@@ -153,11 +153,6 @@ Strict-Transport-Security: max-age=&lt;expire-time&gt;; preload
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Strict-Transport-Security")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/te/index.html
+++ b/files/en-us/web/http/headers/te/index.html
@@ -86,11 +86,6 @@ TE: trailers, deflate;q=0.5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.TE")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -103,11 +103,6 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out 
-  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Trailer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -130,11 +130,6 @@ Network\r\n
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Transfer-Encoding")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/upgrade/index.html
+++ b/files/en-us/web/http/headers/upgrade/index.html
@@ -127,8 +127,6 @@ Upgrade: websocket
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Upgrade")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/vary/index.html
+++ b/files/en-us/web/http/headers/vary/index.html
@@ -83,11 +83,6 @@ Vary: &lt;header-name&gt;, &lt;header-name&gt;, ...
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Vary")}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>

--- a/files/en-us/web/http/headers/via/index.html
+++ b/files/en-us/web/http/headers/via/index.html
@@ -72,11 +72,6 @@ Via: 1.0 fred, 1.1 p.example.net
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Via")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/want-digest/index.html
+++ b/files/en-us/web/http/headers/want-digest/index.html
@@ -148,11 +148,6 @@ Response:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Want-Digest")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/headers/warning/index.html
+++ b/files/en-us/web/http/headers/warning/index.html
@@ -155,11 +155,6 @@ Warning: 112 - "cache down" "Wed, 21 Oct 2015 07:28:00 GMT"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Warning")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/methods/delete/index.html
+++ b/files/en-us/web/http/methods/delete/index.html
@@ -96,11 +96,6 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.methods.DELETE")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/100/index.html
+++ b/files/en-us/web/http/status/100/index.html
@@ -38,11 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.100")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/201/index.html
+++ b/files/en-us/web/http/status/201/index.html
@@ -41,10 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("http.status.201")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/204/index.html
+++ b/files/en-us/web/http/status/204/index.html
@@ -41,11 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.204")}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>

--- a/files/en-us/web/http/status/206/index.html
+++ b/files/en-us/web/http/status/206/index.html
@@ -76,11 +76,6 @@ Content-Range: bytes 4590-7999/8000
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.206")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/304/index.html
+++ b/files/en-us/web/http/status/304/index.html
@@ -48,11 +48,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.304")}}</p>
 
 <h2 id="Compatibility_Notes">Compatibility Notes</h2>

--- a/files/en-us/web/http/status/401/index.html
+++ b/files/en-us/web/http/status/401/index.html
@@ -46,11 +46,6 @@ WWW-Authenticate: Basic realm="Access to staging site"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.401")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/406/index.html
+++ b/files/en-us/web/http/status/406/index.html
@@ -56,11 +56,6 @@ tags:
     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).
 </p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.406")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/407/index.html
+++ b/files/en-us/web/http/status/407/index.html
@@ -44,11 +44,6 @@ Proxy-Authenticate: Basic realm="Access to internal site"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.407")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/412/index.html
+++ b/files/en-us/web/http/status/412/index.html
@@ -69,11 +69,6 @@ ETag: W/"0815"</code></pre>
     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).
 </p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.412")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/425/index.html
+++ b/files/en-us/web/http/status/425/index.html
@@ -36,9 +36,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("http.status.425")}}</p>

--- a/files/en-us/web/http/status/500/index.html
+++ b/files/en-us/web/http/status/500/index.html
@@ -37,8 +37,6 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("http.status.500")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/http/status/501/index.html
+++ b/files/en-us/web/http/status/501/index.html
@@ -48,6 +48,4 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("http.status.501")}}</p>

--- a/files/en-us/web/http/status/502/index.html
+++ b/files/en-us/web/http/status/502/index.html
@@ -40,8 +40,6 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("http.status.502")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/security/subresource_integrity/index.html
+++ b/files/en-us/web/security/subresource_integrity/index.html
@@ -145,8 +145,6 @@ pause
 
 <h3 id="&lt;script_integrity&gt;">&lt;script integrity&gt;</h3>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("html.elements.script.integrity")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/web_components/html_imports/index.html
+++ b/files/en-us/web/web_components/html_imports/index.html
@@ -42,6 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("html.elements.link.rel.import")}}</p>


### PR DESCRIPTION


<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Redundant BCD comments
> MDN URL of the main page changed

Numerous (96)
> Issue number (if there is an associated issue)

#2228 

> Anything else that could help us review it

After this one only web/api and mozilla/add-ons/webextensions will still have this redundant message.