### PR TITLE
Fix String.slice with negative values as second argument

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.html
@@ -52,10 +52,10 @@ slice(beginIndex, endIndex)
       <code>Number(<var>endIndex</var>)</code> is not positive,
       an empty string is returned.</p>
 
-    <p>If <code><var>endIndex</var></code> is specified,
+    <p>If <code><var>endIndex</var></code> is specified and positive or equal to zero,
       <code><var>endIndex</var></code> should be greater than
       <code><var>beginIndex</var></code>, otherwise an empty string is returned. (For
-      example, <code>slice(-3, 0)</code>, <code>slice(-1, -3)</code>, or <code>slice(3, 1)</code>
+      example, <code>slice(-3, 0)</code>, or <code>slice(3, 1)</code>
       returns <code>""</code>.)</p>
   </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.html
@@ -43,20 +43,21 @@ slice(beginIndex, endIndex)
     <p>The zero-based index <em>before</em> which to end extraction. The character at this
       index will not be included.</p>
 
-    <p>If <code><var>endIndex</var></code> is omitted or undefined, or greater than
-      <code><var>str</var>.length</code>, <code>slice()</code> extracts to the end of the
-      string. If negative, it is treated as
-      <code><var>str</var>.length + <var>endIndex</var></code>. (For example, if
-      <code><var>endIndex</var></code> is <code>-3</code>, it is treated as
-      <code><var>str</var>.length - 3</code>.) If it is not undefined, and
-      <code>Number(<var>endIndex</var>)</code> is not positive,
-      an empty string is returned.</p>
+    <p>If <code><var>endIndex</var></code> is omitted or undefined, <code>slice()</code> extracts
+      to the end of the string. (E.g. <code>"test".slice(2)</code> returns <code>"st"</code>)</p>
 
-    <p>If <code><var>endIndex</var></code> is specified and positive or equal to zero,
-      <code><var>endIndex</var></code> should be greater than
-      <code><var>beginIndex</var></code>, otherwise an empty string is returned. (For
-      example, <code>slice(-3, 0)</code>, or <code>slice(3, 1)</code>
-      returns <code>""</code>.)</p>
+    <p>If <code><var>endIndex</var></code> is greater than <code><var>str</var>.length</code>,
+      <code>slice()</code> also extracts to the end of the string.
+      (E.g. <code>"test".slice(2, 10)</code> returns <code>"st"</code>)</p>
+
+    <p>If <code><var>endIndex</var></code> is negative, <code>slice()</code> is treated as
+      <code><var>str</var>.length + <var>endIndex</var></code>. (E.g, if
+      <code><var>endIndex</var></code> is <code>-2</code>, it is treated as
+      <code><var>str</var>.length - 2</code> and <code>"test".slice(1, -2)</code> returns <code>"e"</code>) .</p>
+
+    <p>If <code><var>endIndex</var></code> represents a position that is before the one represented
+      by <code><var>startIndex</var></code>, <code>slice()</code> returns <code>""</code>.
+      (E.g <code>"test".slice(2, -10)</code>, <code>"test".slice(-1, -2)</code> or <code>"test".slice(3, 2)</code>).
   </dd>
 </dl>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

If the second argument of String.slice() is negative and smaller than the first argument, the page incorrectly stated that the result will be "".

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice

> Issue number (if there is an associated issue)

Fix #5371

> Anything else that could help us review it

Testing using the live sample on the page.
