### PR TITLE
Put browser-compat info in front-runner for api/b*

### DIFF
--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - BackgroundFetchEvent
+browser-compat: api.BackgroundFetchEvent.BackgroundFetchEvent
 ---
 <div>{{DefaultAPISidebar("null")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchEvent.BackgroundFetchEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchevent/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchEvent
+browser-compat: api.BackgroundFetchEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.html
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - registration
   - BackgroundFetchEvent
+browser-compat: api.BackgroundFetchEvent.registration
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchEvent.registration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Service Workers
   - Fetch
+browser-compat: api.BackgroundFetchManager.fetch
 ---
 <div>{{DefaultAPISidebar("Background Fetch")}}</div>
 
@@ -107,4 +108,4 @@ method.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchManager.fetch")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Service Workers
   - Fetch
+browser-compat: api.BackgroundFetchManager.get
 ---
 <div>{{DefaultAPISidebar("Background Fetch")}}</div>
 
@@ -58,4 +59,4 @@ my code block</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchManager.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Service Workers
   - Fetch
+browser-compat: api.BackgroundFetchManager.getIds
 ---
 <div>{{DefaultAPISidebar("Background Fetch")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchManager.getIds")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchmanager/index.html
+++ b/files/en-us/web/api/backgroundfetchmanager/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Service Workers
   - Fetch
+browser-compat: api.BackgroundFetchManager
 ---
 <div>{{DefaultAPISidebar("Background Fetch")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchManager")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchrecord/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchRecord
+browser-compat: api.BackgroundFetchRecord
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRecord")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - request
   - BackgroundFetchRecord
+browser-compat: api.BackgroundFetchRecord.request
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRecord.request")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - responseReady
   - BackgroundFetchRecord
+browser-compat: api.BackgroundFetchRecord.responseReady
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRecord.responseReady")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - abort
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.abort
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.abort")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - downloaded
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.downloaded
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.downloaded")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - downloadTotal
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.downloadTotal
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.downloadTotal")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - failureReason
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.failureReason
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.failureReason")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - id
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.id
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -129,4 +130,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - match
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.match
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -96,4 +97,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.match")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - matchAll
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.matchAll
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -82,4 +83,4 @@ console.log(records); // an array of BackgroundFetchRecord objects
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.matchAll")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/onprogress/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - onprogress
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.onprogress
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -57,4 +58,4 @@ BackgroundRegistration.addEventListener('progress', function);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.onprogress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - recordsAvailable
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.recordsAvailable
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.recordsAvailable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/result/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/result/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - result
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.result
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.result")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - uploaded
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.uploaded
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.uploaded")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - uploadTotal
   - BackgroundFetchRegistration
+browser-compat: api.BackgroundFetchRegistration.uploadTotal
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchRegistration.uploadTotal")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - BackgroundFetchUpdateUIEvent
+browser-compat: api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchupdateuievent/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchUpdateUIEvent
+browser-compat: api.BackgroundFetchUpdateUIEvent
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchUpdateUIEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - updateUI
   - BackgroundFetchUpdateUIEvent
+browser-compat: api.BackgroundFetchUpdateUIEvent.updateUI
 ---
 <div>{{DefaultAPISidebar("Background Fetch API")}}</div>
 
@@ -91,4 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BackgroundFetchUpdateUIEvent.updateUI")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/barcodedetector/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/barcodedetector/index.html
@@ -8,6 +8,7 @@ tags:
 - barcode
 - barcode detection
 - shape detection
+browser-compat: api.BarcodeDetector.BarcodeDetector
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
@@ -70,4 +71,4 @@ if (barcodeDetector) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BarcodeDetector.BarcodeDetector")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/barcodedetector/detect/index.html
+++ b/files/en-us/web/api/barcodedetector/detect/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - barcode
 - shape detection
+browser-compat: api.BarcodeDetector.detect
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BarcodeDetector.detect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - barcode
   - shape detection
+browser-compat: api.BarcodeDetector.getSupportedFormats
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
@@ -64,4 +65,4 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BarcodeDetector.getSupportedFormats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/barcodedetector/index.html
+++ b/files/en-us/web/api/barcodedetector/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - barcode
   - barcode detector
+browser-compat: api.BarcodeDetector
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}</div>
 
@@ -93,7 +94,7 @@ BarcodeDetector.getSupportedFormats()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BarcodeDetector")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/audioworklet/index.html
+++ b/files/en-us/web/api/baseaudiocontext/audioworklet/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - Worklet
+browser-compat: api.BaseAudioContext.audioWorklet
 ---
 <p>{{ APIRef("Web Audio API") }}{{securecontext_header}}</p>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.audioWorklet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createAnalyser
+browser-compat: api.BaseAudioContext.createAnalyser
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -110,7 +111,7 @@ function draw() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createAnalyser")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createBiquadFilter
+browser-compat: api.BaseAudioContext.createBiquadFilter
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -78,7 +79,7 @@ biquadFilter.gain.setValueAtTime(25, audioCtx.currentTime);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createBiquadFilter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.html
@@ -13,6 +13,7 @@ tags:
   - Web Audio
   - Web Audio API
   - createBuffer
+browser-compat: api.BaseAudioContext.createBuffer
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -163,7 +164,7 @@ source.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createBufferSource
+browser-compat: api.BaseAudioContext.createBufferSource
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -105,7 +106,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createBufferSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - createChannelMerger
+browser-compat: api.BaseAudioContext.createChannelMerger
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -88,7 +89,7 @@ ac.decodeAudioData(someStereoBuffer, function(data) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createChannelMerger")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createChannelSplitter
+browser-compat: api.BaseAudioContext.createChannelSplitter
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -89,7 +90,7 @@ ac.decodeAudioData(someStereoBuffer, function(data) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createChannelSplitter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.html
@@ -10,6 +10,7 @@ tags:
 - Media
 - Method
 - createConstantSource
+browser-compat: api.BaseAudioContext.createConstantSource
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createConstantSource")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createConvolver
+browser-compat: api.BaseAudioContext.createConvolver
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -89,7 +90,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createConvolver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createDelay
+browser-compat: api.BaseAudioContext.createDelay
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -99,7 +100,7 @@ rangeSynth.oninput = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createDelay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createDynamicsCompressor
+browser-compat: api.BaseAudioContext.createDynamicsCompressor
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -96,7 +97,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createDynamicsCompressor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.html
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.html
@@ -12,6 +12,7 @@ tags:
   - Web Audio API
   - createGain
   - sound
+browser-compat: api.BaseAudioContext.createGain
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -114,7 +115,7 @@ function voiceMute() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createGain")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - filter
+browser-compat: api.BaseAudioContext.createIIRFilter
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createIIRFilter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createOscillator
+browser-compat: api.BaseAudioContext.createOscillator
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -65,7 +66,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createOscillator")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createPanner
+browser-compat: api.BaseAudioContext.createPanner
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -166,7 +167,7 @@ function positionPanner() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createPanner")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - createPeriodicWave
+browser-compat: api.BaseAudioContext.createPeriodicWave
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -174,7 +175,7 @@ osc.stop(2);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createPeriodicWave")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createScriptProcessor
+browser-compat: api.BaseAudioContext.createScriptProcessor
 ---
 <p>{{APIRef("Web Audio API")}}{{deprecated_header}}</p>
 
@@ -173,7 +174,7 @@ source.onended = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createScriptProcessor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - createStereoPanner
+browser-compat: api.BaseAudioContext.createStereoPanner
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -94,7 +95,7 @@ panNode.connect(audioCtx.destination);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createStereoPanner")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - createWaveShaper
+browser-compat: api.BaseAudioContext.createWaveShaper
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -87,7 +88,7 @@ distortion.oversample = '4x';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.createWaveShaper")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.html
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - currentTime
+browser-compat: api.BaseAudioContext.currentTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -79,7 +80,7 @@ audioCtx.currentTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.currentTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.html
+++ b/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - decodeAudioData
+browser-compat: api.BaseAudioContext.decodeAudioData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -171,7 +172,7 @@ pre.innerHTML = myScript.innerHTML;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.decodeAudioData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/destination/index.html
+++ b/files/en-us/web/api/baseaudiocontext/destination/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - destination
+browser-compat: api.BaseAudioContext.destination
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -65,7 +66,7 @@ gainNode.connect(audioCtx.destination);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.destination")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/index.html
+++ b/files/en-us/web/api/baseaudiocontext/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - sound
+browser-compat: api.BaseAudioContext
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -123,7 +124,7 @@ const finish = audioContext.destination;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/listener/index.html
+++ b/files/en-us/web/api/baseaudiocontext/listener/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Audio API
   - listener
   - spatialization
+browser-compat: api.BaseAudioContext.listener
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,7 +62,7 @@ var myListener = audioCtx.listener;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.listener")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/onstatechange/index.html
+++ b/files/en-us/web/api/baseaudiocontext/onstatechange/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - onstatechange
+browser-compat: api.BaseAudioContext.onstatechange
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.onstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.html
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - sampleRate
+browser-compat: api.BaseAudioContext.sampleRate
 ---
 <div>{{ APIRef("Web Audio API") }}</div>
 
@@ -66,7 +67,7 @@ console.log(audioCtx.sampleRate);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.sampleRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/baseaudiocontext/state/index.html
+++ b/files/en-us/web/api/baseaudiocontext/state/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - state
+browser-compat: api.BaseAudioContext.state
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -85,7 +86,7 @@ function play() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BaseAudioContext.state")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/basiccardrequest/index.html
+++ b/files/en-us/web/api/basiccardrequest/index.html
@@ -15,6 +15,7 @@ tags:
   - Reference
   - card
   - payment
+browser-compat: api.BasicCardRequest
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -135,4 +136,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
+++ b/files/en-us/web/api/basiccardrequest/supportednetworks/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - supportedNetworks
+browser-compat: api.BasicCardRequest.supportedNetworks
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -86,4 +87,4 @@ var request = new PaymentRequest(supportedInstruments, details, options);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardRequest.supportedNetworks")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardrequest/supportedtypes/index.html
+++ b/files/en-us/web/api/basiccardrequest/supportedtypes/index.html
@@ -15,6 +15,7 @@ tags:
 - Reference
 - payment
 - supportedTypes
+browser-compat: api.BasicCardRequest.supportedTypes
 ---
 <p>{{securecontext_header}}{{deprecated_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -70,4 +71,4 @@ var request = new PaymentRequest(supportedInstruments, details, options);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardRequest.supportedTypes")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/billingaddress/index.html
+++ b/files/en-us/web/api/basiccardresponse/billingaddress/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - billingAddress
+browser-compat: api.BasicCardResponse.billingAddress
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -82,4 +83,4 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse.billingAddress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/cardholdername/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardholdername/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - cardholderName
+browser-compat: api.BasicCardResponse.cardholderName
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -80,4 +81,4 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse.cardholderName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/cardnumber/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardnumber/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - cardNumber
+browser-compat: api.BasicCardResponse.cardNumber
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -80,4 +81,4 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse.cardNumber")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
+++ b/files/en-us/web/api/basiccardresponse/cardsecuritycode/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - cardSecurityCode
+browser-compat: api.BasicCardResponse.cardSecurityCode
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -80,4 +81,4 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse.cardSecurityCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/expirymonth/index.html
+++ b/files/en-us/web/api/basiccardresponse/expirymonth/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - expiryMonth
+browser-compat: api.BasicCardResponse.expiryMonth
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -81,4 +82,4 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse.expiryMonth")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/expiryyear/index.html
+++ b/files/en-us/web/api/basiccardresponse/expiryyear/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - expiryYear
+browser-compat: api.BasicCardResponse.expiryYear
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -81,4 +82,4 @@ request.show().then(function(instrumentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse.expiryYear")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/basiccardresponse/index.html
+++ b/files/en-us/web/api/basiccardresponse/index.html
@@ -10,6 +10,7 @@ tags:
   - Payment Request
   - Payment Request API
   - Reference
+browser-compat: api.BasicCardResponse
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -114,4 +115,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BasicCardResponse")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/batterymanager/charging/index.html
+++ b/files/en-us/web/api/batterymanager/charging/index.html
@@ -7,6 +7,7 @@ tags:
 - NeedsMarkupWork
 - Property
 - Reference
+browser-compat: api.BatteryManager.charging
 ---
 <div>{{deprecated_header}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.charging")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/chargingtime/index.html
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.html
@@ -6,6 +6,7 @@ tags:
   - Battery API
   - Property
   - Reference
+browser-compat: api.BatteryManager.chargingTime
 ---
 <div>{{deprecated_header}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.chargingTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.html
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.BatteryManager.dischargingTime
 ---
 <div>{{deprecated_header}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.dischargingTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/index.html
+++ b/files/en-us/web/api/batterymanager/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Deprecated
   - Reference
+browser-compat: api.BatteryManager
 ---
 <div>{{APIRef}}{{deprecated_header}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/level/index.html
+++ b/files/en-us/web/api/batterymanager/level/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.BatteryManager.level
 ---
 <div>{{deprecated_header}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.level")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/onchargingchange/index.html
+++ b/files/en-us/web/api/batterymanager/onchargingchange/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsMarkupWork
 - Property
 - Reference
+browser-compat: api.BatteryManager.onchargingchange
 ---
 <div>{{deprecated_header}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.onchargingchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/onchargingtimechange/index.html
+++ b/files/en-us/web/api/batterymanager/onchargingtimechange/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsMarkupWork
 - Property
 - Reference
+browser-compat: api.BatteryManager.onchargingtimechange
 ---
 <div>{{deprecated_header}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.onchargingtimechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/ondischargingtimechange/index.html
+++ b/files/en-us/web/api/batterymanager/ondischargingtimechange/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsMarkupWork
 - Property
 - Reference
+browser-compat: api.BatteryManager.ondischargingtimechange
 ---
 <div>{{deprecated_header}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.ondischargingtimechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/batterymanager/onlevelchange/index.html
+++ b/files/en-us/web/api/batterymanager/onlevelchange/index.html
@@ -7,6 +7,7 @@ tags:
 - Event Handler
 - Property
 - Reference
+browser-compat: api.BatteryManager.onlevelchange
 ---
 <div>{{deprecated_header}} {{APIRef("Battery API")}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BatteryManager.onlevelchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/beforeinstallpromptevent/index.html
+++ b/files/en-us/web/api/beforeinstallpromptevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.BeforeInstallPromptEvent
 ---
 <div>The <code><strong>BeforeInstallPromptEvent</strong></code> is fired at the {{domxref("Window.onbeforeinstallprompt")}} handler before a user is prompted to "install" a web site to a home screen on mobile.</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BeforeInstallPromptEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/beforeinstallpromptevent/prompt/index.html
+++ b/files/en-us/web/api/beforeinstallpromptevent/prompt/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - prompt
+browser-compat: api.BeforeInstallPromptEvent.prompt
 ---
 <div><span class="seoSummary">The <strong><code>prompt()</code></strong> method of the
     {{domxref("BeforeInstallPromptEvent")}} interface allows a developer to show the
@@ -44,4 +45,4 @@ window.addEventListener("beforeinstallprompt", function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BeforeInstallPromptEvent.prompt")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/beforeunloadevent/index.html
+++ b/files/en-us/web/api/beforeunloadevent/index.html
@@ -4,6 +4,7 @@ slug: Web/API/BeforeUnloadEvent
 tags:
   - API
   - Reference
+browser-compat: api.BeforeUnloadEvent
 ---
 <p>{{APIRef}}</p>
 
@@ -74,7 +75,7 @@ window.addEventListener("beforeunload", function( event ) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BeforeUnloadEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/biquadfilternode/index.html
@@ -9,6 +9,7 @@ tags:
 - Media
 - Reference
 - Web Audio API
+browser-compat: api.BiquadFilterNode.BiquadFilterNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -175,4 +176,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.BiquadFilterNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/biquadfilternode/detune/index.html
+++ b/files/en-us/web/api/biquadfilternode/detune/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - detune
+browser-compat: api.BiquadFilterNode.detune
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -79,7 +80,7 @@ biquadFilter.detune.value = 100;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.detune")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/frequency/index.html
+++ b/files/en-us/web/api/biquadfilternode/frequency/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - frequency
+browser-compat: api.BiquadFilterNode.frequency
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -80,7 +81,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.frequency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/gain/index.html
+++ b/files/en-us/web/api/biquadfilternode/gain/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Web Audio API
+browser-compat: api.BiquadFilterNode.gain
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -80,7 +81,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.gain")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.html
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Audio API
   - filter
   - getFrequencyResponse
+browser-compat: api.BiquadFilterNode.getFrequencyResponse
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -136,7 +137,7 @@ calcFrequencyResponse();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.getFrequencyResponse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/index.html
+++ b/files/en-us/web/api/biquadfilternode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.BiquadFilterNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -171,7 +172,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/q/index.html
+++ b/files/en-us/web/api/biquadfilternode/q/index.html
@@ -8,6 +8,7 @@ tags:
   - Q
   - Reference
   - Web Audio API
+browser-compat: api.BiquadFilterNode.Q
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -85,7 +86,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.Q")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/biquadfilternode/type/index.html
+++ b/files/en-us/web/api/biquadfilternode/type/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Type
   - Web Audio API
+browser-compat: api.BiquadFilterNode.type
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -144,7 +145,7 @@ biquadFilter.gain.value = 25;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BiquadFilterNode.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/arraybuffer/index.html
+++ b/files/en-us/web/api/blob/arraybuffer/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - binary
 - read
+browser-compat: api.Blob.arrayBuffer
 ---
 <p>{{APIRef("File API")}}</p>
 
@@ -65,7 +66,7 @@ var <em>buffer</em> = await <em>blob</em>.arrayBuffer();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.arrayBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/blob/index.html
+++ b/files/en-us/web/api/blob/blob/index.html
@@ -7,6 +7,7 @@ tags:
 - Constructor
 - File API
 - Reference
+browser-compat: api.Blob.Blob
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -75,7 +76,7 @@ var oMyBlob = new Blob(aFileParts, {type : 'text/html'}); // the blob</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.Blob")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/index.html
+++ b/files/en-us/web/api/blob/index.html
@@ -9,6 +9,7 @@ tags:
   - Raw
   - Reference
   - data
+browser-compat: api.Blob
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -139,7 +140,7 @@ reader.readAsArrayBuffer(blob);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/size/index.html
+++ b/files/en-us/web/api/blob/size/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - length
 - size
+browser-compat: api.Blob.size
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -62,7 +63,7 @@ for (var i = 0; i &lt; files.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.size")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/slice/index.html
+++ b/files/en-us/web/api/blob/slice/index.html
@@ -13,6 +13,7 @@ tags:
 - data
 - slice
 - split
+browser-compat: api.Blob.slice
 ---
 <p>{{APIRef("File API")}}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.slice")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/stream/index.html
+++ b/files/en-us/web/api/blob/stream/index.html
@@ -11,6 +11,7 @@ tags:
 - ReadableStream
 - Reference
 - stream
+browser-compat: api.Blob.stream
 ---
 <p>{{APIRef("File API")}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.stream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/text/index.html
+++ b/files/en-us/web/api/blob/text/index.html
@@ -12,6 +12,7 @@ tags:
 - Utf-8
 - get
 - read
+browser-compat: api.Blob.text
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -70,7 +71,7 @@ var <em>text</em> = await <em>blob</em>.text();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.text")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blob/type/index.html
+++ b/files/en-us/web/api/blob/type/index.html
@@ -13,6 +13,7 @@ tags:
 - Property
 - Reference
 - Type
+browser-compat: api.Blob.type
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -73,7 +74,7 @@ for (i = 0; i &lt; files.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Blob.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blobbuilder/index.html
+++ b/files/en-us/web/api/blobbuilder/index.html
@@ -8,6 +8,7 @@ tags:
   - File API
   - Deprecated
   - Reference
+browser-compat: api.BlobBuilder
 ---
 <p>{{APIRef("File API")}}{{ deprecated_header}}</p>
 
@@ -144,7 +145,7 @@ void append(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BlobBuilder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blobevent/blobevent/index.html
+++ b/files/en-us/web/api/blobevent/blobevent/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Media Stream Encoding
 - Reference
+browser-compat: api.BlobEvent.BlobEvent
 ---
 <p>{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BlobEvent.BlobEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blobevent/data/index.html
+++ b/files/en-us/web/api/blobevent/data/index.html
@@ -10,6 +10,7 @@ tags:
 - Media Stream Recording
 - Property
 - Reference
+browser-compat: api.BlobEvent.data
 ---
 <p>{{ apiref("Media Capture and Streams") }} {{ SeeCompatTable() }}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BlobEvent.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blobevent/index.html
+++ b/files/en-us/web/api/blobevent/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Video
   - events
+browser-compat: api.BlobEvent
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BlobEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/blobevent/timecode/index.html
+++ b/files/en-us/web/api/blobevent/timecode/index.html
@@ -8,6 +8,7 @@ tags:
 - Media Stream Recording
 - Property
 - Reference
+browser-compat: api.BlobEvent.timecode
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Capture and Streams")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BlobEvent.timecode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetooth/getavailability/index.html
+++ b/files/en-us/web/api/bluetooth/getavailability/index.html
@@ -6,6 +6,7 @@ tags:
 - Bluetooth
 - Reference
 - Web Bluetooth API
+browser-compat: api.Bluetooth.getAvailability
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Bluetooth API")}}</p>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Bluetooth.getAvailability")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetooth/getdevices/index.html
+++ b/files/en-us/web/api/bluetooth/getdevices/index.html
@@ -6,6 +6,7 @@ tags:
 - Bluetooth
 - Reference
 - Web Bluetooth API
+browser-compat: api.Bluetooth.getDevices
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Bluetooth API")}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Bluetooth.getDevices")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetooth/index.html
+++ b/files/en-us/web/api/bluetooth/index.html
@@ -8,6 +8,7 @@ tags:
 - Interface
 - Reference
 - Web Bluetooth API
+browser-compat: api.Bluetooth
 ---
 <p>{{APIRef("Bluetooth API")}}{{securecontext_header}}{{SeeCompatTable}}</p>
 
@@ -87,4 +88,4 @@ Bluetooth includes ServiceEventHandlers;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Bluetooth")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetooth/onavailabilitychanged/index.html
+++ b/files/en-us/web/api/bluetooth/onavailabilitychanged/index.html
@@ -5,6 +5,7 @@ tags:
 - API
 - Bluetooth
 - Web Bluetooth API
+browser-compat: api.Bluetooth.onavailabilitychanged
 ---
 <p>{{APIRef("Bluetooth API")}}{{securecontext_header}}{{SeeCompatTable}}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Bluetooth.onavailabilitychanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/bluetooth/referringdevice/index.html
+++ b/files/en-us/web/api/bluetooth/referringdevice/index.html
@@ -6,6 +6,7 @@ tags:
 - Bluetooth
 - Reference
 - Web Bluetooth API
+browser-compat: api.Bluetooth.referringDevice
 ---
 <p>{{APIRef("Bluetooth API")}}{{securecontext_header}}{{SeeCompatTable}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Bluetooth.referringDevice")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetooth/requestdevice/index.html
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - requestDevice
+browser-compat: api.Bluetooth.requestDevice
 ---
 <p>{{APIRef("Bluetooth API")}} {{securecontext_header}}{{SeeCompatTable}}</p>
 
@@ -114,4 +115,4 @@ navigator.bluetooth.requestDevice(options).then(function(device) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Bluetooth.requestDevice")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/appearance/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/appearance/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - appearance
+browser-compat: api.BluetoothAdvertisingData.appearance
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -24,4 +25,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothAdvertisingData.appearance")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/index.html
@@ -10,6 +10,7 @@ tags:
   - Deprecated
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothAdvertisingData
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothAdvertisingData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/manufacturerdata/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/manufacturerdata/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - manufacturerData
+browser-compat: api.BluetoothAdvertisingData.manufacturerData
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -24,4 +25,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothAdvertisingData.manufacturerData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/rssi/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/rssi/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - rssi
+browser-compat: api.BluetoothAdvertisingData.rssi
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -25,4 +26,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothAdvertisingData.rssi")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/servicedata/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/servicedata/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - serviceData
+browser-compat: api.BluetoothAdvertisingData.serviceData
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -24,4 +25,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothAdvertisingData.serviceData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothadvertisingdata/txpower/index.html
+++ b/files/en-us/web/api/bluetoothadvertisingdata/txpower/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - txPower
+browser-compat: api.BluetoothAdvertisingData.txPower
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -25,4 +26,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothAdvertisingData.txPower")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - authenticatedSignedWrites
+browser-compat: api.BluetoothCharacteristicProperties.authenticatedSignedWrites
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.authenticatedSignedWrites")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - broadcast
+browser-compat: api.BluetoothCharacteristicProperties.broadcast
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.broadcast")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothCharacteristicProperties
 ---
 <p>{{APIRef("Bluetooth API")}}{{Draft}}{{securecontext_header}}{{SeeCompatTable}}</p>
 
@@ -75,4 +76,4 @@ if (characteristic.properties.notify) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - indicate
+browser-compat: api.BluetoothCharacteristicProperties.indicate
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.indicate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - notify
+browser-compat: api.BluetoothCharacteristicProperties.notify
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.notify")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - read
+browser-compat: api.BluetoothCharacteristicProperties.read
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.read")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - reliableWrite
+browser-compat: api.BluetoothCharacteristicProperties.reliableWrite
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.reliableWrite")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/write/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - write
+browser-compat: api.BluetoothCharacteristicProperties.write
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -47,6 +48,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.write")}}</p>
+<p>{{Compat}}</p>
 
 <p>null</p>

--- a/files/en-us/web/api/bluetoothdevice/addata/index.html
+++ b/files/en-us/web/api/bluetoothdevice/addata/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - adData
+browser-compat: api.BluetoothDevice.adData
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -29,4 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.adData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/connectgatt/index.html
+++ b/files/en-us/web/api/bluetoothdevice/connectgatt/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - connectGATT
+browser-compat: api.BluetoothDevice.connectGATT
 ---
 <p>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</p>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.connectGATT")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/deviceclass/index.html
+++ b/files/en-us/web/api/bluetoothdevice/deviceclass/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - deviceClass
+browser-compat: api.BluetoothDevice.deviceClass
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -28,4 +29,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.deviceClass")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/gatt/index.html
+++ b/files/en-us/web/api/bluetoothdevice/gatt/index.html
@@ -8,6 +8,7 @@ tags:
 - GATT server
 - Property
 - Reference
+browser-compat: api.BluetoothDevice.gatt
 ---
 <div>{{APIRef("Bluetooth API") }}{{SeeCompatTable}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.gatt")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/gattserver/index.html
+++ b/files/en-us/web/api/bluetoothdevice/gattserver/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - gattServer
+browser-compat: api.BluetoothDevice.gattServer
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -27,4 +28,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.gattServer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/id/index.html
+++ b/files/en-us/web/api/bluetoothdevice/id/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - id
+browser-compat: api.BluetoothDevice.id
 ---
 <div>{{APIRef("Bluetooth API")}}{{SeeCompatTable}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/index.html
+++ b/files/en-us/web/api/bluetoothdevice/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothDevice
 ---
 <p>{{APIRef("Bluetooth API")}}{{SeeCompatTable}}</p>
 
@@ -127,4 +128,4 @@ BluetoothDevice implements ServiceEventHandlers;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/name/index.html
+++ b/files/en-us/web/api/bluetoothdevice/name/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - name
+browser-compat: api.BluetoothDevice.name
 ---
 <div>{{APIRef("Bluetooth API")}}{{SeeCompatTable}}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/paired/index.html
+++ b/files/en-us/web/api/bluetoothdevice/paired/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Web Bluetooth API
+browser-compat: api.BluetoothDevice.paired
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -33,4 +34,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.paired")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/productid/index.html
+++ b/files/en-us/web/api/bluetoothdevice/productid/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - productID
+browser-compat: api.BluetoothDevice.productID
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -29,4 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.productID")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/productversion/index.html
+++ b/files/en-us/web/api/bluetoothdevice/productversion/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - productVersion
+browser-compat: api.BluetoothDevice.productVersion
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -29,4 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.productVersion")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/uuids/index.html
+++ b/files/en-us/web/api/bluetoothdevice/uuids/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - UUIDs
 - Web Bluetooth API
+browser-compat: api.BluetoothDevice.uuids
 ---
 <div>{{APIRef("Bluetooth API")}}{{deprecated_header}}</div>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.uuids")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/vendorid/index.html
+++ b/files/en-us/web/api/bluetoothdevice/vendorid/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - vendorID
+browser-compat: api.BluetoothDevice.vendorID
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -28,4 +29,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.vendorID")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothdevice/vendoridsource/index.html
+++ b/files/en-us/web/api/bluetoothdevice/vendoridsource/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - vendorIDSource
+browser-compat: api.BluetoothDevice.vendorIDSource
 ---
 <div>{{APIRef("Bluetooth API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -28,4 +29,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothDevice.vendorIDSource")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getDescriptor()
+browser-compat: api.BluetoothRemoteGATTCharacteristic.getDescriptor
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -48,6 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.getDescriptor")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getDescriptors()
+browser-compat: api.BluetoothRemoteGATTCharacteristic.getDescriptors
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -49,6 +50,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.getDescriptors")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTCharacteristic
 ---
 <div>{{APIRef("Bluetooth API")}}{{SeeCompatTable}}</div>
 
@@ -81,4 +82,4 @@ BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - properties
+browser-compat: api.BluetoothRemoteGATTCharacteristic.properties
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -46,6 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.properties")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - readValue
+browser-compat: api.BluetoothRemoteGATTCharacteristic.readValue
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -47,6 +48,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.readValue")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Service
   - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTCharacteristic.service
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -46,6 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.service")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - startNotifications()
+browser-compat: api.BluetoothRemoteGATTCharacteristic.startNotifications
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -48,6 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.startNotifications")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - stopNotifications
+browser-compat: api.BluetoothRemoteGATTCharacteristic.stopNotifications
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -48,6 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.stopNotifications")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.html
@@ -11,6 +11,7 @@ tags:
 - Service
 - Web Bluetooth API
 - uuid
+browser-compat: api.BluetoothRemoteGATTCharacteristic.uuid
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -48,6 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.uuid")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - value
+browser-compat: api.BluetoothRemoteGATTCharacteristic.value
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -46,6 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.value")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - writeValue
+browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValue
 ---
 <p>{{Deprecated_header}}</p>
 
@@ -55,6 +56,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTCharacteristic.writeValue")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - characteristic
+browser-compat: api.BluetoothRemoteGATTDescriptor.characteristic
 ---
 <p>{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTDescriptor.characteristic")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTDescriptor
 ---
 <div>{{APIRef("Bluetooth API")}}{{SeeCompatTable}}</div>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTDescriptor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - readValue()
+browser-compat: api.BluetoothRemoteGATTDescriptor.readValue
 ---
 <p>{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTDescriptor.readValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - uuid
+browser-compat: api.BluetoothRemoteGATTDescriptor.uuid
 ---
 <p>{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTDescriptor.uuid")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - value
+browser-compat: api.BluetoothRemoteGATTDescriptor.value
 ---
 <p>{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTDescriptor.value")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - writeValue()
+browser-compat: api.BluetoothRemoteGATTDescriptor.writeValue
 ---
 <p>{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTDescriptor.writeValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - connect()
+browser-compat: api.BluetoothRemoteGATTServer.connect
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -51,6 +52,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer.connect")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattserver/connected/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/connected/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTServer.connected
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -42,6 +43,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer.connected")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattserver/device/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/device/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Property
 - Reference
+browser-compat: api.BluetoothRemoteGATTServer.device
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -39,6 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer.device")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - disconnect()
+browser-compat: api.BluetoothRemoteGATTServer.disconnect
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -48,6 +49,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer.disconnect")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getPrimaryService()
+browser-compat: api.BluetoothRemoteGATTServer.getPrimaryService
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -54,6 +55,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer.getPrimaryService")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getPrimaryServices()
+browser-compat: api.BluetoothRemoteGATTServer.getPrimaryServices
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -54,6 +55,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer.getPrimaryServices")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattserver/index.html
+++ b/files/en-us/web/api/bluetoothremotegattserver/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTServer
 ---
 <div>{{APIRef("Bluetooth API")}}{{SeeCompatTable}}</div>
 
@@ -83,6 +84,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTServer")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/device/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/device/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTService.device
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -46,6 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.device")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getCharacteristic()
+browser-compat: api.BluetoothRemoteGATTService.getCharacteristic
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -57,6 +58,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.getCharacteristic")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getCharacteristics()
+browser-compat: api.BluetoothRemoteGATTService.getCharacteristics
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -57,6 +58,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.getCharacteristics")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/getincludedservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getincludedservice/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getIncludedService
+browser-compat: api.BluetoothRemoteGATTService.getIncludedService
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -54,6 +55,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.getIncludedService")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/getincludedservices/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/getincludedservices/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - getIncludedServices()
+browser-compat: api.BluetoothRemoteGATTService.getIncludedServices
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -55,6 +56,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.getIncludedServices")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - Web Bluetooth API
+browser-compat: api.BluetoothRemoteGATTService
 ---
 <div>{{SeeCompatTable}}
   <div class="overheadIndicator note">
@@ -91,6 +92,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - isPrimary
+browser-compat: api.BluetoothRemoteGATTService.isPrimary
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -46,6 +47,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.isPrimary")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/bluetoothremotegattservice/uuid/index.html
+++ b/files/en-us/web/api/bluetoothremotegattservice/uuid/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - uuid
+browser-compat: api.BluetoothRemoteGATTService.uuid
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -45,6 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothRemoteGATTService.uuid")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Web Bluetooth")}}</div>

--- a/files/en-us/web/api/body/arraybuffer/index.html
+++ b/files/en-us/web/api/body/arraybuffer/index.html
@@ -9,6 +9,7 @@ tags:
   - Fetch
   - Method
   - Reference
+browser-compat: api.Body.arrayBuffer
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -112,7 +113,7 @@ play.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.arrayBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/blob/index.html
+++ b/files/en-us/web/api/body/blob/index.html
@@ -9,6 +9,7 @@ tags:
   - Fetch
   - Method
   - Reference
+browser-compat: api.Body.blob
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -78,7 +79,7 @@ fetch(myRequest)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.blob")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/body/index.html
+++ b/files/en-us/web/api/body/body/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Streams
+browser-compat: api.Body.body
 ---
 <div>{{APIRef("Fetch")}}{{SeeCompatTable}}</div>
 
@@ -88,7 +89,7 @@ fetch('./tortoise.png')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.body")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/bodyused/index.html
+++ b/files/en-us/web/api/body/bodyused/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - bodyUsed
+browser-compat: api.Body.bodyUsed
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -80,7 +81,7 @@ fetch('https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg').the
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.bodyUsed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/formdata/index.html
+++ b/files/en-us/web/api/body/formdata/index.html
@@ -11,6 +11,7 @@ tags:
   - Method
   - NeedsExample
   - Reference
+browser-compat: api.Body.formData
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.formData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/index.html
+++ b/files/en-us/web/api/body/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - request
+browser-compat: api.Body
 ---
 <div>{{ APIRef("Fetch") }}</div>
 
@@ -81,7 +82,7 @@ fetch('https://upload.wikimedia.org/wikipedia/commons/7/77/Delete_key1.jpg')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/json/index.html
+++ b/files/en-us/web/api/body/json/index.html
@@ -9,6 +9,7 @@ tags:
   - JSON
   - Method
   - Reference
+browser-compat: api.Body.json
 ---
 <div>{{APIRef("Fetch API")}}</div>
 
@@ -89,7 +90,7 @@ fetch(myRequest)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.json")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/body/text/index.html
+++ b/files/en-us/web/api/body/text/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Text
+browser-compat: api.Body.text
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -90,7 +91,7 @@ function getData(pageId) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Body.text")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/broadcastchannel/index.html
+++ b/files/en-us/web/api/broadcastchannel/broadcastchannel/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - HTML API
 - Reference
+browser-compat: api.BroadcastChannel.BroadcastChannel
 ---
 <p>{{APIRef("BroadCastChannel API")}}</p>
 
@@ -59,7 +60,7 @@ bc.postMessage('New listening connected!');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.BroadcastChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/close/index.html
+++ b/files/en-us/web/api/broadcastchannel/close/index.html
@@ -9,6 +9,7 @@ tags:
   - HTML API
   - Method
   - Reference
+browser-compat: api.BroadcastChannel.close
 ---
 <p>{{APIRef("BroadCastChannel API")}}</p>
 
@@ -55,7 +56,7 @@ bc.close();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/index.html
+++ b/files/en-us/web/api/broadcastchannel/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML API
   - Interface
   - Reference
+browser-compat: api.BroadcastChannel
 ---
 <p>{{APIRef("Broadcast Channel API")}}</p>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/message_event/index.html
+++ b/files/en-us/web/api/broadcastchannel/message_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - message
   - messaging
+browser-compat: api.BroadcastChannel.message_event
 ---
 <div>{{APIRef}}</div>
 
@@ -158,7 +159,7 @@ channel.addEventListener('message', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.message_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/messageerror_event/index.html
+++ b/files/en-us/web/api/broadcastchannel/messageerror_event/index.html
@@ -3,6 +3,7 @@ title: 'BroadcastChannel: messageerror event'
 slug: Web/API/BroadcastChannel/messageerror_event
 tags:
   - Event
+browser-compat: api.BroadcastChannel.messageerror_event
 ---
 <div>{{APIRef}}</div>
 
@@ -73,7 +74,7 @@ channel.onmessageerror = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.messageerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/name/index.html
+++ b/files/en-us/web/api/broadcastchannel/name/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Read-only
   - Reference
+browser-compat: api.BroadcastChannel.name
 ---
 <p>{{APIRef("BroadCastChannel API")}}</p>
 
@@ -57,7 +58,7 @@ bc.close();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/onmessage/index.html
+++ b/files/en-us/web/api/broadcastchannel/onmessage/index.html
@@ -10,6 +10,7 @@ tags:
 - HTML API
 - Property
 - Reference
+browser-compat: api.BroadcastChannel.onmessage
 ---
 <p>{{APIRef("BroadCastChannel API")}}</p>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.onmessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/onmessageerror/index.html
+++ b/files/en-us/web/api/broadcastchannel/onmessageerror/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - onmessageerror
+browser-compat: api.BroadcastChannel.onmessageerror
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.onmessageerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/broadcastchannel/postmessage/index.html
+++ b/files/en-us/web/api/broadcastchannel/postmessage/index.html
@@ -9,6 +9,7 @@ tags:
 - HTML API
 - Method
 - Reference
+browser-compat: api.BroadcastChannel.postMessage
 ---
 <p>{{APIRef("BroadCastChannel API")}}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BroadcastChannel.postMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Reference
   - Streams
+browser-compat: api.ByteLengthQueuingStrategy.ByteLengthQueuingStrategy
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -75,4 +76,4 @@ var size = queuingStrategy.size(chunk);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ByteLengthQueuingStrategy.ByteLengthQueuingStrategy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Streams
+browser-compat: api.ByteLengthQueuingStrategy
 ---
 <p>{{SeeCompatTable}}{{APIRef("Streams")}}</p>
 
@@ -68,4 +69,4 @@ var size = queueingStrategy.size(chunk);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ByteLengthQueuingStrategy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.html
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Streams
   - size
+browser-compat: api.ByteLengthQueuingStrategy.size
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -70,4 +71,4 @@ var size = queueingStrategy.size(chunk);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ByteLengthQueuingStrategy.size")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/b* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

186 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
