### PR TITLE
Remove inline styles for text-overflow

### DIFF
--- a/files/en-us/web/css/text-overflow/index.html
+++ b/files/en-us/web/css/text-overflow/index.html
@@ -61,20 +61,45 @@ white-space: nowrap;</pre>
 
 <h2 id="Examples">Examples</h2>
 
-<h3 id="CSS">CSS</h3>
+<h3 id="one-value_syntax">One-value syntax</h3>
+
+<p>This example shows different values for <code>text-overflow</code> applied to a paragraph, for left-to-right and right-to-left text.</p>
+
+<h4 id="HTML">HTML</h4>
+
+<pre class="brush: html">
+
+&lt;div class="ltr"&gt;
+  &lt;h2&gt;Left to right text&lt;/h2&gt;
+  &lt;pre&gt;clip&lt;/pre&gt;
+  &lt;p class="overflow-clip"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+  &lt;pre&gt;ellipsis&lt;/pre&gt;
+  &lt;p class="overflow-ellipsis"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+  &lt;pre&gt;" [..]"&lt;/pre&gt;
+  &lt;p class="overflow-string"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;div class="rtl"&gt;
+  &lt;h2&gt;Right to left text&lt;/h2&gt;
+  &lt;pre&gt;clip&lt;/pre&gt;
+  &lt;p class="overflow-clip"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+  &lt;pre&gt;ellipsis&lt;/pre&gt;
+  &lt;p class="overflow-ellipsis"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+  &lt;pre&gt;" [..]"&lt;/pre&gt;
+  &lt;p class="overflow-string"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+&lt;/div&gt;
+</pre>
+
+<h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">p {
   width: 200px;
   border: 1px solid;
   padding: 2px 5px;
 
-  /* BOTH of the following are required for text-overflow */
+  /* Both of the following are required for text-overflow */
   white-space: nowrap;
   overflow: hidden;
-}
-
-.overflow-visible {
-  white-space: initial;
 }
 
 .overflow-clip {
@@ -86,197 +111,88 @@ white-space: nowrap;</pre>
 }
 
 .overflow-string {
-  /* Not supported in most browsers,
-     see the 'Browser compatibility' section below */
   text-overflow: " [..]";
+}
+
+body {
+  display: flex;
+  justify-content: space-around;
+}
+
+.ltr > p {
+  direction: ltr;
+}
+
+.rtl > p {
+  direction: rtl;
 }
 </pre>
 
-<h3 id="HTML">HTML</h3>
+<h4 id="Result">Result</h4>
 
-<pre class="brush: html">&lt;p class="overflow-visible"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
-&lt;p class="overflow-clip"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
-&lt;p class="overflow-ellipsis"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
-&lt;p class="overflow-string"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+<p>{{EmbedLiveSample('one-value_syntax', 600, 320)}}</p>
+
+<h3 id="two-value_syntax">Two-value syntax</h3>
+
+<p>This example shows the two-value syntax for <code>text-overflow</code>, where you can define different overflow behavior for the start and end of the text.
+To show the effect we have to scroll the line so the start of the line is also hidden.</p>
+
+<h4 id="HTML">HTML</h4>
+
+<pre class="brush: html">
+&lt;pre&gt;clip clip&lt;/pre&gt;
+&lt;p class="overflow-clip-clip"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+&lt;pre&gt;clip ellipsis&lt;/pre&gt;
+&lt;p class="overflow-clip-ellipsis"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+&lt;pre&gt;ellipsis ellipsis&lt;/pre&gt;
+&lt;p class="overflow-ellipsis-ellipsis"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
+&lt;pre&gt;ellipsis " [..]"&lt;/pre&gt;
+&lt;p class="overflow-ellipsis-string"&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit.&lt;/p&gt;
 </pre>
 
-<h3 id="Result">Result</h3>
+<h4 id="CSS">CSS</h4>
 
