### PR TITLE
Updating pab members list

### DIFF
--- a/files/en-us/mdn/mdn_product_advisory_board/members/index.html
+++ b/files/en-us/mdn/mdn_product_advisory_board/members/index.html
@@ -24,9 +24,6 @@ tags:
  <dt><strong>Hermina Condei</strong><br>
  <strong>Head of Product CE, Marketing Operations, Mozilla</strong></dt>
  <dd>Hermina Condei leads product management and engineering for MDN Web Docs and platform engineering for SUMO, at Mozilla. Over the past years, she's driven company-wide projects focused on access and identity management for employees and community. She also led the product team in the Open Innovation Group<strong>,</strong> with a focus on managing internal and external stakeholders for the team's portfolio of projects.</dd>
- <dt><strong>Daniel Ehrenberg</strong><br>
- Software Engineer, Igalia</dt>
- <dd>Daniel is an engineer at Igalia, a free software cooperative, participates in TC39, the JavaScript standards committee, and has dabbled in WebAssembly and web standards. He's also worked on V8, the JavaScript engine in Chrome.</dd>
  <dt><strong>Dominique Hazael-Massieux</strong><br>
  W3C Web Technology Expert including <a href="https://www.w3.org/Telco/">Telecommunications Vertical champion</a>, <a href="https://www.w3.org/2011/04/webrtc/">Web Real-Time Communications Working Group</a>, <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
  <dd>Dominique Hazael-Massieux is part of the W3C staff, where he leads W3C efforts in developer relationship. Dom has been working for W3C since 2000, and in addition to devrel, is currently involved in the standardization of WebRTC, device APIs and WebVR.</dd>
@@ -36,9 +33,9 @@ tags:
  <dt><strong>Joe Medley</strong><br>
  Senior Technical Writer, Web Developer Relations at Google</dt>
  <dd>Joe has lead Google’s effort to create web platform reference documentation for the last five years, which means he spends much on MDN. In addition to editing the Chrome beta release announcements targeted at web developers, he writes the occasional article for web.dev. Joe came to Web Developer Relations after a long career writing developer reference documentation for enterprise applications and a degree in education from the University of Central Missouri.</dd>
- <dt><strong>Chris Mills</strong><br>
- Writers' team manager, MDN Web Docs. Product Advisory Board Chair</dt>
- <dd>Chris works at Mozilla as content lead for MDN, helping to pull together a strategy for what needs documenting in the short and long term. He also contributes a large number of beginner’s tutorials and reference articles covering DOM APIs, HTML and CSS features, web games, WebAssembly, and more. He also manages the MDN writers' team.</dd>
+ <dt><strong>Eric Meyer</strong><br>
+ Developer Advocate, Igalia</dt>
+ <dd><a href="http://meyerweb.com/">Eric</a> (<a href="http://twitter.com/meyerweb">@meyerweb</a>) is an <a href="http://meyerweb.com/eric/writing.html">author</a>, speaker, blogger, sometimes teacher and consultant, Developer Advocate at <a href="http://igalia.com/">Igalia</a>, and co-founder of <a href="https://aneventapart.com/">An Event Apart</a>.  He's been working on the Web since 1993 and still finds it deeply compelling.</dd>
  <dt><strong>Robert Nyman</strong><br>
  Global Lead for Programs &amp; Initiatives, Web Developer Relations, at Google</dt>
  <dd>Robert Nyman is the Global Lead for Developer Feedback &amp; Communities, Web Platform at Google. In his role, he works to make the web the best platform for developers. Prior to Google, Robert was a technical evangelist at Mozilla, focused on the Open Web and the company’s various products and initiatives. He lives in Stockholm, and has a passion for traveling and meeting people. He claims the title of “Most Well-Traveled Speaker” on Lanyrd, having presented in 42 countries.</dd>
@@ -58,6 +55,7 @@ tags:
  <li>Erika Doyle Navara, Microsoft</li>
  <li>Patrick Kettner, Microsoft</li>
  <li>Travis Leithead, Microsoft</li>
+ <li>Chris Mills, Mozilla</li>
  <li>Kadir Topal, Mozilla</li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

PAB members have changed

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Members

> Issue number (if there is an associated issue)

> Anything else that could help us review it

The two changes are simple:

* Add Eric Meyer, as one of the new org reps for Igalia
* Remove me, as I am leaving Mozilla
