### PR TITLE
Remove redundant BCD messages from webextensions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.Alarm")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.html
@@ -49,8 +49,6 @@ clearAlarm.then(onCleared);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.clear")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.html
@@ -44,8 +44,6 @@ clearAlarms.then(onClearedAll);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.clearAll")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
@@ -83,8 +83,6 @@ browser.alarms.create("my-periodic-alarm", {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.create")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.html
@@ -51,8 +51,6 @@ getAlarm.then(gotAlarm);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.get")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.html
@@ -46,8 +46,6 @@ getAlarms.then(gotAll);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.getAll")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
@@ -64,8 +64,6 @@ browser.alarms.onAlarm.addListener(handleAlarm);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.alarms.onAlarm")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
@@ -45,8 +45,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNode", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.html
@@ -27,8 +27,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeType", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
@@ -59,8 +59,6 @@ createBookmark.then(onCreated);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.create")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.CreateDetails", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/export/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/export/index.html
@@ -32,8 +32,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.export")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.html
@@ -55,8 +55,6 @@ gettingBookmarks.then(onFulfilled, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.get")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
@@ -59,8 +59,6 @@ gettingChildren.then(onFulfilled, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.getChildren")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
@@ -57,8 +57,6 @@ gettingRecent.then(onFulfilled, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.getRecent")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.html
@@ -79,8 +79,6 @@ gettingSubTree.then(logSubTree, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.getSubTree")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.html
@@ -72,8 +72,6 @@ gettingTree.then(logTree, onRejected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.getTree")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
@@ -74,8 +74,6 @@ movingBookmark.then(onMoved, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.move")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
@@ -83,8 +83,6 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onChanged")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
@@ -66,8 +66,6 @@ browser.bookmarks.onChildrenReordered.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onChildrenReordered")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
@@ -68,8 +68,6 @@ browser.bookmarks.onCreated.addListener(handleCreated);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onCreated")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.html
@@ -49,8 +49,6 @@ browser.bookmarks.onImportBegan.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onImportBegan")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.html
@@ -49,8 +49,6 @@ browser.bookmarks.onImportEnded.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onImportEnded")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
@@ -72,8 +72,6 @@ browser.bookmarks.onMoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onMoved")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
@@ -86,8 +86,6 @@ browser.browserAction.onClicked.addListener(handleClick);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.onRemoved")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
@@ -61,8 +61,6 @@ removingBookmark.then(onRemoved, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.remove")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
@@ -68,8 +68,6 @@ searchingBookmarks.then(removeMDN, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.removeTree")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
@@ -105,8 +105,6 @@ browser.browserAction.onClicked.addListener(checkActiveTab);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.search")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
@@ -82,8 +82,6 @@ searching.then(updateFolders, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.update")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
@@ -29,8 +29,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.ColorArray")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
@@ -32,8 +32,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.disable")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.html
@@ -32,8 +32,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.enable")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
@@ -50,8 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.getBadgeBackgroundColor",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
@@ -51,8 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.getBadgeText",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
@@ -53,8 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.getBadgeTextColor",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
@@ -51,8 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.getPopup",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
@@ -53,8 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.getTitle",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.ImageDataType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.html
@@ -50,8 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.isEnabled",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
@@ -61,8 +61,6 @@ browser.browserAction.onClicked.hasListener(listener)
 
  <h2 id="Browser_compatibility">Browser compatibility</h2>
 
- <p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
  <p>{{Compat("webextensions.api.browserAction.onClicked")}}</p>
 
  <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.openPopup", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
@@ -57,8 +57,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.setBadgeBackgroundColor",2)}}</p>
 
 <p>The default color in Firefox is: <code>[217, 0, 0, 255]</code>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
@@ -58,8 +58,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.setBadgeText",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.setBadgeTextColor",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
@@ -91,8 +91,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.setIcon",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
@@ -64,8 +64,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.setPopup",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.html
@@ -29,8 +29,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.allowPopupsForUserEvents")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.html
@@ -19,8 +19,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.cacheEnabled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.html
@@ -22,6 +22,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.closeTabsByDoubleClick")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.html
@@ -21,8 +21,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.contextMenuShowEvent")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.html
@@ -25,8 +25,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.ftpProtocolEnabled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.html
@@ -19,8 +19,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.homepageOverride", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.html
@@ -24,8 +24,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.imageAnimationBehavior", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.html
@@ -19,8 +19,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.newTabPageOverride", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.html
@@ -25,8 +25,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.newTabPosition", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.html
@@ -19,8 +19,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.openBookmarksInNewTabs")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.html
@@ -21,8 +21,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.openSearchResultsInNewTabs")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.html
@@ -21,8 +21,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.openUrlbarResultsInNewTabs")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.html
@@ -27,8 +27,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.overrideDocumentColors")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.html
@@ -26,8 +26,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.useDocumentFonts")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.html
@@ -27,8 +27,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.webNotificationsDisabled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.html
@@ -26,8 +26,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.zoomFullPage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.html
@@ -36,8 +36,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.zoomSiteSpecific")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
@@ -57,8 +57,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.DataTypeSet")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.remove")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
@@ -39,8 +39,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeCache")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeCookies")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeDownloads")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeFormData")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeHistory", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeLocalStorage", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removePasswords")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removePluginData")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
@@ -47,8 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.settings")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.captivePortal.getLastChecked")}}</p>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.html
@@ -27,8 +27,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.captivePortal.getState")}}</p>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.html
@@ -63,8 +63,6 @@ browser.captivePortal.onConnectivityAvailable.addListener(handleConnectivity);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.captivePortal.onConnectivityAvailable")}}</p>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.html
@@ -65,8 +65,6 @@ browser.captivePortal.onStateChanged.addListener(handlePortalStatus)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.captivePortal.onStateChanged")}}</p>
 
 <div class="hidden">

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
@@ -48,8 +48,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.clipboard.setImageData", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.commands.Command")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.commands.getAll")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
@@ -54,8 +54,6 @@ browser.commands.onCommand.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.commands.onCommand")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.html
@@ -39,8 +39,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.commands.reset")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.commands.update", 5)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
@@ -70,8 +70,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contentScripts.register", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.html
@@ -28,8 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contentScripts.RegisteredContentScript", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.html
@@ -28,8 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contentScripts.RegisteredContentScript.unregister", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.html
@@ -70,6 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.ContextualIdentity")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.html
@@ -82,8 +82,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.create")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.html
@@ -39,8 +39,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.get")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.html
@@ -51,8 +51,6 @@ browser.contextualIdentities.onCreated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.onCreated")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.html
@@ -51,8 +51,6 @@ browser.contextualIdentities.onRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.onRemoved")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.html
@@ -51,8 +51,6 @@ browser.contextualIdentities.onUpdated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.onUpdated")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.query")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.html
@@ -39,8 +39,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.remove")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.html
@@ -87,8 +87,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contextualIdentities.update")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
@@ -49,8 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.Cookie")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.CookieStore")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.get")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
@@ -59,8 +59,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.getAll")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.getAllCookieStores")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
@@ -71,8 +71,6 @@ browser.cookies.onChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.onChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.OnChangedCause")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.remove")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
@@ -66,8 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.set")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
@@ -96,8 +96,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.inspectedWindow.eval")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>This tests whether jQuery is defined in the inspected window, and logs the result. Note that this wouldn't work in a content script, because even if jQuery were defined, the content script would not see it.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
@@ -43,8 +43,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.inspectedWindow.reload")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Reload the inspected window, setting the user agent and injecting a script:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
@@ -42,8 +42,6 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p>{{Compat("webextensions.api.devtools.inspectedWindow.tabId")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{WebExtExamples}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.html
@@ -30,8 +30,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.network.getHAR")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
@@ -52,8 +52,6 @@ browser.devtools.network.onNavigated.hasListener(listener)
 
 <p>{{Compat("webextensions.api.devtools.network.onNavigated")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <pre class="brush: js">function handleNavigated(url) {

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
@@ -57,8 +57,6 @@ browser.devtools.network.onRequestFinished.hasListener(listener)
 
 <p>{{Compat("webextensions.api.devtools.network.onRequestFinished")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Add a listener that logs the server IP address and response body for every network request.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.html
@@ -45,8 +45,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.panels.create")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Create a new panel, and add listeners to its onShown and onHidden events:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.html
@@ -17,8 +17,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.elements", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
@@ -47,8 +47,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.panels.ElementsPanel.createSidebarPane", 10)}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Create a new pane, and populate it with a JSON object. You could run this code in a script loaded by your extension's <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page">devtools page</a>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.html
@@ -32,8 +32,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.ElementsPanel", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.html
@@ -48,8 +48,6 @@ browser.devtools.panels.elements.onSelectionChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.ElementsPanel.onSelectionChanged", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.html
@@ -27,8 +27,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.panels.ExtensionPanel")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>This code creates a new panel, then adds handlers for its <code>onShown</code> and <code>onHidden</code> events.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.html
@@ -48,8 +48,6 @@ browser.devtools.panels.onHidden.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.onHidden", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.html
@@ -47,8 +47,6 @@ browser.devtools.panels.onShown.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.onShown", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.html
@@ -47,8 +47,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setExpression", 10)}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>This code creates a sidebar pane that displays the <code><a href="/en-US/docs/Web/API/Element/tagName">tagName</a></code> of the currently selected element:</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
@@ -45,8 +45,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setObject", 10)}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="Examples">Examples</h2>
 
 <p>Create a new pane, and populate it with a JSON object. You could run this code in a script loaded by your extension's <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page">devtools page</a>.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
@@ -51,8 +51,6 @@ tags:
 
 <p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setPage", 10)}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <div class="note"><strong>Acknowledgements</strong>
 
 <p>This API is based on Chromium's <a href="https://developer.chrome.com/extensions/devtools_panels"><code>chrome.devtools.panels</code></a> API.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
@@ -51,8 +51,6 @@ browser.devtools.panels.onThemeChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.onThemeChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.html
@@ -25,8 +25,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.devtools.panels.themeName")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.html
@@ -63,8 +63,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.dns.resolve")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.acceptDanger")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
@@ -29,8 +29,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.BooleanDelta")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.cancel")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
@@ -47,8 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.DangerType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
@@ -29,8 +29,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.DoubleDelta")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
@@ -80,8 +80,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.download")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
@@ -65,8 +65,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.DownloadItem")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
@@ -77,8 +77,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.DownloadQuery")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.DownloadTime")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.drag")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.erase")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.FilenameConflictAction")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
@@ -51,8 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.getFileIcon")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.html
@@ -73,8 +73,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.InterruptReason")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
@@ -91,8 +91,6 @@ browser.downloads.onChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.onChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
@@ -54,8 +54,6 @@ browser.downloads.onCreated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.onCreated")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
@@ -54,8 +54,6 @@ browser.downloads.onErased.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.onErased")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.open")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.pause")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
@@ -46,8 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.removeFile")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.resume")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.html
@@ -36,8 +36,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.search")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.setShelfEnabled")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.show")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.html
@@ -27,8 +27,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.showDefaultFolder")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
@@ -37,8 +37,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.State")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
@@ -29,8 +29,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.downloads.StringDelta")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.html
@@ -41,8 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.events.Event")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.events.Rule")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
@@ -100,8 +100,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.events.UrlFilter")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
@@ -54,8 +54,6 @@ page.foo(); // -&gt; "I'm defined in background.js"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.getBackgroundPage")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
@@ -42,8 +42,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.getExtensionTabs")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
@@ -53,8 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.getViews")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.html
@@ -26,8 +26,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.inIncognitoContext")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.isAllowedFileSchemeAccess")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.html
@@ -44,8 +44,6 @@ isAllowed.then(logIsAllowed);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.isAllowedIncognitoAccess")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.html
@@ -18,8 +18,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.lastError")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
@@ -70,8 +70,6 @@ chrome.extension.onRequest.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.onRequest")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
@@ -70,8 +70,6 @@ chrome.extension.onRequestExternal.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.onRequestExternal")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.sendRequest")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.html
@@ -32,8 +32,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.setUpdateUrlData")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extension.ViewType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
@@ -43,8 +43,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extensionTypes.ImageDetails")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extensionTypes.ImageFormat")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
@@ -30,8 +30,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extensionTypes.RunAt")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
@@ -117,8 +117,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.find.find", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.html
@@ -50,8 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.find.highlightResults", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.html
@@ -30,8 +30,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.find.removeHighlighting", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
@@ -50,8 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.addUrl")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.deleteAll")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
@@ -46,8 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.deleteRange")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.deleteUrl")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.getVisits")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
@@ -37,8 +37,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.HistoryItem")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
@@ -88,8 +88,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history")}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
@@ -58,8 +58,6 @@ browser.history.onTitleChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.onTitleChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
@@ -56,8 +56,6 @@ browser.history.onVisited.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.onVisited")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
@@ -64,8 +64,6 @@ browser.history.onVisitRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.onVisitRemoved")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
@@ -111,8 +111,6 @@ searching.then(onGot);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.search")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.html
@@ -47,8 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.TransitionType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.VisitItem")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
@@ -53,8 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.detectLanguage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.getAcceptLanguages")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
@@ -46,8 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.getMessage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.getUILanguage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.LanguageCode")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.identity.getRedirectURL")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
@@ -79,8 +79,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.identity.launchWebAuthFlow")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.idle.IdleState")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
@@ -58,8 +58,6 @@ browser.idle.onStateChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.idle.onStateChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.idle.queryState")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.idle.setDetectionInterval")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
@@ -82,8 +82,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.ExtensionInfo")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.get")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.getAll")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.html
@@ -41,8 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.getPermissionWarningsById")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.html
@@ -41,8 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.getPermissionWarningsByManifest")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.getSelf")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.install")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
@@ -52,8 +52,6 @@ browser.management.onDisabled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.onDisabled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
@@ -52,8 +52,6 @@ browser.management.onEnabled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.onEnabled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
@@ -52,8 +52,6 @@ browser.management.onInstalled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.onInstalled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
@@ -52,8 +52,6 @@ browser.management.onUninstalled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.onUninstalled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.html
@@ -45,8 +45,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.setEnabled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.html
@@ -46,8 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.management.uninstall")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
@@ -44,8 +44,6 @@ tags:
 
  <h2 id="Browser_compatibility">Browser compatibility</h2>
 
