### PR TITLE
Encode bang (!) in data urls

### DIFF
--- a/files/en-us/web/http/basics_of_http/data_uris/index.html
+++ b/files/en-us/web/http/basics_of_http/data_uris/index.html
@@ -32,11 +32,11 @@ tags:
 <p>A few examples:</p>
 
 <dl>
- <dt><code>data:,Hello%2C%20World!</code></dt>
+ <dt><code>data:,Hello%2C%20World%21</code></dt>
  <dd>The text/plain data <code>Hello, World!</code>. Note how the comma is  <a href="/en-US/docs/Glossary/percent-encoding">percent-encoded</a> as <code>%2C</code>, and the space character as <code>%20</code>.</dd>
  <dt><code>data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==</code></dt>
  <dd>base64-encoded version of the above</dd>
- <dt><code>data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E</code></dt>
+ <dt><code>data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E</code></dt>
  <dd>An HTML document with <code>&lt;h1&gt;Hello, World!&lt;/h1&gt;</code></dd>
  <dt><code>data:text/html,&lt;script&gt;alert('hi');&lt;/script&gt;</code></dt>
  <dd>An HTML document that executes a JavaScript alert. Note that the closing script tag is required.</dd>
@@ -95,7 +95,7 @@ base64 a.txt&gt;b.txt
  <dt>Syntax</dt>
  <dd>The format for <code>data</code> URLs is very simple, but it's easy to forget to put a comma before the "data" segment, or to incorrectly encode the data into base64 format.</dd>
  <dt>Formatting in HTML</dt>
- <dd>A <code>data</code> URL provides a file within a file, which can potentially be very wide relative to the width of the enclosing document. As a URL, the <code>data</code> should be formatable with whitespace (linefeed, tab, or spaces), but there are practical issues that arise <a href="http://bugzilla.mozilla.org/show_bug.cgi?id=73026#c12">when using base64 encoding</a>.</dd>
+ <dd>A <code>data</code> URL provides a file within a file, which can potentially be very wide relative to the width of the enclosing document. As a URL, the <code>data</code> should be formatable with whitespace (linefeed, tab, or spaces), but there are practical issues that arise <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=73026#c12">when using base64 encoding</a>.</dd>
  <dt>Length limitations</dt>
  <dd>Although Firefox supports <code>data</code> URLs of essentially unlimited length, browsers are not required to support any particular maximum length of data. For example, the Opera 11 browser limited URLs to 65535 characters long which limits <code>data</code> URLs to 65529 characters (65529 characters being the length of the encoded data, not the source, if you use the plain <code>data:</code>, without specifying a MIME type).</dd>
  <dt>Lack of error handling</dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Characters ! (bang) must be %-encoded (%21).

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

> Issue number (if there is an associated issue)

Fix #5060

> Anything else that could help us review it

I double-checked using https://www.urlencoder.org/ (and I fixed a flaw on the page at the same time http->https in an url)