-<p>{{EmbedLiveSample('Examples', 300, 220, '', 'Web/CSS/text-overflow')}}</p>
+<pre class="brush: css">p {
+  width: 200px;
+  border: 1px solid;
+  padding: 2px 5px;
 
-<p class="note"><strong>Note:</strong> Live results in the following table may be shown incorrectly due to a limitation of the MDN Editor which removes the all contents of style attributes which have <code>text-overflow</code> properties with string value.</p>
+  /* Both of the following are required for text-overflow */
+  white-space: nowrap;
+  overflow: scroll;
+}
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th rowspan="2" scope="col" style="width: 15em;">CSS value</th>
-   <th colspan="2" scope="col" style="text-align: center;"><code>direction: ltr</code></th>
-   <th colspan="2" scope="col" style="text-align: center;"><code>direction: rtl</code></th>
-  </tr>
-  <tr>
-   <th scope="col">Expected Result</th>
-   <th scope="col">Live result</th>
-   <th scope="col">Expected Result</th>
-   <th scope="col">Live result</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><em>visible overflow</em></td>
-   <td style="font-family: monospace;">1234567890</td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: visible;">1234567890</div>
-   </td>
-   <td style="font-family: monospace;">0987654321</td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: visible;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: clip</code></td>
-   <td style="padding: 1px; font-family: monospace;"><img alt="t-o_clip.png" class="default internal" src="t-o_clip.png"></td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: clip;">1234567890</div>
-   </td>
-   <td style="padding: 1px; font-family: monospace;"><img alt="t-o_clip_rtl.png" class="default internal" src="t-o_clip_rtl.png"></td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: clip;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ''</code></td>
-   <td style="font-family: monospace;">12345</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">54321</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ellipsis</code></td>
-   <td style="font-family: monospace;">1234…</td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: ellipsis;">1234567890</div>
-   </td>
-   <td style="font-family: monospace;">…4321</td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: ellipsis;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: '.'</code></td>
-   <td style="font-family: monospace;">1234.</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">.4321</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: clip clip</code></td>
-   <td style="font-family: monospace;">123456</td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: clip clip;">1234567890</div>
-   </td>
-   <td style="font-family: monospace;">654321</td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: clip clip;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: clip ellipsis</code></td>
-   <td style="font-family: monospace;">1234…</td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: clip ellipsis;">1234567890</div>
-   </td>
-   <td style="font-family: monospace;">6543…</td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: clip ellipsis;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: clip '.'</code></td>
-   <td style="font-family: monospace;">1234.</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">6543.</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ellipsis clip</code></td>
-   <td style="font-family: monospace;">…3456</td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: ellipsis clip;">1234567890</div>
-   </td>
-   <td style="font-family: monospace;">…4321</td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: ellipsis clip;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ellipsis ellipsis</code></td>
-   <td style="font-family: monospace;">…34…</td>
-   <td style="direction: ltr;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: ellipsis ellipsis;">1234567890</div>
-   </td>
-   <td style="font-family: monospace;">…43…</td>
-   <td style="direction: rtl;">
-    <div style="font-family: monospace; white-space: nowrap; max-width: 3.35em; overflow: hidden; text-overflow: ellipsis ellipsis;">1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ellipsis '.'</code></td>
-   <td style="font-family: monospace;">…34.</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">…43.</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ',' clip</code></td>
-   <td style="font-family: monospace;">,3456</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">,4321</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ',' ellipsis</code></td>
-   <td style="font-family: monospace;">,34…</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">,43…</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
-  <tr>
-   <td><code>text-overflow: ',' '.'</code></td>
-   <td style="font-family: monospace;">,34.</td>
-   <td style="direction: ltr;">
-    <div>1234567890</div>
-   </td>
-   <td style="font-family: monospace;">,43.</td>
-   <td style="direction: rtl;">
-    <div>1234567890</div>
-   </td>
-  </tr>
- </tbody>
-</table>
+.overflow-clip-clip {
+  text-overflow: clip clip;
+}
+
+.overflow-clip-ellipsis {
+  text-overflow: clip ellipsis;
+}
+
+.overflow-ellipsis-ellipsis {
+  text-overflow: ellipsis ellipsis;
+}
+
+.overflow-ellipsis-string {
+  text-overflow: ellipsis " [..]";
+}
+</pre>
+
+
+<h4 id="JavaScript">JavaScript</h4>
+
+<pre class="brush: js">// Scroll each paragraph so the start is also hidden
+const paras = document.querySelectorAll("p");
+
+for (let para of paras) {
+  para.scroll(100, 0);
+}
+</pre>
+
+<h4 id="Result">Result</h4>
+
+<p>{{EmbedLiveSample('two-value_syntax', 600, 360)}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
This PR removes the inline styles from https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow . 

That page did use a live sample for some basic usages, then a big table for lots more. The big table used inline styles, and apart from that had some other problems:

* it didn't actually show the effect in many cases, apparently because of an old Kuma issue?
* because of that, it needed twice as many cells, one to show what was expected and one to show what actually happened. This made it hard to read.
* with the two-value syntax it didn't show the effect either, because the line wasn't scrolled to cut off the start

So I reorganized things a bit, extending the first live sample to show one-value syntax with LTR and RTL text, and adding a new live sample to show two-value syntax with just LTR. I didn't show every combination because I think after a while you get the idea.

I also removed the "visible overflow" case, as that didn't seem needed and I wanted to keep things as simple as possible.