- <p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 {{Compat("webextensions.api.management.uninstallSelf")}}
 
  <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
@@ -62,8 +62,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.ContextType", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
@@ -184,8 +184,6 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.create", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
@@ -94,8 +94,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.createProperties", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.html
@@ -37,8 +37,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.ItemType", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
@@ -61,8 +61,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.OnClickData", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
@@ -59,8 +59,6 @@ browser.menus.onClicked.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.onClicked", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.html
@@ -52,8 +52,6 @@ browser.menus.onHidden.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.onHidden", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.html
@@ -124,8 +124,6 @@ browser.menus.onShown.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.onShown", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.refresh", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.html
@@ -68,8 +68,6 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.remove", 10)}}</p>
 
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.html
@@ -36,8 +36,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.removeAll", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
@@ -151,8 +151,6 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.update", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.clear")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
@@ -49,8 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.create")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.getAll")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
@@ -77,8 +77,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.NotificationOptions")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
@@ -54,8 +54,6 @@ browser.notifications.onButtonClicked.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.onButtonClicked")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
@@ -52,8 +52,6 @@ browser.notifications.onClicked.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.onClicked")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
@@ -54,8 +54,6 @@ browser.notifications.onClosed.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.onClosed")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
@@ -52,8 +52,6 @@ browser.notifications.onShown.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.onShown")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
@@ -54,8 +54,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.TemplateType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.html
@@ -41,8 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.update")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.html
@@ -39,8 +39,6 @@ browser.omnibox.onInputCancelled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.onInputCancelled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.html
@@ -59,8 +59,6 @@ browser.omnibox.onInputChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.onInputChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.html
@@ -59,8 +59,6 @@ browser.omnibox.onInputEntered.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.onInputEntered")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
@@ -32,8 +32,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.OnInputEnteredDisposition")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.html
@@ -48,8 +48,6 @@ browser.omnibox.onInputStarted.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.onInputStarted")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.html
@@ -37,8 +37,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.setDefaultSuggestion")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
@@ -30,8 +30,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.omnibox.SuggestResult")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.getPopup")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.getTitle")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.hide")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.ImageDataType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.html
@@ -43,8 +43,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.isShown")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
@@ -61,8 +61,6 @@ browser.pageAction.onClicked.hasListener(listener)
 
 	<h2 id="Browser_compatibility">Browser compatibility</h2>
 
