### PR TITLE
Fix Element.ariaDisabled value description

### DIFF
--- a/files/en-us/web/api/element/ariadisabled/index.html
+++ b/files/en-us/web/api/element/ariadisabled/index.html
@@ -29,10 +29,9 @@ tags:
 
 <dl>
   <dt><code>"true"</code></dt>
-  <dd>The element is enabled.</dd>
+  <dd>The element and all focusable descendants are disabled, but perceivable, and its value cannot be changed by the user.</dd>
   <dt><code>"false"</code></dt>
-  <dd>The element and all focusable descendants are disabled and its value cannot be changed by the user.</dd>
-</dl>
+  <dd>The element is enabled.</dl>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/web/api/element/ariadisabled/index.html
+++ b/files/en-us/web/api/element/ariadisabled/index.html
@@ -15,8 +15,7 @@ tags:
 <p class="summary">The <strong><code>ariaDisabled</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
 
 <div class="notecard note">
-  <h3>Note</h3>
-  <p>Where possible use an HTML {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>

--- a/files/en-us/web/api/element/ariadisabled/index.html
+++ b/files/en-us/web/api/element/ariadisabled/index.html
@@ -28,7 +28,7 @@ tags:
 
 <dl>
   <dt><code>"true"</code></dt>
-  <dd>The element and all focusable descendants are disabled, but perceivable, and its value cannot be changed by the user.</dd>
+  <dd>The element and all focusable descendants are disabled, but perceivable, and their values cannot be changed by the user.</dd>
   <dt><code>"false"</code></dt>
   <dd>The element is enabled.</dl>
 

--- a/files/en-us/web/api/element/ariadisabled/index.html
+++ b/files/en-us/web/api/element/ariadisabled/index.html
@@ -15,7 +15,7 @@ tags:
 <p class="summary">The <strong><code>ariaDisabled</code></strong> property of the {{domxref("Element")}} interface reflects the value of the <code>aria-disabled</code> attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.</p>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> Where possible use an HTML {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.</p>
+  <p><strong>Note:</strong> Where possible, use the {{htmlelement("input")}} element with <code>type="button"</code> or the {{htmlelement("button")}} element —  because those elements have built in semantics and do not require ARIA attributes.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The description of the value 'true' and 'false' were inverted.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaDisabled

> Issue number (if there is an associated issue)

Fix #5275 

> Anything else that could help us review it
I also fixed the note near the top that wasn't displayed.