### PR TITLE
Remove remaining redundant BCD messages in whole of content.

### DIFF
--- a/files/en-us/mdn/structures/compatibility_tables/index.html
+++ b/files/en-us/mdn/structures/compatibility_tables/index.html
@@ -453,8 +453,6 @@ git push</pre>
 <p>As another example, The compat table for the {{domxref("VRDisplay.capabilities")}} property is generated using <code>\{{Compat("api.VRDisplay.capabilities")}}</code>. The macro call generates the following table (and corresponding set of notes):</p>
 
 <hr>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.VRDisplay.capabilities")}}</p>
 
 <div class="notecard note">

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -111,10 +111,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfTheConstructor")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
@@ -89,10 +89,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfTheProperty")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -123,10 +123,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfAPI")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.html
@@ -110,10 +110,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfTheProperty")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.html
@@ -160,10 +160,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfTheElement")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
@@ -113,10 +113,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfTheHeader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.html
@@ -114,10 +114,6 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("path.to.feature.NameOfTheElement")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/abstractrange/collapsed/index.html
+++ b/files/en-us/web/api/abstractrange/collapsed/index.html
@@ -50,6 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.AbstractRange.collapsed")}}</p>

--- a/files/en-us/web/api/abstractrange/endcontainer/index.html
+++ b/files/en-us/web/api/abstractrange/endcontainer/index.html
@@ -55,6 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.AbstractRange.endContainer")}}</p>

--- a/files/en-us/web/api/abstractrange/index.html
+++ b/files/en-us/web/api/abstractrange/index.html
@@ -191,6 +191,4 @@ document.body.appendChild(fragment);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.AbstractRange")}}</p>

