### PR TITLE
Put browser-compat info in front-runner for api/c*

### DIFF
--- a/files/en-us/web/api/cache/add/index.html
+++ b/files/en-us/web/api/cache/add/index.html
@@ -10,6 +10,7 @@ tags:
   - Service Workers
   - Service worker API
   - ServiceWorker
+browser-compat: api.Cache.add
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.add")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/addall/index.html
+++ b/files/en-us/web/api/cache/addall/index.html
@@ -12,6 +12,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - addAll
+browser-compat: api.Cache.addAll
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -116,7 +117,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.addAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/delete/index.html
+++ b/files/en-us/web/api/cache/delete/index.html
@@ -12,6 +12,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - delete
+browser-compat: api.Cache.delete
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.delete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/index.html
+++ b/files/en-us/web/api/cache/index.html
@@ -12,6 +12,7 @@ tags:
   - Service Workers
   - Service worker API
   - Storage
+browser-compat: api.Cache
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -181,7 +182,7 @@ self.addEventListener('fetch', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/keys/index.html
+++ b/files/en-us/web/api/cache/keys/index.html
@@ -10,6 +10,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - keys
+browser-compat: api.Cache.keys
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/match/index.html
+++ b/files/en-us/web/api/cache/match/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - match
+browser-compat: api.Cache.match
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -122,7 +123,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.match")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/matchall/index.html
+++ b/files/en-us/web/api/cache/matchall/index.html
@@ -10,6 +10,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - matchAll
+browser-compat: api.Cache.matchAll
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.matchAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cache/put/index.html
+++ b/files/en-us/web/api/cache/put/index.html
@@ -12,6 +12,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - put
+browser-compat: api.Cache.put
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -122,7 +123,7 @@ var cachedResponse = caches.match(event.request).catch(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Cache.put")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cachestorage/delete/index.html
+++ b/files/en-us/web/api/cachestorage/delete/index.html
@@ -10,6 +10,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - delete
+browser-compat: api.CacheStorage.delete
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CacheStorage.delete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cachestorage/has/index.html
+++ b/files/en-us/web/api/cachestorage/has/index.html
@@ -10,6 +10,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - has
+browser-compat: api.CacheStorage.has
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CacheStorage.has")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cachestorage/index.html
+++ b/files/en-us/web/api/cachestorage/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Service Workers
   - ServiceWorker
+browser-compat: api.CacheStorage
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -194,7 +195,7 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CacheStorage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cachestorage/keys/index.html
+++ b/files/en-us/web/api/cachestorage/keys/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - keys
+browser-compat: api.CacheStorage.keys
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CacheStorage.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cachestorage/match/index.html
+++ b/files/en-us/web/api/cachestorage/match/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - match
+browser-compat: api.CacheStorage.match
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -137,7 +138,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CacheStorage.match")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cachestorage/open/index.html
+++ b/files/en-us/web/api/cachestorage/open/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - open
+browser-compat: api.CacheStorage.open
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CacheStorage.open")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.html
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - Web
+browser-compat: api.CanvasCaptureMediaStreamTrack.canvas
 ---
 <div>{{APIRef}}</div>
 
@@ -66,7 +67,7 @@ var canvas = stream.canvas;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasCaptureMediaStreamTrack.canvas")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/index.html
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/index.html
@@ -10,6 +10,7 @@ tags:
   - Media Capture
   - Reference
   - Web
+browser-compat: api.CanvasCaptureMediaStreamTrack
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasCaptureMediaStreamTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.html
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.html
@@ -11,6 +11,7 @@ tags:
   - Method
   - Reference
   - requestFrame
+browser-compat: api.CanvasCaptureMediaStreamTrack.requestFrame
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -77,7 +78,7 @@ stream.getVideoTracks()[0].requestFrame();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasCaptureMediaStreamTrack.requestFrame")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.html
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.html
@@ -8,6 +8,7 @@ tags:
 - Gradients
 - Method
 - Reference
+browser-compat: api.CanvasGradient.addColorStop
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -84,7 +85,7 @@ ctx.fillRect(10, 10, 200, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasGradient.addColorStop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasgradient/index.html
+++ b/files/en-us/web/api/canvasgradient/index.html
@@ -8,6 +8,7 @@ tags:
   - Gradients
   - Interface
   - Reference
+browser-compat: api.CanvasGradient
 ---
 <p>The <code><strong>CanvasGradient</strong></code> interface represents an <a href="https://en.wikipedia.org/wiki/Opaque_data_type">opaque object</a> describing a gradient. It is returned by the methods {{domxref("CanvasRenderingContext2D.createLinearGradient()")}}, {{domxref("CanvasRenderingContext2D.createConicGradient()")}} or {{domxref("CanvasRenderingContext2D.createRadialGradient()")}}.</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasGradient")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvaspattern/index.html
+++ b/files/en-us/web/api/canvaspattern/index.html
@@ -6,6 +6,7 @@ tags:
   - Canvas
   - Interface
   - Reference
+browser-compat: api.CanvasPattern
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasPattern")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvaspattern/settransform/index.html
+++ b/files/en-us/web/api/canvaspattern/settransform/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Method
 - Reference
+browser-compat: api.CanvasPattern.setTransform
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -145,7 +146,7 @@ window.addEventListener('load', drawCanvas);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasPattern.setTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/addhitregion/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/addhitregion/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - Deprecated
+browser-compat: api.CanvasRenderingContext2D.addHitRegion
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 
@@ -181,7 +182,7 @@ window.addEventListener("load", drawCanvas);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.addHitRegion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/arc/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arc/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.arc
 ---
 <div>{{APIRef}}</div>
 
@@ -136,7 +137,7 @@ for (let i = 0; i &lt;= 3; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.arc")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.arcTo
 ---
 <div>{{APIRef}}</div>
 
@@ -276,7 +277,7 @@ loop(0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.arcTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.beginPath
 ---
 <div>{{APIRef}}</div>
 
@@ -83,7 +84,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.beginPath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.bezierCurveTo
 ---
 <div>{{APIRef}}</div>
 
@@ -138,7 +139,7 @@ ctx.stroke();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.bezierCurveTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.canvas
 ---
 <div>{{APIRef}}</div>
 
@@ -55,7 +56,7 @@ ctx.canvas // HTMLCanvasElement
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.canvas")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearhitregions/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearhitregions/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - Deprecated
+browser-compat: api.CanvasRenderingContext2D.clearHitRegions
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 
@@ -56,7 +57,7 @@ ctx.clearHitRegions();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.clearHitRegions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.clearRect
 ---
 <div>{{APIRef}}</div>
 
@@ -121,7 +122,7 @@ ctx.clearRect(10, 10, 120, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.clearRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.clip
 ---
 <div>{{APIRef}}</div>
 
@@ -181,7 +182,7 @@ ctx.fillRect(0, 0, canvas.width, canvas.height);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.clip")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.closePath
 ---
 <div>{{APIRef}}</div>
 
@@ -114,7 +115,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.closePath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.html
@@ -9,6 +9,7 @@ tags:
 - Conic
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.createConicGradient
 ---
 
 <div>{{APIRef}}</div>
@@ -100,7 +101,7 @@ ctx.fillRect(20, 20, 200, 200);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.createConicGradient")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.createImageData
 ---
 <div>{{APIRef}}</div>
 
@@ -137,7 +138,7 @@ ctx.putImageData(imageData, 20, 20);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.createImageData")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.html
@@ -8,6 +8,7 @@ tags:
   - Gradients
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.createLinearGradient
 ---
 <div>{{APIRef}}</div>
 
@@ -117,7 +118,7 @@ ctx.fillRect(20, 20, 200, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.createLinearGradient")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.createPattern
 ---
 <div>{{APIRef}}</div>
 
@@ -153,7 +154,7 @@ document.body.appendChild(canvas);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.createPattern")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.html
@@ -8,6 +8,7 @@ tags:
 - Gradients
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.createRadialGradient
 ---
 <div>{{APIRef}}</div>
 
@@ -119,7 +120,7 @@ ctx.fillRect(20, 20, 160, 160);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.createRadialGradient")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/currenttransform/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - Deprecated
+browser-compat: api.CanvasRenderingContext2D.currentTransform
 ---
 <div>{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -63,7 +64,7 @@ ctx.fillRect(0, 0, 100, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.currentTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/direction/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/direction/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.direction
 ---
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
@@ -85,7 +86,7 @@ ctx.fillText('Hi!', 150, 130);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.direction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.html
@@ -8,6 +8,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.drawFocusIfNeeded
 ---
 <div>{{APIRef}}</div>
 
@@ -131,7 +132,7 @@ function drawButton(el, x, y) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.drawFocusIfNeeded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.drawImage
 ---
 <div>{{APIRef}}</div>
 
@@ -184,7 +185,7 @@ function drawImageActualSize() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.drawImage")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Non-standard
 - Reference
+browser-compat: api.CanvasRenderingContext2D.drawWidgetAsOnScreen
 ---
 <div>{{APIRef}} {{non-standard_header}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.drawWidgetAsOnScreen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.html
@@ -9,6 +9,7 @@ tags:
 - Non-standard
 - Reference
 - Deprecated
+browser-compat: api.CanvasRenderingContext2D.drawWindow
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 
@@ -134,7 +135,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.drawWindow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.ellipse
 ---
 <div>{{APIRef}}</div>
 
@@ -138,7 +139,7 @@ ctx.fill();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.ellipse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fill/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fill/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.fill
 ---
 <div>{{APIRef}}</div>
 
@@ -120,7 +121,7 @@ ctx.fill(region, 'evenodd');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.fill")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.fillRect
 ---
 <div>{{APIRef}}</div>
 
@@ -102,7 +103,7 @@ ctx.fillRect(0, 0, canvas.width, canvas.height);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.fillRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.fillStyle
 ---
 <div>{{APIRef}}</div>
 
@@ -119,7 +120,7 @@ for (let i = 0; i &lt; 6; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.fillStyle")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_note">WebKit/Blink-specific note</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.html
@@ -15,6 +15,7 @@ tags:
 - Reference
 - Text
 - fillText
+browser-compat: api.CanvasRenderingContext2D.fillText
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -154,7 +155,7 @@ ctx.fillText('Hello world', 50, 90, 140);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.fillText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Experimental
   - Property
+browser-compat: api.CanvasRenderingContext2D.filter
 ---
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
@@ -169,7 +170,7 @@ image.addEventListener('load', e =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.filter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/font/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/font/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.font
 ---
 <div>{{APIRef}}</div>
 
@@ -86,7 +87,7 @@ f.load().then(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.font")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - Canvas
 - CanvasRenderingContext2D
+browser-compat: api.CanvasRenderingContext2D.getContextAttributes
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -76,7 +77,7 @@ ctx.getContextAttributes();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.getContextAttributes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.html
@@ -15,6 +15,7 @@ tags:
 - copy
 - getImageData
 - img
+browser-compat: api.CanvasRenderingContext2D.getImageData
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -132,7 +133,7 @@ ctx.putImageData(imageData, 150, 10);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.getImageData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.getLineDash
 ---
 <div>{{APIRef}}</div>
 
@@ -80,7 +81,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.getLineDash")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.getTransform
 ---
 <div>{{APIRef}}</div>
 
@@ -144,7 +145,7 @@ ctx2.fill();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.getTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.globalAlpha
 ---
 <div>{{APIRef}}</div>
 
@@ -132,7 +133,7 @@ for (let i = 0; i &lt; 7; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.globalAlpha")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.html
@@ -9,6 +9,7 @@ tags:
 - Compositing
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.globalCompositeOperation
 ---
 <div>{{APIRef}}</div>
 
@@ -90,7 +91,7 @@ ctx.fillRect(50, 50, 100, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.globalCompositeOperation")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.imageSmoothingEnabled
 ---
 <div>{{APIRef}}</div>
 
@@ -104,7 +105,7 @@ img.onload = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.imageSmoothingEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - imageSmoothingQuality
+browser-compat: api.CanvasRenderingContext2D.imageSmoothingQuality
 ---
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
@@ -90,7 +91,7 @@ img.onload = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.imageSmoothingQuality")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.html
@@ -8,6 +8,7 @@ tags:
   - Games
   - Graphics
   - Reference
+browser-compat: api.CanvasRenderingContext2D
 ---
 <div>{{APIRef}}</div>
 
@@ -405,7 +406,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.isPointInPath
 ---
 <div>{{APIRef}}</div>
 
@@ -145,7 +146,7 @@ canvas.addEventListener('mousemove', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.isPointInPath")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_note">Gecko-specific note</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.isPointInStroke
 ---
 <div>{{APIRef}}</div>
 
@@ -135,7 +136,7 @@ canvas.addEventListener('mousemove', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.isPointInStroke")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.lineCap
 ---
 <div>{{APIRef}}</div>
 
@@ -132,7 +133,7 @@ for (let i = 0; i &lt; lineCap.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.lineCap")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.lineDashOffset
 ---
 <div>{{APIRef}}</div>
 
@@ -127,7 +128,7 @@ march();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.lineDashOffset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Property
   - Reference
+browser-compat: api.CanvasRenderingContext2D.lineJoin
 ---
 <div>{{APIRef}}</div>
 
@@ -134,7 +135,7 @@ for (let i = 0; i &lt; lineJoin.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.lineJoin")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.lineTo
 ---
 <div>{{APIRef}}</div>
 
@@ -113,7 +114,7 @@ ctx.stroke();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.lineTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.lineWidth
 ---
 <div>{{APIRef}}</div>
 
@@ -90,7 +91,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.lineWidth")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.measureText
 ---
 <div>{{APIRef}}</div>
 
@@ -66,7 +67,7 @@ console.log(text.width);  // 56;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.measureText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Property
   - Reference
+browser-compat: api.CanvasRenderingContext2D.miterLimit
 ---
 <div>{{APIRef}}</div>
 
@@ -108,7 +109,7 @@ window.addEventListener("load", drawCanvas);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.miterLimit")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.moveTo
 ---
 <div>{{APIRef}}</div>
 
@@ -81,7 +82,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.moveTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.putImageData
 ---
 <div>{{APIRef}}</div>
 
@@ -168,7 +169,7 @@ after: Uint8ClampedArray(4) [ 255, 255, 255, 1 ]</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.putImageData")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.quadraticCurveTo
 ---
 <div>{{APIRef}}</div>
 
@@ -128,7 +129,7 @@ ctx.stroke();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.quadraticCurveTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.rect
 ---
 <div>{{APIRef}}</div>
 
@@ -95,7 +96,7 @@ ctx.fill();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.rect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/removehitregion/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/removehitregion/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - Deprecated
+browser-compat: api.CanvasRenderingContext2D.removeHitRegion
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 
@@ -62,7 +63,7 @@ ctx.removeHitRegion('eyes');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.removeHitRegion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.html
@@ -7,6 +7,7 @@ tags:
 - Experimental
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.resetTransform
 ---
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
@@ -116,7 +117,7 @@ ctx.fillRect(40, 90, 50, 20);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.resetTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.restore
 ---
 <div>{{APIRef}}</div>
 
@@ -78,7 +79,7 @@ ctx.fillRect(150, 40, 100, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.restore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.rotate
 ---
 <div>{{APIRef}}</div>
 
@@ -147,7 +148,7 @@ ctx.fillRect(80, 60, 140, 30);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.rotate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.save
 ---
 <div>{{APIRef}}</div>
 
@@ -103,7 +104,7 @@ ctx.fillRect(150, 40, 100, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.save")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.scale
 ---
 <div>{{APIRef}}</div>
 
@@ -133,7 +134,7 @@ ctx.setTransform(1, 0, 0, 1, 0, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.scale")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.scrollPathIntoView
 ---
 <div>{{APIRef}} {{SeeCompatTable}}</div>
 
@@ -116,7 +117,7 @@ window.addEventListener("load", drawCanvas);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.scrollPathIntoView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - patterns
 - setLineDash
+browser-compat: api.CanvasRenderingContext2D.setLineDash
 ---
 <div>{{APIRef}}</div>
 
@@ -142,7 +143,7 @@ drawDashedLine([12, 3, 3]);  // Equals [12, 3, 3, 12, 3, 3]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.setLineDash")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.setTransform
 ---
 <div>{{APIRef}}</div>
 
@@ -189,7 +190,7 @@ ctx2.fill();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.setTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.shadowBlur
 ---
 <div>{{APIRef}}</div>
 
@@ -88,7 +89,7 @@ ctx.fillRect(20, 20, 150, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.shadowBlur")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.shadowColor
 ---
 <div>{{APIRef}}</div>
 
@@ -133,7 +134,7 @@ ctx.strokeRect(10, 10, 150, 100);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.shadowColor")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_notes">WebKit/Blink-specific notes</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.shadowOffsetX
 ---
 <div>{{APIRef}}</div>
 
@@ -91,7 +92,7 @@ ctx.fillRect(20, 20, 150, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.shadowOffsetX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.shadowOffsetY
 ---
 <div>{{APIRef}}</div>
 
@@ -90,7 +91,7 @@ ctx.fillRect(20, 20, 150, 80);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.shadowOffsetY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.stroke
 ---
 <div>{{APIRef}}</div>
 
@@ -160,7 +161,7 @@ ctx.fill();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.stroke")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.strokeRect
 ---
 <div>{{APIRef}}</div>
 
@@ -115,7 +116,7 @@ ctx.strokeRect(30, 30, 160, 90);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.strokeRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.strokeStyle
 ---
 <div>{{APIRef}}</div>
 
@@ -118,7 +119,7 @@ for (let i = 0; i &lt; 6; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.strokeStyle")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebKitBlink-specific_note">WebKit/Blink-specific note</h3>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.html
@@ -14,6 +14,7 @@ tags:
 - Stroke String
 - Stroking Text
 - strokeText
+browser-compat: api.CanvasRenderingContext2D.strokeText
 ---
 <div>{{APIRef}}</div>
 
@@ -146,7 +147,7 @@ ctx.strokeText('Hello world', 50, 90, 140);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.strokeText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.textAlign
 ---
 <div>{{APIRef}}</div>
 
@@ -138,7 +139,7 @@ ctx.fillText('End-aligned', canvas.width, 120);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.textAlign")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Property
 - Reference
+browser-compat: api.CanvasRenderingContext2D.textBaseline
 ---
 <div>{{APIRef}}</div>
 
@@ -101,7 +102,7 @@ baselines.forEach(function (baseline, index) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.textBaseline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.html
@@ -7,6 +7,7 @@ tags:
 - CanvasRenderingContext2D
 - Method
 - Reference
+browser-compat: api.CanvasRenderingContext2D.transform
 ---
 <div>{{APIRef}}</div>
 
@@ -136,7 +137,7 @@ ctx.fillRect(0, 0, 100, 100);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.transform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.html
@@ -7,6 +7,7 @@ tags:
   - CanvasRenderingContext2D
   - Method
   - Reference
+browser-compat: api.CanvasRenderingContext2D.translate
 ---
 <div>{{APIRef}}</div>
 
@@ -99,7 +100,7 @@ ctx.fillRect(0, 0, 80, 80);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CanvasRenderingContext2D.translate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/caretposition/index.html
+++ b/files/en-us/web/api/caretposition/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.CaretPosition
 ---
 <p>{{SeeCompatTable}} {{ APIRef("CSSOM") }}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CaretPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cdatasection/index.html
+++ b/files/en-us/web/api/cdatasection/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM
 - Interface
 - Reference
+browser-compat: api.CDATASection
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CDATASection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.html
@@ -8,6 +8,7 @@ tags:
   - Constructor
   - Reference
   - Web Audio API
+browser-compat: api.ChannelMergerNode.ChannelMergerNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -70,4 +71,4 @@ var myMerger = new ChannelMergerNode(ac, options);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChannelMergerNode.ChannelMergerNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/channelmergernode/index.html
+++ b/files/en-us/web/api/channelmergernode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.ChannelMergerNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChannelMergerNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.html
@@ -10,6 +10,7 @@ tags:
   - Splitter
   - Web Audio
   - Web Audio API
+browser-compat: api.ChannelSplitterNode.ChannelSplitterNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -67,4 +68,4 @@ var mySplitter = new ChannelSplitterNode(ac, options);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChannelSplitterNode.ChannelSplitterNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/channelsplitternode/index.html
+++ b/files/en-us/web/api/channelsplitternode/index.html
@@ -10,6 +10,7 @@ tags:
   - Splitter
   - Web Audio
   - Web Audio API
+browser-compat: api.ChannelSplitterNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChannelSplitterNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/characterdata/appenddata/index.html
+++ b/files/en-us/web/api/characterdata/appenddata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - CharacterData
+browser-compat: api.CharacterData.appendData
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.appendData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/characterdata/data/index.html
+++ b/files/en-us/web/api/characterdata/data/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - CharacterData
+browser-compat: api.CharacterData.data
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -36,4 +37,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.data")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/characterdata/deletedata/index.html
+++ b/files/en-us/web/api/characterdata/deletedata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - CharacterData
+browser-compat: api.CharacterData.deleteData
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.deleteData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/characterdata/index.html
+++ b/files/en-us/web/api/characterdata/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Interface
   - Node
+browser-compat: api.CharacterData
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/characterdata/insertdata/index.html
+++ b/files/en-us/web/api/characterdata/insertdata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - CharacterData
+browser-compat: api.CharacterData.insertData
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.insertData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/characterdata/remove/index.html
+++ b/files/en-us/web/api/characterdata/remove/index.html
@@ -6,6 +6,7 @@ tags:
   - CharacterData
   - DOM
   - Method
+browser-compat: api.CharacterData.remove
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -48,7 +49,7 @@ text.remove(); // Removes the text
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/characterdata/replacedata/index.html
+++ b/files/en-us/web/api/characterdata/replacedata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - CharacterData
+browser-compat: api.CharacterData.replaceData
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.replaceData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/characterdata/substringdata/index.html
+++ b/files/en-us/web/api/characterdata/substringdata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - CharacterData
+browser-compat: api.CharacterData.substringData
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CharacterData.substringData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/childnode/after/index.html
+++ b/files/en-us/web/api/childnode/after/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.ChildNode.after
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -172,7 +173,7 @@ minified:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChildNode.after")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/childnode/before/index.html
+++ b/files/en-us/web/api/childnode/before/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.ChildNode.before
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -133,7 +134,7 @@ console.log(parent.outerHTML);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChildNode.before")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/childnode/index.html
+++ b/files/en-us/web/api/childnode/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Interface
   - Node
+browser-compat: api.ChildNode
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ChildNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/client/frametype/index.html
+++ b/files/en-us/web/api/client/frametype/index.html
@@ -11,6 +11,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - frameType
+browser-compat: api.Client.frameType
 ---
 <p>{{SeeCompatTable}}{{APIRef("Service Workers API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Client.frameType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/client/id/index.html
+++ b/files/en-us/web/api/client/id/index.html
@@ -11,6 +11,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - id
+browser-compat: api.Client.id
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Client.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/client/index.html
+++ b/files/en-us/web/api/client/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorkerClient
   - ServiceWorkers
+browser-compat: api.Client
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Client")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/client/postmessage/index.html
+++ b/files/en-us/web/api/client/postmessage/index.html
@@ -11,6 +11,7 @@ tags:
 - Service worker API
 - ServiceWorker
 - postMessage
+browser-compat: api.Client.postMessage
 ---
 <p>{{APIRef("Service Worker API")}}</p>
 
@@ -97,4 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Client.postMessage")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/client/type/index.html
+++ b/files/en-us/web/api/client/type/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Service Workers
 - Type
+browser-compat: api.Client.type
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -70,4 +71,4 @@ self.addEventListener("message", function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Client.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/client/url/index.html
+++ b/files/en-us/web/api/client/url/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - URL
+browser-compat: api.Client.url
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Client.url")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/clients/claim/index.html
+++ b/files/en-us/web/api/clients/claim/index.html
@@ -10,6 +10,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - claim
+browser-compat: api.Clients.claim
 ---
 <p>{{APIRef("Service Worker Clients")}}</p>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clients.claim")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clients/get/index.html
+++ b/files/en-us/web/api/clients/get/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - get
+browser-compat: api.Clients.get
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clients.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/clients/index.html
+++ b/files/en-us/web/api/clients/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - Workers
+browser-compat: api.Clients
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clients")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clients/matchall/index.html
+++ b/files/en-us/web/api/clients/matchall/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - ServiceWorker
+browser-compat: api.Clients.matchAll
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -81,4 +82,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clients.matchAll")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/clients/openwindow/index.html
+++ b/files/en-us/web/api/clients/openwindow/index.html
@@ -10,6 +10,7 @@ tags:
 - Service Workers
 - ServiceWorker
 - openWindow
+browser-compat: api.Clients.openWindow
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -93,4 +94,4 @@ self.addEventListener('notificationclick', e =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clients.openWindow")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/clipboard/index.html
+++ b/files/en-us/web/api/clipboard/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - copy
   - paste
+browser-compat: api.Clipboard
 ---
 <p>{{APIRef("Clipboard API")}}</p>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clipboard")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboard/read/index.html
+++ b/files/en-us/web/api/clipboard/read/index.html
@@ -15,6 +15,7 @@ tags:
 - copy
 - paste
 - read
+browser-compat: api.Clipboard.read
 ---
 <div>{{APIRef("Clipboard API")}}</div>
 
@@ -108,7 +109,7 @@ navigator.permissions.query({name: "clipboard-read"}).then(result =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clipboard.read")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboard/readtext/index.html
+++ b/files/en-us/web/api/clipboard/readtext/index.html
@@ -16,6 +16,7 @@ tags:
 - copy
 - paste
 - readText
+browser-compat: api.Clipboard.readText
 ---
 <div>{{APIRef("Clipboard API")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clipboard.readText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboard/write/index.html
+++ b/files/en-us/web/api/clipboard/write/index.html
@@ -14,6 +14,7 @@ tags:
 - copy
 - paste
 - write
+browser-compat: api.Clipboard.write
 ---
 <div>{{APIRef("Clipboard API")}}</div>
 
@@ -113,7 +114,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clipboard.write")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboard/writetext/index.html
+++ b/files/en-us/web/api/clipboard/writetext/index.html
@@ -14,6 +14,7 @@ tags:
 - copy
 - paste
 - writeText
+browser-compat: api.Clipboard.writeText
 ---
 <div>{{APIRef("Clipboard API")}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Clipboard.writeText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboardevent/clipboarddata/index.html
+++ b/files/en-us/web/api/clipboardevent/clipboarddata/index.html
@@ -12,6 +12,7 @@ tags:
 - Read-only
 - copy
 - paste
+browser-compat: api.ClipboardEvent.clipboardData
 ---
 <p>{{ apiref("Clipboard API") }} {{SeeCompatTable}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardEvent.clipboardData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboardevent/clipboardevent/index.html
+++ b/files/en-us/web/api/clipboardevent/clipboardevent/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - copy
   - paste
+browser-compat: api.ClipboardEvent.ClipboardEvent
 ---
 <p>{{APIRef("Clipboard API")}}{{SeeCompatTable}}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardEvent.ClipboardEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboardevent/index.html
+++ b/files/en-us/web/api/clipboardevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Interface
   - copy
   - paste
+browser-compat: api.ClipboardEvent
 ---
 <p>{{APIRef("Clipboard API")}} {{SeeCompatTable}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - copy
 - paste
+browser-compat: api.ClipboardItem.ClipboardItem
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardItem.ClipboardItem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboarditem/gettype/index.html
+++ b/files/en-us/web/api/clipboarditem/gettype/index.html
@@ -10,6 +10,7 @@ tags:
 - copy
 - getTypes
 - paste
+browser-compat: api.ClipboardItem.getType
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardItem.getType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboarditem/index.html
+++ b/files/en-us/web/api/clipboarditem/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - copy
   - paste
+browser-compat: api.ClipboardItem
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
@@ -123,7 +124,7 @@ tags:
 
 <h2 id="browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardItem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/clipboarditem/types/index.html
+++ b/files/en-us/web/api/clipboarditem/types/index.html
@@ -13,6 +13,7 @@ tags:
 - Types
 - copy
 - paste
+browser-compat: api.ClipboardItem.types
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardItem.types")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/closeevent/closeevent/index.html
+++ b/files/en-us/web/api/closeevent/closeevent/index.html
@@ -6,6 +6,7 @@ tags:
 - CloseEvent
 - Constructor
 - Reference
+browser-compat: api.CloseEvent.CloseEvent
 ---
 <div>{{APIRef("Websockets API")}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CloseEvent.CloseEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/closeevent/index.html
+++ b/files/en-us/web/api/closeevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Web
   - WebSocket
   - WebSockets
+browser-compat: api.CloseEvent
 ---
 <div>{{APIRef("Websockets API")}}</div>
 
@@ -178,7 +179,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CloseEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/closeevent/initcloseevent/index.html
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - Deprecated
+browser-compat: api.CloseEvent.initCloseEvent
 ---
 <p>{{APIRef("Websockets API")}}{{deprecated_header}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CloseEvent.initCloseEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/comment/comment/index.html
+++ b/files/en-us/web/api/comment/comment/index.html
@@ -6,6 +6,7 @@ tags:
   - Comment
   - Constructor
   - DOM
+browser-compat: api.Comment.Comment
 ---
 <p>{{ApiRef("DOM")}}{{SeeCompatTable}}</p>
 
@@ -42,7 +43,7 @@ comment2 = new Comment(&quot;This is a comment&quot;);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Comment.Comment")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note">
   <p><strong>Note</strong>: For browsers where this constructor is not supported,

--- a/files/en-us/web/api/comment/index.html
+++ b/files/en-us/web/api/comment/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - DOM
   - Reference
+browser-compat: api.Comment
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Comment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/compositionevent/compositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/compositionevent/index.html
@@ -6,6 +6,7 @@ tags:
 - CompositionEvent
 - Constructor
 - Reference
+browser-compat: api.CompositionEvent.CompositionEvent
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompositionEvent.CompositionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/compositionevent/data/index.html
+++ b/files/en-us/web/api/compositionevent/data/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - data
+browser-compat: api.CompositionEvent.data
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompositionEvent.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/compositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Event
   - Reference
+browser-compat: api.CompositionEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompositionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.html
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - initCompositionEvent
+browser-compat: api.CompositionEvent.initCompositionEvent
 ---
 <p>{{deprecated_header}}{{APIRef("DOM Events")}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompositionEvent.initCompositionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/compositionevent/locale/index.html
+++ b/files/en-us/web/api/compositionevent/locale/index.html
@@ -8,6 +8,7 @@ tags:
 - Locale
 - Property
 - Reference
+browser-compat: api.CompositionEvent.locale
 ---
 <div>{{deprecated_header}}{{APIRef("DOM Events")}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompositionEvent.locale")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/compressionstream/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - CompressionStream
+browser-compat: api.CompressionStream.CompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompressionStream.CompressionStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/compressionstream/index.html
+++ b/files/en-us/web/api/compressionstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - CompressionStream
+browser-compat: api.CompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompressionStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/compressionstream/readable/index.html
+++ b/files/en-us/web/api/compressionstream/readable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - readable
   - CompressionStream
+browser-compat: api.CompressionStream.readable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -45,4 +46,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompressionStream.readable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/compressionstream/writable/index.html
+++ b/files/en-us/web/api/compressionstream/writable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - writable
   - CompressionStream
+browser-compat: api.CompressionStream.writable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -43,4 +44,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CompressionStream.writable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/assert/index.html
+++ b/files/en-us/web/api/console/assert/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Development
   - console
   - web console
+browser-compat: api.Console.assert
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -105,4 +106,4 @@ for (let number = 2; number &lt;= 5; number += 1) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.assert")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/clear/index.html
+++ b/files/en-us/web/api/console/clear/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - console
 - web console
+browser-compat: api.Console.clear
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.clear")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/count/index.html
+++ b/files/en-us/web/api/console/count/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Development
 - web console
+browser-compat: api.Console.count
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -106,4 +107,4 @@ console.count("alice");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.count")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/countreset/index.html
+++ b/files/en-us/web/api/console/countreset/index.html
@@ -10,6 +10,7 @@ tags:
 - Web Development
 - console
 - web console
+browser-compat: api.Console.countReset
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -114,4 +115,4 @@ console.count("alice");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.countReset")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/debug/index.html
+++ b/files/en-us/web/api/console/debug/index.html
@@ -13,6 +13,7 @@ tags:
   - log
   - output
   - print
+browser-compat: api.Console.debug
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -71,4 +72,4 @@ console.debug(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.debug")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/dir/index.html
+++ b/files/en-us/web/api/console/dir/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Development
   - console
   - web console
+browser-compat: api.Console.dir
 ---
 <p>{{APIRef("Console API")}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.dir")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/dirxml/index.html
+++ b/files/en-us/web/api/console/dirxml/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Web Development
 - web console
+browser-compat: api.Console.dirxml
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -49,5 +50,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.dirxml")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/console/error/index.html
+++ b/files/en-us/web/api/console/error/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Web Development
   - web console
+browser-compat: api.Console.error
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -62,7 +63,7 @@ console.error(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <div>
 
-	<p>{{Compat("api.Console.error")}}</p>
+	<p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/console/group/index.html
+++ b/files/en-us/web/api/console/group/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Web Development
   - web console
+browser-compat: api.Console.group
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -86,5 +87,5 @@ console.log("Back to the outer level");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.group")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/console/groupcollapsed/index.html
+++ b/files/en-us/web/api/console/groupcollapsed/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Development
   - web console
+browser-compat: api.Console.groupCollapsed
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -59,5 +60,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.groupCollapsed")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/console/groupend/index.html
+++ b/files/en-us/web/api/console/groupend/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Web Development
   - web console
+browser-compat: api.Console.groupEnd
 ---
 <p>{{APIRef("Console API")}}</p>
 
@@ -49,5 +50,5 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.groupEnd")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/console/index.html
+++ b/files/en-us/web/api/console/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - console
   - web console
+browser-compat: api.Console
 ---
 <p>{{APIRef("Console API")}}</p>
 
@@ -267,7 +268,7 @@ foo();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/api/console/info/index.html
+++ b/files/en-us/web/api/console/info/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Web Development
   - web console
+browser-compat: api.Console.info
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -61,7 +62,7 @@ console.info(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.info")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/log/index.html
+++ b/files/en-us/web/api/console/log/index.html
@@ -14,6 +14,7 @@ tags:
   - console.log()
   - difference
   - web console
+browser-compat: api.Console.log
 ---
 <p>{{APIRef("Console API")}}</p>
 
@@ -106,7 +107,7 @@ console.log(<var>msg</var> [, <var>subst1</var>, ..., <var>substN</var>]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.log")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/profile/index.html
+++ b/files/en-us/web/api/console/profile/index.html
@@ -11,6 +11,7 @@ tags:
 - Web Development
 - profile
 - web console
+browser-compat: api.Console.profile
 ---
 <p>{{APIRef("Console API")}}{{Non-standard_header}}</p>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.profile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/profileend/index.html
+++ b/files/en-us/web/api/console/profileend/index.html
@@ -11,6 +11,7 @@ tags:
 - Web Development
 - profileEnd
 - web console
+browser-compat: api.Console.profileEnd
 ---
 <p>{{APIRef("Console API")}}{{Non-standard_header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.profileEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/table/index.html
+++ b/files/en-us/web/api/console/table/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Web Development
   - web console
+browser-compat: api.Console.table
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -160,4 +161,4 @@ console.table(data, columns);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.table")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/console/time/index.html
+++ b/files/en-us/web/api/console/time/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Development
   - console
   - web console
+browser-compat: api.Console.time
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.time")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/timeend/index.html
+++ b/files/en-us/web/api/console/timeend/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Development
   - console
   - web console
+browser-compat: api.Console.timeEnd
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -78,6 +79,6 @@ console.timeEnd("answer time");
 
 <div>
 
-	<p>{{Compat("api.Console.timeEnd")}}</p>
+	<p>{{Compat}}</p>
 </div>
 

--- a/files/en-us/web/api/console/timelog/index.html
+++ b/files/en-us/web/api/console/timelog/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Development
   - console
   - web console
+browser-compat: api.Console.timeLog
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -93,5 +94,5 @@ console.timeEnd("answer time");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.timeLog")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/console/timestamp/index.html
+++ b/files/en-us/web/api/console/timestamp/index.html
@@ -9,6 +9,7 @@ tags:
   - Non-standard
   - Web Development
   - web console
+browser-compat: api.Console.timeStamp
 ---
 <div>{{APIRef("Console API")}}{{Non-standard_header}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.timeStamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/console/trace/index.html
+++ b/files/en-us/web/api/console/trace/index.html
@@ -14,6 +14,7 @@ tags:
   - console.trace()
   - trace
   - web console
+browser-compat: api.Console.trace
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -79,5 +80,5 @@ foo
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.trace")}}</p>
+<p>{{Compat}}</p>
 

--- a/files/en-us/web/api/console/warn/index.html
+++ b/files/en-us/web/api/console/warn/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Web Development
   - web console
+browser-compat: api.Console.warn
 ---
 <div>{{APIRef("Console API")}}</div>
 
@@ -64,7 +65,7 @@ console.warn(<em>msg</em> [, <em>subst1</em>, ..., <em>substN</em>]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Console.warn")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constantsourcenode/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/constantsourcenode/index.html
@@ -9,6 +9,7 @@ tags:
 - Constructor
 - Reference
 - Web Audio API
+browser-compat: api.ConstantSourceNode.ConstantSourceNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -74,4 +75,4 @@ let myConstantSource = new ConstantSourceNode(audioContext, { offset: 0.5 });</p
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstantSourceNode.ConstantSourceNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/constantsourcenode/index.html
+++ b/files/en-us/web/api/constantsourcenode/index.html
@@ -9,6 +9,7 @@ tags:
   - Media
   - Reference
   - Web Audio API
+browser-compat: api.ConstantSourceNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -116,7 +117,7 @@ gainNode3.connect(context.destination);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstantSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constantsourcenode/offset/index.html
+++ b/files/en-us/web/api/constantsourcenode/offset/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Web Audio API
+browser-compat: api.ConstantSourceNode.offset
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -99,7 +100,7 @@ constantSource.connect(gainNode3.gain);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstantSourceNode.offset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constrainboolean/index.html
+++ b/files/en-us/web/api/constrainboolean/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Web
   - WebRTC
+browser-compat: api.ConstrainBoolean
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstrainBoolean")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constraindomstring/index.html
+++ b/files/en-us/web/api/constraindomstring/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Web
   - WebRTC
+browser-compat: api.ConstrainDOMString
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstrainDOMString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constraindouble/index.html
+++ b/files/en-us/web/api/constraindouble/index.html
@@ -11,6 +11,7 @@ tags:
   - Media Stream API
   - Reference
   - WebRTC
+browser-compat: api.ConstrainDouble
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstrainDouble")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/constrainulong/index.html
+++ b/files/en-us/web/api/constrainulong/index.html
@@ -12,6 +12,7 @@ tags:
   - Media Streams API
   - Reference
   - WebRTC
+browser-compat: api.ConstrainULong
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConstrainULong")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contactsmanager/getproperties/index.html
+++ b/files/en-us/web/api/contactsmanager/getproperties/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - PWA
 - contact picker
+browser-compat: api.ContactsManager.getProperties
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContactsManager.getProperties")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/contactsmanager/index.html
+++ b/files/en-us/web/api/contactsmanager/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - PWA
   - contact picker
+browser-compat: api.ContactsManager
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
@@ -95,7 +96,7 @@ async function getContacts() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContactsManager")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contactsmanager/select/index.html
+++ b/files/en-us/web/api/contactsmanager/select/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - PWA
 - contact picker
+browser-compat: api.ContactsManager.select
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
@@ -104,4 +105,4 @@ async function getContacts() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContactsManager.select")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/contentindex/add/index.html
+++ b/files/en-us/web/api/contentindex/add/index.html
@@ -10,6 +10,7 @@ tags:
 - PWA
 - content index
 - content indexing
+browser-compat: api.ContentIndex.add
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -155,7 +156,7 @@ self.registration.index.add(item);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndex.add")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contentindex/delete/index.html
+++ b/files/en-us/web/api/contentindex/delete/index.html
@@ -11,6 +11,7 @@ tags:
 - content index
 - content indexing
 - delete
+browser-compat: api.ContentIndex.delete
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndex.delete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contentindex/getall/index.html
+++ b/files/en-us/web/api/contentindex/getall/index.html
@@ -10,6 +10,7 @@ tags:
 - PWA
 - content indexing
 - getAll
+browser-compat: api.ContentIndex.getAll
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -140,7 +141,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndex.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contentindex/index.html
+++ b/files/en-us/web/api/contentindex/index.html
@@ -8,6 +8,7 @@ tags:
   - PWA
   - content index
   - content indexing
+browser-compat: api.ContentIndex
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -175,7 +176,7 @@ const contentIndexItems = self.registration.index.getAll();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndex")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.html
@@ -10,6 +10,7 @@ tags:
 - content index
 - content indexing
 - events
+browser-compat: api.ContentIndexEvent.ContentIndexEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -76,7 +77,7 @@ ciEvent.id; // should return 'unique-content-id'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndexEvent.ContentIndexEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contentindexevent/id/index.html
+++ b/files/en-us/web/api/contentindexevent/id/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - content indexing
 - events
+browser-compat: api.ContentIndexEvent.id
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndexEvent.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/contentindexevent/index.html
+++ b/files/en-us/web/api/contentindexevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - PWA
   - content indexing
+browser-compat: api.ContentIndexEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Content Index API")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ContentIndexEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/convolvernode/buffer/index.html
+++ b/files/en-us/web/api/convolvernode/buffer/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Web Audio API
+browser-compat: api.ConvolverNode.buffer
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -79,7 +80,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConvolverNode.buffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/convolvernode/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.html
@@ -8,6 +8,7 @@ tags:
 - Convolver
 - Reference
 - Web Audio API
+browser-compat: api.ConvolverNode.ConvolverNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConvolverNode.ConvolverNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/convolvernode/index.html
+++ b/files/en-us/web/api/convolvernode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.ConvolverNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -112,7 +113,7 @@ reverb.connect(audioCtx.destination);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConvolverNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/convolvernode/normalize/index.html
+++ b/files/en-us/web/api/convolvernode/normalize/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - parent
+browser-compat: api.ConvolverNode.normalize
 ---
 <div>{{ APIRef("Web Audio API") }}</div>
 
@@ -83,7 +84,7 @@ convolver.buffer = concertHallBuffer;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ConvolverNode.normalize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.html
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - changed
   - CookieChangeEvent
+browser-compat: api.CookieChangeEvent.changed
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -86,4 +87,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieChangeEvent.changed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - CookieChangeEvent
+browser-compat: api.CookieChangeEvent.CookieChangeEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieChangeEvent.CookieChangeEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.html
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - deleted
   - CookieChangeEvent
+browser-compat: api.CookieChangeEvent.deleted
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieChangeEvent.deleted")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiechangeevent/index.html
+++ b/files/en-us/web/api/cookiechangeevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - CookieChangeEvent
+browser-compat: api.CookieChangeEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -77,4 +78,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieChangeEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestore/delete/index.html
+++ b/files/en-us/web/api/cookiestore/delete/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - delete()
   - CookieStore
+browser-compat: api.CookieStore.delete
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
@@ -79,4 +80,4 @@ console.log(result);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStore.delete")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestore/get/index.html
+++ b/files/en-us/web/api/cookiestore/get/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - get()
   - CookieStore
+browser-compat: api.CookieStore.get
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
@@ -114,4 +115,4 @@ if (cookie) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStore.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestore/getall/index.html
+++ b/files/en-us/web/api/cookiestore/getall/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - getAll()
   - CookieStore
+browser-compat: api.CookieStore.getAll
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
@@ -79,4 +80,4 @@ if (cookies) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStore.getAll")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestore/index.html
+++ b/files/en-us/web/api/cookiestore/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - CookieStore
+browser-compat: api.CookieStore
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
@@ -74,4 +75,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStore")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestore/onchange/index.html
+++ b/files/en-us/web/api/cookiestore/onchange/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - onchange
   - CookieStore
+browser-compat: api.CookieStore.onchange
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
@@ -50,4 +51,4 @@ CookieStore.addEventListener('change', function() { ... })</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStore.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestore/set/index.html
+++ b/files/en-us/web/api/cookiestore/set/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - set()
   - CookieStore
+browser-compat: api.CookieStore.set
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}</div>
 
@@ -103,4 +104,4 @@ cookieStore.set({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStore.set")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - getSubscriptions
   - CookieStoreManager
+browser-compat: api.CookieStoreManager.getSubscriptions
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStoreManager.getSubscriptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestoremanager/index.html
+++ b/files/en-us/web/api/cookiestoremanager/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - CookieStoreManager
+browser-compat: api.CookieStoreManager
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -56,4 +57,4 @@ await registration.cookies.subscribe(subscriptions);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStoreManager")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - subscribe
   - CookieStoreManager
+browser-compat: api.CookieStoreManager.subscribe
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -73,4 +74,4 @@ cookieStore.set({name: 'cookie1', value: 'cookie-value', path: '/path/two/'}); /
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStoreManager.subscribe")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - unsubscribe
   - CookieStoreManager
+browser-compat: api.CookieStoreManager.unsubscribe
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}</div>
 
@@ -67,4 +68,4 @@ await registration.cookies.unsubscribe(subscriptions);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CookieStoreManager.unsubscribe")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Reference
   - Streams
+browser-compat: api.CountQueuingStrategy.CountQueuingStrategy
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -75,4 +76,4 @@ var size = queuingStrategy.size();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CountQueuingStrategy.CountQueuingStrategy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/countqueuingstrategy/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Streams
+browser-compat: api.CountQueuingStrategy
 ---
 <p>{{SeeCompatTable}}{{APIRef("Streams")}}</p>
 
@@ -70,4 +71,4 @@ var size = queueingStrategy.size();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CountQueuingStrategy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/countqueuingstrategy/size/index.html
+++ b/files/en-us/web/api/countqueuingstrategy/size/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Streams
   - size
+browser-compat: api.CountQueuingStrategy.size
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -68,4 +69,4 @@ var size = queuingStrategy.size();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CountQueuingStrategy.size")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/crashreportbody/index.html
+++ b/files/en-us/web/api/crashreportbody/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Reporting API
+browser-compat: api.CrashReportBody
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CrashReportBody")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/credential/id/index.html
+++ b/files/en-us/web/api/credential/id/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - credential management
 - id
+browser-compat: api.Credential.id
 ---
 <p>{{SeeCompatTable}}{{APIRef("")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Credential.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/credential/index.html
+++ b/files/en-us/web/api/credential/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - credential management
+browser-compat: api.Credential
 ---
 <div>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</div>
 
@@ -71,4 +72,4 @@ console.assert(pwdCredential.type === "password");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Credential")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/credential/type/index.html
+++ b/files/en-us/web/api/credential/type/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - credential management
+browser-compat: api.Credential.type
 ---
 <p>{{SeeCompatTable}}{{APIRef("")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Credential.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/credentialscontainer/create/index.html
+++ b/files/en-us/web/api/credentialscontainer/create/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - credential management
+browser-compat: api.CredentialsContainer.create
 ---
 <p>{{APIRef("Credential Management")}}{{SeeCompatTable}}</p>
 
@@ -96,4 +97,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CredentialsContainer.create")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/credentialscontainer/get/index.html
+++ b/files/en-us/web/api/credentialscontainer/get/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsExample
 - Reference
 - credential management
+browser-compat: api.CredentialsContainer.get
 ---
 <p>{{APIRef("Credential Management")}}{{SeeCompatTable}}</p>
 
@@ -111,7 +112,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.CredentialsContainer.get")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/credentialscontainer/index.html
+++ b/files/en-us/web/api/credentialscontainer/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsExample
   - Reference
   - credential management
+browser-compat: api.CredentialsContainer
 ---
 <p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</p>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CredentialsContainer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - credential management
+browser-compat: api.CredentialsContainer.preventSilentAccess
 ---
 <p>{{APIRef("")}}{{SeeCompatTable}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CredentialsContainer.preventSilentAccess")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/credentialscontainer/store/index.html
+++ b/files/en-us/web/api/credentialscontainer/store/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsExample
 - Reference
 - credential management
+browser-compat: api.CredentialsContainer.store
 ---
 <p>{{APIRef("")}}{{SeeCompatTable}}</p>
 
@@ -82,4 +83,4 @@ if ("PasswordCredential" in window) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CredentialsContainer.store")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/crypto/getrandomvalues/index.html
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.html
@@ -15,6 +15,7 @@ tags:
 - Reference
 - Web Crypto API
 - getRandomValues
+browser-compat: api.Crypto.getRandomValues
 ---
 <p>{{APIRef("Web Crypto API")}}</p>
 
@@ -110,7 +111,7 @@ for (var i = 0; i &lt; array.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Crypto.getRandomValues")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/crypto/index.html
+++ b/files/en-us/web/api/crypto/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Security
   - Web Crypto API
+browser-compat: api.Crypto
 ---
 <p>{{APIRef("Web Crypto API")}}</p>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Crypto")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/crypto/subtle/index.html
+++ b/files/en-us/web/api/crypto/subtle/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - Web Crypto API
+browser-compat: api.Crypto.subtle
 ---
 <p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Crypto.subtle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cryptokey/index.html
+++ b/files/en-us/web/api/cryptokey/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Security
   - Web Crypto API
+browser-compat: api.CryptoKey
 ---
 <div>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</div>
 
@@ -106,7 +107,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CryptoKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cryptokeypair/index.html
+++ b/files/en-us/web/api/cryptokeypair/index.html
@@ -7,6 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
+browser-compat: api.CryptoKeyPair
 ---
 <div>{{APIRef("Web Crypto API")}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CryptoKeyPair")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/css/escape/index.html
+++ b/files/en-us/web/api/css/escape/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Static
 - escape()
+browser-compat: api.CSS.escape
 ---
 <p>{{APIRef("CSSOM")}}{{SeeCompatTable}}</p>
 
@@ -71,7 +72,7 @@ CSS.escape('\0')              // "\ufffd", the Unicode REPLACEMENT CHARACTER</pr
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSS.escape")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/css/paintworklet/index.html
+++ b/files/en-us/web/api/css/paintworklet/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Worklet
 - paintWorklet
+browser-compat: api.CSS.paintWorklet
 ---
 <p>{{APIRef("CSSOM")}}{{Draft}}{{SeeCompatTable}}{{SecureContext_Header}}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSS.paintWorklet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/css/supports/index.html
+++ b/files/en-us/web/api/css/supports/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - supports
+browser-compat: api.CSS.supports
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -76,7 +77,7 @@ result = CSS.supports(`(transform-style: preserve) or (-moz-transform-style: pre
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSS.supports")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssanimation/animationname/index.html
+++ b/files/en-us/web/api/cssanimation/animationname/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSAnimation
 - Property
 - Reference
+browser-compat: api.CSSAnimation.animationName
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
@@ -68,4 +69,4 @@ console.log(animations[0].animationName);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSAnimation.animationName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssanimation/index.html
+++ b/files/en-us/web/api/cssanimation/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSAnimation
   - Interface
   - Reference
+browser-compat: api.CSSAnimation
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
@@ -70,4 +71,4 @@ console.log(animations[0]);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSAnimation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssconditionrule/conditiontext/index.html
+++ b/files/en-us/web/api/cssconditionrule/conditiontext/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSConditionRule
   - Property
   - Reference
+browser-compat: api.CSSConditionRule.conditionText
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -63,7 +64,7 @@ console.log(text);  // "(min-width: 400px)"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSConditionRule.conditionText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssconditionrule/index.html
+++ b/files/en-us/web/api/cssconditionrule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSConditionRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSConditionRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csscounterstylerule/index.html
+++ b/files/en-us/web/api/csscounterstylerule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSS Counter Styles
   - Interface
   - Reference
+browser-compat: api.CSSCounterStyleRule
 ---
 <p>{{APIRef("CSS Counter Styles")}}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSCounterStyleRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssfontfacerule/index.html
+++ b/files/en-us/web/api/cssfontfacerule/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSFontFaceRule
   - Interface
   - Reference
+browser-compat: api.CSSFontFaceRule
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -68,4 +69,4 @@ console.log(myRules[0]); //a CSSFontFaceRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSFontFaceRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssfontfacerule/style/index.html
+++ b/files/en-us/web/api/cssfontfacerule/style/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Read-only
+browser-compat: api.CSSFontFaceRule.style
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSFontFaceRule.style")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssgroupingrule/index.html
+++ b/files/en-us/web/api/cssgroupingrule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSGroupingRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSGroupingRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssimagevalue/index.html
+++ b/files/en-us/web/api/cssimagevalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSImageValue
 ---
 <div>{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -70,7 +71,7 @@ console.log( allComputedStyles.get('background-image').toString() );
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSImageValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssimportrule/href/index.html
+++ b/files/en-us/web/api/cssimportrule/href/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - CSSImportRule
 - Read-only
+browser-compat: api.CSSImportRule.href
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -66,4 +67,4 @@ console.log(myRules[0].href); //returns style.css</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSImportRule.href")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssimportrule/index.html
+++ b/files/en-us/web/api/cssimportrule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSImportRule
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -65,4 +66,4 @@ console.log(myRules[0]); //a CSSImportRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSImportRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssimportrule/media/index.html
+++ b/files/en-us/web/api/cssimportrule/media/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - CSSImportRule
 - Read-only
+browser-compat: api.CSSImportRule.media
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -64,4 +65,4 @@ console.log(myRules[0].media); //returns a MediaList</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSImportRule.media")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.html
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - CSSImportRule
 - Read-only
+browser-compat: api.CSSImportRule.styleSheet
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -66,4 +67,4 @@ console.log(myRules[0].styleSheet); //returns a CSSStyleSheet object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSImportRule.styleSheet")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframerule/index.html
+++ b/files/en-us/web/api/csskeyframerule/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSKeyframeRule
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -71,7 +72,7 @@ console.log(keyframes[0]); // a CSSKeyframeRule representing an individual keyfr
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframeRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csskeyframerule/keytext/index.html
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Property
   - Reference
+browser-compat: api.CSSKeyframeRule.keyText
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -70,4 +71,4 @@ console.log(keyframes[0].keyText); // a string containing 0%</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframeRule.keyText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframerule/style/index.html
+++ b/files/en-us/web/api/csskeyframerule/style/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Property
   - Reference
+browser-compat: api.CSSKeyframeRule.style
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -75,4 +76,4 @@ console.log(keyframes[0].style); // a CSSStyleDeclaration</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframeRule.style")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframesrule/appendrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/appendrule/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Method
   - Reference
+browser-compat: api.CSSKeyframesRule.appendRule
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -68,4 +69,4 @@ console.log(keyframes.cssRules); // a CSSRuleList object with two rules</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframesRule.appendRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.html
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Property
   - Reference
+browser-compat: api.CSSKeyframesRule.cssRules
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -62,4 +63,4 @@ console.log(keyframes.cssRules); // a CSSRuleList object with two rules</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframesRule.cssRules")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframesrule/deleterule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/deleterule/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Method
   - Reference
+browser-compat: api.CSSKeyframesRule.deleteRule
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -79,4 +80,4 @@ console.log(keyframes.cssRules); // a CSSRuleList object with one rule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframesRule.deleteRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframesrule/findrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/findrule/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Method
   - Reference
+browser-compat: api.CSSKeyframesRule.findRule
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -76,4 +77,4 @@ console.log(keyframes.findRule('to'));  // a CSSKeyframeRule object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframesRule.findRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeyframesrule/index.html
+++ b/files/en-us/web/api/csskeyframesrule/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSKeyframesRule
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -78,7 +79,7 @@ let keyframes = myRules[0]; // a CSSKeyframesRule </pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframesRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csskeyframesrule/name/index.html
+++ b/files/en-us/web/api/csskeyframesrule/name/index.html
@@ -8,6 +8,7 @@ tags:
   - CSS Animations
   - Property
   - Reference
+browser-compat: api.CSSKeyframesRule.name
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -63,4 +64,4 @@ console.log(keyframes.name); // "slidein"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeyframesRule.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - Houdini
 - Reference
+browser-compat: api.CSSKeywordValue.CSSKeywordValue
 ---
 <div>{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -80,4 +81,4 @@ console.dir( keyword );
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeywordValue.CSSKeywordValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csskeywordvalue/index.html
+++ b/files/en-us/web/api/csskeywordvalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSKeywordValue
 ---
 <div>{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -68,7 +69,7 @@ console.log( myElement.get('display').value);  // 'initial'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeywordValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.html
+++ b/files/en-us/web/api/csskeywordvalue/value/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - value
+browser-compat: api.CSSKeywordValue.value
 ---
 <div>{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -61,4 +62,4 @@ indicator.attributeStyleMap.get('display').value // 'initial'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSKeywordValue.value")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.html
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.html
@@ -9,6 +9,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSMathInvert.CSSMathInvert
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathInvert.CSSMathInvert")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathinvert/index.html
+++ b/files/en-us/web/api/cssmathinvert/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSMathInvert
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathInvert")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathinvert/value/index.html
+++ b/files/en-us/web/api/cssmathinvert/value/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSMathInvert.value
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathInvert.value")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.html
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.html
@@ -9,6 +9,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSMathMax.CSSMathMax
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathMax.CSSMathMax")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathmax/index.html
+++ b/files/en-us/web/api/cssmathmax/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSMathMax
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathMax")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathmax/values/index.html
+++ b/files/en-us/web/api/cssmathmax/values/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSMathMax.values
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathMax.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.html
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.html
@@ -9,6 +9,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSMathMin.CSSMathMin
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathMin.CSSMathMin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathmin/index.html
+++ b/files/en-us/web/api/cssmathmin/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSMathMin
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathMin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathmin/values/index.html
+++ b/files/en-us/web/api/cssmathmin/values/index.html
@@ -10,6 +10,7 @@ tags:
 - Houdini
 - Property
 - Read-only
+browser-compat: api.CSSMathMin.values
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathMin.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.html
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.html
@@ -9,6 +9,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSMathNegate.CSSMathNegate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathNegate.CSSMathNegate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathnegate/index.html
+++ b/files/en-us/web/api/cssmathnegate/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSMathNegate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathNegate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathnegate/value/index.html
+++ b/files/en-us/web/api/cssmathnegate/value/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSMathNegate.value
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathNegate.value")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Reference
+browser-compat: api.CSSMathProduct.CSSMathProduct
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathProduct.CSSMathProduct")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathproduct/index.html
+++ b/files/en-us/web/api/cssmathproduct/index.html
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSMathProduct
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathProduct")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathproduct/values/index.html
+++ b/files/en-us/web/api/cssmathproduct/values/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - values
+browser-compat: api.CSSMathProduct.values
 ---
 <p>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathProduct.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Reference
+browser-compat: api.CSSMathSum.CSSMathSum
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathSum.CSSMathSum")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathsum/index.html
+++ b/files/en-us/web/api/cssmathsum/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSMathSum
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -93,4 +94,4 @@ console.log( styleMap.get('width').values[1].value.unit ); // 'px'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathSum")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathsum/values/index.html
+++ b/files/en-us/web/api/cssmathsum/values/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - values
+browser-compat: api.CSSMathSum.values
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathSum.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathvalue/index.html
+++ b/files/en-us/web/api/cssmathvalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSMathValue
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -89,4 +90,4 @@ console.log( styleMap.get('width').values[1].value );  // -20
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmathvalue/operator/index.html
+++ b/files/en-us/web/api/cssmathvalue/operator/index.html
@@ -10,6 +10,7 @@ tags:
   - Operator
   - Property
   - Reference
+browser-compat: api.CSSMathValue.operator
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -116,4 +117,4 @@ console.log( styleMap.get('width').values[1].operator ) // 'negate'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMathValue.operator")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSMatrixComponent.CSSMatrixComponent
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMatrixComponent.CSSMatrixComponent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmatrixcomponent/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSMatrixComponent
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMatrixComponent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.html
@@ -11,6 +11,7 @@ tags:
 - Houdini
 - Property
 - matrix
+browser-compat: api.CSSMatrixComponent.matrix
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMatrixComponent.matrix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmediarule/index.html
+++ b/files/en-us/web/api/cssmediarule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSMediaRule
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
@@ -73,4 +74,4 @@ console.log(myRules[0]); // a CSSMediaRule representing the media query.</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMediaRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssmediarule/media/index.html
+++ b/files/en-us/web/api/cssmediarule/media/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSMediaRule
 - Property
 - Reference
+browser-compat: api.CSSMediaRule.media
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
@@ -74,4 +75,4 @@ console.log(myRules[0].media); // a MediaList</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSMediaRule.media")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnamespacerule/index.html
+++ b/files/en-us/web/api/cssnamespacerule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSNamespaceRule
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -58,4 +59,4 @@ console.log(myRules[0]); //a CSSNamespaceRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNamespaceRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnamespacerule/namespaceuri/index.html
+++ b/files/en-us/web/api/cssnamespacerule/namespaceuri/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - namespaceURI
+browser-compat: api.CSSNamespaceRule.namespaceURI
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -49,4 +50,4 @@ console.log(myRules[0].namespaceURI); //http://www.w3.org/1999/xhtml</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNamespaceRule.namespaceURI")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnamespacerule/prefix/index.html
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - prefix
+browser-compat: api.CSSNamespaceRule.prefix
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -51,4 +52,4 @@ console.log(myRules[1].namespaceURI); "svg"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNamespaceRule.prefix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericarray/index.html
+++ b/files/en-us/web/api/cssnumericarray/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSNumericArray
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericArray")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericarray/length/index.html
+++ b/files/en-us/web/api/cssnumericarray/length/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSNumericArray.length
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericArray.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/add/index.html
+++ b/files/en-us/web/api/cssnumericvalue/add/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - add()
+browser-compat: api.CSSNumericValue.add
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -65,4 +66,4 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.add")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/div/index.html
+++ b/files/en-us/web/api/cssnumericvalue/div/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - div()
+browser-compat: api.CSSNumericValue.div
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -65,4 +66,4 @@ mathProduct.toString();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.div")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/equals/index.html
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - equals()
+browser-compat: api.CSSNumericValue.equals
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -76,4 +77,4 @@ console.log(CSS.cm("1").equal(CSS.in("0.393701")));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.equals")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/index.html
+++ b/files/en-us/web/api/cssnumericvalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSNumericValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/max/index.html
+++ b/files/en-us/web/api/cssnumericvalue/max/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - max()
+browser-compat: api.CSSNumericValue.max
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -70,4 +71,4 @@ console.log(CSS.cm("1").max(CSS.in("0.393701")).toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.max")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/min/index.html
+++ b/files/en-us/web/api/cssnumericvalue/min/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - min()
+browser-compat: api.CSSNumericValue.min
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -70,4 +71,4 @@ console.log(CSS.cm("1").max(CSS.in("0.393701")).toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.min")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/mul/index.html
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - mul()
+browser-compat: api.CSSNumericValue.mul
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -65,4 +66,4 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.mul")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/parse/index.html
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - parse()
+browser-compat: api.CSSNumericValue.parse
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.parse")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/sub/index.html
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - sub()
+browser-compat: api.CSSNumericValue.sub
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -67,4 +68,4 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.sub")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/to/index.html
+++ b/files/en-us/web/api/cssnumericvalue/to/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - to()
+browser-compat: api.CSSNumericValue.to
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -66,4 +67,4 @@ console.log(CSS.px("23").to("cm").toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.to")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.html
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - toSum()
+browser-compat: api.CSSNumericValue.toSum
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -67,4 +68,4 @@ v.toSum("px", "percent").toString() // =&gt; "calc(1000.39px + 4%)"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.toSum")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssnumericvalue/type/index.html
+++ b/files/en-us/web/api/cssnumericvalue/type/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Type
+browser-compat: api.CSSNumericValue.type
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -62,4 +63,4 @@ let cssNumericType = mathSum.type();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspagerule/index.html
+++ b/files/en-us/web/api/csspagerule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSPageRule
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -67,4 +68,4 @@ console.log(myRules[0]); // a CSSPageRule
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPageRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspagerule/selectortext/index.html
+++ b/files/en-us/web/api/csspagerule/selectortext/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - CSSPageRule
+browser-compat: api.CSSPageRule.selectorText
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -62,4 +63,4 @@ console.log(myRules[1].selectorText); // returns the string ":first"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPageRule.selectorText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspagerule/style/index.html
+++ b/files/en-us/web/api/csspagerule/style/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - CSSPageRule
   - Read-only
+browser-compat: api.CSSPageRule.style
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -68,4 +69,4 @@ console.log(myRules[0].style); // returns a CSSStyleDeclaration object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPageRule.style")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssperspective/cssperspective/index.html
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSPerspective.CSSPerspective
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPerspective.CSSPerspective")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssperspective/index.html
+++ b/files/en-us/web/api/cssperspective/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSPerspective
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPerspective")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssperspective/length/index.html
+++ b/files/en-us/web/api/cssperspective/length/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSPerspective.length
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPerspective.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - Reference
   - Deprecated
+browser-compat: api.CSSPositionValue.CSSPositionValue
 ---
 <div>{{APIRef("CSS Typed Object Model API")}}{{deprecated_header}}</div>
 
@@ -45,7 +46,7 @@ console.log(position.x.value, position.y.value);  // 5 10</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPositionValue.CSSPositionValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csspositionvalue/index.html
+++ b/files/en-us/web/api/csspositionvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - Deprecated
+browser-compat: api.CSSPositionValue
 ---
 <div>{{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -63,7 +64,7 @@ console.log( replacedEl.computedStyleMap().get('object-position') );</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPositionValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csspositionvalue/x/index.html
+++ b/files/en-us/web/api/csspositionvalue/x/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Deprecated
 - x
+browser-compat: api.CSSPositionValue.x
 ---
 <div>{{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -39,7 +40,7 @@ console.log(position.x.value, position.y.value);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPositionValue.x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csspositionvalue/y/index.html
+++ b/files/en-us/web/api/csspositionvalue/y/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Deprecated
 - 'y'
+browser-compat: api.CSSPositionValue.y
 ---
 <div>{{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -39,7 +40,7 @@ console.log(position.x.value, position.y.value);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPositionValue.y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsExample
 - getCounterValue
 - Deprecated
+browser-compat: api.CSSPrimitiveValue.getCounterValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.getCounterValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - getFloatValue
 - Deprecated
+browser-compat: api.CSSPrimitiveValue.getFloatValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -158,4 +159,4 @@ console.log(cssValue.getFloatValue(CSSPrimitiveValue.CSS_CM));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.getFloatValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - getRectValue
 - Deprecated
+browser-compat: api.CSSPrimitiveValue.getRectValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -69,4 +70,4 @@ console.log(cssValue.getRectValue());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.getRectValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - getRGBColorValue
 - Deprecated
+browser-compat: api.CSSPrimitiveValue.getRGBColorValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -69,4 +70,4 @@ console.log(cssValue.getRGBColorValue());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.getRGBColorValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - getStringValue
 - Deprecated
+browser-compat: api.CSSPrimitiveValue.getStringValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -67,4 +68,4 @@ console.log(cssValue.getStringValue());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.getStringValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssprimitivevalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Deprecated
+browser-compat: api.CSSPrimitiveValue
 ---
 <div>{{APIRef("CSSOM")}}{{deprecated_header}}</div>
 
@@ -179,7 +180,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.html
@@ -8,6 +8,7 @@ tags:
   - Read-only
   - Reference
   - primitiveValue
+browser-compat: api.CSSPrimitiveValue.primitiveType
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -192,7 +193,7 @@ console.log(cssValue.primitiveType);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.primitiveType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsExample
 - setFloatValue
 - Deprecated
+browser-compat: api.CSSPrimitiveValue.setFloatValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -156,4 +157,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.setFloatValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsExample
   - setStringValue
   - Deprecated
+browser-compat: api.CSSPrimitiveValue.setStringValue
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -100,4 +101,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPrimitiveValue.setStringValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspropertyrule/index.html
+++ b/files/en-us/web/api/csspropertyrule/index.html
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSPropertyRule
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
@@ -68,4 +69,4 @@ console.log(myRules[0]); //a CSSPropertyRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPropertyRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspropertyrule/inherits/index.html
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - Read-only
+browser-compat: api.CSSPropertyRule.inherits
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
@@ -55,4 +56,4 @@ console.log(myRules[0].inherits); //returns false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPropertyRule.inherits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.html
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - Read-only
+browser-compat: api.CSSPropertyRule.initialValue
 ---
 <div>{{APIRef("CSS Properties and Values API")}}{{SeeCompatTable}}</div>
 
@@ -57,4 +58,4 @@ console.log(myRules[0].initialValue); //the string "#c0ffee"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPropertyRule.initialValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspropertyrule/name/index.html
+++ b/files/en-us/web/api/csspropertyrule/name/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - Read-only
+browser-compat: api.CSSPropertyRule.name
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
@@ -57,4 +58,4 @@ console.log(myRules[0].name); //the string "--property-name"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPropertyRule.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspropertyrule/syntax/index.html
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - Read-only
+browser-compat: api.CSSPropertyRule.syntax
 ---
 <div>{{APIRef("CSS Properties and Values API")}}</div>
 
@@ -55,4 +56,4 @@ console.log(myRules[0].syntax); //the string "&lt;color&gt;"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSPropertyRule.syntax")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrotate/angle/index.html
+++ b/files/en-us/web/api/cssrotate/angle/index.html
@@ -11,6 +11,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSRotate.angle
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRotate.angle")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrotate/cssrotate/index.html
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSRotate.CSSRotate
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -75,4 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRotate.CSSRotate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrotate/index.html
+++ b/files/en-us/web/api/cssrotate/index.html
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSRotate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRotate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrotate/x/index.html
+++ b/files/en-us/web/api/cssrotate/x/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSRotate.x
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRotate.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrotate/y/index.html
+++ b/files/en-us/web/api/cssrotate/y/index.html
@@ -11,6 +11,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSRotate.y
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRotate.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrotate/z/index.html
+++ b/files/en-us/web/api/cssrotate/z/index.html
@@ -11,6 +11,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSRotate.z
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRotate.z")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrule/csstext/index.html
+++ b/files/en-us/web/api/cssrule/csstext/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Property
 - Reference
+browser-compat: api.CSSRule.cssText
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -65,4 +66,4 @@ console.log(stylesheet.cssRules[0].cssText); // body { background-color: darkblu
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRule.cssText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrule/index.html
+++ b/files/en-us/web/api/cssrule/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSRule
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -97,7 +98,7 @@ console.log(myRules);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssrule/parentrule/index.html
+++ b/files/en-us/web/api/cssrule/parentrule/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSRule
 - Property
 - Reference
+browser-compat: api.CSSRule.parentRule
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
@@ -67,4 +68,4 @@ console.log(childRules[0].parentRule); // a CSSMediaRule</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRule.parentRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.html
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSRule
 - Property
 - Reference
+browser-compat: api.CSSRule.parentStyleSheet
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
@@ -52,4 +53,4 @@ console.log(myRules.parentStyleSheet);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRule.parentStyleSheet")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrule/type/index.html
+++ b/files/en-us/web/api/cssrule/type/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Read-only
 - Deprecated
+browser-compat: api.CSSRule.type
 ---
 <div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
@@ -167,4 +168,4 @@ console.log(myRules[0].type);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRule.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssrulelist/index.html
+++ b/files/en-us/web/api/cssrulelist/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.CSSRuleList
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -57,7 +58,7 @@ var first_rule = document.styleSheets[0].cssRules[0];
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSRuleList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssscale/cssscale/index.html
+++ b/files/en-us/web/api/cssscale/cssscale/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSScale.CSSScale
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSScale.CSSScale")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssscale/index.html
+++ b/files/en-us/web/api/cssscale/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSScale
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSScale")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssscale/x/index.html
+++ b/files/en-us/web/api/cssscale/x/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSScale.x
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSScale.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssscale/y/index.html
+++ b/files/en-us/web/api/cssscale/y/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSScale.y
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSScale.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssscale/z/index.html
+++ b/files/en-us/web/api/cssscale/z/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSScale.z
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSScale.z")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskew/ax/index.html
+++ b/files/en-us/web/api/cssskew/ax/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSSkew.ax
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkew.ax")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskew/ay/index.html
+++ b/files/en-us/web/api/cssskew/ay/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSSkew.ay
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkew.ay")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskew/cssskew/index.html
+++ b/files/en-us/web/api/cssskew/cssskew/index.html
@@ -11,6 +11,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSSkew.CSSSkew
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkew.CSSSkew")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskew/index.html
+++ b/files/en-us/web/api/cssskew/index.html
@@ -11,6 +11,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSSkew
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkew")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskewx/ax/index.html
+++ b/files/en-us/web/api/cssskewx/ax/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSSkewX.ax
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkewX.ax")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskewx/cssskewx/index.html
+++ b/files/en-us/web/api/cssskewx/cssskewx/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSSkewX.CSSSkewX
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkewX.CSSSkewX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskewx/index.html
+++ b/files/en-us/web/api/cssskewx/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSSkewX
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkewX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskewy/ay/index.html
+++ b/files/en-us/web/api/cssskewy/ay/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSSkewY.ay
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkewY.ay")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskewy/cssskewy/index.html
+++ b/files/en-us/web/api/cssskewy/cssskewy/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSSkewY.CSSSkewY
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkewY.CSSSkewY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssskewy/index.html
+++ b/files/en-us/web/api/cssskewy/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSSkewY
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSkewY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/cssfloat/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/cssfloat/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - CSSStyleDeclaration
   - Reference
+browser-compat: api.CSSStyleDeclaration.cssFloat
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -57,4 +58,4 @@ console.log(rule.style.cssFloat); //right</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.cssFloat")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/csstext/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/csstext/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - NeedsSpecTable
   - Reference
+browser-compat: api.CSSStyleDeclaration.cssText
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.cssText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Deprecated
 - Reference
+browser-compat: api.CSSStyleDeclaration.getPropertyCSSValue
 ---
 <p>{{ APIRef("CSSOM") }} {{deprecated_header}}</p>
 
@@ -69,4 +70,4 @@ var rgbObj = style.getPropertyCSSValue('color').getRGBColorValue();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.getPropertyCSSValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Method
 - Reference
+browser-compat: api.CSSStyleDeclaration.getPropertyPriority
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -70,4 +71,4 @@ var isImportant = declaration.getPropertyPriority('margin') === 'important';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.getPropertyPriority")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Method
 - Reference
+browser-compat: api.CSSStyleDeclaration.getPropertyValue
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -68,4 +69,4 @@ var value = declaration.getPropertyValue('margin'); // "1px 2px"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.getPropertyValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSRule
   - Interface
   - Reference
+browser-compat: api.CSSStyleDeclaration
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -96,7 +97,7 @@ console.log(styleObj.cssText);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstyledeclaration/item/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/item/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Method
 - Reference
+browser-compat: api.CSSStyleDeclaration.item
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -73,4 +74,4 @@ var propertyName = style.item(1); // or style[1] - returns the second style list
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.item")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/length/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/length/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Property
 - Reference
+browser-compat: api.CSSStyleDeclaration.length
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/parentrule/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/parentrule/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Property
 - Reference
+browser-compat: api.CSSStyleDeclaration.parentRule
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -60,4 +61,4 @@ var rule = declaration.parentRule;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.parentRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/removeproperty/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/removeproperty/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Method
 - Reference
+browser-compat: api.CSSStyleDeclaration.removeProperty
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -76,4 +77,4 @@ var oldValue = declaration.removeProperty('background-color');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.removeProperty")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.html
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Method
 - Reference
+browser-compat: api.CSSStyleDeclaration.setProperty
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -219,4 +220,4 @@ colorBtn.addEventListener('click', setRandomColor);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleDeclaration.setProperty")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstylerule/index.html
+++ b/files/en-us/web/api/cssstylerule/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSStyleRule
   - Interface
   - Reference
+browser-compat: api.CSSStyleRule
 ---
 <div>{{ APIRef("CSSOM") }}</div>
 
@@ -71,4 +72,4 @@ console.log(myRules[0]); // a CSSStyleRule representing the h1.</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleRule")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstylerule/selectortext/index.html
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSStyleRule
   - Property
   - Reference
+browser-compat: api.CSSStyleRule.selectorText
 ---
 <div>{{APIRef("CSSOM") }}</div>
 
@@ -55,4 +56,4 @@ console.log(myRules[0].selectorText); // a string containing "h1".</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleRule.selectorText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstylerule/style/index.html
+++ b/files/en-us/web/api/cssstylerule/style/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSStyleRule
   - Property
   - Reference
+browser-compat: api.CSSStyleRule.style
 ---
 <p>{{ APIRef("CSSOM") }}</p>
 
@@ -71,4 +72,4 @@ console.log(myRules[0].style); // a CSSStyleDeclaration representing the declara
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleRule.style")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstylerule/stylemap/index.html
+++ b/files/en-us/web/api/cssstylerule/stylemap/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Houdini
   - Experimental
+browser-compat: api.CSSStyleRule.styleMap
 ---
 <div>{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
@@ -56,4 +57,4 @@ Object.values(stylesheet.cssRules).forEach(block =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleRule.styleMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstylesheet/addrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/addrule/index.html
@@ -17,6 +17,7 @@ tags:
 - legacy
 - rules
 - Deprecated
+browser-compat: api.CSSStyleSheet.addRule
 ---
 <p>{{APIRef("CSSOM")}}{{deprecated_header}}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.addRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylesheet/cssrules/index.html
+++ b/files/en-us/web/api/cssstylesheet/cssrules/index.html
@@ -13,6 +13,7 @@ tags:
 - Read-only
 - Reference
 - StyleSheet
+browser-compat: api.CSSStyleSheet.cssRules
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -76,7 +77,7 @@ for (let rule of ruleList) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.cssRules")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylesheet/deleterule/index.html
+++ b/files/en-us/web/api/cssstylesheet/deleterule/index.html
@@ -16,6 +16,7 @@ tags:
 - delete
 - deleteRule
 - remove
+browser-compat: api.CSSStyleSheet.deleteRule
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.deleteRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylesheet/index.html
+++ b/files/en-us/web/api/cssstylesheet/index.html
@@ -12,6 +12,7 @@ tags:
   - Object Model
   - Reference
   - StyleSheet
+browser-compat: api.CSSStyleSheet
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -170,7 +171,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSStyleSheet
   - Method
   - Reference
+browser-compat: api.CSSStyleSheet.insertRule
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -210,7 +211,7 @@ function addStylesheetRules (rules) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.insertRule")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Legacy_browser_support">Legacy browser support</h3>
 

--- a/files/en-us/web/api/cssstylesheet/ownerrule/index.html
+++ b/files/en-us/web/api/cssstylesheet/ownerrule/index.html
@@ -16,6 +16,7 @@ tags:
 - StyleSheet
 - import
 - ownerRule
+browser-compat: api.CSSStyleSheet.ownerRule
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -81,7 +82,7 @@ for (let rule of ruleList) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.ownerRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylesheet/removerule/index.html
+++ b/files/en-us/web/api/cssstylesheet/removerule/index.html
@@ -18,6 +18,7 @@ tags:
 - remove
 - removeRule
 - Deprecated
+browser-compat: api.CSSStyleSheet.removeRule
 ---
 <p>{{APIRef("CSSOM")}}{{deprecated_header}}</p>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.removeRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylesheet/rules/index.html
+++ b/files/en-us/web/api/cssstylesheet/rules/index.html
@@ -16,6 +16,7 @@ tags:
 - StyleSheet
 - legacy
 - Deprecated
+browser-compat: api.CSSStyleSheet.rules
 ---
 <p>{{APIRef("CSSOM")}}{{deprecated_header}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleSheet.rules")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylevalue/index.html
+++ b/files/en-us/web/api/cssstylevalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSStyleValue
 ---
 <p>{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssstylevalue/parse/index.html
+++ b/files/en-us/web/api/cssstylevalue/parse/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - parse()
+browser-compat: api.CSSStyleValue.parse
 ---
 <p>{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleValue.parse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssstylevalue/parseall/index.html
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - parseAll()
+browser-compat: api.CSSStyleValue.parseAll
 ---
 <p>{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSStyleValue.parseAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csssupportsrule/index.html
+++ b/files/en-us/web/api/csssupportsrule/index.html
@@ -6,6 +6,7 @@ tags:
 - CSSOM
 - Interface
 - Reference
+browser-compat: api.CSSSupportsRule
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -59,7 +60,7 @@ console.log(myRules[0]); // a CSSSupportsRule representing the feature query.</p
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSSupportsRule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csstransformcomponent/index.html
+++ b/files/en-us/web/api/csstransformcomponent/index.html
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSTransformComponent
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformComponent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.html
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - is2D
+browser-compat: api.CSSTransformComponent.is2D
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformComponent.is2D")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - toMatrix
+browser-compat: api.CSSTransformComponent.toMatrix
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformComponent.toMatrix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.html
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.html
@@ -10,6 +10,7 @@ tags:
 - Houdini
 - Method
 - Reference
+browser-compat: api.CSSTransformComponent.toString
 ---
 <div>{{APIRef("CSS Typed OM")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformComponent.toString")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Reference
+browser-compat: api.CSSTransformValue.CSSTransformValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.CSSTransformValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/entries/index.html
+++ b/files/en-us/web/api/csstransformvalue/entries/index.html
@@ -10,6 +10,7 @@ tags:
 - Houdini
 - Method
 - Reference
+browser-compat: api.CSSTransformValue.entries
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.entries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/foreach/index.html
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.html
@@ -10,6 +10,7 @@ tags:
   - Method
   - Reference
   - forEach
+browser-compat: api.CSSTransformValue.forEach
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.forEach")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/index.html
+++ b/files/en-us/web/api/csstransformvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSTransformValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/is2d/index.html
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.html
@@ -10,6 +10,7 @@ tags:
 - Houdini
 - Property
 - is2D
+browser-compat: api.CSSTransformValue.is2D
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.is2D")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/keys/index.html
+++ b/files/en-us/web/api/csstransformvalue/keys/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - keys
+browser-compat: api.CSSTransformValue.keys
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.keys")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/length/index.html
+++ b/files/en-us/web/api/csstransformvalue/length/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - length
+browser-compat: api.CSSTransformValue.length
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.html
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.html
@@ -10,6 +10,7 @@ tags:
 - Houdini
 - Method
 - toMatrix
+browser-compat: api.CSSTransformValue.toMatrix
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.toMatrix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransformvalue/values/index.html
+++ b/files/en-us/web/api/csstransformvalue/values/index.html
@@ -11,6 +11,7 @@ tags:
 - Method
 - Reference
 - values
+browser-compat: api.CSSTransformValue.values
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{Draft}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransformValue.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstransition/index.html
+++ b/files/en-us/web/api/csstransition/index.html
@@ -7,6 +7,7 @@ tags:
   - CSSTransition
   - Interface
   - Reference
+browser-compat: api.CSSTransition
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
@@ -72,4 +73,4 @@ item.addEventListener('transitionrun', () => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTransition")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstranslate/csstranslate/index.html
+++ b/files/en-us/web/api/csstranslate/csstranslate/index.html
@@ -10,6 +10,7 @@ tags:
 - Constructor
 - Experimental
 - Houdini
+browser-compat: api.CSSTranslate.CSSTranslate
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTranslate.CSSTranslate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstranslate/index.html
+++ b/files/en-us/web/api/csstranslate/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Houdini
   - Interface
+browser-compat: api.CSSTranslate
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTranslate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstranslate/x/index.html
+++ b/files/en-us/web/api/csstranslate/x/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSTranslate.x
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTranslate.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstranslate/y/index.html
+++ b/files/en-us/web/api/csstranslate/y/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSTranslate.y
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTranslate.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csstranslate/z/index.html
+++ b/files/en-us/web/api/csstranslate/z/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Houdini
 - Property
+browser-compat: api.CSSTranslate.z
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}{{draft}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSTranslate.z")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.html
@@ -9,6 +9,7 @@ tags:
 - Experimental
 - Houdini
 - Reference
+browser-compat: api.CSSUnitValue.CSSUnitValue
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnitValue.CSSUnitValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunitvalue/index.html
+++ b/files/en-us/web/api/cssunitvalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSUnitValue
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnitValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssunitvalue/unit/index.html
+++ b/files/en-us/web/api/cssunitvalue/unit/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - unit
+browser-compat: api.CSSUnitValue.unit
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ console.log( pos.y.unit ); // "em"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnitValue.unit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunitvalue/value/index.html
+++ b/files/en-us/web/api/cssunitvalue/value/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - value
+browser-compat: api.CSSUnitValue.value
 ---
 <div>{{draft}}{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ console.log( pos.y.value ); // 10
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnitValue.value")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.html
@@ -10,6 +10,7 @@ tags:
 - Houdini
 - NeedsExample
 - Reference
+browser-compat: api.CSSUnparsedValue.CSSUnparsedValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -58,7 +59,7 @@ console.log( values ); // CSSUnparsedValue {0: "1em", 1: "#445566", 2: "-45px", 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue.CSSUnparsedValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.html
@@ -12,6 +12,7 @@ tags:
 - Method
 - NeedsExample
 - Reference
+browser-compat: api.CSSUnparsedValue.entries
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue.entries")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.html
@@ -12,6 +12,7 @@ tags:
 - NeedsExample
 - Reference
 - forEach()
+browser-compat: api.CSSUnparsedValue.forEach
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue.forEach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - NeedsExample
   - Reference
+browser-compat: api.CSSUnparsedValue
 ---
 <div>{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.html
@@ -12,6 +12,7 @@ tags:
 - NeedsExample
 - Reference
 - keys()
+browser-compat: api.CSSUnparsedValue.keys
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/length/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - length
+browser-compat: api.CSSUnparsedValue.length
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -55,7 +56,7 @@ console.log( values.length ) // 3</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue.length")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssunparsedvalue/values/index.html
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.html
@@ -12,6 +12,7 @@ tags:
 - NeedsExample
 - Reference
 - values()
+browser-compat: api.CSSUnparsedValue.values
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSUnparsedValue.values")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvalue/csstext/index.html
+++ b/files/en-us/web/api/cssvalue/csstext/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - cssText
 - Deprecated
+browser-compat: api.CSSValue.cssText
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
@@ -50,7 +51,7 @@ console.log(cssValue.cssText);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSValue.cssText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.html
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - cssValueType
 - Deprecated
+browser-compat: api.CSSValue.cssValueType
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
@@ -84,4 +85,4 @@ console.log(cssValue.cssValueType);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSValue.cssValueType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssvalue/index.html
+++ b/files/en-us/web/api/cssvalue/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - Deprecated
+browser-compat: api.CSSValue
 ---
 <div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvaluelist/index.html
+++ b/files/en-us/web/api/cssvaluelist/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Deprecated
+browser-compat: api.CSSValueList
 ---
 <div>{{APIRef("CSSOM")}}{{Deprecated_header}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSValueList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssvaluelist/item/index.html
+++ b/files/en-us/web/api/cssvaluelist/item/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - item
 - Deprecated
+browser-compat: api.CSSValueList.item
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSValueList.item")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssvaluelist/length/index.html
+++ b/files/en-us/web/api/cssvaluelist/length/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - length
 - Deprecated
+browser-compat: api.CSSValueList.length
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSValueList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - NeedsExample
   - Reference
+browser-compat: api.CSSVariableReferenceValue.CSSVariableReferenceValue
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSVariableReferenceValue.CSSVariableReferenceValue")}}</p>
+<p>{{Compat}}</p>
 
 <dl>
   <dt><var>variable</var></dt>

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - fallback
+browser-compat: api.CSSVariableReferenceValue.fallback
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSVariableReferenceValue.fallback")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssvariablereferencevalue/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.html
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Interface
   - Reference
+browser-compat: api.CSSVariableReferenceValue
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSVariableReferenceValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - variable
+browser-compat: api.CSSVariableReferenceValue.variable
 ---
 <div>{{draft}}{{APIRef("CSSOM")}}{{SeeCompatTable}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSVariableReferenceValue.variable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/customelementregistry/define/index.html
+++ b/files/en-us/web/api/customelementregistry/define/index.html
@@ -9,6 +9,7 @@ tags:
 - Web Components
 - custom elements
 - define
+browser-compat: api.CustomElementRegistry.define
 ---
 <p>{{APIRef("CustomElementRegistry")}}</p>
 
@@ -253,4 +254,4 @@ customElements.define('word-count', WordCount, { extends: 'p' });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomElementRegistry.define")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/customelementregistry/get/index.html
+++ b/files/en-us/web/api/customelementregistry/get/index.html
@@ -10,6 +10,7 @@ tags:
 - Web Components
 - custom elements
 - get
+browser-compat: api.CustomElementRegistry.get
 ---
 <p>{{APIRef("CustomElementRegistry")}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomElementRegistry.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/customelementregistry/index.html
+++ b/files/en-us/web/api/customelementregistry/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Components
   - custom elements
+browser-compat: api.CustomElementRegistry
 ---
 <div>{{DefaultAPISidebar("Web Components")}}</div>
 
@@ -92,4 +93,4 @@ customElements.define('word-count', WordCount, { extends: 'p' });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomElementRegistry")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/customelementregistry/upgrade/index.html
+++ b/files/en-us/web/api/customelementregistry/upgrade/index.html
@@ -9,6 +9,7 @@ tags:
 - Upgrade
 - Web Components
 - custom elements
+browser-compat: api.CustomElementRegistry.upgrade
 ---
 <p>{{APIRef("CustomElementRegistry")}}</p>
 
@@ -73,4 +74,4 @@ console.assert(el instanceof SpiderMan);    // upgraded!
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomElementRegistry.upgrade")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/customelementregistry/whendefined/index.html
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Components
   - custom elements
   - whenDefined
+browser-compat: api.CustomElementRegistry.whenDefined
 ---
 <p>{{APIRef("CustomElementRegistry")}}</p>
 
@@ -111,4 +112,4 @@ container.removeChild(placeholder);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomElementRegistry.whenDefined")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/customevent/customevent/index.html
+++ b/files/en-us/web/api/customevent/customevent/index.html
@@ -7,6 +7,7 @@ tags:
 - CustomEvent
 - Reference
 - events
+browser-compat: api.CustomEvent.CustomEvent
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -81,7 +82,7 @@ obj.dispatchEvent(event);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomEvent.CustomEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/api/customevent/detail/index.html
+++ b/files/en-us/web/api/customevent/detail/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - detail
+browser-compat: api.CustomEvent.detail
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -64,7 +65,7 @@ let myDetail = <em>event.detail</em>;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomEvent.detail")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/customevent/index.html
+++ b/files/en-us/web/api/customevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - NeedsExample
   - Reference
+browser-compat: api.CustomEvent
 ---
 <div>{{APIRef("DOM")}}</div>
 <p>The <strong><code>CustomEvent</code></strong> interface represents events initialized by an application for any purpose.</p>
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Firing_from_privileged_code_to_non-privileged_code">Firing from privileged code to non-privileged code</h2>
 

--- a/files/en-us/web/api/customevent/initcustomevent/index.html
+++ b/files/en-us/web/api/customevent/initcustomevent/index.html
@@ -8,6 +8,7 @@ tags:
 - Deprecated
 - Method
 - Reference
+browser-compat: api.CustomEvent.initCustomEvent
 ---
 <p>{{APIRef("DOM")}}{{Deprecated_header}}</p>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CustomEvent.initCustomEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/c* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

418 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