-	<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 	<p>{{Compat("webextensions.api.pageAction.onClicked")}}</p>
 
 	<h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.html
@@ -35,8 +35,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.openPopup", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
@@ -81,8 +81,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <div>{{Compat("webextensions.api.pageAction.setIcon")}}</div>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
@@ -42,8 +42,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.setPopup")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
@@ -41,8 +41,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.setTitle")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.show")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.contains")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.getAll")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
@@ -50,8 +50,6 @@ browser.permissions.onAdded.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.onAdded")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
@@ -50,8 +50,6 @@ browser.permissions.onRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.onRemoved")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
@@ -26,8 +26,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.Permissions")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.remove")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.permissions.request")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.html
@@ -63,8 +63,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pkcs11.getModuleSlots")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.html
@@ -42,8 +42,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pkcs11.installModule", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.html
@@ -39,8 +39,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pkcs11.isModuleInstalled", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.html
@@ -39,8 +39,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pkcs11.uninstallModule", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.html
@@ -55,5 +55,3 @@ browser.proxy.onError.hasListener(listener)
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("webextensions.api.proxy.onError")}}</p>
-
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.html
@@ -81,8 +81,6 @@ browser.proxy.onRequest.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.proxy.onRequest", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.proxy.ProxyInfo")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -154,8 +154,6 @@ browser.proxy.register(proxyScriptURL);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.proxy.register")}}</p>
 
 <div class="notecard note">

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.proxy.RequestDetails")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.html
@@ -65,6 +65,4 @@ browser.proxy.settings.set({value: proxySettings});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.proxy.settings", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
@@ -48,8 +48,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.proxy.unregister")}}</p>
 
 <div class="notecard note">

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
@@ -57,8 +57,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.connect")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.html
@@ -48,8 +48,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.connectNative")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
@@ -49,8 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.getBackgroundPage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.getManifest")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.getPackageDirectoryEntry")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.getPlatformInfo")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.getURL")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.html
@@ -26,8 +26,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.id")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.html
@@ -72,8 +72,6 @@ setCookie.then(logCookie, logError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.lastError")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.MessageSender")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.html
@@ -48,8 +48,6 @@ browser.runtime.onBrowserUpdateAvailable.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onBrowserUpdateAvailable")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
@@ -52,8 +52,6 @@ browser.runtime.onConnect.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onConnect")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
@@ -56,8 +56,6 @@ browser.runtime.onConnectExternal.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onConnectExternal")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
@@ -66,8 +66,6 @@ browser.runtime.onInstalled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onInstalled", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.OnInstalledReason")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -138,8 +138,6 @@ browser.runtime.onMessage.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onMessage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
@@ -84,8 +84,6 @@ browser.runtime.onMessageExternal.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onMessageExternal")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
@@ -52,8 +52,6 @@ browser.runtime.onRestartRequired.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onRestartRequired")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.html
@@ -28,8 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.OnRestartRequiredReason")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.html
@@ -49,8 +49,6 @@ browser.runtime.onStartup.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onStartup")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
@@ -51,8 +51,6 @@ browser.runtime.onSuspend.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onSuspend")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.html
@@ -47,8 +47,6 @@ browser.runtime.onSuspendCanceled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onSuspendCanceled")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
@@ -60,8 +60,6 @@ browser.runtime.onUpdateAvailable.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onUpdateAvailable")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.openOptionsPage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.PlatformArch")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.PlatformInfo")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.PlatformNaclArch")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.html
@@ -37,11 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
-
 <p>{{Compat("webextensions.api.runtime.PlatformOs")}}</p>