--- a/files/en-us/web/api/blob/slice/index.html
+++ b/files/en-us/web/api/blob/slice/index.html
@@ -71,11 +71,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like
-  to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.Blob.slice")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.html
@@ -76,13 +76,6 @@ ctx.getContextAttributes();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out
-  <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.
-</p>
-
 <p>{{Compat("api.CanvasRenderingContext2D.getContextAttributes")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/caretposition/index.html
+++ b/files/en-us/web/api/caretposition/index.html
@@ -51,10 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.CaretPosition")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/channel_messaging_api/index.html
+++ b/files/en-us/web/api/channel_messaging_api/index.html
@@ -69,8 +69,6 @@ tags:
 
 <h3 id="MessagePort"><code>MessagePort</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.MessagePort", 0)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.html
+++ b/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.html
@@ -157,8 +157,6 @@ function onMessage(e) {
 
 <h3 id="MessagePort"><code>MessagePort</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.MessagePort", 0)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.html
@@ -70,6 +70,4 @@ var myMerger = new ChannelMergerNode(ac, options);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.ChannelMergerNode.ChannelMergerNode")}}</p>

--- a/files/en-us/web/api/characterdata/index.html
+++ b/files/en-us/web/api/characterdata/index.html
@@ -83,10 +83,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.CharacterData")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/clipboard_api/index.html
+++ b/files/en-us/web/api/clipboard_api/index.html
@@ -70,8 +70,6 @@ tags:
 
 <h3 id="ClipboardEvent">ClipboardEvent</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.ClipboardEvent")}}</p>
 
 <h3 id="ClipboardItem">ClipboardItem</h3>

--- a/files/en-us/web/api/compression_streams_api/index.html
+++ b/files/en-us/web/api/compression_streams_api/index.html
@@ -57,6 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.CompressionStream")}}</p>

--- a/files/en-us/web/api/cssanimation/animationname/index.html
+++ b/files/en-us/web/api/cssanimation/animationname/index.html
@@ -68,9 +68,4 @@ console.log(animations[0].animationName);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSAnimation.animationName")}}</p>

--- a/files/en-us/web/api/cssgroupingrule/cssrules/index.html
+++ b/files/en-us/web/api/cssgroupingrule/cssrules/index.html
@@ -50,9 +50,4 @@ console.log(myRules);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSGroupingRule")}}</p>

--- a/files/en-us/web/api/cssgroupingrule/deleterule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/deleterule/index.html
@@ -73,9 +73,4 @@ myRules[0].deleteRule(2); /* deletes the rule at index 2 */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSGroupingRule")}}</p>

--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.html
@@ -77,9 +77,4 @@ myRules[0].insertRule('html {background-color: blue;}',0); /* inserts a rule for
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSGroupingRule")}}</p>

--- a/files/en-us/web/api/cssimportrule/href/index.html
+++ b/files/en-us/web/api/cssimportrule/href/index.html
@@ -66,9 +66,4 @@ console.log(myRules[0].href); //returns style.css</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-	data. If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</div>
-
 <p>{{Compat("api.CSSImportRule.href")}}</p>

--- a/files/en-us/web/api/cssimportrule/media/index.html
+++ b/files/en-us/web/api/cssimportrule/media/index.html
@@ -64,9 +64,4 @@ console.log(myRules[0].media); //returns a MediaList</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-	data. If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</div>
-
 <p>{{Compat("api.CSSImportRule.media")}}</p>

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.html
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.html
@@ -66,9 +66,4 @@ console.log(myRules[0].styleSheet); //returns a CSSStyleSheet object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-	data. If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</div>
-
 <p>{{Compat("api.CSSImportRule.styleSheet")}}</p>

--- a/files/en-us/web/api/cssmediarule/media/index.html
+++ b/files/en-us/web/api/cssmediarule/media/index.html
@@ -74,12 +74,4 @@ console.log(myRules[0].media); // a MediaList</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  The compatibility table in this page is generated from structured data. If
-  you'd like to contribute to the data, please check out
-  <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.
-</div>
-
 <p>{{Compat("api.CSSMediaRule.media")}}</p>

--- a/files/en-us/web/api/csspropertyrule/inherits/index.html
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.html
@@ -55,9 +55,4 @@ console.log(myRules[0].inherits); //returns false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPropertyRule.inherits")}}</p>

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.html
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.html
@@ -57,9 +57,4 @@ console.log(myRules[0].initialValue); //the string "#c0ffee"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPropertyRule.initialValue")}}</p>

--- a/files/en-us/web/api/csspropertyrule/name/index.html
+++ b/files/en-us/web/api/csspropertyrule/name/index.html
@@ -57,9 +57,4 @@ console.log(myRules[0].name); //the string "--property-name"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPropertyRule.name")}}</p>

--- a/files/en-us/web/api/csspropertyrule/syntax/index.html
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.html
@@ -55,9 +55,4 @@ console.log(myRules[0].syntax); //the string "&lt;color&gt;"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSPropertyRule.syntax")}}</p>

--- a/files/en-us/web/api/csspseudoelement/index.html
+++ b/files/en-us/web/api/csspseudoelement/index.html
@@ -66,10 +66,6 @@ console.log(cssPseudoElement.type); // Outputs '::before'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat('api.CSSPseudoElement')}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/cssrule/type/index.html
+++ b/files/en-us/web/api/cssrule/type/index.html
@@ -167,9 +167,4 @@ console.log(myRules[0].type);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSRule.type")}}</p>

--- a/files/en-us/web/api/csstransition/transitionproperty/index.html
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.html
@@ -72,9 +72,4 @@ item.addEventListener('transitionrun', () => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.CSSAnimation.transitionProperty")}}</p>

--- a/files/en-us/web/api/device_memory_api/index.html
+++ b/files/en-us/web/api/device_memory_api/index.html
@@ -47,8 +47,6 @@ tags:
 
 <h3 id="Client_Hints_extension">Client Hints extension</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("http.headers.Device-Memory")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
@@ -66,11 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like
-  to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.DeviceMotionEvent.accelerationIncludingGravity")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/document/bgcolor/index.html
+++ b/files/en-us/web/api/document/bgcolor/index.html
@@ -49,9 +49,4 @@ document.bgColor =<em>color</em>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like
-  to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.Document.bgColor")}}</p>

--- a/files/en-us/web/api/element/attributes/index.html
+++ b/files/en-us/web/api/element/attributes/index.html
@@ -113,13 +113,6 @@ var atts = para.attributes;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.Element.attributes")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/element/insertadjacentelement/index.html
+++ b/files/en-us/web/api/element/insertadjacentelement/index.html
@@ -133,13 +133,6 @@ afterBtn.addEventListener('click', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.Element.insertAdjacentElement")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.html
@@ -61,11 +61,6 @@ ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.beginQueryEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.html
@@ -53,11 +53,6 @@ var query = ext.createQueryExt();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.createQueryEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.html
@@ -59,11 +59,6 @@ ext.deleteQueryEXT(query);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.deleteQueryEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.html
@@ -60,11 +60,6 @@ ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.endQueryEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.html
@@ -72,11 +72,6 @@ var currentQuery = ext.getQueryEXT(ext.TIMESTAMP_EXT,
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.getQueryEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.html
@@ -79,11 +79,6 @@ if (available &amp;&amp; !disjoint) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.getQueryObjectEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.html
@@ -61,11 +61,6 @@ ext.isQueryEXT(query);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.isQueryEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.html
+++ b/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.html
@@ -65,11 +65,6 @@ ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_disjoint_timer_query.queryCounterEXT")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_texture_compression_bptc/index.html
+++ b/files/en-us/web/api/ext_texture_compression_bptc/index.html
@@ -61,8 +61,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_BPTC_UNORM_EXT, 12
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_texture_compression_bptc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ext_texture_compression_rgtc/index.html
+++ b/files/en-us/web/api/ext_texture_compression_rgtc/index.html
@@ -61,8 +61,6 @@ gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RED_RGTC1_EXT, 128, 128
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.EXT_texture_compression_rgtc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/file_and_directory_entries_api/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/index.html
@@ -117,8 +117,6 @@ tags:
 
 <h3 id="FileSystemSync_property"><code>FileSystemSync</code> property</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.FileSystemSync", 0)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.html
@@ -226,8 +226,6 @@ tags:
 
 <h3 id="FileSystemSync_property"><code>FileSystemSync</code> property</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.FileSystemSync", 0)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
@@ -137,11 +137,6 @@ function loadDictionaryForLanguage(appDataDirEntry, lang) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.FileSystemDirectoryEntry.getFile")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/fullscreen_api/guide/index.html
+++ b/files/en-us/web/api/fullscreen_api/guide/index.html
@@ -209,8 +209,6 @@ if (elem.requestFullscreen) {
 
 <h3 id="Document.fullscreenEnabled"><code>Document.fullscreenEnabled</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Document.fullscreenEnabled")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/fullscreen_api/index.html
+++ b/files/en-us/web/api/fullscreen_api/index.html
@@ -189,25 +189,17 @@ tags:
 
 <h3 id="Document.fullscreenElement"><code>Document.fullscreenElement</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Document.fullscreenElement")}}</p>
 
 <h3 id="Document.fullscreenEnabled"><code>Document.fullscreenEnabled</code></h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.Document.fullscreenEnabled")}}</p>
 
 <h3 id="Document.exitFullscreen"><code>Document.exitFullscreen</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Document.exitFullscreen")}}</p>
 
 <h3 id="Element.requestFullscreen"><code>Element.requestFullscreen</code></h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.Element.requestFullscreen")}}</p>
 

--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.html
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.html
@@ -339,8 +339,4 @@ if (!haveEvents) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.Gamepad")}}</p>

--- a/files/en-us/web/api/htmlaudioelement/audio/index.html
+++ b/files/en-us/web/api/htmlaudioelement/audio/index.html
@@ -106,11 +106,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like
-	to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-	send us a pull request.</p>
-
 <p>{{Compat("api.HTMLAudioElement.Audio")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.html
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.html
@@ -113,9 +113,4 @@ if (myForm.requestSubmit) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like
-  to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLFormElement.requestSubmit")}}</p>

--- a/files/en-us/web/api/htmlimageelement/hspace/index.html
+++ b/files/en-us/web/api/htmlimageelement/hspace/index.html
@@ -80,9 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-  send us a pull request.</p>
-
 <p>{{Compat("api.HTMLImageElement.hspace")}}</p>

--- a/files/en-us/web/api/htmlimageelement/ismap/index.html
+++ b/files/en-us/web/api/htmlimageelement/ismap/index.html
@@ -71,9 +71,4 @@ let isMap = <em>htmlImageElement</em>.isMap;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>The compatibility table on this page is generated from structured data. If you'd like
-	to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-	send us a pull request.</p>
-
 <p>{{Compat("api.HTMLImageElement.isMap")}}</p>

--- a/files/en-us/web/api/htmlimageelement/name/index.html
+++ b/files/en-us/web/api/htmlimageelement/name/index.html
@@ -63,9 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-  send us a pull request.</div>
-
 <p>{{Compat("api.HTMLImageElement.name")}}</p>

--- a/files/en-us/web/api/htmlimageelement/usemap/index.html
+++ b/files/en-us/web/api/htmlimageelement/usemap/index.html
@@ -95,9 +95,4 @@ let <em>imageMapAnchor</em> = <em>htmlImageElement</em>.useMap;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-  send us a pull request.</div>
-
 <p>{{Compat("api.HTMLImageElement.useMap")}}</p>

--- a/files/en-us/web/api/htmlinputelement/index.html
+++ b/files/en-us/web/api/htmlinputelement/index.html
@@ -413,8 +413,6 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.HTMLInputElement")}}</p>
 </div>
 

--- a/files/en-us/web/api/htmlselectelement/add/index.html
+++ b/files/en-us/web/api/htmlselectelement/add/index.html
@@ -176,9 +176,4 @@ sel.add(opt, sel.options[1]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.add")}}</p>

--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.html
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.html
@@ -47,11 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.checkValidity")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlselectelement/disabled/index.html
+++ b/files/en-us/web/api/htmlselectelement/disabled/index.html
@@ -82,9 +82,4 @@ allowDrinksCheckbox.addEventListener("change", function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.disabled")}}</p>

--- a/files/en-us/web/api/htmlselectelement/form/index.html
+++ b/files/en-us/web/api/htmlselectelement/form/index.html
@@ -74,9 +74,4 @@ else
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.form")}}</p>

--- a/files/en-us/web/api/htmlselectelement/item/index.html
+++ b/files/en-us/web/api/htmlselectelement/item/index.html
@@ -80,11 +80,6 @@ elem1 = document.forms[0]['myFormControl'][1];
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.item")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlselectelement/labels/index.html
+++ b/files/en-us/web/api/htmlselectelement/labels/index.html
@@ -73,9 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.labels")}}</p>

--- a/files/en-us/web/api/htmlselectelement/nameditem/index.html
+++ b/files/en-us/web/api/htmlselectelement/nameditem/index.html
@@ -80,11 +80,6 @@ var <em>item </em>=<em> collection</em>[<em>str</em>];
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.namedItem")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlselectelement/options/index.html
+++ b/files/en-us/web/api/htmlselectelement/options/index.html
@@ -73,9 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.options")}}</p>

--- a/files/en-us/web/api/htmlselectelement/remove/index.html
+++ b/files/en-us/web/api/htmlselectelement/remove/index.html
@@ -87,11 +87,6 @@ sel.remove(1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.remove")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.html
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.html
@@ -77,9 +77,4 @@ selectElem.addEventListener('change', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.selectedIndex")}}</p>

--- a/files/en-us/web/api/htmlselectelement/selectedoptions/index.html
+++ b/files/en-us/web/api/htmlselectelement/selectedoptions/index.html
@@ -145,11 +145,6 @@ orderButton.addEventListener("click", function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.selectedOptions")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.html
+++ b/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.html
@@ -54,11 +54,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.setCustomValidity")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/htmlselectelement/type/index.html
+++ b/files/en-us/web/api/htmlselectelement/type/index.html
@@ -77,11 +77,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.type")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/idbcursor/request/index.html
+++ b/files/en-us/web/api/idbcursor/request/index.html
@@ -69,10 +69,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.IDBCursor.request")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/idbfactory/databases/index.html
+++ b/files/en-us/web/api/idbfactory/databases/index.html
@@ -89,10 +89,6 @@ promise.then(databases =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.IDBFactory.databases")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/idbtransaction/commit/index.html
+++ b/files/en-us/web/api/idbtransaction/commit/index.html
@@ -97,10 +97,6 @@ transaction.commit();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.IDBTransaction.commit")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/idbtransaction/durability/index.html
+++ b/files/en-us/web/api/idbtransaction/durability/index.html
@@ -62,9 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.IDBTransaction.durability")}}</p>

--- a/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.html
@@ -66,9 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.IDBVersionChangeEvent.IDBVersionChangeEvent")}}</p>

--- a/files/en-us/web/api/intersectionobserver/disconnect/index.html
+++ b/files/en-us/web/api/intersectionobserver/disconnect/index.html
@@ -52,11 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.disconnect")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
@@ -118,9 +118,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.IntersectionObserver")}}</p>

--- a/files/en-us/web/api/intersectionobserver/observe/index.html
+++ b/files/en-us/web/api/intersectionobserver/observe/index.html
@@ -65,11 +65,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.observe")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserver/root/index.html
+++ b/files/en-us/web/api/intersectionobserver/root/index.html
@@ -67,11 +67,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.root")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserver/rootmargin/index.html
+++ b/files/en-us/web/api/intersectionobserver/rootmargin/index.html
@@ -69,9 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.rootMargin")}}</p>

--- a/files/en-us/web/api/intersectionobserver/takerecords/index.html
+++ b/files/en-us/web/api/intersectionobserver/takerecords/index.html
@@ -64,11 +64,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.takeRecords")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserver/thresholds/index.html
+++ b/files/en-us/web/api/intersectionobserver/thresholds/index.html
@@ -70,9 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.thresholds")}}</p>

--- a/files/en-us/web/api/intersectionobserver/unobserve/index.html
+++ b/files/en-us/web/api/intersectionobserver/unobserve/index.html
@@ -67,11 +67,6 @@ observer.unobserve(document.getElementById("elementToObserve"));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.unobserve")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.html
@@ -56,9 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.boundingClientRect")}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/intersectionratio/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/intersectionratio/index.html
@@ -72,9 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.intersectionRatio")}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/intersectionrect/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/intersectionrect/index.html
@@ -71,9 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.intersectionRect")}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/isintersecting/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/isintersecting/index.html
@@ -74,9 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.isIntersecting")}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/rootbounds/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/rootbounds/index.html
@@ -54,9 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.rootBounds")}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/target/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/target/index.html
@@ -66,9 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.target")}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/time/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/time/index.html
@@ -58,9 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserverEntry.time")}}</p>

--- a/files/en-us/web/api/long_tasks_api/index.html
+++ b/files/en-us/web/api/long_tasks_api/index.html
@@ -105,8 +105,6 @@ observer.observe({entryTypes: ["longtask"]});
 <h3 id="TaskAttributionTiming"><code>TaskAttributionTiming</code></h3>
 
 <div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TaskAttributionTiming")}}</p>
 </div>
 

--- a/files/en-us/web/api/media_session_api/index.html
+++ b/files/en-us/web/api/media_session_api/index.html
@@ -111,8 +111,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MediaSession")}}</p>

--- a/files/en-us/web/api/mediaimage/index.html
+++ b/files/en-us/web/api/mediaimage/index.html
@@ -38,8 +38,6 @@ slug: Web/API/MediaImage
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.MediaImage")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/mediapositionstate/duration/index.html
+++ b/files/en-us/web/api/mediapositionstate/duration/index.html
@@ -86,9 +86,4 @@ navigator.mediaSession.setPositionState(positionState);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.MediaPositionState.duration")}}</p>

--- a/files/en-us/web/api/mediapositionstate/index.html
+++ b/files/en-us/web/api/mediapositionstate/index.html
@@ -53,6 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.MediaPositionState")}}</p>

--- a/files/en-us/web/api/mediapositionstate/playbackrate/index.html
+++ b/files/en-us/web/api/mediapositionstate/playbackrate/index.html
@@ -96,9 +96,4 @@ navigator.mediaSession.setPositionState(positionState);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.MediaPositionState.playbackRate")}}</p>

--- a/files/en-us/web/api/mediapositionstate/position/index.html
+++ b/files/en-us/web/api/mediapositionstate/position/index.html
@@ -90,9 +90,4 @@ let <em>duration</em> = <em>positionState</em>.duration;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.MediaPositionState.position")}}</p>

--- a/files/en-us/web/api/mediarecordererrorevent/error/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/error/index.html
@@ -116,13 +116,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MediaRecorderErrorEvent.error")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/index.html
@@ -62,9 +62,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MediaRecorderErrorEvent")}}</p>

--- a/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
@@ -76,11 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MediaRecorderErrorEvent.MediaRecorderErrorEvent")}}</p>

--- a/files/en-us/web/api/mediasession/index.html
+++ b/files/en-us/web/api/mediasession/index.html
@@ -122,6 +122,4 @@ for (const [action, handler] of actionHandlers) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.MediaSession")}}</p>

--- a/files/en-us/web/api/mediasession/setpositionstate/index.html
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.html
@@ -117,9 +117,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.MediaSession.setPositionState")}}</p>

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.html
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.html
@@ -88,11 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MediaStream.getAudioTracks")}}</p>

--- a/files/en-us/web/api/mediastream/gettracks/index.html
+++ b/files/en-us/web/api/mediastream/gettracks/index.html
@@ -66,11 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MediaStream.getTracks")}}</p>

--- a/files/en-us/web/api/mediastream_image_capture_api/index.html
+++ b/files/en-us/web/api/mediastream_image_capture_api/index.html
@@ -82,8 +82,6 @@ track.applyConstraints({ advanced : [{ zoom: zoom.value }] });
 
 <h3 id="PhotoCapabilities"><code>PhotoCapabilities</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PhotoCapabilities")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/midimessageevent/index.html
+++ b/files/en-us/web/api/midimessageevent/index.html
@@ -58,9 +58,4 @@ navigator.requestMIDIAccess().then(midiAccess =&gt; {
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.MIDIMessageEvent")}}</p>

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -184,6 +184,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <div>{{Compat("api.Navigator")}}</div>

--- a/files/en-us/web/api/navigator/mediasession/index.html
+++ b/files/en-us/web/api/navigator/mediasession/index.html
@@ -83,9 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.Navigator.mediaSession")}}</p>

--- a/files/en-us/web/api/navigator/serviceworker/index.html
+++ b/files/en-us/web/api/navigator/serviceworker/index.html
@@ -60,11 +60,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a class="external"
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</div>
-
 <p>{{Compat("api.Navigator.serviceWorker")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/network_information_api/index.html
+++ b/files/en-us/web/api/network_information_api/index.html
@@ -77,8 +77,6 @@ if (connection) {
 
 <h3 id="Navigator.connection">Navigator.connection</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Navigator.connection")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.html
@@ -62,11 +62,6 @@ ext.bindVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.OES_vertex_array_object.bindVertexArrayOES")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.html
@@ -62,11 +62,6 @@ ext.bindVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.OES_vertex_array_object.createVertexArrayOES")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.html
@@ -61,11 +61,6 @@ ext.deleteVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.OES_vertex_array_object.deleteVertexArrayOES")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.html
@@ -63,11 +63,6 @@ ext.isVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.OES_vertex_array_object.isVertexArrayOES")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.html
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.html
@@ -75,11 +75,6 @@ offscreen.convertToBlob().then(function(blob) {
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.OffscreenCanvas.convertToBlob")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.html
+++ b/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.html
@@ -154,11 +154,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.OVR_multiview2.framebufferTextureMultiviewOVR")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/ovr_multiview2/index.html
+++ b/files/en-us/web/api/ovr_multiview2/index.html
@@ -102,8 +102,6 @@ void main() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.OVR_multiview2")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/paymentrequestevent/index.html
+++ b/files/en-us/web/api/paymentrequestevent/index.html
@@ -67,9 +67,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PaymentRequestEvent")}}</p>

--- a/files/en-us/web/api/picture-in-picture_api/index.html
+++ b/files/en-us/web/api/picture-in-picture_api/index.html
@@ -142,37 +142,25 @@ tags:
 
 <h3 id="HTMLVideoElement.autoPictureInPicture"><code>HTMLVideoElement.autoPictureInPicture</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.HTMLVideoElement.autoPictureInPicture")}}</p>
 
 <h3 id="HTMLVideoElement.disablePictureInPicture"><code>HTMLVideoElement.disablePictureInPicture</code></h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.HTMLVideoElement.disablePictureInPicture")}}</p>
 
 <h3 id="Document.pictureInPictureEnabled"><code>Document.pictureInPictureEnabled</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Document.pictureInPictureEnabled")}}</p>
 
 <h3 id="Document.exitPictureInPicture"><code>Document.exitPictureInPicture</code></h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.Document.exitPictureInPicture")}}</p>
 
 <h3 id="Document.pictureInPictureElement"><code>Document.pictureInPictureElement</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Document.pictureInPictureElement")}}</p>
 
 <h3 id="PictureInPictureWindow"><code>PictureInPictureWindow</code></h3>
-
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
 <p>{{Compat("api.PictureInPictureWindow")}}</p>
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -484,11 +484,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent")}}</p>
 
 <p>Some new values have been defined for the {{cssxref("touch-action", "CSS touch-action")}} property as part of the {{SpecName('Pointer Events 3')}} specification but currently those new values have limited implementation support.</p>

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
@@ -48,11 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.getCoalescedEvents")}}</p>

--- a/files/en-us/web/api/pointerevent/height/index.html
+++ b/files/en-us/web/api/pointerevent/height/index.html
@@ -62,11 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.height")}}</p>

--- a/files/en-us/web/api/pointerevent/isprimary/index.html
+++ b/files/en-us/web/api/pointerevent/isprimary/index.html
@@ -88,11 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.isPrimary")}}</p>

--- a/files/en-us/web/api/pointerevent/pointerevent/index.html
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.html
@@ -86,11 +86,4 @@ var downEvent = new PointerEvent("pointerdown",
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-	<p>The compatibility table on this page is generated from structured data. If you'd
-		like to contribute to the data, please check out <a
-			href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-		and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.PointerEvent")}}</p>

--- a/files/en-us/web/api/pointerevent/pointerid/index.html
+++ b/files/en-us/web/api/pointerevent/pointerid/index.html
@@ -68,11 +68,4 @@ target.addEventListener('pointerdown', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.pointerId")}}</p>

--- a/files/en-us/web/api/pointerevent/pointertype/index.html
+++ b/files/en-us/web/api/pointerevent/pointertype/index.html
@@ -99,11 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.pointerType", 2)}}</p>

--- a/files/en-us/web/api/pointerevent/pressure/index.html
+++ b/files/en-us/web/api/pointerevent/pressure/index.html
@@ -76,13 +76,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.pressure")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pointerevent/tangentialpressure/index.html
+++ b/files/en-us/web/api/pointerevent/tangentialpressure/index.html
@@ -72,13 +72,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.tangentialPressure")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pointerevent/tiltx/index.html
+++ b/files/en-us/web/api/pointerevent/tiltx/index.html
@@ -69,11 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.tiltX")}}</p>

--- a/files/en-us/web/api/pointerevent/tilty/index.html
+++ b/files/en-us/web/api/pointerevent/tilty/index.html
@@ -68,11 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.tiltY")}}</p>

--- a/files/en-us/web/api/pointerevent/twist/index.html
+++ b/files/en-us/web/api/pointerevent/twist/index.html
@@ -63,13 +63,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.twist")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pointerevent/width/index.html
+++ b/files/en-us/web/api/pointerevent/width/index.html
@@ -69,11 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.PointerEvent.width")}}</p>

--- a/files/en-us/web/api/push_api/index.html
+++ b/files/en-us/web/api/push_api/index.html
@@ -94,8 +94,6 @@ tags:
 
 <h3 id="PushMessageData"><code>PushMessageData</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.PushMessageData")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
@@ -49,11 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableByteStreamController.byobRequest")}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.html
@@ -64,11 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableByteStreamController.close")}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
@@ -48,11 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableByteStreamController.desiredSize")}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
@@ -64,11 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableByteStreamController.enqueue")}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/error/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/error/index.html
@@ -63,11 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableByteStreamController.error")}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/index.html
@@ -61,10 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableByteStreamController")}}</p>
-</div>

--- a/files/en-us/web/api/readablestream/cancel/index.html
+++ b/files/en-us/web/api/readablestream/cancel/index.html
@@ -136,11 +136,4 @@ fetch(url).then(response =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.cancel")}}</p>

--- a/files/en-us/web/api/readablestream/getreader/index.html
+++ b/files/en-us/web/api/readablestream/getreader/index.html
@@ -112,11 +112,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.getReader")}}</p>

--- a/files/en-us/web/api/readablestream/locked/index.html
+++ b/files/en-us/web/api/readablestream/locked/index.html
@@ -55,11 +55,4 @@ stream.locked
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.locked")}}</p>

--- a/files/en-us/web/api/readablestream/pipethrough/index.html
+++ b/files/en-us/web/api/readablestream/pipethrough/index.html
@@ -118,11 +118,4 @@ fetch('png-logo.png')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.pipeThrough")}}</p>

--- a/files/en-us/web/api/readablestream/pipeto/index.html
+++ b/files/en-us/web/api/readablestream/pipeto/index.html
@@ -102,11 +102,4 @@ fetch('png-logo.png')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.pipeTo")}}</p>

--- a/files/en-us/web/api/readablestream/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/readablestream/index.html
@@ -163,11 +163,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table on this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.ReadableStream")}}</p>

--- a/files/en-us/web/api/readablestream/tee/index.html
+++ b/files/en-us/web/api/readablestream/tee/index.html
@@ -108,11 +108,4 @@ function fetchStream(stream, list) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStream.tee")}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.html
@@ -70,11 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamBYOBReader.cancel")}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/closed/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.html
@@ -50,11 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamBYOBReader.closed")}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/index.html
@@ -62,10 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamBYOBReader")}}</p>
-</div>

--- a/files/en-us/web/api/readablestreambyobreader/read/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.html
@@ -73,11 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamBYOBReader.read")}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
@@ -69,11 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamBYOBReader.ReadableStreamBYOBReader")}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
@@ -67,11 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamBYOBReader.releaseLock")}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
@@ -52,11 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamDefaultController.desiredSize")}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
@@ -102,11 +102,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.ReadableStreamDefaultController.enqueue")}}</p>

--- a/files/en-us/web/api/streams_api/index.html
+++ b/files/en-us/web/api/streams_api/index.html
@@ -131,11 +131,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <h3 id="ReadableStream">ReadableStream</h3>
 
 <p>{{Compat("api.ReadableStream")}}</p>

--- a/files/en-us/web/api/svganimatedinteger/index.html
+++ b/files/en-us/web/api/svganimatedinteger/index.html
@@ -72,9 +72,4 @@ tags:
 <p>The <code>SVGAnimatedInteger</code> interface do not provide any specific methods.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.SVGAnimatedInteger")}}</p>

--- a/files/en-us/web/api/svganimatedlength/index.html
+++ b/files/en-us/web/api/svganimatedlength/index.html
@@ -69,9 +69,4 @@ tags:
 <p>The <code>SVGAnimatedLength</code> interface do not provide any specific methods.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.SVGAnimatedLength")}}</p>

--- a/files/en-us/web/api/texttrack/cuechange_event/index.html
+++ b/files/en-us/web/api/texttrack/cuechange_event/index.html
@@ -93,8 +93,6 @@ textTrackElem.oncuechange = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextTrack.cuechange_event")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -60,11 +60,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.VRDisplayEvent.VRDisplayEvent")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/web_speech_api/index.html
+++ b/files/en-us/web/api/web_speech_api/index.html
@@ -97,8 +97,6 @@ tags:
 
 <h3 id="SpeechSynthesis"><code>SpeechSynthesis</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.SpeechSynthesis", 0)}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/web_storage_api/index.html
+++ b/files/en-us/web/api/web_storage_api/index.html
@@ -91,8 +91,6 @@ tags:
 
 <h3 id="Window.sessionStorage"><code>Window.sessionStorage</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Window.sessionStorage")}}</p>
 
 <h2 id="Private_Browsing_Incognito_modes">Private Browsing / Incognito modes</h2>

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.html
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.html
@@ -212,8 +212,6 @@ imageForm.onchange = populateStorage;</pre>
 
 <h3 id="Window.sessionStorage"><code>Window.sessionStorage</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.Window.sessionStorage")}}</p>
 
 <p>All browsers have varying capacity levels for both localStorage and sessionStorage. Here is a <a href="http://dev-test.nemikor.com/web-storage/support-test/">detailed rundown of all the storage capacities for various browsers</a>.</p>

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.html
@@ -74,11 +74,6 @@ gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.beginQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.html
@@ -71,11 +71,6 @@ gl.drawArrays(gl.TRIANGLES, 0, 3);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.beginTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.html
@@ -71,11 +71,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.bindBufferBase")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.html
@@ -77,11 +77,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.bindBufferRange")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.html
@@ -63,11 +63,6 @@ gl.bindSampler(0, sampler);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.bindSampler")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.html
@@ -64,11 +64,6 @@ gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.bindTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.html
@@ -66,11 +66,6 @@ gl.bindVertexArray(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.bindVertexArray")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.html
@@ -83,11 +83,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.blitFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
@@ -87,11 +87,6 @@ gl.clearBufferfi(gl.DEPTH_STENCIL, 0, 1.0, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.clearBufferiv")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.html
@@ -78,11 +78,6 @@ var status = gl.clientWaitSync(sync, 0, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.clientWaitSync")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.html
@@ -111,11 +111,6 @@ void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width,
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.compressedTexSubImage3D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.html
@@ -99,11 +99,6 @@ gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.ARRAY_BUFFER, 0, 0, length);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.copyBufferSubData")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.html
@@ -85,11 +85,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.copyTexSubImage3D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/createquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createquery/index.html
@@ -60,11 +60,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.createQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/createsampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createsampler/index.html
@@ -59,11 +59,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.createSampler")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.html
@@ -60,11 +60,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.createTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.html
@@ -66,11 +66,6 @@ gl.bindVertexArray(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.createVertexArray")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.html
@@ -66,11 +66,6 @@ gl.deleteQuery(query);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.deleteQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.html
@@ -66,11 +66,6 @@ gl.deleteSampler(sampler);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.deleteSampler")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.html
@@ -66,11 +66,6 @@ gl.deleteSync(sync);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.deleteSync")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.html
@@ -67,11 +67,6 @@ gl.deleteTransformFeedback(transformFeedback);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.deleteTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.html
@@ -65,11 +65,6 @@ gl.deleteVertexArray(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.deleteVertexArray")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.html
@@ -91,11 +91,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.drawArraysInstanced")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.html
@@ -77,11 +77,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.drawBuffers")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.html
@@ -116,11 +116,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.drawElementsInstanced")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.html
@@ -107,11 +107,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.drawRangeElements")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.html
@@ -74,11 +74,6 @@ gl.endQuery(gl.ANY_SAMPLES_PASSED);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.endQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.html
@@ -61,11 +61,6 @@ gl.endTransformFeedback();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.endTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/fencesync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/fencesync/index.html
@@ -67,11 +67,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.fenceSync")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.html
@@ -93,11 +93,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.framebufferTextureLayer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.html
@@ -62,11 +62,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getActiveUniformBlockName")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.html
@@ -85,11 +85,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getActiveUniformBlockParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.html
@@ -87,11 +87,6 @@ var uniformOffsets = gl.getActiveUniforms(program, uniformIndices, gl.UNIFORM_OF
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getActiveUniforms")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.html
@@ -107,11 +107,6 @@ gl.getBufferSubData(gl.ARRAY_BUFFER, 0, arrBuffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getBufferSubData")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.html
@@ -65,11 +65,6 @@ gl.getFragDataLocation(program, 'fragColor');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getFragDataLocation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.html
@@ -76,11 +76,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getIndexedParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.html
@@ -79,11 +79,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getInternalformatParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.html
@@ -72,11 +72,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.html
@@ -73,11 +73,6 @@ var result = gl.getQueryParameter(query, gl.QUERY_RESULT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getQueryParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.html
@@ -85,11 +85,6 @@ gl.getSamplerParameter(sampler, gl.TEXTURE_COMPARE_FUNC);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getSamplerParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.html
@@ -75,11 +75,6 @@ gl.getSyncParameter(sync, gl.SYNC_STATUS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getSyncParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.html
@@ -64,11 +64,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getTransformFeedbackVarying")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.html
@@ -69,11 +69,6 @@ var blockIndex = gl.getUniformBlockIndex(program, 'UBOData');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getUniformBlockIndex")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.html
@@ -63,11 +63,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.getUniformIndices")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.html
@@ -83,11 +83,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.invalidateFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.html
@@ -96,11 +96,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.invalidateSubFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.html
@@ -67,11 +67,6 @@ gl.isQuery(query);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.isQuery")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.html
@@ -67,11 +67,6 @@ gl.isSampler(sampler);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.isSampler")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.html
@@ -67,11 +67,6 @@ gl.isSync(sync);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.isSync")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.html
@@ -69,11 +69,6 @@ gl.isTransformFeedback(transformFeedback);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.isTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.html
@@ -66,11 +66,6 @@ gl.isVertexArray(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.isVertexArray")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.html
@@ -64,11 +64,6 @@ gl.endTransformFeedback();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.pauseTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.html
@@ -70,11 +70,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.readBuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.html
@@ -115,11 +115,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.renderbufferStorageMultisample")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.html
@@ -64,11 +64,6 @@ gl.endTransformFeedback();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.resumeTransformFeedback")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.html
@@ -65,11 +65,6 @@ gl.samplerParameteri(sampler, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
 <h2 id="Specifications">Specifications</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.samplerParameteri")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.html
@@ -177,11 +177,6 @@ void <var>gl</var>.texImage3D(target, level, internalformat, width, height, dept
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.texImage3D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.html
@@ -118,11 +118,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.texStorage2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.html
@@ -111,11 +111,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.texStorage3D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.html
@@ -181,11 +181,6 @@ void <var>gl</var>.texSubImage3D(<var>target</var>, <var>level</var>, <var>xoffs
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.texSubImage3D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.html
@@ -73,11 +73,6 @@ gl.linkProgram(shaderProg);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.transformFeedbackVaryings")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/uniform/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniform/index.html
@@ -88,11 +88,6 @@ void gl.uniform4uiv(location, data, optional srcOffset, optional srcLength);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.uniform1ui")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.html
@@ -66,11 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.uniformBlockBinding")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
@@ -78,11 +78,6 @@ void gl.uniformMatrix4fv(location, transpose, data, optional srcOffset, optional
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.uniformMatrix2fv")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.html
@@ -73,11 +73,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.vertexAttribDivisor")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
@@ -71,11 +71,6 @@ void <var>gl</var>.vertexAttribI4uiv(<var>index</var>, <var>value</var>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.vertexAttribI4i")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.html
@@ -119,11 +119,6 @@ void main() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.vertexAttribIPointer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl2renderingcontext/waitsync/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/waitsync/index.html
@@ -69,11 +69,6 @@ gl.waitSync(sync, 0, gl.TIMEOUT_IGNORED);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGL2RenderingContext.waitSync")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_api/index.html
+++ b/files/en-us/web/api/webgl_api/index.html
@@ -235,8 +235,6 @@ tags:
 
 <h3 id="WebGL_2_2">WebGL 2</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.WebGL2RenderingContext", 0)}}</p>
 
 <h3 id="Compatibility_notes">Compatibility notes</h3>

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.html
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.html
@@ -60,11 +60,6 @@ ext.getSupportedProfiles(); // ["ldr"]</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_compressed_texture_astc.getSupportedProfiles")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.html
+++ b/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.html
@@ -74,11 +74,6 @@ console.log(src);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_debug_shaders.getTranslatedShaderSource")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.html
@@ -98,11 +98,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_draw_buffers.drawBuffersWEBGL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.html
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.html
@@ -60,11 +60,6 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_lose_context.loseContext")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.html
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.html
@@ -60,11 +60,6 @@ gl.getExtension('WEBGL_lose_context').restoreContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WEBGL_lose_context.restoreContext")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_multi_draw/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/index.html
@@ -137,11 +137,6 @@ ext.multiDrawElementsInstancedWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-If you'd like to contribute to the data, please check out
-<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-and send us a pull request.</p>
-
 <p>{{Compat("WEBGL_multi_draw")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
@@ -130,13 +130,6 @@ ext.multiDrawArraysInstancedWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-   If you'd like to contribute to the data, please check out
-   <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-   and send us a pull request.
-</p>
-
 <p>{{Compat("api.WEBGL_multi_draw.multiDrawArraysWEBGL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.html
@@ -116,13 +116,6 @@ ext.multiDrawArraysWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, firsts.length);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-   If you'd like to contribute to the data, please check out
-   <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-   and send us a pull request.
-</p>
-
 <p>{{Compat("api.WEBGL_multi_draw.multiDrawArraysWEBGL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
@@ -142,13 +142,6 @@ ext.multiDrawElementsInstancedWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out
-  <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.
-</p>
-
 <p>{{Compat("api.WEBGL_multi_draw.multiDrawElementsWEBGL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.html
@@ -129,13 +129,6 @@ ext.multiDrawElementsWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out
-  <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.
-</p>
-
 <p>{{Compat("api.WEBGL_multi_draw.multiDrawElementsWEBGL")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/activetexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/activetexture/index.html
@@ -84,11 +84,6 @@ gl.getParameter(gl.ACTIVE_TEXTURE);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.activeTexture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/attachshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/attachshader/index.html
@@ -67,11 +67,6 @@ if ( !gl.getProgramParameter( program, gl.LINK_STATUS) ) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.attachShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.html
@@ -66,11 +66,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bindAttribLocation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.html
@@ -130,11 +130,6 @@ gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bindBuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.html
@@ -111,11 +111,6 @@ gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bindFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.html
@@ -87,11 +87,6 @@ gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bindRenderbuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.html
@@ -105,11 +105,6 @@ gl.bindTexture(gl.TEXTURE_2D, texture);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bindTexture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/blendcolor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendcolor/index.html
@@ -73,11 +73,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.blendColor")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/blendequation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendequation/index.html
@@ -111,11 +111,6 @@ gl.getParameter(gl.BLEND_EQUATION_ALPHA) === gl.FUNC_ADD;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.blendEquation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.html
@@ -131,11 +131,6 @@ gl.getParameter(gl.BLEND_EQUATION_ALPHA) === gl.FUNC_ADD;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.blendEquationSeparate")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfunc/index.html
@@ -192,11 +192,6 @@ gl.getParameter(gl.BLEND_SRC_RGB) == gl.SRC_COLOR;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.blendFunc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.html
@@ -225,11 +225,6 @@ gl.getParameter(gl.BLEND_SRC_RGB) == gl.SRC_COLOR;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.blendFuncSeparate")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.html
@@ -201,11 +201,6 @@ var sizeInBytes = dataArray.length * dataArray.BYTES_PER_ELEMENT;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bufferData")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.html
@@ -129,11 +129,6 @@ gl.bufferSubData(gl.ARRAY_BUFFER, 512, data);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.bufferSubData")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.html
@@ -69,11 +69,6 @@ gl.canvas; // OffscreenCanvas</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.canvas")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.html
@@ -124,11 +124,6 @@ gl.checkFramebufferStatus(gl.FRAMEBUFFER);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.checkFramebufferStatus")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.html
@@ -89,11 +89,6 @@ gl.getParameter(gl.STENCIL_CLEAR_VALUE);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.clear")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/clearcolor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clearcolor/index.html
@@ -80,11 +80,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.clearColor")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/cleardepth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/cleardepth/index.html
@@ -70,11 +70,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.clearDepth")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/clearstencil/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/clearstencil/index.html
@@ -69,11 +69,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.clearStencil")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/colormask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/colormask/index.html
@@ -76,11 +76,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.colorMask")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.html
@@ -54,11 +54,6 @@ gl.commit();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.commit")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.html
@@ -57,11 +57,6 @@ gl.compileShader(shader);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.compileShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
@@ -246,11 +246,6 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <h3 id="compressedTexImage2D">compressedTexImage2D</h3>
 
 <p>{{Compat("api.WebGLRenderingContext.compressedTexImage2D")}}</p>

--- a/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.html
@@ -224,11 +224,6 @@ gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 256, 256, 512, 512, ext.COMPRESSED_
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.compressedTexSubImage2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.html
@@ -108,11 +108,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.copyTexImage2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.html
@@ -96,11 +96,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.copyTexSubImage2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/createbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createbuffer/index.html
@@ -60,11 +60,6 @@ var buffer = gl.createBuffer();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.createBuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.html
@@ -60,11 +60,6 @@ var framebuffer = gl.createFramebuffer();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.createFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/createprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createprogram/index.html
@@ -74,11 +74,6 @@ if ( !gl.getProgramParameter( program, gl.LINK_STATUS) ) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.createProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.html
@@ -62,11 +62,6 @@ var renderBuffer = gl.createRenderbuffer();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.createRenderbuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/createshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createshader/index.html
@@ -58,11 +58,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.createShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/createtexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/createtexture/index.html
@@ -65,11 +65,6 @@ var texture = gl.createTexture();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.createTexture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/cullface/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/cullface/index.html
@@ -80,11 +80,6 @@ gl.cullFace(gl.FRONT_AND_BACK);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.cullFace")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.html
@@ -67,11 +67,6 @@ gl.deleteBuffer(buffer);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.deleteBuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.html
@@ -68,11 +68,6 @@ gl.deleteFramebuffer(framebuffer);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.deleteFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.html
@@ -67,11 +67,6 @@ gl.deleteProgram(program);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.deleteProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.html
@@ -68,11 +68,6 @@ gl.deleteRenderbuffer(renderbuffer);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.deleteRenderbuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/deleteshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deleteshader/index.html
@@ -63,11 +63,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.deleteShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/deletetexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/deletetexture/index.html
@@ -68,11 +68,6 @@ gl.deleteTexture(texture);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.deleteTexture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/depthfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthfunc/index.html
@@ -90,11 +90,6 @@ gl.depthFunc(gl.NEVER);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.depthFunc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/depthmask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthmask/index.html
@@ -67,11 +67,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.depthMask")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/depthrange/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/depthrange/index.html
@@ -74,11 +74,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.depthRange")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/detachshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/detachshader/index.html
@@ -49,11 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.detachShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/disable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disable/index.html
@@ -148,11 +148,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.disable")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.html
@@ -61,11 +61,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.disableVertexAttribArray")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.html
@@ -91,11 +91,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.drawArrays")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.html
@@ -104,11 +104,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.drawElements")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.html
@@ -56,11 +56,6 @@ gl.drawingBufferHeight; // 150
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.drawingBufferHeight")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.html
@@ -56,11 +56,6 @@ gl.drawingBufferWidth; // 300
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.drawingBufferWidth")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/enable/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enable/index.html
@@ -148,11 +148,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.enable")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.html
@@ -148,11 +148,6 @@ gl.drawArrays(gl.TRIANGLES, 0, vertexCount);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.enableVertexAttribArray")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/finish/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/finish/index.html
@@ -51,11 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.finish")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/flush/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/flush/index.html
@@ -51,11 +51,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.flush")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.html
@@ -156,11 +156,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.framebufferRenderbuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.html
@@ -184,11 +184,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.framebufferTexture2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/frontface/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/frontface/index.html
@@ -65,11 +65,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.frontFace")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.html
@@ -84,11 +84,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.generateMipmap")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.html
@@ -70,11 +70,6 @@ for (let i = 0; i &lt; numAttribs; ++i) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getActiveAttrib")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.html
@@ -165,11 +165,6 @@ for (let i = 0; i &lt; numUniforms; ++i) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getActiveUniform")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.html
@@ -67,11 +67,6 @@ gl.getAttachedShaders(program);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getAttachedShaders")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.html
@@ -64,11 +64,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getAttribLocation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.html
@@ -137,11 +137,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getBufferParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.html
@@ -83,11 +83,6 @@ gl.getContextAttributes();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getContextAttributes")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/geterror/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/geterror/index.html
@@ -101,11 +101,6 @@ gl.getError(); // gl.INVALID_ENUM;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getError")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.html
@@ -305,11 +305,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getFramebufferAttachmentParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.html
@@ -1021,11 +1021,6 @@ gl.getParameter(gl.VIEWPORT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.html
@@ -73,11 +73,6 @@ gl.getProgramInfoLog(program);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getProgramInfoLog")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.html
@@ -100,11 +100,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getProgramParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.html
@@ -123,11 +123,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getRenderbufferParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.html
@@ -74,11 +74,6 @@ if (message.length &gt; 0) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getShaderInfoLog")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.html
@@ -71,11 +71,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getShaderParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.html
@@ -82,11 +82,6 @@ gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getShaderPrecisionFormat")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getshadersource/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getshadersource/index.html
@@ -61,11 +61,6 @@ var source = gl.getShaderSource(shader);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getShaderSource")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.html
@@ -202,11 +202,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getTexParameter")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getuniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getuniform/index.html
@@ -202,11 +202,6 @@ gl.getUniform(program, loc);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getUniform")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.html
@@ -188,11 +188,6 @@ gl.uniform4fv(uGlobalColor, [0.1, 0.7, 0.2, 1.0]);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-    If you'd like to contribute to the data, please check out <a
-        href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getUniformLocation")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.html
@@ -119,11 +119,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getVertexAttrib")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.html
@@ -63,11 +63,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.getVertexAttribOffset")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/hint/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/hint/index.html
@@ -91,11 +91,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.hint")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/isbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isbuffer/index.html
@@ -65,11 +65,6 @@ gl.isBuffer(buffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isBuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.html
@@ -80,11 +80,6 @@ if (!gl.getProgramParameter(program, gl.LINK_STATUS) &amp;&amp; !gl.isContextLos
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isContextLost")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/isenabled/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isenabled/index.html
@@ -159,11 +159,6 @@ gl.disable(gl.STENCIL_TEST);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isEnabled")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.html
@@ -65,11 +65,6 @@ gl.isFramebuffer(framebuffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isFramebuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.html
@@ -67,11 +67,6 @@ gl.isProgram(program);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.html
@@ -65,11 +65,6 @@ gl.isRenderbuffer(renderbuffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isRenderbuffer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.html
@@ -67,11 +67,6 @@ gl.isShader(shader);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isShader")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/istexture/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/istexture/index.html
@@ -65,11 +65,6 @@ gl.isTexture(texture);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.isTexture")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.html
@@ -81,11 +81,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.lineWidth")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/linkprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/linkprogram/index.html
@@ -70,11 +70,6 @@ gl.linkProgram(program);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.linkProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.html
@@ -236,11 +236,6 @@ gl.getParameter(gl.UNPACK_ALIGNMENT);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.pixelStorei")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.html
@@ -80,11 +80,6 @@ gl.getParameter(gl.POLYGON_OFFSET_UNITS);  // 3
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.polygonOffset")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.html
@@ -155,11 +155,6 @@ console.log(pixels); // Uint8Array
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.readPixels")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.html
@@ -152,11 +152,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.renderbufferStorage")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.html
@@ -76,11 +76,6 @@ gl.getParameter(gl.SAMPLE_COVERAGE_INVERT); // false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.sampleCoverage")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/scissor/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/scissor/index.html
@@ -93,11 +93,6 @@ gl.getParameter(gl.SCISSOR_BOX);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.scissor")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.html
@@ -63,11 +63,6 @@ var source = gl.getShaderSource(shader);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.shaderSource")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.html
@@ -107,11 +107,6 @@ gl.getParameter(gl.STENCIL_BITS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.stencilFunc")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.html
@@ -117,11 +117,6 @@ gl.getParameter(gl.STENCIL_BITS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.stencilFuncSeparate")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/stencilmask/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmask/index.html
@@ -74,11 +74,6 @@ gl.getParameter(gl.STENCIL_BITS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.stencilMask")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.html
@@ -84,11 +84,6 @@ gl.getParameter(gl.STENCIL_BITS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.stencilMaskSeparate")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.html
@@ -114,11 +114,6 @@ gl.getParameter(gl.STENCIL_BITS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.stencilOp")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.html
@@ -125,11 +125,6 @@ gl.getParameter(gl.STENCIL_BITS);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.stencilOpSeparate")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.html
@@ -889,11 +889,6 @@ void gl.texImage2D(target, level, internalformat, width, height, border, format,
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.texImage2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.html
@@ -179,11 +179,6 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <h3 id="WebGLRenderingContext.texParameterf">
   <code>WebGLRenderingContext.texParameterf()</code></h3>
 

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.html
@@ -214,11 +214,6 @@ void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, ty
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.texSubImage2D")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.html
@@ -99,11 +99,6 @@ void <var>gl</var>.uniform4iv(<var>location</var>, <var>value</var>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.uniform1f")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.html
@@ -83,11 +83,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.uniformMatrix2fv")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/useprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/useprogram/index.html
@@ -66,11 +66,6 @@ gl.useProgram(program);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-	If you'd like to contribute to the data, please check out <a
-		href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-	and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.useProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/validateprogram/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/validateprogram/index.html
@@ -74,11 +74,6 @@ gl.useProgram(program);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.validateProgram")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.html
@@ -112,11 +112,6 @@ gl.vertexAttrib3f(matrix3x3Location + 2, 2, 5, 8);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.vertexAttrib1f")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.html
@@ -334,11 +334,6 @@ gl.enableVertexAttribArray(locTexUV);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.vertexAttribPointer")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webglrenderingcontext/viewport/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/viewport/index.html
@@ -93,11 +93,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.WebGLRenderingContext.viewport")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/webvtt_api/index.html
+++ b/files/en-us/web/api/webvtt_api/index.html
@@ -893,8 +893,6 @@ Sur les &lt;i.foreignphrase&gt;&lt;lang en&gt;playground&lt;/lang&gt;&lt;/i&gt;,
 
 <h3 id="TextTrack_interface"><code>TextTrack</code> interface</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.TextTrack", 0)}}</p>
 
 <h3 id="Notes">Notes</h3>

--- a/files/en-us/web/api/window/appinstalled_event/index.html
+++ b/files/en-us/web/api/window/appinstalled_event/index.html
@@ -50,11 +50,6 @@ tags:
 };</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.Window.onappinstalled")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/windoworworkerglobalscope/queuemicrotask/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/queuemicrotask/index.html
@@ -126,16 +126,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured
-  data. If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.<br>
-  <br>
-  NOTE: data on this has been submitted; just waiting on it to be reviewed, merged, and
-  for a new data release before it will show up here. See
-  https://github.com/mdn/browser-compat-data/pull/4754 for PR.
-</div>
-
 <p>{{Compat("api.WindowOrWorkerGlobalScope.queueMicrotask")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/worklet/addmodule/index.html
+++ b/files/en-us/web/api/worklet/addmodule/index.html
@@ -101,9 +101,4 @@ await audioWorklet.addModule('modules/bypassFilter.js', {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.Worklet.addModule")}}</p>

--- a/files/en-us/web/api/writablestream/abort/index.html
+++ b/files/en-us/web/api/writablestream/abort/index.html
@@ -82,11 +82,4 @@ writableStream.abort();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.WritableStream.abort")}}</p>

--- a/files/en-us/web/api/writablestream/getwriter/index.html
+++ b/files/en-us/web/api/writablestream/getwriter/index.html
@@ -136,11 +136,4 @@ sendMessage("Hello, world.", writableStream);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.WritableStream.getWriter")}}</p>

--- a/files/en-us/web/api/writablestream/locked/index.html
+++ b/files/en-us/web/api/writablestream/locked/index.html
@@ -65,11 +65,4 @@ writableStream.locked
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.WritableStream.locked")}}</p>

--- a/files/en-us/web/api/writablestream/writablestream/index.html
+++ b/files/en-us/web/api/writablestream/writablestream/index.html
@@ -209,11 +209,4 @@ sendMessage("Hello, world.", writableStream);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.WritableStream.WritableStream")}}</p>

--- a/files/en-us/web/api/xmlhttprequest/open/index.html
+++ b/files/en-us/web/api/xmlhttprequest/open/index.html
@@ -75,11 +75,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.XMLHttpRequest.open")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.html
@@ -963,11 +963,6 @@ oReq.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data.
-  If you'd like to contribute to the data, please check out <a
-    href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-  and send us a pull request.</p>
-
 <p>{{Compat("api.XMLHttpRequest")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
@@ -122,11 +122,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRBoundedReferenceSpace.boundsGeometry")}}</p>

--- a/files/en-us/web/api/xrboundedreferencespace/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/index.html
@@ -53,11 +53,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRBoundedReferenceSpace")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrhandedness/index.html
+++ b/files/en-us/web/api/xrhandedness/index.html
@@ -71,11 +71,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRHandedness")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrinputsource/handedness/index.html
+++ b/files/en-us/web/api/xrinputsource/handedness/index.html
@@ -70,13 +70,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRInputSource.handedness")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrinputsource/profiles/index.html
+++ b/files/en-us/web/api/xrinputsource/profiles/index.html
@@ -85,13 +85,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRInputSource.profiles")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.html
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.html
@@ -71,13 +71,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRInputSource.targetRayMode")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.html
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.html
@@ -108,13 +108,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>
-    and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRInputSource.targetRaySpace")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
@@ -206,11 +206,4 @@ function rotateViewBy(dx, dy) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpace.getOffsetReferenceSpace")}}</p>

--- a/files/en-us/web/api/xrreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/index.html
@@ -100,11 +100,6 @@ xrReferenceSpace = xrReferenceSpace.getOffsetReferenceSpace(offsetTransform);</p
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpace")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrreferencespace/onreset/index.html
+++ b/files/en-us/web/api/xrreferencespace/onreset/index.html
@@ -66,11 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpace.onreset")}}</p>

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.html
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.html
@@ -113,9 +113,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpace.reset_event")}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/index.html
@@ -70,9 +70,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEvent")}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
@@ -58,11 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEvent.referenceSpace")}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.html
@@ -91,11 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEvent.transform")}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
@@ -77,11 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEvent.XRReferenceSpaceEvent")}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/index.html
@@ -67,9 +67,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEventInit")}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/referencespace/index.html
@@ -63,11 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEventInit.referenceSpace")}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/transform/index.html
@@ -65,11 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRReferenceSpaceEventInit.transform")}}</p>

--- a/files/en-us/web/api/xrtargetraymode/index.html
+++ b/files/en-us/web/api/xrtargetraymode/index.html
@@ -90,11 +90,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRTargetRayMode")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrviewerpose/index.html
+++ b/files/en-us/web/api/xrviewerpose/index.html
@@ -65,11 +65,6 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div class="hidden">
-<p>The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRViewerPose")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/xrviewerpose/views/index.html
+++ b/files/en-us/web/api/xrviewerpose/views/index.html
@@ -102,13 +102,6 @@ if (pose) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">
-  <p>The compatibility table in this page is generated from structured data. If you'd like
-    to contribute to the data, please check out <a
-      href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and
-    send us a pull request.</p>
-</div>
-
 <p>{{Compat("api.XRViewerPose.views")}}</p>
 
 <h2 id="See_also">See also</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Redundant BCD comments
> MDN URL of the main page changed

Numerous
> Issue number (if there is an associated issue)

#2228 (yes, this one should be wholly fixed with this one)

> Anything else that could help us review it

This clears web/api, but also the templates at mdn/structures (these were the reason the amount of these messages was still increasing).

Once this lands, we will need a final check before closing #2228 from the content perspective.