### PR TITLE
Fix typo/grammatical error in setSelectionRange().

### DIFF
--- a/files/en-us/web/api/htmlinputelement/setselectionrange/index.html
+++ b/files/en-us/web/api/htmlinputelement/setselectionrange/index.html
@@ -24,7 +24,7 @@ tags:
   <code>selectionEnd</code>, and <code>selectionDirection</code> properties in one call.
 </p>
 
-<p>Note that accordingly to the <a
+<p>Note that according to the <a
     href="https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply">WHATWG
     forms spec</a> <code>selectionStart</code>, <code>selectionEnd</code> properties and
   <code>setSelectionRange</code> method apply only to inputs of types text, search, URL,


### PR DESCRIPTION
**What was wrong/why is this fix needed?**
It fixes a simple grammatical error.

**MDN URL of the main page changed:**
https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

**Issue number:**
#5396