-
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -95,8 +95,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.Port")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.html
@@ -29,8 +29,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.reload")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
@@ -46,8 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.requestUpdateCheck")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.RequestUpdateCheckStatus")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -82,8 +82,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.sendMessage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
@@ -47,8 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.sendNativeMessage")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.html
@@ -38,8 +38,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.setUninstallURL")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.html
@@ -51,8 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.search.search", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.html
@@ -55,8 +55,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.search.search", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
@@ -27,8 +27,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.Filter")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.html
@@ -46,8 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.forgetClosedTab")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.html
@@ -43,8 +43,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.forgetClosedWindow")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.getRecentlyClosed")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.html
@@ -42,8 +42,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.getTabValue", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.html
@@ -42,8 +42,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.getWindowValue", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.html
@@ -18,8 +18,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.MAX_SESSION_RESULTS")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.html
@@ -47,8 +47,6 @@ browser.sessions.onChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.onChanged")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.removeTabValue", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.html
@@ -40,8 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.removeWindowValue", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.html
@@ -37,8 +37,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.restore")}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
@@ -44,8 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.Session")}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.html
@@ -45,8 +45,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.setTabValue", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.html
@@ -45,8 +45,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sessions.setWindowValue", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.close", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.getPanel",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.getTitle",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.html
@@ -21,8 +21,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.ImageDataType")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.html
@@ -50,8 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.isOpen",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.html
@@ -36,8 +36,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.open", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
@@ -100,8 +100,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.setIcon",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
@@ -88,10 +88,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.setPanel",2)}}</p>
-
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
@@ -65,8 +65,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.setTitle",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.sidebarAction.toggle", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -103,8 +103,6 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.create", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.html
@@ -74,8 +74,6 @@ discarding.then(onDiscarded, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.discard", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
@@ -56,8 +56,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.highlight",2)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.html
@@ -47,6 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.moveInSuccession", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
@@ -239,8 +239,6 @@ browser.tabs.onUpdated.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.onUpdated", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.html
@@ -87,8 +87,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.Tab", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.html
@@ -72,6 +72,4 @@ browser.tabs.onUpdated.addListener(switchToReaderMode);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.toggleReaderMode")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
@@ -125,8 +125,6 @@ querying.then(updateFirstTab, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.update", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.html
@@ -37,8 +37,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.theme.getCurrent", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.html
@@ -65,8 +65,6 @@ browser.theme.onUpdated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.theme.onUpdated", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.theme.update", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.html
@@ -28,6 +28,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.userScripts.RegisteredUserScript", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
@@ -71,8 +71,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.CertificateInfo", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.html
@@ -73,6 +73,4 @@ browser.webRequest.onBeforeRequest.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.filterResponseData", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.html
@@ -52,8 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.getSecurityInfo", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.html
@@ -228,8 +228,6 @@ browser.webRequest.onAuthRequired.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onAuthRequired", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.html
@@ -166,8 +166,6 @@ browser.webRequest.onBeforeRedirect.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onBeforeRedirect", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
@@ -193,8 +193,6 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onBeforeRequest", 10)}}</p>
 
 <h3 id="DNS_resolution_ordering_when_BlockingResponse_is_used">DNS resolution ordering when BlockingResponse is used</h3>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.html
@@ -179,8 +179,6 @@ browser.webRequest.onBeforeSendHeaders.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onBeforeSendHeaders", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
@@ -164,8 +164,6 @@ browser.webRequest.onCompleted.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onCompleted", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.html
@@ -156,8 +156,6 @@ browser.webRequest.onErrorOccurred.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onErrorOccurred", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.html
@@ -185,8 +185,6 @@ browser.webRequest.onHeadersReceived.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onHeadersReceived", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.html
@@ -164,8 +164,6 @@ browser.webRequest.onResponseStarted.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onResponseStarted", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
@@ -156,8 +156,6 @@ browser.webRequest.onSendHeaders.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.onSendHeaders", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
@@ -90,8 +90,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.SecurityInfo", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.html
@@ -34,8 +34,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.close", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.html
@@ -36,8 +36,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.disconnect", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
@@ -16,8 +16,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.error", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.html
@@ -83,8 +83,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.html
@@ -318,6 +318,4 @@ browser.webRequest.onBeforeRequest.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.ondata", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.html
@@ -22,8 +22,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.onerror", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
@@ -16,8 +16,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.onstart", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.html
@@ -16,8 +16,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.onstop", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.resume", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.html
@@ -33,8 +33,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.status", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.html
@@ -31,8 +31,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.suspend", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.html
@@ -36,8 +36,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.webRequest.StreamFilter.write", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
@@ -148,8 +148,6 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.windows.create", 10)}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
@@ -53,8 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.windows.get",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
@@ -53,8 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.windows.getCurrent",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
@@ -51,8 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.windows.getLastFocused",2)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.html
@@ -38,6 +38,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.author")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.html
@@ -109,6 +109,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.background", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
@@ -130,6 +130,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.chrome_settings_overrides", 10)}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
@@ -91,6 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.chrome_url_overrides")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.html
@@ -194,6 +194,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.commands")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -246,6 +246,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.content_scripts")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
@@ -38,6 +38,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.default_locale")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.html
@@ -38,6 +38,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.description")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.html
@@ -46,6 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.developer")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
@@ -44,6 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.devtools_page")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.html
@@ -43,6 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.dictionaries")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.html
@@ -61,8 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("webextensions.manifest.externally_connectable")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
@@ -40,6 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.homepage_url")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.html
@@ -79,6 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.icons")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
@@ -64,6 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.incognito")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
@@ -39,6 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.manifest_version")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/name/index.html
@@ -40,6 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.name")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
@@ -44,6 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.omnibox")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
@@ -101,6 +101,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.optional_permissions")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -91,6 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.protocol_handlers")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
@@ -38,6 +38,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.short_name")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
@@ -57,8 +57,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.storage", 10)}}</p>
 
 <div class="notecard note">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -1337,8 +1337,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.theme")}}</p>
 
 <h3 id="Colors">Colors</h3>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
@@ -187,6 +187,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.theme_experiment")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
@@ -55,8 +55,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.user_scripts")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
@@ -57,6 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.version")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
@@ -34,6 +34,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.version_name")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
@@ -94,6 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.web_accessible_resources")}}</p>


### PR DESCRIPTION

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Redundant BCD comments
> MDN URL of the main page changed

Numerous (401)
> Issue number (if there is an associated issue)

#2228 

> Anything else that could help us review it

After this one only web/api  will still have this redundant message.