### PR TITLE
Adds MIDIOutput

### DIFF
--- a/files/en-us/web/api/midioutput/clear/index.html
+++ b/files/en-us/web/api/midioutput/clear/index.html
@@ -1,0 +1,44 @@
+---
+title: MIDIOutput.clear()
+slug: Web/API/MIDIOutput/clear
+tags:
+  - API
+  - Method
+  - Reference
+  - clear
+  - MIDIOutput
+---
+<div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
+
+<p class="summary">The <strong><code>clear()</code></strong> method of the {{domxref("MIDIOutput")}} interface clears the queue of messages being sent to the output device.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">MIDIOutput.clear();</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<p>None.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('WebMIDI API','#ref-for-dom-midioutput-clear-1')}}</td>
+    <td>{{Spec2('WebMIDI API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.MIDIOutput.clear")}}</p>

--- a/files/en-us/web/api/midioutput/clear/index.html
+++ b/files/en-us/web/api/midioutput/clear/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - clear
   - MIDIOutput
+browser-compat: api.MIDIOutput.clear
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
@@ -41,4 +42,4 @@ tags:
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.MIDIOutput.clear")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutput/clear/index.html
+++ b/files/en-us/web/api/midioutput/clear/index.html
@@ -23,20 +23,7 @@ browser-compat: api.MIDIOutput.clear
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('WebMIDI API','#ref-for-dom-midioutput-clear-1')}}</td>
-    <td>{{Spec2('WebMIDI API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midioutput/index.html
+++ b/files/en-us/web/api/midioutput/index.html
@@ -1,0 +1,60 @@
+---
+title: MIDIOutput
+slug: Web/API/MIDIOutput
+tags:
+  - API
+  - Interface
+  - Reference
+  - MIDIOutput
+---
+<div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
+
+<p class="summary">The <strong><code>MIDIOutput</code></strong> interface of the {{domxref('Web MIDI API','','',' ')}} provides methods to add messages to the queue of an output device, and to clear the queue of messages.</p>
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>This interface doesn't implement any specific properties, but inherits properties from {{domxref("MIDIPort")}}.</em></p>
+
+<h2 id="Methods">Methods</h2>
+
+<p><em>This interface also inherits methods from {{domxref("MIDIPort")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("MIDIoutput.send()")}}</dt>
+  <dd>Queues a message to be sent to the MIDI port.</dd>
+  <dt>{{domxref("MIDIOutput.clear()")}}</dt>
+  <dd>Clears any pending send data from the queue.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The following example sends a middle C immediately on MIDI channel 1.</p>
+
+<pre class="brush: js">function sendMiddleC( midiAccess, portID ) {
+  var noteOnMessage = [0x90, 60, 0x7f];    // note on, middle C, full velocity
+  var output = midiAccess.outputs.get(portID);
+  output.send(noteOnMessage); // sends the message.
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('WebMIDI API','#midioutput-interface')}}</td>
+    <td>{{Spec2('WebMIDI API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.MIDIOutput")}}</p>

--- a/files/en-us/web/api/midioutput/index.html
+++ b/files/en-us/web/api/midioutput/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - MIDIOutput
+browser-compat: api.MIDIOutput
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.MIDIOutput")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutput/index.html
+++ b/files/en-us/web/api/midioutput/index.html
@@ -39,20 +39,7 @@ browser-compat: api.MIDIOutput
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('WebMIDI API','#midioutput-interface')}}</td>
-    <td>{{Spec2('WebMIDI API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -1,0 +1,71 @@
+---
+title: MIDIOutput.send()
+slug: Web/API/MIDIOutput/send
+tags:
+  - API
+  - Method
+  - Reference
+  - send
+  - MIDIOutput
+---
+<div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
+
+<p class="summary">The <strong><code>send()</code></strong> method of the {{domxref("MIDIOutput")}} interface queues messages for the corresponding MIDI port. The message can be sent immediately, or with an optional timestamp to delay sending.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">MIDIOutput.send(data, timestamp);</pre>
+
+<h3 id="Parameters">Parameters</h3>
+
+<dl>
+  <dt><code>data</code></dt>
+  <dd>A sequence of one or more valid MIDI messages. Each entry represents a single byte of data.</dd>
+  <dt><code>timestamp</code>{{Optional_Inline}}</dt>
+  <dd>A {{domxref("DOMHighResTimestamp")}} with the time in milliseconds, which is the delay before sending the message.</dd>
+</dl>
+
+<h3 id="Exceptions">Exceptions</h3>
+
+<dl>
+  <dt>{{jsxref("TypeError")}}</dt>
+  <dd>Thrown if <code>data</code> is not a valid sequence, or does not contain a valid MIDI message.</dd>
+  <dt><code>InvalidAccessError</code></dt>
+  <dd>Thrown if <code>data</code> is a system exclusive message, and the {{domxref("MIDIAccess")}} did not enable eclusive access.</dd>
+  <dt><code>InvalidStateError</code></dt>
+  <dd>Thrown if the port is disconnected.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In the following example a middle C note is sent immediately, followed by a note off message one second later.</p>
+
+<pre class="brush: js">function sendMiddleC( midiAccess, portID ) {
+  var noteOnMessage = [0x90, 60, 0x7f];    // note on, middle C, full velocity
+  var output = midiAccess.outputs.get(portID);
+  output.send( noteOnMessage );  //omitting the timestamp means send immediately.
+  output.send( [0x80, 60, 0x40], window.performance.now() + 1000.0 ); // timestamp = now + 1000ms.
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+  <tbody>
+   <tr>
+    <th scope="col">Specification</th>
+    <th scope="col">Status</th>
+    <th scope="col">Comment</th>
+   </tr>
+   <tr>
+    <td>{{SpecName('WebMIDI API','#widl-MIDIOutput-send-void-sequence-octet--data-double-timestamp')}}</td>
+    <td>{{Spec2('WebMIDI API')}}</td>
+    <td>Initial definition.</td>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
+<p>{{Compat("api.MIDIOutput.send")}}</p>

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -50,20 +50,7 @@ browser-compat: api.MIDIOutput.send
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <tbody>
-   <tr>
-    <th scope="col">Specification</th>
-    <th scope="col">Status</th>
-    <th scope="col">Comment</th>
-   </tr>
-   <tr>
-    <td>{{SpecName('WebMIDI API','#widl-MIDIOutput-send-void-sequence-octet--data-double-timestamp')}}</td>
-    <td>{{Spec2('WebMIDI API')}}</td>
-    <td>Initial definition.</td>
-   </tr>
-  </tbody>
- </table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - send
   - MIDIOutput
+browser-compat: api.MIDIOutput.send
 ---
 <div>{{securecontext_header}}{{APIRef("Web MIDI API")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
 
-<p>{{Compat("api.MIDIOutput.send")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -42,7 +42,7 @@ browser-compat: api.MIDIOutput.send
 <p>In the following example a middle C note is sent immediately, followed by a note off message one second later.</p>
 
 <pre class="brush: js">function sendMiddleC( midiAccess, portID ) {
-  var noteOnMessage = [0x90, 60, 0x7f];    // note on, middle C, full velocity
+  var noteOnMessage = [0x90, 60, 0x7f];    // note on middle C, full velocity
   var output = midiAccess.outputs.get(portID);
   output.send( noteOnMessage );  //omitting the timestamp means send immediately.
   output.send( [0x80, 60, 0x40], window.performance.now() + 1000.0 ); // timestamp = now + 1000ms.

--- a/files/en-us/web/api/midioutput/send/index.html
+++ b/files/en-us/web/api/midioutput/send/index.html
@@ -21,7 +21,7 @@ browser-compat: api.MIDIOutput.send
 
 <dl>
   <dt><code>data</code></dt>
-  <dd>A sequence of one or more valid MIDI messages. Each entry represents a single byte of data.</dd>
+  <dd>A sequence of one or more <a href="https://www.midi.org/midi-articles/about-midi-part-3-midi-messages">valid MIDI messages</a>. Each entry represents a single byte of data.</dd>
   <dt><code>timestamp</code>{{Optional_Inline}}</dt>
   <dd>A {{domxref("DOMHighResTimestamp")}} with the time in milliseconds, which is the delay before sending the message.</dd>
 </dl>


### PR DESCRIPTION
Adds the MIDIOutput Interface

Reviewer: @jpmedley 

On looking at this I discovered that there is an additional method `clear()` unimplemented by Chrome, and with no BCD. I did a search and [found a bug](https://bugs.chromium.org/p/chromium/issues/detail?id=471798#c22), with a note that it might be implemented for 93. So I made a basic documentation page for the method and I'll submit BCD with a link to the bug, I can always update it if it does ship.

The MIDI interfaces are fairly sparsely documented. Mostly just overview pages.
