### PR TITLE
Put browser-compat info in front-runner for api/a*

### DIFF
--- a/files/en-us/web/api/abortcontroller/abort/index.html
+++ b/files/en-us/web/api/abortcontroller/abort/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - abort()
+browser-compat: api.AbortController.abort
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -81,7 +82,7 @@ function fetchVideo() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortController.abort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.html
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Fetch
   - Reference
+browser-compat: api.AbortController.AbortController
 ---
 <div>{{APIRef("DOM")}}{{SeeCompatTable}}</div>
 
@@ -76,7 +77,7 @@ function fetchVideo() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortController.AbortController")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortcontroller/index.html
+++ b/files/en-us/web/api/abortcontroller/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.AbortController
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -90,7 +91,7 @@ function fetchVideo() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortController")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortcontroller/signal/index.html
+++ b/files/en-us/web/api/abortcontroller/signal/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - signal
+browser-compat: api.AbortController.signal
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -77,7 +78,7 @@ function fetchVideo() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortController.signal")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortsignal/abort/index.html
+++ b/files/en-us/web/api/abortsignal/abort/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - abort
+browser-compat: api.AbortSignal.abort
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -53,4 +54,4 @@ return controller.signal;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortSignal.abort")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abortsignal/abort_event/index.html
+++ b/files/en-us/web/api/abortsignal/abort_event/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Event
   - abort
+browser-compat: api.AbortSignal.abort_event
 ---
 <div>{{APIRef}}</div>
 
