### PR TITLE
Webdriver conformance changes for Firefox 89

### DIFF
--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -63,7 +63,10 @@ tags:
 
 <h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
-<p><em>No changes.</em></p>
+<h4 id="removals_webdriver">Removals</h4>
+<ul>
+  <li>The <code>rotatable</code> capability that is not part of the WebDriver specification is no longer used ({{bug(1697630)}}).</li>
+</ul>
 
 <h2 id="Changes_for_add-on_developers">Changes for add-on developers</h2>
 


### PR DESCRIPTION
From the [list of all the Marionette changes](https://bugzilla.mozilla.org/buglist.cgi?j_top=OR&f1=cf_status_firefox89&o1=equals&resolution=FIXED&o2=equals&query_format=advanced&f2=cf_status_firefox89&v1=fixed&component=Marionette&v2=verified&product=Testing&list_id=15723575) for Firefox 89 there is only a single release notes worthy entry.

CC'ing @juliandescottes 