@@ -73,7 +74,7 @@ signal.onabort = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortSignal.abort_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortsignal/aborted/index.html
+++ b/files/en-us/web/api/abortsignal/aborted/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - aborted
+browser-compat: api.AbortSignal.aborted
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -52,7 +53,7 @@ signal.aborted ? console.log('Request has been aborted') : console.log('Request 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortSignal.aborted")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortsignal/index.html
+++ b/files/en-us/web/api/abortsignal/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.AbortSignal
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -106,7 +107,7 @@ function fetchVideo() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortSignal")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abortsignal/onabort/index.html
+++ b/files/en-us/web/api/abortsignal/onabort/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - onabort
+browser-compat: api.AbortSignal.onabort
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -50,7 +51,7 @@ signal.onabort = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbortSignal.onabort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/absoluteorientationsensor/absoluteorientationsensor/index.html
+++ b/files/en-us/web/api/absoluteorientationsensor/absoluteorientationsensor/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.AbsoluteOrientationSensor.AbsoluteOrientationSensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbsoluteOrientationSensor.AbsoluteOrientationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/absoluteorientationsensor/index.html
+++ b/files/en-us/web/api/absoluteorientationsensor/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.AbsoluteOrientationSensor
 ---
 <div>{{APIRef("Orientation Sensor")}}</div>
 
@@ -101,4 +102,4 @@ Promise.all([navigator.permissions.query({ name: "accelerometer" }),
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbsoluteOrientationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractrange/collapsed/index.html
+++ b/files/en-us/web/api/abstractrange/collapsed/index.html
@@ -11,6 +11,7 @@ tags:
   - Range
   - Reference
   - collapsed
+browser-compat: api.AbstractRange.collapsed
 ---
 <p>{{APIRef("DOM WHATWG")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractRange.collapsed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractrange/endcontainer/index.html
+++ b/files/en-us/web/api/abstractrange/endcontainer/index.html
@@ -15,6 +15,7 @@ tags:
   - Reference
   - container
   - endContainer
+browser-compat: api.AbstractRange.endContainer
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractRange.endContainer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractrange/endoffset/index.html
+++ b/files/en-us/web/api/abstractrange/endoffset/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - endOffset
   - offset
+browser-compat: api.AbstractRange.endOffset
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractRange.endOffset")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractrange/index.html
+++ b/files/en-us/web/api/abstractrange/index.html
@@ -11,6 +11,7 @@ tags:
   - Interface
   - Range
   - Reference
+browser-compat: api.AbstractRange
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -191,4 +192,4 @@ document.body.appendChild(fragment);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractRange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractrange/startcontainer/index.html
+++ b/files/en-us/web/api/abstractrange/startcontainer/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - start
   - startContainer
+browser-compat: api.AbstractRange.startContainer
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractRange.startContainer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractrange/startoffset/index.html
+++ b/files/en-us/web/api/abstractrange/startoffset/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - offset
   - startOffset
+browser-compat: api.AbstractRange.startOffset
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractRange.startOffset")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/abstractworker/index.html
+++ b/files/en-us/web/api/abstractworker/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Workers
   - Web Workers API
   - Worker
+browser-compat: api.AbstractWorker
 ---
 <div>{{ APIRef("Web Workers API") }}</div>
 
@@ -74,7 +75,7 @@ first.onchange = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractWorker")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/abstractworker/onerror/index.html
+++ b/files/en-us/web/api/abstractworker/onerror/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Workers
   - Workers
   - onerror
+browser-compat: api.AbstractWorker.onerror
 ---
 <p>{{ APIRef("Web Workers API") }}</p>
 
@@ -48,7 +49,7 @@ myWorker.onerror = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AbstractWorker.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Cross-origin_worker_error_behavior">Cross-origin worker error behavior</h3>
 

--- a/files/en-us/web/api/accelerometer/accelerometer/index.html
+++ b/files/en-us/web/api/accelerometer/accelerometer/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.Accelerometer.Accelerometer
 ---
 <div>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Accelerometer.Accelerometer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/accelerometer/index.html
+++ b/files/en-us/web/api/accelerometer/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.Accelerometer
 ---
 <div>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</div>
 
@@ -76,4 +77,4 @@ acl.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Accelerometer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/accelerometer/x/index.html
+++ b/files/en-us/web/api/accelerometer/x/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor APIs
   - Sensors
   - x
+browser-compat: api.Accelerometer.x
 ---
 <div>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</div>
 
@@ -64,4 +65,4 @@ accelerometer.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Accelerometer.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/accelerometer/y/index.html
+++ b/files/en-us/web/api/accelerometer/y/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor APIs
   - Sensors
   - 'y'
+browser-compat: api.Accelerometer.y
 ---
 <div>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</div>
 
@@ -64,4 +65,4 @@ accelerometer.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Accelerometer.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/accelerometer/z/index.html
+++ b/files/en-us/web/api/accelerometer/z/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor APIs
   - Sensors
   - z
+browser-compat: api.Accelerometer.z
 ---
 <div>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</div>
 
@@ -64,4 +65,4 @@ accelerometer.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Accelerometer.z")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/addressline/index.html
+++ b/files/en-us/web/api/addresserrors/addressline/index.html
@@ -12,6 +12,7 @@ tags:
   - Validation
   - addressLine
   - payment
+browser-compat: api.AddressErrors.addressLine
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.addressLine")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/city/index.html
+++ b/files/en-us/web/api/addresserrors/city/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - city
   - payment
+browser-compat: api.AddressErrors.city
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.city")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/country/index.html
+++ b/files/en-us/web/api/addresserrors/country/index.html
@@ -12,6 +12,7 @@ tags:
   - Validation
   - country
   - payment
+browser-compat: api.AddressErrors.country
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.country")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/dependentlocality/index.html
+++ b/files/en-us/web/api/addresserrors/dependentlocality/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - dependentLocality
   - payment
+browser-compat: api.AddressErrors.dependentLocality
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.dependentLocality")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/index.html
+++ b/files/en-us/web/api/addresserrors/index.html
@@ -14,6 +14,7 @@ tags:
   - Reference
   - payment
   - paymentAddress
+browser-compat: api.AddressErrors
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -252,4 +253,4 @@ not-useless gift as a token of our thanks!&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/languagecode/index.html
+++ b/files/en-us/web/api/addresserrors/languagecode/index.html
@@ -14,6 +14,7 @@ tags:
   - Property
   - Reference
   - payment
+browser-compat: api.AddressErrors.languageCode
 ---
 <div>{{APIRef("Payment Request API")}}{{deprecated_header}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.languageCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/organization/index.html
+++ b/files/en-us/web/api/addresserrors/organization/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - organization
   - payment
+browser-compat: api.AddressErrors.organization
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.organization")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/phone/index.html
+++ b/files/en-us/web/api/addresserrors/phone/index.html
@@ -16,6 +16,7 @@ tags:
   - Téléphone
   - Validation
   - payment
+browser-compat: api.AddressErrors.phone
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.phone")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/postalcode/index.html
+++ b/files/en-us/web/api/addresserrors/postalcode/index.html
@@ -17,6 +17,7 @@ tags:
   - ZIP Code
   - payment
   - postalCode
+browser-compat: api.AddressErrors.postalCode
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.postalCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/recipient/index.html
+++ b/files/en-us/web/api/addresserrors/recipient/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - name
   - payment
+browser-compat: api.AddressErrors.recipient
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.recipient")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/region/index.html
+++ b/files/en-us/web/api/addresserrors/region/index.html
@@ -14,6 +14,7 @@ tags:
   - Validation
   - payment
   - region
+browser-compat: api.AddressErrors.region
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.region")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/addresserrors/regioncode/index.html
+++ b/files/en-us/web/api/addresserrors/regioncode/index.html
@@ -14,6 +14,7 @@ tags:
   - paymentAddress
   - region
   - regionCode
+browser-compat: api.AddressErrors.regionCode
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.regionCode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/addresserrors/sortingcode/index.html
+++ b/files/en-us/web/api/addresserrors/sortingcode/index.html
@@ -14,6 +14,7 @@ tags:
   - Validation
   - payment
   - sortingCode
+browser-compat: api.AddressErrors.sortingCode
 ---
 <div>{{APIRef("Payment Request API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AddressErrors.sortingCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.html
+++ b/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.html
@@ -7,6 +7,7 @@ tags:
   - AmbientLightSensor
   - Constructor
   - Reference
+browser-compat: api.AmbientLightSensor.AmbientLightSensor
 ---
 <p>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AmbientLightSensor.AmbientLightSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ambientlightsensor/illuminance/index.html
+++ b/files/en-us/web/api/ambientlightsensor/illuminance/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor APIs
   - Sensors
   - illuminance
+browser-compat: api.AmbientLightSensor.illuminance
 ---
 <p>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AmbientLightSensor.illuminance")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ambientlightsensor/index.html
+++ b/files/en-us/web/api/ambientlightsensor/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.AmbientLightSensor
 ---
 <p>{{APIRef("Generic Sensor API")}}{{SeeCompatTable}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AmbientLightSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/analysernode/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/analysernode/index.html
@@ -9,6 +9,7 @@ tags:
   - Media
   - Reference
   - Web Audio API
+browser-compat: api.AnalyserNode.AnalyserNode
 ---
 <p>{{APIRef("'Web Audio API'")}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.AnalyserNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/fftsize/index.html
+++ b/files/en-us/web/api/analysernode/fftsize/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - fftSize
+browser-compat: api.AnalyserNode.fftSize
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -99,7 +100,7 @@ function draw() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.fftSize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/frequencybincount/index.html
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - frequencyBinCount
+browser-compat: api.AnalyserNode.frequencyBinCount
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -85,7 +86,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.frequencyBinCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AnalyserNode.getByteFrequencyData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -105,7 +106,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.getByteFrequencyData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.html
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AnalyserNode.getByteTimeDomainData
 ---
 <p>{{ APIRef("Mountain View APIRef Project") }}</p>
 
@@ -101,7 +102,7 @@ draw();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.getByteTimeDomainData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AnalyserNode.getFloatFrequencyData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -132,7 +133,7 @@ draw();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.getFloatFrequencyData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.html
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AnalyserNode.getFloatTimeDomainData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -107,7 +108,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.getFloatTimeDomainData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/index.html
+++ b/files/en-us/web/api/analysernode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.AnalyserNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -173,7 +174,7 @@ draw();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.html
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - maxDecibels
+browser-compat: api.AnalyserNode.maxDecibels
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -88,7 +89,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.maxDecibels")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/mindecibels/index.html
+++ b/files/en-us/web/api/analysernode/mindecibels/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - minDecibels
+browser-compat: api.AnalyserNode.minDecibels
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -90,7 +91,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.minDecibels")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.html
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - smoothingTimeConstant
+browser-compat: api.AnalyserNode.smoothingTimeConstant
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -95,7 +96,7 @@ draw();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnalyserNode.smoothingTimeConstant")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.ANGLE_instanced_arrays.drawArraysInstancedANGLE
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -82,7 +83,7 @@ ext.drawArraysInstancedANGLE(gl.POINTS, 0, 8, 4);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ANGLE_instanced_arrays.drawArraysInstancedANGLE")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.ANGLE_instanced_arrays.drawElementsInstancedANGLE
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -94,7 +95,7 @@ ext.drawElementsInstancedANGLE(gl.POINTS, 2, gl.UNSIGNED_SHORT, 0, 4);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ANGLE_instanced_arrays.drawElementsInstancedANGLE")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/angle_instanced_arrays/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.ANGLE_instanced_arrays
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ANGLE_instanced_arrays")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.html
+++ b/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.ANGLE_instanced_arrays.vertexAttribDivisorANGLE
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -60,7 +61,7 @@ ext.vertexAttribDivisorANGLE(0, 2);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ANGLE_instanced_arrays.vertexAttribDivisorANGLE")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/animation/index.html
+++ b/files/en-us/web/api/animation/animation/index.html
@@ -8,6 +8,7 @@ tags:
   - Constructor
   - Reference
   - web animations api
+browser-compat: api.Animation.Animation
 ---
 <p>{{ APIRef("Web Animations API") }}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.Animation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/cancel/index.html
+++ b/files/en-us/web/api/animation/cancel/index.html
@@ -10,6 +10,7 @@ tags:
   - cancel
   - waapi
   - web animations api
+browser-compat: api.Animation.cancel
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.cancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/commitstyles/index.html
+++ b/files/en-us/web/api/animation/commitstyles/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - commitStyles
   - web animations api
+browser-compat: api.Animation.commitStyles
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -60,7 +61,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.commitStyles")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/currenttime/index.html
+++ b/files/en-us/web/api/animation/currenttime/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Animations
   - web animations api
+browser-compat: api.Animation.currentTime
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -78,7 +79,7 @@ animation.currentTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.currentTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/effect/index.html
+++ b/files/en-us/web/api/animation/effect/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - effect
   - web animations api
+browser-compat: api.Animation.effect
 ---
 <div>{{ SeeCompatTable() }} {{ APIRef("Web Animations") }}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.effect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/finish/index.html
+++ b/files/en-us/web/api/animation/finish/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Animations
   - waapi
   - web animations api
+browser-compat: api.Animation.finish
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.finish")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/finished/index.html
+++ b/files/en-us/web/api/animation/finished/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - finished
   - web animations api
+browser-compat: api.Animation.finished
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.finished")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/id/index.html
+++ b/files/en-us/web/api/animation/id/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - id
   - web animations api
+browser-compat: api.Animation.id
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/index.html
+++ b/files/en-us/web/api/animation/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Animations
   - waapi
   - web animations api
+browser-compat: api.Animation
 ---
 <div>{{ APIRef("Web Animations") }}</div>
 
@@ -126,7 +127,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/oncancel/index.html
+++ b/files/en-us/web/api/animation/oncancel/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - oncancel
   - web animations api
+browser-compat: api.Animation.oncancel
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.oncancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/onfinish/index.html
+++ b/files/en-us/web/api/animation/onfinish/index.html
@@ -12,6 +12,7 @@ tags:
 - onfinish
 - waapi
 - web animations api
+browser-compat: api.Animation.onfinish
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -90,7 +91,7 @@ bringUI.onfinish = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.onfinish")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/onremove/index.html
+++ b/files/en-us/web/api/animation/onremove/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - onremove
   - web animations api
+browser-compat: api.Animation.onremove
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -71,7 +72,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.onremove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/pause/index.html
+++ b/files/en-us/web/api/animation/pause/index.html
@@ -9,6 +9,7 @@ tags:
   - pause
   - waapi
   - web animations api
+browser-compat: api.Animation.pause
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -88,7 +89,7 @@ bottle.addEventListener("mouseup", stopPlayingAlice, false);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.pause")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/pending/index.html
+++ b/files/en-us/web/api/animation/pending/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Animations
   - web animations api
+browser-compat: api.Animation.pending
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.pending")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/persist/index.html
+++ b/files/en-us/web/api/animation/persist/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - persist
   - web animations api
+browser-compat: api.Animation.persist
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -72,7 +73,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.persist")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/play/index.html
+++ b/files/en-us/web/api/animation/play/index.html
@@ -11,6 +11,7 @@ tags:
   - play
   - waapi
   - web animations api
+browser-compat: api.Animation.play
 ---
 <div>{{ APIRef("Web Animations") }}{{SeeCompatTable}}</div>
 
@@ -82,7 +83,7 @@ cake.addEventListener("touchstart", growAlice, false);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.play")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/playbackrate/index.html
+++ b/files/en-us/web/api/animation/playbackrate/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - playbackRate
   - web animations api
+browser-compat: api.Animation.playbackRate
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -100,7 +101,7 @@ document.addEventListener("touchstart", goFaster);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.playbackRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/playstate/index.html
+++ b/files/en-us/web/api/animation/playstate/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Animations
   - playState
   - web animations api
+browser-compat: api.Animation.playState
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -91,7 +92,7 @@ tears.forEach(function(el) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.playState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/ready/index.html
+++ b/files/en-us/web/api/animation/ready/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Animations
   - web animations api
+browser-compat: api.Animation.ready
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -65,7 +66,7 @@ animation.play();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.ready")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/replacestate/index.html
+++ b/files/en-us/web/api/animation/replacestate/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - replaceState
   - web animations api
+browser-compat: api.Animation.replaceState
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -75,7 +76,7 @@ document.body.addEventListener('mousemove', evt =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.replaceState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/reverse/index.html
+++ b/files/en-us/web/api/animation/reverse/index.html
@@ -11,6 +11,7 @@ tags:
   - reverse
   - waapi
   - web animations api
+browser-compat: api.Animation.reverse
 ---
 <div>{{APIRef("Web Animations")}}{{SeeCompatTable}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.reverse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/starttime/index.html
+++ b/files/en-us/web/api/animation/starttime/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - startTime
   - web animations api
+browser-compat: api.Animation.startTime
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -97,7 +98,7 @@ animation.startTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.startTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/timeline/index.html
+++ b/files/en-us/web/api/animation/timeline/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - timeline
   - web animations api
+browser-compat: api.Animation.timeline
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.timeline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animation/updateplaybackrate/index.html
+++ b/files/en-us/web/api/animation/updateplaybackrate/index.html
@@ -13,6 +13,7 @@ tags:
 - updatePlaybackRate
 - waapi
 - web animations api
+browser-compat: api.Animation.updatePlaybackRate
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Animation.updatePlaybackRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.html
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.html
@@ -9,6 +9,7 @@ tags:
   - getComputedTiming
   - waapi
   - web animations api
+browser-compat: api.AnimationEffect.getComputedTiming
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEffect.getComputedTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.html
+++ b/files/en-us/web/api/animationeffect/gettiming/index.html
@@ -9,6 +9,7 @@ tags:
   - Timing
   - waapi
   - web animations api
+browser-compat: api.AnimationEffect.getTiming
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEffect.getTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationeffect/index.html
+++ b/files/en-us/web/api/animationeffect/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Animations
   - web animations api
+browser-compat: api.AnimationEffect
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEffect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationeffect/updatetiming/index.html
+++ b/files/en-us/web/api/animationeffect/updatetiming/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Animations
   - waapi
   - web animations api
+browser-compat: api.AnimationEffect.updateTiming
 ---
 <p>{{SeeCompatTable}} {{ APIRef("Web Animations API") }}</p>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEffect.updateTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationevent/animationevent/index.html
+++ b/files/en-us/web/api/animationevent/animationevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Reference
   - Web Animations
+browser-compat: api.AnimationEvent.AnimationEvent
 ---
 <p>{{APIRef("Web Animations")}}{{SeeCompatTable}}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEvent.AnimationEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationevent/animationname/index.html
+++ b/files/en-us/web/api/animationevent/animationname/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Web Animations
+browser-compat: api.AnimationEvent.animationName
 ---
 <p>{{SeeCompatTable}}{{ apiref("Web Animations API") }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEvent.animationName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationevent/elapsedtime/index.html
+++ b/files/en-us/web/api/animationevent/elapsedtime/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - Web Animations
+browser-compat: api.AnimationEvent.elapsedTime
 ---
 <div>{{SeeCompatTable}}{{ apiref("Web Animations API") }}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEvent.elapsedTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationevent/index.html
+++ b/files/en-us/web/api/animationevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Animations
+browser-compat: api.AnimationEvent
 ---
 <div>{{SeeCompatTable}}{{APIRef("Web Animations API")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationevent/initanimationevent/index.html
+++ b/files/en-us/web/api/animationevent/initanimationevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Deprecated
   - Web Animations
+browser-compat: api.AnimationEvent.initAnimationEvent
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{ apiref("Web Animations API") }}</p>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEvent.initAnimationEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationevent/pseudoelement/index.html
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - Web Animations
+browser-compat: api.AnimationEvent.pseudoElement
 ---
 <p>{{SeeCompatTable}}{{ apiref("Web Animations API") }}</p>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationEvent.pseudoElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.html
+++ b/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - waapi
   - web animations api
+browser-compat: api.AnimationPlaybackEvent.AnimationPlaybackEvent
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationPlaybackEvent.AnimationPlaybackEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationplaybackevent/currenttime/index.html
+++ b/files/en-us/web/api/animationplaybackevent/currenttime/index.html
@@ -12,6 +12,7 @@ tags:
   - currentTime
   - waapi
   - web animations api
+browser-compat: api.AnimationPlaybackEvent.currentTime
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -62,7 +63,7 @@ playbackEvent.currentTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationPlaybackEvent.currentTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationplaybackevent/index.html
+++ b/files/en-us/web/api/animationplaybackevent/index.html
@@ -11,6 +11,7 @@ tags:
   - events
   - waapi
   - web animations api
+browser-compat: api.AnimationPlaybackEvent
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationPlaybackEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationplaybackevent/timelinetime/index.html
+++ b/files/en-us/web/api/animationplaybackevent/timelinetime/index.html
@@ -12,6 +12,7 @@ tags:
   - timelineTime
   - waapi
   - web animations api
+browser-compat: api.AnimationPlaybackEvent.timelineTime
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationPlaybackEvent.timelineTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationtimeline/currenttime/index.html
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.html
@@ -12,6 +12,7 @@ tags:
   - currentTime
   - waapi
   - web animations api
+browser-compat: api.AnimationTimeline.currentTime
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
@@ -66,7 +67,7 @@ animationTimeline.currentTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationTimeline.currentTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/animationtimeline/index.html
+++ b/files/en-us/web/api/animationtimeline/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Animations
   - waapi
   - web animations api
+browser-compat: api.AnimationTimeline
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AnimationTimeline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/attr/index.html
+++ b/files/en-us/web/api/attr/index.html
@@ -4,6 +4,7 @@ slug: Web/API/Attr
 tags:
   - API
   - DOM
+browser-compat: api.Attr
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -148,4 +149,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Attr")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/attr/localname/index.html
+++ b/files/en-us/web/api/attr/localname/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - Reference
+browser-compat: api.Attr.localName
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,7 +77,7 @@ element.addEventListener("click", function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Attr.localName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/attr/namespaceuri/index.html
+++ b/files/en-us/web/api/attr/namespaceuri/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.Attr.namespaceURI
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Attr.namespaceURI")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/attr/prefix/index.html
+++ b/files/en-us/web/api/attr/prefix/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - Reference
+browser-compat: api.Attr.prefix
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Attr.prefix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.html
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.html
@@ -12,6 +12,7 @@ tags:
 - Web Audio
 - Web Audio API
 - sound
+browser-compat: api.AudioBuffer.AudioBuffer
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.AudioBuffer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiobuffer/copyfromchannel/index.html
+++ b/files/en-us/web/api/audiobuffer/copyfromchannel/index.html
@@ -15,6 +15,7 @@ tags:
 - copy
 - copyFromChannel
 - sound
+browser-compat: api.AudioBuffer.copyFromChannel
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -96,7 +97,7 @@ myArrayBuffer.copyFromChannel(anotherArray, 1, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.copyFromChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/copytochannel/index.html
+++ b/files/en-us/web/api/audiobuffer/copytochannel/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Audio API
 - copyToChannel
+browser-compat: api.AudioBuffer.copyToChannel
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -65,7 +66,7 @@ myArrayBuffer.copyToChannel (anotherArray,0,0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.copyToChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/duration/index.html
+++ b/files/en-us/web/api/audiobuffer/duration/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - duration
+browser-compat: api.AudioBuffer.duration
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -72,7 +73,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.duration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.html
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AudioBuffer.getChannelData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -91,7 +92,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.getChannelData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/index.html
+++ b/files/en-us/web/api/audiobuffer/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.AudioBuffer
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -100,7 +101,7 @@ source.start();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/length/index.html
+++ b/files/en-us/web/api/audiobuffer/length/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - length
+browser-compat: api.AudioBuffer.length
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -69,7 +70,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.length")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/numberofchannels/index.html
+++ b/files/en-us/web/api/audiobuffer/numberofchannels/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - numberOfChannels
+browser-compat: api.AudioBuffer.numberOfChannels
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -72,7 +73,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.numberOfChannels")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffer/samplerate/index.html
+++ b/files/en-us/web/api/audiobuffer/samplerate/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - sampleRate
+browser-compat: api.AudioBuffer.sampleRate
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -70,7 +71,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBuffer.sampleRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
@@ -9,6 +9,7 @@ tags:
 - Media
 - Reference
 - Web Audio API
+browser-compat: api.AudioBufferSourceNode.AudioBufferSourceNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -94,4 +95,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.AudioBufferSourceNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Audio API
 - sound
+browser-compat: api.AudioBufferSourceNode.buffer
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -82,7 +83,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.buffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - detune
+browser-compat: api.AudioBufferSourceNode.detune
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -80,7 +81,7 @@ source.start();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.detune")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/index.html
@@ -9,6 +9,7 @@ tags:
   - Media
   - Reference
   - Web Audio API
+browser-compat: api.AudioBufferSourceNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -135,7 +136,7 @@ source.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.AudioBufferSourceNode.loop
 ---
 <div>{{ APIRef("Web Audio API") }}</div>
 
@@ -111,7 +112,7 @@ play.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.loop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Audio API
   - loopEnd
   - sound
+browser-compat: api.AudioBufferSourceNode.loopEnd
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -123,7 +124,7 @@ loopendControl.oninput = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.loopEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Audio API
   - loopStart
   - sound
+browser-compat: api.AudioBufferSourceNode.loopStart
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -116,7 +117,7 @@ loopendControl.oninput = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.loopStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - playbackRate
+browser-compat: api.AudioBufferSourceNode.playbackRate
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -130,7 +131,7 @@ playbackControl.oninput = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.playbackRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiobuffersourcenode/start/index.html
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Audio API
   - sound
   - start
+browser-compat: api.AudioBufferSourceNode.start
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -102,7 +103,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioBufferSourceNode.start")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioconfiguration/index.html
+++ b/files/en-us/web/api/audioconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
   - Media Capabilities API
   - Reference
   - Video
+browser-compat: api.AudioConfiguration
 ---
 <div>{{APIRef("Media Capabilities API")}}</div>
 
@@ -68,7 +69,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/audiocontext/index.html
+++ b/files/en-us/web/api/audiocontext/audiocontext/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - Web Audio
 - Web Audio API
+browser-compat: api.AudioContext.AudioContext
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -104,7 +105,7 @@ var audioCtx = new AudioContext({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.AudioContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/baselatency/index.html
+++ b/files/en-us/web/api/audiocontext/baselatency/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Web Audio API
   - baseLatency
+browser-compat: api.AudioContext.baseLatency
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -63,7 +64,7 @@ console.log(audioCtx2.baseLatency); // 0.15
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.baseLatency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/close/index.html
+++ b/files/en-us/web/api/audiocontext/close/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - close
+browser-compat: api.AudioContext.close
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,7 +62,7 @@ await audioCtx.close();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/createmediaelementsource/index.html
+++ b/files/en-us/web/api/audiocontext/createmediaelementsource/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - createMediaElementSource
+browser-compat: api.AudioContext.createMediaElementSource
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -98,7 +99,7 @@ gainNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.createMediaElementSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.html
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - createMediaStreamDestination
+browser-compat: api.AudioContext.createMediaStreamDestination
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -107,7 +108,7 @@ var destination = audioCtx.createMediaStreamDestination();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.createMediaStreamDestination")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.html
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.html
@@ -15,6 +15,7 @@ tags:
   - Web Audio
   - Web Audio API
   - createMediastreamSource
+browser-compat: api.AudioContext.createMediaStreamSource
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -147,7 +148,7 @@ pre.innerHTML = myScript.innerHTML;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.createMediaStreamSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.html
+++ b/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.html
@@ -15,6 +15,7 @@ tags:
   - sound
   - source
   - track
+browser-compat: api.AudioContext.createMediaStreamTrackSource
 ---
 <p>{{draft}}{{ APIRef("Web Audio API") }}</p>
 
@@ -106,7 +107,7 @@ var <em>track</em> = <em>audioCtx</em>.createMediaStreamTrackSource(<em>track</e
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.createMediaStreamTrackSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.html
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Audio API
   - getOutputTimestamp
   - sound
+browser-compat: api.AudioContext.getOutputTimestamp
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -113,4 +114,4 @@ function outputTimestamps() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.getOutputTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiocontext/index.html
+++ b/files/en-us/web/api/audiocontext/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.AudioContext
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -92,7 +93,7 @@ var finish = audioCtx.destination;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/outputlatency/index.html
+++ b/files/en-us/web/api/audiocontext/outputlatency/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - outputLatency
+browser-compat: api.AudioContext.outputLatency
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -56,7 +57,7 @@ console.log(audioCtx.outputLatency);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.outputLatency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/resume/index.html
+++ b/files/en-us/web/api/audiocontext/resume/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - resume
+browser-compat: api.AudioContext.resume
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.resume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontext/suspend/index.html
+++ b/files/en-us/web/api/audiocontext/suspend/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - suspend
+browser-compat: api.AudioContext.suspend
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -62,7 +63,7 @@ audioCtx.suspend().then(function() { ... });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContext.suspend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontextoptions/index.html
+++ b/files/en-us/web/api/audiocontextoptions/index.html
@@ -15,6 +15,7 @@ tags:
   - Settings
   - Web Audio API
   - sampleRate
+browser-compat: api.AudioContextOptions
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -64,4 +65,4 @@ You can also specify a preferred maximum latency in seconds.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContextOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiocontextoptions/latencyhint/index.html
+++ b/files/en-us/web/api/audiocontextoptions/latencyhint/index.html
@@ -15,6 +15,7 @@ tags:
 - Web Audio API
 - latency
 - latencyHint
+browser-compat: api.AudioContextOptions.latencyHint
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -69,7 +70,7 @@ var <em>latencyHint</em> = <em>audioContextOptions</em>.latencyHint;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContextOptions.latencyHint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiocontextoptions/samplerate/index.html
+++ b/files/en-us/web/api/audiocontextoptions/samplerate/index.html
@@ -15,6 +15,7 @@ tags:
 - Web Audio
 - Web Audio API
 - sampleRate
+browser-compat: api.AudioContextOptions.sampleRate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -62,7 +63,7 @@ var <em>sampleRate</em> = <em>audioContextOptions</em>.sampleRate;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioContextOptions.sampleRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiodestinationnode/index.html
+++ b/files/en-us/web/api/audiodestinationnode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.AudioDestinationNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -84,7 +85,7 @@ gainNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioDestinationNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.html
+++ b/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - maxChannelCount
+browser-compat: api.AudioDestinationNode.maxChannelCount
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -59,7 +60,7 @@ gainNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioDestinationNode.maxChannelCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.html
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.html
@@ -13,6 +13,7 @@ tags:
   - Web Audio API
   - dopplerFactor
   - effects
+browser-compat: api.AudioListener.dopplerFactor
 ---
 <div>{{ APIRef("Web Audio API") }}{{deprecated_header}}</div>
 
@@ -37,7 +38,7 @@ myListener.dopplerFactor = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.dopplerFactor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.html
+++ b/files/en-us/web/api/audiolistener/forwardx/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - forwardX
+browser-compat: api.AudioListener.forwardX
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -53,7 +54,7 @@ myListener.forwardX.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.forwardX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardy/index.html
+++ b/files/en-us/web/api/audiolistener/forwardy/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - forwardY
+browser-compat: api.AudioListener.forwardY
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -53,7 +54,7 @@ myListener.forwardY.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.forwardY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/forwardz/index.html
+++ b/files/en-us/web/api/audiolistener/forwardz/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - forwardZ
+browser-compat: api.AudioListener.forwardZ
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -53,7 +54,7 @@ myListener.forwardZ.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.forwardZ")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/index.html
+++ b/files/en-us/web/api/audiolistener/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.AudioListener
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/positionx/index.html
+++ b/files/en-us/web/api/audiolistener/positionx/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - positionX
+browser-compat: api.AudioListener.positionX
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -52,7 +53,7 @@ myListener.positionX.value = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.positionX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/positiony/index.html
+++ b/files/en-us/web/api/audiolistener/positiony/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - positionY
+browser-compat: api.AudioListener.positionY
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -52,7 +53,7 @@ myListener.positionY.value = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.positionY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/positionz/index.html
+++ b/files/en-us/web/api/audiolistener/positionz/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - positionZ
+browser-compat: api.AudioListener.positionZ
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -52,7 +53,7 @@ myListener.positionZ.value = 1;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.positionZ")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/setorientation/index.html
+++ b/files/en-us/web/api/audiolistener/setorientation/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - setOrientation
+browser-compat: api.AudioListener.setOrientation
 ---
 <p>{{ APIRef("Web Audio API") }}{{deprecated_header}}</p>
 
@@ -57,7 +58,7 @@ myListener.setOrientation(0,0,-1,0,1,0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.setOrientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/setposition/index.html
+++ b/files/en-us/web/api/audiolistener/setposition/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - setPosition
+browser-compat: api.AudioListener.setPosition
 ---
 <p>{{ APIRef("Web Audio API") }} {{deprecated_header}}</p>
 
@@ -64,7 +65,7 @@ myListener.setPosition(1,1,1);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.setPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/speedofsound/index.html
+++ b/files/en-us/web/api/audiolistener/speedofsound/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - speedOfSound
+browser-compat: api.AudioListener.speedOfSound
 ---
 <div>{{ APIRef("Web Audio API") }}{{deprecated_header}}</div>
 
@@ -43,7 +44,7 @@ var <em>myListener</em> = <em>audioCtx</em>.listener;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.speedOfSound")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/upx/index.html
+++ b/files/en-us/web/api/audiolistener/upx/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - upX
+browser-compat: api.AudioListener.upX
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -52,7 +53,7 @@ myListener.upX.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.upX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/upy/index.html
+++ b/files/en-us/web/api/audiolistener/upy/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - upY
+browser-compat: api.AudioListener.upY
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -51,7 +52,7 @@ myListener.upY.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.upY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiolistener/upz/index.html
+++ b/files/en-us/web/api/audiolistener/upz/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - upZ
+browser-compat: api.AudioListener.upZ
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -52,7 +53,7 @@ myListener.upZ.value = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioListener.upZ")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/channelcount/index.html
+++ b/files/en-us/web/api/audionode/channelcount/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - channelCount
+browser-compat: api.AudioNode.channelCount
 ---
 <div>{{ APIRef("Web Audio API") }}</div>
 
@@ -64,7 +65,7 @@ oscillator.channelCount;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.channelCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/channelcountmode/index.html
+++ b/files/en-us/web/api/audionode/channelcountmode/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - channelCountMode
+browser-compat: api.AudioNode.channelCountMode
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -89,7 +90,7 @@ oscillator.channelCountMode = 'explicit';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.channelCountMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/channelinterpretation/index.html
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - channelInterpretation
+browser-compat: api.AudioNode.channelInterpretation
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -58,7 +59,7 @@ oscillator.channelInterpretation = 'discrete';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.channelInterpretation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/connect/index.html
+++ b/files/en-us/web/api/audionode/connect/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - connect
+browser-compat: api.AudioNode.connect
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -192,7 +193,7 @@ lfo.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.connect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/context/index.html
+++ b/files/en-us/web/api/audionode/context/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - Web Audio API
+browser-compat: api.AudioNode.context
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -58,7 +59,7 @@ console.log(oscillator.context === audioCtx); // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/disconnect/index.html
+++ b/files/en-us/web/api/audionode/disconnect/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AudioNode.disconnect
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -87,7 +88,7 @@ gainNode.disconnect();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.disconnect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/index.html
+++ b/files/en-us/web/api/audionode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.AudioNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -136,7 +137,7 @@ oscillator.channelCount;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/numberofinputs/index.html
+++ b/files/en-us/web/api/audionode/numberofinputs/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - numberOfInputs
+browser-compat: api.AudioNode.numberOfInputs
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -59,7 +60,7 @@ console.log(audioCtx.destination.numberOfInputs); // 1
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.numberOfInputs")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionode/numberofoutputs/index.html
+++ b/files/en-us/web/api/audionode/numberofoutputs/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - numberOfOutputs
+browser-compat: api.AudioNode.numberOfOutputs
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -59,7 +60,7 @@ console.log(audioCtx.destination.numberOfOutputs); // 0
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNode.numberOfOutputs")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audionodeoptions/index.html
+++ b/files/en-us/web/api/audionodeoptions/index.html
@@ -10,6 +10,7 @@ tags:
   - Options
   - Reference
   - Web Audio API
+browser-compat: api.AudioNodeOptions
 ---
 <p>{{APIRef("'Web Audio API'")}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioNodeOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audioparam/cancelandholdattime/index.html
+++ b/files/en-us/web/api/audioparam/cancelandholdattime/index.html
@@ -11,6 +11,7 @@ tags:
 - Web Audio API
 - cancelAndHoldAtTime
 - cancelValuesAndHoldAtTime
+browser-compat: api.AudioParam.cancelAndHoldAtTime
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.cancelAndHoldAtTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audioparam/cancelscheduledvalues/index.html
+++ b/files/en-us/web/api/audioparam/cancelscheduledvalues/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - cancelScheduledValues
+browser-compat: api.AudioParam.cancelScheduledValues
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,7 +62,7 @@ gainNode.gain.cancelScheduledValues(audioCtx.currentTime);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.cancelScheduledValues")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/defaultvalue/index.html
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - defaultValue
+browser-compat: api.AudioParam.defaultValue
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -54,7 +55,7 @@ console.log(defaultVal === gainNode.gain.value); // true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.defaultValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.html
+++ b/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - exponentialRampToValueAtTime
+browser-compat: api.AudioParam.exponentialRampToValueAtTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -120,7 +121,7 @@ expRampMinus.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.exponentialRampToValueAtTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/index.html
+++ b/files/en-us/web/api/audioparam/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.AudioParam
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -96,7 +97,7 @@ compressor.release.setValueAtTime(0.25, audioCtx.currentTime);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/linearramptovalueattime/index.html
+++ b/files/en-us/web/api/audioparam/linearramptovalueattime/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - linearRampToValueAtTime
+browser-compat: api.AudioParam.linearRampToValueAtTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -111,7 +112,7 @@ linearRampMinus.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.linearRampToValueAtTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/maxvalue/index.html
+++ b/files/en-us/web/api/audioparam/maxvalue/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Audio API
 - maxValue
+browser-compat: api.AudioParam.maxValue
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -54,7 +55,7 @@ console.log(gainNode.gain.maxValue); // 3.4028234663852886e38</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.maxValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/minvalue/index.html
+++ b/files/en-us/web/api/audioparam/minvalue/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Audio API
 - minValue
+browser-compat: api.AudioParam.minValue
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -55,7 +56,7 @@ console.log(gainNode.gain.minValue); // -3.4028234663852886e38
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.minValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/settargetattime/index.html
+++ b/files/en-us/web/api/audioparam/settargetattime/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - setTargetAtTime
+browser-compat: api.AudioParam.setTargetAtTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -220,7 +221,7 @@ atTimeMinus.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.setTargetAtTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/setvalueattime/index.html
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - setValueAtTime
+browser-compat: api.AudioParam.setValueAtTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -109,7 +110,7 @@ targetAtTimeMinus.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.setValueAtTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparam/setvaluecurveattime/index.html
+++ b/files/en-us/web/api/audioparam/setvaluecurveattime/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Audio
   - Web Audio API
   - setValueCurveAtTime
+browser-compat: api.AudioParam.setValueCurveAtTime
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -150,7 +151,7 @@ valueCurve.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.setValueCurveAtTime")}}</p>
+<p>{{Compat}}</p>
 
 <p>Versions before Chrome 46 use nearest neighbor instead of linear interpolation.</p>
 

--- a/files/en-us/web/api/audioparam/value/index.html
+++ b/files/en-us/web/api/audioparam/value/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Audio API
   - sound
   - value
+browser-compat: api.AudioParam.value
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -132,7 +133,7 @@ gainNode.gain.setValueAtTime(0.4, audioCtx.currentTime);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParam.value")}}</p>
+<p>{{Compat}}</p>
 
 <p>When changing the gain value of a {{domxref("GainNode")}}, Google Chrome prior to
   version 64 (January 2018) would perform a smooth interpolation to prevent dezippering.

--- a/files/en-us/web/api/audioparamdescriptor/index.html
+++ b/files/en-us/web/api/audioparamdescriptor/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - parameterDescriptors
+browser-compat: api.AudioParamDescriptor
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -70,7 +71,7 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParamDescriptor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioparammap/index.html
+++ b/files/en-us/web/api/audioparammap/index.html
@@ -4,6 +4,7 @@ slug: Web/API/AudioParamMap
 tags:
   - Draft
   - Experimental
+browser-compat: api.AudioParamMap
 ---
 <div>{{draft}}{{APIRef("Web Audio API")}}</div>
 
@@ -35,4 +36,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioParamMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.html
@@ -12,6 +12,7 @@ tags:
   - Video
   - Web Audio API
   - ended
+browser-compat: api.AudioScheduledSourceNode.ended_event
 ---
 <p>{{DefaultAPISidebar("Web Audio API")}}</p>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioScheduledSourceNode.ended_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Related_events">Related events</h2>
 

--- a/files/en-us/web/api/audioscheduledsourcenode/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.AudioScheduledSourceNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioScheduledSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioscheduledsourcenode/onended/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/onended/index.html
@@ -13,6 +13,7 @@ tags:
 - Property
 - Web Audio API
 - onended
+browser-compat: api.AudioScheduledSourceNode.onended
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioScheduledSourceNode.onended")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioscheduledsourcenode/start/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/start/index.html
@@ -14,6 +14,7 @@ tags:
   - play
   - sound
   - start
+browser-compat: api.AudioScheduledSourceNode.start
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -97,7 +98,7 @@ osc.stop(context.currentTime + 3);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioScheduledSourceNode.start")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioscheduledsourcenode/stop/index.html
+++ b/files/en-us/web/api/audioscheduledsourcenode/stop/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Audio API
   - sound
   - stop
+browser-compat: api.AudioScheduledSourceNode.stop
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -93,7 +94,7 @@ osc.stop(context.currentTime + 1);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioScheduledSourceNode.stop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiotrack/enabled/index.html
+++ b/files/en-us/web/api/audiotrack/enabled/index.html
@@ -14,6 +14,7 @@ tags:
 - enabled
 - mute
 - track
+browser-compat: api.AudioTrack.enabled
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -112,4 +113,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack.enabled")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotrack/id/index.html
+++ b/files/en-us/web/api/audiotrack/id/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - id
 - track
+browser-compat: api.AudioTrack.id
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotrack/index.html
+++ b/files/en-us/web/api/audiotrack/index.html
@@ -10,6 +10,7 @@ tags:
   - Media
   - Reference
   - track
+browser-compat: api.AudioTrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -89,4 +90,4 @@ var tracks = el.audioTracks;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotrack/kind/index.html
+++ b/files/en-us/web/api/audiotrack/kind/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - id
 - track
+browser-compat: api.AudioTrack.kind
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack.kind")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotrack/label/index.html
+++ b/files/en-us/web/api/audiotrack/label/index.html
@@ -14,6 +14,7 @@ tags:
 - label
 - metadata
 - track
+browser-compat: api.AudioTrack.label
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -95,4 +96,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack.label")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotrack/language/index.html
+++ b/files/en-us/web/api/audiotrack/language/index.html
@@ -15,6 +15,7 @@ tags:
 - Translated
 - Translation
 - track
+browser-compat: api.AudioTrack.language
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -94,4 +95,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack.language")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotrack/sourcebuffer/index.html
+++ b/files/en-us/web/api/audiotrack/sourcebuffer/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - SourceBuffer
 - track
+browser-compat: api.AudioTrack.sourceBuffer
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrack.sourceBuffer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/addtrack_event/index.html
+++ b/files/en-us/web/api/audiotracklist/addtrack_event/index.html
@@ -3,6 +3,7 @@ title: 'AudioTrackList: addtrack event'
 slug: Web/API/AudioTrackList/addtrack_event
 tags:
   - Event
+browser-compat: api.AudioTrackList.addtrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -64,7 +65,7 @@ videoElement.audioTracks.onaddtrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.addtrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiotracklist/change_event/index.html
+++ b/files/en-us/web/api/audiotracklist/change_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Change
   - Event
   - HTML API
+browser-compat: api.AudioTrackList.change_event
 ---
 <div>{{APIRef}}</div>
 
@@ -83,7 +84,7 @@ toggleTrackButton.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.change_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audiotracklist/gettrackbyid/index.html
+++ b/files/en-us/web/api/audiotracklist/gettrackbyid/index.html
@@ -15,6 +15,7 @@ tags:
 - getTrackById
 - id
 - track
+browser-compat: api.AudioTrackList.getTrackById
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -97,4 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.getTrackById")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/index.html
+++ b/files/en-us/web/api/audiotracklist/index.html
@@ -12,6 +12,7 @@ tags:
   - Track List
   - Tracks
   - list
+browser-compat: api.AudioTrackList
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -113,4 +114,4 @@ function updateTrackCount(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/length/index.html
+++ b/files/en-us/web/api/audiotracklist/length/index.html
@@ -13,6 +13,7 @@ tags:
 - length
 - list
 - track
+browser-compat: api.AudioTrackList.length
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -79,4 +80,4 @@ if (videoElem.audioTracks) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/audiotracklist/onaddtrack/index.html
@@ -15,6 +15,7 @@ tags:
 - addTrack
 - onaddtrack
 - track
+browser-compat: api.AudioTrackList.onaddtrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -92,4 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.onaddtrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/onchange/index.html
+++ b/files/en-us/web/api/audiotracklist/onchange/index.html
@@ -15,6 +15,7 @@ tags:
 - addTrack
 - onchange
 - track
+browser-compat: api.AudioTrackList.onchange
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -93,4 +94,4 @@ trackList.onchange = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/audiotracklist/onremovetrack/index.html
@@ -16,6 +16,7 @@ tags:
 - remove
 - removeTrack
 - track
+browser-compat: api.AudioTrackList.onremovetrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.onremovetrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audiotracklist/removetrack_event/index.html
+++ b/files/en-us/web/api/audiotracklist/removetrack_event/index.html
@@ -3,6 +3,7 @@ title: 'AudioTrackList: removetrack event'
 slug: Web/API/AudioTrackList/removetrack_event
 tags:
   - Event
+browser-compat: api.AudioTrackList.removetrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -64,7 +65,7 @@ videoElement.audioTracks.onremovetrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioTrackList.removetrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworklet/index.html
+++ b/files/en-us/web/api/audioworklet/index.html
@@ -15,6 +15,7 @@ tags:
   - Zero-latency
   - latency
   - sound
+browser-compat: api.AudioWorklet
 ---
 <p>{{APIRef("Web Audio API")}}{{securecontext_header}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorklet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletglobalscope/index.html
+++ b/files/en-us/web/api/audioworkletglobalscope/index.html
@@ -14,6 +14,7 @@ tags:
   - global
   - scope
   - sound
+browser-compat: api.AudioWorkletGlobalScope
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -101,7 +102,7 @@ testNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletGlobalScope")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.html
+++ b/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Web Audio API
+browser-compat: api.AudioWorkletGlobalScope.registerProcessor
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -112,7 +113,7 @@ node.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletGlobalScope.registerProcessor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletnode/audioworkletnode/index.html
+++ b/files/en-us/web/api/audioworkletnode/audioworkletnode/index.html
@@ -7,6 +7,7 @@ tags:
 - Constructor
 - Reference
 - Web Audio API
+browser-compat: api.AudioWorkletNode.AudioWorkletNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -80,7 +81,7 @@ var <em>node</em> = new AudioWorkletNode(<em>context</em>, <em>name</em>, <em>op
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletNode.AudioWorkletNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletnode/index.html
+++ b/files/en-us/web/api/audioworkletnode/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.AudioWorkletNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -96,7 +97,7 @@ whiteNoiseNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletnode/onprocessorerror/index.html
+++ b/files/en-us/web/api/audioworkletnode/onprocessorerror/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - onprocessorerror
+browser-compat: api.AudioWorkletNode.onprocessorerror
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletNode.onprocessorerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletnode/port/index.html
+++ b/files/en-us/web/api/audioworkletnode/port/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - port
+browser-compat: api.AudioWorkletNode.port
 ---
 <div>{{APIRef("Web Audio API")}}{{SeeCompatTable}}</div>
 
@@ -93,7 +94,7 @@ pingPongNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletNode.port")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletnodeoptions/index.html
+++ b/files/en-us/web/api/audioworkletnodeoptions/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.AudioWorkletNodeOptions
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletNodeOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.html
@@ -9,6 +9,7 @@ tags:
 - Constructor
 - Reference
 - Web Audio API
+browser-compat: api.AudioWorkletProcessor.AudioWorkletProcessor
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -118,7 +119,7 @@ const testNode = new AudioWorkletNode(audioContext, 'test-processor', {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletProcessor.AudioWorkletProcessor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.AudioWorkletProcessor
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -115,7 +116,7 @@ whiteNoiseNode.connect(audioContext.destination)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletProcessor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/port/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/port/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - Web Audio API
+browser-compat: api.AudioWorkletProcessor.port
 ---
 <div>{{APIRef("Web Audio API")}}{{SeeCompatTable}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletProcessor.port")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/audioworkletprocessor/process/index.html
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.html
@@ -11,6 +11,7 @@ tags:
 - Process
 - Reference
 - Web Audio API
+browser-compat: api.AudioWorkletProcessor.process
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -215,7 +216,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AudioWorkletProcessor.process")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/authenticatordata/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.AuthenticatorAssertionResponse.authenticatorData
 ---
 <p>{{securecontext_header}}{{DefaultAPISidebar("Web Authentication API")}}</p>
 
@@ -83,4 +84,4 @@ navigator.credentials.get({  publickey: options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAssertionResponse.authenticatorData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/authenticatorassertionresponse/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.AuthenticatorAssertionResponse
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -77,7 +78,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAssertionResponse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/authenticatorassertionresponse/signature/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/signature/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.AuthenticatorAssertionResponse.signature
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -90,4 +91,4 @@ navigator.credentials.get({  publickey: options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAssertionResponse.signature")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.html
+++ b/files/en-us/web/api/authenticatorassertionresponse/userhandle/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.AuthenticatorAssertionResponse.userHandle
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -85,7 +86,7 @@ navigator.credentials.get({  publickey: options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAssertionResponse.userHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.html
+++ b/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.AuthenticatorAttestationResponse.attestationObject
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -122,7 +123,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAttestationResponse.attestationObject")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.html
+++ b/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.AuthenticatorAttestationResponse.getTransports
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -110,4 +111,4 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAttestationResponse.getTransports")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/authenticatorattestationresponse/index.html
+++ b/files/en-us/web/api/authenticatorattestationresponse/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.AuthenticatorAttestationResponse
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -87,7 +88,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorAttestationResponse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/authenticatorresponse/clientdatajson/index.html
+++ b/files/en-us/web/api/authenticatorresponse/clientdatajson/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.AuthenticatorResponse.clientDataJSON
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -108,4 +109,4 @@ console.log(clientDataObj.origin);    // the window.origin
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorResponse.clientDataJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/authenticatorresponse/index.html
+++ b/files/en-us/web/api/authenticatorresponse/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.AuthenticatorResponse
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -104,7 +105,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.AuthenticatorResponse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/a* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

215 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
