### PR TITLE
Put browser-compat info in front-runner for api/d*

### DIFF
--- a/files/en-us/web/api/datatransfer/addelement/index.html
+++ b/files/en-us/web/api/datatransfer/addelement/index.html
@@ -7,6 +7,7 @@ tags:
 - Non-standard
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.addElement
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.addElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.html
+++ b/files/en-us/web/api/datatransfer/cleardata/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - clearData
 - drag and drop
+browser-compat: api.DataTransfer.clearData
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -192,7 +193,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.clearData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/datatransfer/index.html
+++ b/files/en-us/web/api/datatransfer/datatransfer/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML Drag and Drop API
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.DataTransfer
 ---
 <p>{{APIRef("HTML Drag and Drop API")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.DataTransfer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/datatransfer/dropeffect/index.html
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.dropEffect
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -147,7 +148,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.dropEffect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/effectallowed/index.html
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.effectAllowed
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -147,7 +148,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.effectAllowed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/files/index.html
+++ b/files/en-us/web/api/datatransfer/files/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.files
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.files")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/datatransfer/getdata/index.html
+++ b/files/en-us/web/api/datatransfer/getdata/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.getData
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -126,7 +127,7 @@ function drop(dropevent) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.getData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/index.html
+++ b/files/en-us/web/api/datatransfer/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Development
   - drag and drop
+browser-compat: api.DataTransfer
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -130,7 +131,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/items/index.html
+++ b/files/en-us/web/api/datatransfer/items/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.items
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -116,7 +117,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.items")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - drag and drop
 - Deprecated
+browser-compat: api.DataTransfer.mozClearDataAt
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozClearDataAt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozcursor/index.html
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.mozCursor
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozCursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - drag and drop
 - Deprecated
+browser-compat: api.DataTransfer.mozGetDataAt
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozGetDataAt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.html
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - drag and drop
 - Deprecated
+browser-compat: api.DataTransfer.mozItemCount
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozItemCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.html
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - drag and drop
 - Deprecated
+browser-compat: api.DataTransfer.mozSetDataAt
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozSetDataAt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.html
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.mozSourceNode
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/moztypesat/index.html
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - drag and drop
 - Deprecated
+browser-compat: api.DataTransfer.mozTypesAt
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozTypesAt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.html
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.mozUserCancelled
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.mozUserCancelled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/setdata/index.html
+++ b/files/en-us/web/api/datatransfer/setdata/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.setData
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -129,7 +130,7 @@ function drop_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.setData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/setdragimage/index.html
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.setDragImage
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -142,7 +143,7 @@ function drop_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.setDragImage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransfer/types/index.html
+++ b/files/en-us/web/api/datatransfer/types/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DataTransfer.types
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -121,7 +122,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransfer.types")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitem/getasfile/index.html
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - drag and drop
+browser-compat: api.DataTransferItem.getAsFile
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -93,7 +94,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem.getAsFile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.html
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.html
@@ -7,6 +7,7 @@ tags:
   - File
   - File System Access API
   - Method
+browser-compat: api.DataTransferItem.getAsFileSystemHandle
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("HTML Drag and Drop API")}}
 </div>
@@ -79,7 +80,7 @@ elem.addEventListener('drop', async (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem.getAsFileSystemHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitem/getasstring/index.html
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - drag and drop
 - getAsString
+browser-compat: api.DataTransferItem.getAsString
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -106,7 +107,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem.getAsString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitem/index.html
+++ b/files/en-us/web/api/datatransferitem/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - drag and drop
+browser-compat: api.DataTransferItem
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/datatransferitem/kind/index.html
+++ b/files/en-us/web/api/datatransferitem/kind/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - drag and drop
 - kind
+browser-compat: api.DataTransferItem.kind
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem.kind")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitem/type/index.html
+++ b/files/en-us/web/api/datatransferitem/type/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Type
   - drag and drop
+browser-compat: api.DataTransferItem.type
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.html
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - drag and drop
 - getAsEntry
+browser-compat: api.DataTransferItem.webkitGetAsEntry
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
@@ -222,7 +223,7 @@ function scanFiles(item, container) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItem.webkitGetAsEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/datatransferitemlist/add/index.html
+++ b/files/en-us/web/api/datatransferitemlist/add/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - drag and drop
+browser-compat: api.DataTransferItemList.add
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -169,4 +170,4 @@ function dragend_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItemList.add")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/datatransferitemlist/clear/index.html
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - clear
 - drag and drop
+browser-compat: api.DataTransferItemList.clear
 ---
 <p><span class="seoSummary">The {{domxref("DataTransferItemList")}} method
     <strong><code>clear()</code></strong> removes all {{domxref("DataTransferItem")}}
@@ -148,6 +149,6 @@ function dragend_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItemList.clear")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("HTML Drag and Drop API")}}</div>

--- a/files/en-us/web/api/datatransferitemlist/datatransferitem/index.html
+++ b/files/en-us/web/api/datatransferitemlist/datatransferitem/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - drag and drop
+browser-compat: api.DataTransferItemList.DataTransferItem
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -147,4 +148,4 @@ function dragend_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItemList.DataTransferItem")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/datatransferitemlist/index.html
+++ b/files/en-us/web/api/datatransferitemlist/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - drag and drop
+browser-compat: api.DataTransferItemList
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -65,4 +66,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("api.DataTransferItemList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/datatransferitemlist/length/index.html
+++ b/files/en-us/web/api/datatransferitemlist/length/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - drag and drop
 - length
+browser-compat: api.DataTransferItemList.length
 ---
 <p>The read-only <code><strong>length</strong></code> property of the
   {{domxref("DataTransferItemList")}} interface returns the number of items currently in
@@ -146,6 +147,6 @@ function dragend_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItemList.length")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("HTML Drag and Drop API")}}</div>

--- a/files/en-us/web/api/datatransferitemlist/remove/index.html
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - drag and drop
 - remove
+browser-compat: api.DataTransferItemList.remove
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -161,4 +162,4 @@ function dragend_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DataTransferItemList.remove")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - DecompressionStream
+browser-compat: api.DecompressionStream.DecompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -60,4 +61,4 @@ const decompressedStream = blob.stream().pipeThrough(ds);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DecompressionStream.DecompressionStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/decompressionstream/index.html
+++ b/files/en-us/web/api/decompressionstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - DecompressionStream
+browser-compat: api.DecompressionStream
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -53,4 +54,4 @@ const decompressedStream = blob.stream().pipeThrough(ds);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DecompressionStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/decompressionstream/readable/index.html
+++ b/files/en-us/web/api/decompressionstream/readable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - readable
   - DecompressionStream
+browser-compat: api.DecompressionStream.readable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -45,4 +46,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DecompressionStream.readable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/decompressionstream/writable/index.html
+++ b/files/en-us/web/api/decompressionstream/writable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - writable
   - DecompressionStream
+browser-compat: api.DecompressionStream.writable
 ---
 <div>{{DefaultAPISidebar("Compression Streams API")}}</div>
 
@@ -43,4 +44,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DecompressionStream.writable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dedicatedworkerglobalscope/close/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/close/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Workers
   - close
+browser-compat: api.DedicatedWorkerGlobalScope.close
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Workers
   - Workers
+browser-compat: api.DedicatedWorkerGlobalScope
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
@@ -115,7 +116,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.html
@@ -3,6 +3,7 @@ title: 'DedicatedWorkerGlobalScope: message event'
 slug: Web/API/DedicatedWorkerGlobalScope/message_event
 tags:
   - Event
+browser-compat: api.DedicatedWorkerGlobalScope.message_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ self.onmessage = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.message_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.html
@@ -3,6 +3,7 @@ title: 'DedicatedWorkerGlobalScope: messageerror event'
 slug: Web/API/DedicatedWorkerGlobalScope/messageerror_event
 tags:
   - Event
+browser-compat: api.DedicatedWorkerGlobalScope.messageerror_event
 ---
 <div>{{APIRef}}</div>
 
@@ -66,7 +67,7 @@ self.onmessageerror = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.messageerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/name/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/name/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Worker
 - name
+browser-compat: api.DedicatedWorkerGlobalScope.name
 ---
 <div>{{APIRef("Web Workers API")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessage/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Workers
   - onmessage
+browser-compat: api.DedicatedWorkerGlobalScope.onmessage
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
@@ -66,7 +67,7 @@ myWorker.onmessage = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.onmessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/onmessageerror/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/onmessageerror/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - onmessageerror
+browser-compat: api.DedicatedWorkerGlobalScope.onmessageerror
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.onmessageerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Workers
   - postMessage
+browser-compat: api.DedicatedWorkerGlobalScope.postMessage
 ---
 <p>{{APIRef("Web Workers API")}}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DedicatedWorkerGlobalScope.postMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/delaynode/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/delaynode/index.html
@@ -9,6 +9,7 @@ tags:
 - Media
 - Reference
 - Web Audio API
+browser-compat: api.DelayNode.DelayNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -73,4 +74,4 @@ const delayNode = new DelayNode(audioCtx, {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DelayNode.DelayNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/delaynode/delaytime/index.html
+++ b/files/en-us/web/api/delaynode/delaytime/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - delayTime
+browser-compat: api.DelayNode.delayTime
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -55,7 +56,7 @@ myDelay.delayTime.value = 3.0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DelayNode.delayTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/delaynode/index.html
+++ b/files/en-us/web/api/delaynode/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.DelayNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DelayNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/deprecationreportbody/index.html
+++ b/files/en-us/web/api/deprecationreportbody/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Reporting API
+browser-compat: api.DeprecationReportBody
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
@@ -98,7 +99,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeprecationReportBody")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicelightevent/index.html
+++ b/files/en-us/web/api/devicelightevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Ambient Light Events
   - Interface
   - Deprecated
+browser-compat: api.DeviceLightEvent
 ---
 <div>{{apiref("Ambient Light Events")}}{{deprecated_header}}</div>
 <div class="notecard warning">
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceLightEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotionevent/acceleration/index.html
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.html
@@ -11,6 +11,7 @@ tags:
   - Orientation
   - Property
   - Reference
+browser-compat: api.DeviceMotionEvent.acceleration
 ---
 <p>{{APIRef("Device Orientation Events")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEvent.acceleration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.html
@@ -11,6 +11,7 @@ tags:
   - Orientation
   - Property
   - Reference
+browser-compat: api.DeviceMotionEvent.accelerationIncludingGravity
 ---
 <p>{{APIRef("Device Orientation Events")}}</p>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEvent.accelerationIncludingGravity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotionevent/devicemotionevent/index.html
+++ b/files/en-us/web/api/devicemotionevent/devicemotionevent/index.html
@@ -12,6 +12,7 @@ tags:
 - Non-standard
 - Orientation
 - Reference
+browser-compat: api.DeviceMotionEvent.DeviceMotionEvent
 ---
 <p>{{APIRef("Device Orientation Events")}}{{Non-standard_header}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEvent.DeviceMotionEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/devicemotionevent/index.html
+++ b/files/en-us/web/api/devicemotionevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Motion
   - Orientation
   - Reference
+browser-compat: api.DeviceMotionEvent
 ---
 <p>{{APIRef("Device Orientation Events")}}{{SeeCompatTable}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotionevent/interval/index.html
+++ b/files/en-us/web/api/devicemotionevent/interval/index.html
@@ -11,6 +11,7 @@ tags:
   - Orientation
   - Property
   - Reference
+browser-compat: api.DeviceMotionEvent.interval
 ---
 <p>{{APIRef("Device Orientation Events")}}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEvent.interval")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.html
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.html
@@ -13,6 +13,7 @@ tags:
   - Orientation
   - Property
   - Reference
+browser-compat: api.DeviceMotionEvent.rotationRate
 ---
 <p>{{APIRef("Device Orientation Events")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEvent.rotationRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - NeedsExample
   - Reference
+browser-compat: api.DeviceMotionEventAcceleration
 ---
 <div>{{ ApiRef("Device Orientation Events") }}{{SeeCompatTable}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventAcceleration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/devicemotioneventacceleration/x/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/x/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsExample
   - Property
   - Reference
+browser-compat: api.DeviceMotionEventAcceleration.x
 ---
 <div>{{ APIRef("Device Orientation Events") }}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventAcceleration.x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/y/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/y/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsExample
   - Property
   - Reference
+browser-compat: api.DeviceMotionEventAcceleration.y
 ---
 <div>{{ APIRef("Device Orientation Events") }}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventAcceleration.y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotioneventacceleration/z/index.html
+++ b/files/en-us/web/api/devicemotioneventacceleration/z/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsExample
   - Property
   - Reference
+browser-compat: api.DeviceMotionEventAcceleration.z
 ---
 <div>{{ APIRef("Device Orientation Events") }}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventAcceleration.z")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.html
@@ -9,6 +9,7 @@ tags:
   - Motion
   - Orientation
   - Reference
+browser-compat: api.DeviceMotionEventRotationRate.alpha
 ---
 <p>{{ ApiRef("Device Orientation Events") }}</p>
 
@@ -53,4 +54,4 @@ tags:
 </table>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventRotationRate.alpha")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/devicemotioneventrotationrate/beta/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/beta/index.html
@@ -9,6 +9,7 @@ tags:
   - Motion
   - Orientation
   - Reference
+browser-compat: api.DeviceMotionEventRotationRate.beta
 ---
 <p>{{ ApiRef("Device Orientation Events") }}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventRotationRate.beta")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.html
@@ -9,6 +9,7 @@ tags:
   - Motion
   - Orientation
   - Reference
+browser-compat: api.DeviceMotionEventRotationRate.gamma
 ---
 <p>{{ ApiRef("Device Orientation Events") }}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventRotationRate.gamma")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/devicemotioneventrotationrate/index.html
+++ b/files/en-us/web/api/devicemotioneventrotationrate/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM Reference
   - Experimental
   - Reference
+browser-compat: api.DeviceMotionEventRotationRate
 ---
 <p>{{ ApiRef("Device Orientation Events") }} {{SeeCompatTable}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceMotionEventRotationRate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/deviceorientationevent/absolute/index.html
+++ b/files/en-us/web/api/deviceorientationevent/absolute/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.DeviceOrientationEvent.absolute
 ---
 <p>{{ apiref("Device Orientation Events") }}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceOrientationEvent.absolute")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/alpha/index.html
+++ b/files/en-us/web/api/deviceorientationevent/alpha/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.DeviceOrientationEvent.alpha
 ---
 <p>{{ ApiRef("Device Orientation Events") }}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceOrientationEvent.alpha")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/beta/index.html
+++ b/files/en-us/web/api/deviceorientationevent/beta/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.DeviceOrientationEvent.beta
 ---
 <p>{{ ApiRef("Device Orientation Events") }}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceOrientationEvent.beta")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.html
+++ b/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.html
@@ -8,6 +8,7 @@ tags:
 - DeviceOrientationEvent
 - Experimental
 - Reference
+browser-compat: api.DeviceOrientationEvent.DeviceOrientationEvent
 ---
 <p>{{APIRef("Device Orientation Events")}}{{Non-standard_header}}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceOrientationEvent.DeviceOrientationEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/deviceorientationevent/gamma/index.html
+++ b/files/en-us/web/api/deviceorientationevent/gamma/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.DeviceOrientationEvent.gamma
 ---
 <p>{{ apiref("Device Orientation Events") }}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceOrientationEvent.gamma")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/deviceorientationevent/index.html
+++ b/files/en-us/web/api/deviceorientationevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.DeviceOrientationEvent
 ---
 <p>{{apiref("Device Orientation Events")}}{{SeeCompatTable}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceOrientationEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/deviceproximityevent/index.html
+++ b/files/en-us/web/api/deviceproximityevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Proximity Events
   - Reference
   - Deprecated
+browser-compat: api.DeviceProximityEvent
 ---
 <div>{{APIRef("Proximity Events")}}{{deprecated_header}}</div>
 <div class="notecard warning">
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeviceProximityEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/directoryentrysync/index.html
+++ b/files/en-us/web/api/directoryentrysync/index.html
@@ -8,6 +8,7 @@ tags:
   - Offline
   - Reference
   - filesystem
+browser-compat: api.DirectoryEntrySync
 ---
 <p>{{APIRef("File System API")}}{{Non-standard_header}}</p>
 
@@ -370,7 +371,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DirectoryEntrySync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/directoryreadersync/index.html
+++ b/files/en-us/web/api/directoryreadersync/index.html
@@ -4,6 +4,7 @@ slug: Web/API/DirectoryReaderSync
 tags:
   - API
   - Reference
+browser-compat: api.DirectoryReaderSync
 ---
 <p>{{APIRef("File System API")}}{{Non-standard_header}}</p>
 
@@ -148,7 +149,7 @@ self.onmessage = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DirectoryReaderSync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/audio/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/audio/index.html
@@ -17,6 +17,7 @@ tags:
 - Sharing
 - screen
 - track
+browser-compat: api.DisplayMediaStreamConstraints.audio
 ---
 <p>{{APIRef("Screen Capture API")}}</p>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DisplayMediaStreamConstraints.audio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/index.html
@@ -16,6 +16,7 @@ tags:
   - display
   - getDisplayMedia
   - screen
+browser-compat: api.DisplayMediaStreamConstraints
 ---
 <p>{{APIRef("Screen Capture API")}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DisplayMediaStreamConstraints")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/displaymediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/displaymediastreamconstraints/video/index.html
@@ -17,6 +17,7 @@ tags:
 - display
 - getDisplayMedia
 - screen
+browser-compat: api.DisplayMediaStreamConstraints.video
 ---
 <p>{{APIRef("Screen Capture API")}}</p>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DisplayMediaStreamConstraints.video")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/activeelement/index.html
+++ b/files/en-us/web/api/document/activeelement/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - ShadowRoot
   - activeElement
+browser-compat: api.Document.activeElement
 ---
 <div>{{APIRef("Shadow DOM")}}</div>
 
@@ -102,4 +103,4 @@ textarea2.addEventListener('mouseup', onMouseUp, false);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.activeElement")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/adoptnode/index.html
+++ b/files/en-us/web/api/document/adoptnode/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsSpecTable
 - NeedsUpdate
 - Reference
+browser-compat: api.Document.adoptNode
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -94,7 +95,7 @@ iframeImages.forEach(function(imgEl) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.adoptNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/alinkcolor/index.html
+++ b/files/en-us/web/api/document/alinkcolor/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.alinkColor
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.alinkColor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/all/index.html
+++ b/files/en-us/web/api/document/all/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - all
+browser-compat: api.Document.all
 ---
 <div>{{APIRef("DOM")}}{{Draft}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.all")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/anchors/index.html
+++ b/files/en-us/web/api/document/anchors/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.anchors
 ---
 <div>{{APIRef("DOM")}} {{Deprecated_Header}}</div>
 
@@ -112,4 +113,4 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.anchors")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/animationcancel_event/index.html
+++ b/files/en-us/web/api/document/animationcancel_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - animationcancel
+browser-compat: api.Document.animationcancel_event
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.animationcancel_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/animationend_event/index.html
+++ b/files/en-us/web/api/document/animationend_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - animationend
+browser-compat: api.Document.animationend_event
 ---
 <div>{{APIRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.animationend_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/animationiteration_event/index.html
+++ b/files/en-us/web/api/document/animationiteration_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Event
   - Reference
   - animationiteration
+browser-compat: api.Document.animationiteration_event
 ---
 <div>{{APIRef}}</div>
 
@@ -81,7 +82,7 @@ document.onanimationiteration = () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.animationiteration_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/animationstart_event/index.html
+++ b/files/en-us/web/api/document/animationstart_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - animationstart
+browser-compat: api.Document.animationstart_event
 ---
 <div>{{APIRef}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.animationstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/append/index.html
+++ b/files/en-us/web/api/document/append/index.html
@@ -8,6 +8,7 @@ tags:
   - Node
   - Document
   - Reference
+browser-compat: api.Document.append
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -78,7 +79,7 @@ doc.children; // HTMLCollection [&lt;html&gt;]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.append")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/applets/index.html
+++ b/files/en-us/web/api/document/applets/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsMarkupWork
 - Property
 - Reference
+browser-compat: api.Document.applets
 ---
 <div>{{APIRef("DOM")}} {{Deprecated_Header}}</div>
 
@@ -67,4 +68,4 @@ my_java_app = document.applets[1];
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.applets")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/bgcolor/index.html
+++ b/files/en-us/web/api/document/bgcolor/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+browser-compat: api.Document.bgColor
 ---
 <p>{{APIRef("DOM")}} {{Deprecated_Header}}</p>
 
@@ -49,4 +50,4 @@ document.bgColor =<em>color</em>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.bgColor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/body/index.html
+++ b/files/en-us/web/api/document/body/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.body
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -73,7 +74,7 @@ alert(document.body.id); // "newBodyElement"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.body")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/caretpositionfrompoint/index.html
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.html
@@ -6,6 +6,7 @@ tags:
   - Document
   - Method
   - Reference
+browser-compat: api.Document.caretPositionFromPoint
 ---
 <p>{{APIRef("CSSOM View")}} {{SeeCompatTable}}</p>
 
@@ -100,7 +101,7 @@ Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit ame
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.caretPositionFromPoint")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/document/caretrangefrompoint/index.html
+++ b/files/en-us/web/api/document/caretrangefrompoint/index.html
@@ -10,6 +10,7 @@ tags:
 - Non-standard
 - Reference
 - caretRangeFromPoint
+browser-compat: api.Document.caretRangeFromPoint
 ---
 <div>{{APIRef("DOM")}}{{Non-standard_header}}</div>
 
@@ -95,4 +96,4 @@ Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit ame
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.caretRangeFromPoint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/characterset/index.html
+++ b/files/en-us/web/api/document/characterset/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.Document.characterSet
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.characterSet")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/childelementcount/index.html
+++ b/files/en-us/web/api/document/childelementcount/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.Document.childElementCount
 ---
 <div>{{ APIRef("DOM") }}</div>
 
@@ -44,7 +45,7 @@ document.childElementCount;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.childElementCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/children/index.html
+++ b/files/en-us/web/api/document/children/index.html
@@ -8,6 +8,7 @@ tags:
   - HTMLCollection
   - Property
   - children
+browser-compat: api.Document.children
 ---
 <div>{{ APIRef("DOM") }}</div>
 
@@ -66,7 +67,7 @@ document.children;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.children")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/clear/index.html
+++ b/files/en-us/web/api/document/clear/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - NeedsSpecTable
 - Reference
+browser-compat: api.Document.clear
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_Header}}</div>
 
@@ -32,4 +33,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.clear")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/close/index.html
+++ b/files/en-us/web/api/document/close/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Method
 - Reference
+browser-compat: api.Document.close
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -56,4 +57,4 @@ document.close();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.close")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/compatmode/index.html
+++ b/files/en-us/web/api/document/compatmode/index.html
@@ -7,6 +7,7 @@ tags:
 - Document
 - Property
 - Reference
+browser-compat: api.Document.compatMode
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.compatMode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/contenttype/index.html
+++ b/files/en-us/web/api/document/contenttype/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.Document.contentType
 ---
 <div>{{APIRef}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.contentType")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/cookie/index.html
+++ b/files/en-us/web/api/document/cookie/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - cookie
+browser-compat: api.Document.cookie
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -450,7 +451,7 @@ Accept: */*
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.cookie")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/copy_event/index.html
+++ b/files/en-us/web/api/document/copy_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - copy
+browser-compat: api.Document.copy_event
 ---
 <div>{{APIRef}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.copy_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createattribute/index.html
+++ b/files/en-us/web/api/document/createattribute/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Reference
+browser-compat: api.Document.createAttribute
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -87,7 +88,7 @@ console.log(node.getAttribute("my_attrib")); // "newVal"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createAttribute")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createcdatasection/index.html
+++ b/files/en-us/web/api/document/createcdatasection/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Reference
+browser-compat: api.Document.createCDATASection
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -71,4 +72,4 @@ alert(new XMLSerializer().serializeToString(docu));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createCDATASection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/createcomment/index.html
+++ b/files/en-us/web/api/document/createcomment/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Reference
+browser-compat: api.Document.createComment
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -57,4 +58,4 @@ alert(new XMLSerializer().serializeToString(docu));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createComment")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/createdocumentfragment/index.html
+++ b/files/en-us/web/api/document/createdocumentfragment/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - createDocumentFragment
+browser-compat: api.Document.createDocumentFragment
 ---
 <p>{{APIRef("DOM WHATWG")}}</p>
 
@@ -95,7 +96,7 @@ element.appendChild(fragment);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createDocumentFragment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createelement/index.html
+++ b/files/en-us/web/api/document/createelement/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - createElement
+browser-compat: api.Document.createElement
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -120,7 +121,7 @@ customElements.define('expanding-list', ExpandingList, { extends: "ul" });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createelementns/index.html
+++ b/files/en-us/web/api/document/createelementns/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Reference
+browser-compat: api.Document.createElementNS
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -134,7 +135,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createElementNS")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createentityreference/index.html
+++ b/files/en-us/web/api/document/createentityreference/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - Deprecated
+browser-compat: api.Document.createEntityReference
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
@@ -18,4 +19,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createEntityReference")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/createevent/index.html
+++ b/files/en-us/web/api/document/createevent/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Reference
+browser-compat: api.Document.createEvent
 ---
 <div class="notecard warning">
   <h4>Warning</h4>
@@ -106,7 +107,7 @@ elem.dispatchEvent(event);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createexpression/index.html
+++ b/files/en-us/web/api/document/createexpression/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - createExpression
+browser-compat: api.Document.createExpression
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createExpression")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createnodeiterator/index.html
+++ b/files/en-us/web/api/document/createnodeiterator/index.html
@@ -7,6 +7,7 @@ tags:
   - Gecko
   - MakeBrowserAgnostic
   - Method
+browser-compat: api.Document.createNodeIterator
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -174,4 +175,4 @@ while (currentNode = nodeIterator.nextNode()) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createNodeIterator")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/creatensresolver/index.html
+++ b/files/en-us/web/api/document/creatensresolver/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM Reference
   - Method
   - Reference
+browser-compat: api.Document.createNSResolver
 ---
 <p>{{ ApiRef("DOM") }}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createNSResolver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createprocessinginstruction/index.html
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - createProcessInstruction
+browser-compat: api.Document.createProcessingInstruction
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -92,4 +93,4 @@ console.log(new XMLSerializer().serializeToString(doc));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createProcessingInstruction")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/createrange/index.html
+++ b/files/en-us/web/api/document/createrange/index.html
@@ -9,6 +9,7 @@ tags:
 - DocumentRange.createRange
 - Method
 - Range
+browser-compat: api.Document.createRange
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -57,4 +58,4 @@ range.setEnd(endNode, endOffset);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.createRange")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/createtextnode/index.html
+++ b/files/en-us/web/api/document/createtextnode/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - createTextNode
+browser-compat: api.Document.createTextNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -78,4 +79,4 @@ function addTextNode(text) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createTextNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/createtouch/index.html
+++ b/files/en-us/web/api/document/createtouch/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - createTouch
 - touch
+browser-compat: api.Document.createTouch
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_Header}}</div>
 
@@ -112,7 +113,7 @@ var touch2 = document.createTouch(window, target, 2, 25, 30, 45, 50);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createTouch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createtouchlist/index.html
+++ b/files/en-us/web/api/document/createtouchlist/index.html
@@ -10,6 +10,7 @@ tags:
 - Mobile
 - createTouchList
 - touch
+browser-compat: api.Document.createTouchList
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_Header}}</div>
 
@@ -93,7 +94,7 @@ var list2 = document.createTouchList(touch1, touch2);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createTouchList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/createtreewalker/index.html
+++ b/files/en-us/web/api/document/createtreewalker/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Document
 - Method
+browser-compat: api.Document.createTreeWalker
 ---
 <div>{{ApiRef("Document")}}</div>
 
@@ -184,7 +185,7 @@ while(currentNode) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.createTreeWalker")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/currentscript/index.html
+++ b/files/en-us/web/api/document/currentscript/index.html
@@ -7,6 +7,7 @@ tags:
 - Document
 - Property
 - Reference
+browser-compat: api.Document.currentScript
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.currentScript")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/cut_event/index.html
+++ b/files/en-us/web/api/document/cut_event/index.html
@@ -3,6 +3,7 @@ title: 'Document: cut event'
 slug: Web/API/Document/cut_event
 tags:
   - Event
+browser-compat: api.Document.cut_event
 ---
 <div>{{APIRef}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.cut_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/defaultview/index.html
+++ b/files/en-us/web/api/document/defaultview/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.defaultView
 ---
 <div>{{ApiRef}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.defaultView")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/designmode/index.html
+++ b/files/en-us/web/api/document/designmode/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - editor
+browser-compat: api.Document.designMode
 ---
 <div>{{ApiRef()}}</div>
 
@@ -60,7 +61,7 @@ document.designMode = <em>value</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.designMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/dir/index.html
+++ b/files/en-us/web/api/document/dir/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.dir
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.dir")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/doctype/index.html
+++ b/files/en-us/web/api/document/doctype/index.html
@@ -7,6 +7,7 @@ tags:
 - Document
 - Property
 - Reference
+browser-compat: api.Document.doctype
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -63,4 +64,4 @@ console.log(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.doctype")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/document/index.html
+++ b/files/en-us/web/api/document/document/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM
 - Document
 - Reference
+browser-compat: api.Document.Document
 ---
 <div>{{APIRef}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.Document")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/documentelement/index.html
+++ b/files/en-us/web/api/document/documentelement/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - root
+browser-compat: api.Document.documentElement
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -59,4 +60,4 @@ for (const child of firstTier) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.documentElement")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/documenturi/index.html
+++ b/files/en-us/web/api/document/documenturi/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.Document.documentURI
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.documentURI")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/documenturiobject/index.html
+++ b/files/en-us/web/api/document/documenturiobject/index.html
@@ -7,6 +7,7 @@ tags:
   - Non-standard
   - Property
   - Reference
+browser-compat: api.Document.documentURIObject
 ---
 <div>{{ApiRef("DOM")}}{{Non-standard_header}}</div>
 
@@ -46,4 +47,4 @@ if (uriObj.schemeIs('http')) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.documentURIObject")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/domain/index.html
+++ b/files/en-us/web/api/document/domain/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Deprecated
+browser-compat: api.Document.domain
 ---
 <div>{{ApiRef}} {{Deprecated_Header}}</div>
 
@@ -170,7 +171,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.domain")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/domcontentloaded_event/index.html
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Document
   - Event
   - Web
+browser-compat: api.Document.DOMContentLoaded_event
 ---
 <div>{{APIRef}}</div>
 
@@ -352,7 +353,7 @@ document.addEventListener('DOMContentLoaded', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.DOMContentLoaded_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/drag_event/index.html
+++ b/files/en-us/web/api/document/drag_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web
   - drag and drop
+browser-compat: api.Document.drag_event
 ---
 <div>{{APIRef}}</div>
 
@@ -152,7 +153,7 @@ document.addEventListener("drop", function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.drag_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/dragend_event/index.html
+++ b/files/en-us/web/api/document/dragend_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - drag and drop
   - dragend
+browser-compat: api.Document.dragend_event
 ---
 <div>{{APIRef}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.dragend_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/dragenter_event/index.html
+++ b/files/en-us/web/api/document/dragenter_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - drag and drop
   - dragenter
+browser-compat: api.Document.dragenter_event
 ---
 <div>{{APIRef}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.dragenter_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/dragleave_event/index.html
+++ b/files/en-us/web/api/document/dragleave_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - drag and drop
   - dragleave
+browser-compat: api.Document.dragleave_event
 ---
 <div>{{APIRef}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.dragleave_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/dragover_event/index.html
+++ b/files/en-us/web/api/document/dragover_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - drag and drop
+browser-compat: api.Document.dragover_event
 ---
 <div>{{APIRef}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.dragover_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/dragstart_event/index.html
+++ b/files/en-us/web/api/document/dragstart_event/index.html
@@ -6,6 +6,7 @@ tags:
   - Event
   - Reference
   - drag and drop
+browser-compat: api.Document.dragstart_event
 ---
 <div>{{APIRef}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.dragstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/drop_event/index.html
+++ b/files/en-us/web/api/document/drop_event/index.html
@@ -9,6 +9,7 @@ tags:
   - HTML 5
   - Reference
   - drag and drop
+browser-compat: api.Document.drop_event
 ---
 <div>{{APIRef}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.drop_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/elementfrompoint/index.html
+++ b/files/en-us/web/api/document/elementfrompoint/index.html
@@ -7,6 +7,7 @@ tags:
   - Document
   - Method
   - Reference
+browser-compat: api.Document.elementFromPoint
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.elementFromPoint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/elementsfrompoint/index.html
+++ b/files/en-us/web/api/document/elementsfrompoint/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - elementsFromPoint
+browser-compat: api.Document.elementsFromPoint
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -82,7 +83,7 @@ if (document.elementsFromPoint) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.elementsFromPoint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/embeds/index.html
+++ b/files/en-us/web/api/document/embeds/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - NeedsExample
 - Property
+browser-compat: api.Document.embeds
 ---
 <div>{{ApiRef}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.embeds")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/enablestylesheetsforset/index.html
+++ b/files/en-us/web/api/document/enablestylesheetsforset/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsSpecTable
   - Reference
   - Deprecated
+browser-compat: api.Document.enableStyleSheetsForSet
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.enableStyleSheetsForSet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/evaluate/index.html
+++ b/files/en-us/web/api/document/evaluate/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - XPath
+browser-compat: api.Document.evaluate
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -204,7 +205,7 @@ alert(alertText); // Alerts the text of all h2 elements
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.evaluate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/execcommand/index.html
+++ b/files/en-us/web/api/document/execcommand/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - editor
   - Deprecated
+browser-compat: api.Document.execCommand
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
@@ -244,7 +245,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.execCommand")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/exitfullscreen/index.html
+++ b/files/en-us/web/api/document/exitfullscreen/index.html
@@ -13,6 +13,7 @@ tags:
 - exitFullscreen
 - fullscreen
 - screen
+browser-compat: api.Document.exitFullscreen
 ---
 <div>{{ApiRef("Fullscreen API")}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.exitFullscreen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/exitpictureinpicture/index.html
+++ b/files/en-us/web/api/document/exitpictureinpicture/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - pip
+browser-compat: api.Document.exitPictureInPicture
 ---
 <div>{{ApiRef("Picture-in-Picture API")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.exitPictureInPicture")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/exitpointerlock/index.html
+++ b/files/en-us/web/api/document/exitpointerlock/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - mouse lock
+browser-compat: api.Document.exitPointerLock
 ---
 <div>{{APIRef("DOM")}} {{SeeCompatTable}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.exitPointerLock")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/featurepolicy/index.html
+++ b/files/en-us/web/api/document/featurepolicy/index.html
@@ -7,6 +7,7 @@ tags:
   - Feature Policy
   - Feature-Policy
   - Reference
+browser-compat: api.Document.featurePolicy
 ---
 <p>{{APIRef("Feature Policy")}}</p>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.featurePolicy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/fgcolor/index.html
+++ b/files/en-us/web/api/document/fgcolor/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+browser-compat: api.Document.fgColor
 ---
 <div>{{ApiRef}}{{Deprecated_header}}</div>
 
@@ -50,4 +51,4 @@ document.bgColor = "darkblue";
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.fgColor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/firstelementchild/index.html
+++ b/files/en-us/web/api/document/firstelementchild/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Element
   - Property
+browser-compat: api.Document.firstElementChild
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -47,7 +48,7 @@ document.firstElementChild;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.firstElementChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fonts/index.html
+++ b/files/en-us/web/api/document/fonts/index.html
@@ -9,6 +9,7 @@ tags:
 - FontFaceSet
 - Fonts
 - font
+browser-compat: api.Document.fonts
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.fonts")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/forms/index.html
+++ b/files/en-us/web/api/document/forms/index.html
@@ -10,6 +10,7 @@ tags:
   - HTML forms
   - Property
   - Reference
+browser-compat: api.Document.forms
 ---
 <p><span class="seoSummary">The <strong><code>forms</code></strong> read-only property of
     the {{domxref("Document")}} interface returns an {{domxref("HTMLCollection")}} listing
@@ -120,7 +121,7 @@ var selectFormElement = document.forms[index].elements[index];
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.forms")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fullscreen/index.html
+++ b/files/en-us/web/api/document/fullscreen/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - fullscreen
   - screen
+browser-compat: api.Document.fullscreen
 ---
 <div>{{APIRef("Fullscreen API")}}{{Deprecated_Header}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.fullscreen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fullscreenchange_event/index.html
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - fullscreen
   - fullscreenchange
+browser-compat: api.Document.fullscreenchange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.fullscreenchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fullscreenelement/index.html
+++ b/files/en-us/web/api/document/fullscreenelement/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - fullscreenElement
   - screen
+browser-compat: api.Document.fullscreenElement
 ---
 <div>{{ApiRef("Fullscreen API")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.fullscreenElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fullscreenenabled/index.html
+++ b/files/en-us/web/api/document/fullscreenenabled/index.html
@@ -12,6 +12,7 @@ tags:
 - fullscreen
 - fullscreenEnabled
 - screen
+browser-compat: api.Document.fullscreenEnabled
 ---
 <div>{{APIRef("Fullscreen API")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.fullscreenEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/fullscreenerror_event/index.html
+++ b/files/en-us/web/api/document/fullscreenerror_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - fullscreen
   - fullscreenerror
+browser-compat: api.Document.fullscreenerror_event
 ---
 <p>{{APIRef}}</p>
 
@@ -69,7 +70,7 @@ requestor.requestFullscreen();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.fullscreenerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/getanimations/index.html
+++ b/files/en-us/web/api/document/getanimations/index.html
@@ -15,6 +15,7 @@ tags:
   - getAnimations
   - waapi
   - web animations api
+browser-compat: api.Document.getAnimations
 ---
 <p>{{APIRef("Web Animations")}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getAnimations")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/getboxobjectfor/index.html
+++ b/files/en-us/web/api/document/getboxobjectfor/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - Deprecated
+browser-compat: api.Document.getBoxObjectFor
 ---
 <div>{{ApiRef("DOM")}} {{deprecated_header}}</div>
 
@@ -45,4 +46,4 @@ alert (
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getBoxObjectFor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/getelementbyid/index.html
+++ b/files/en-us/web/api/document/getelementbyid/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - getElementById
   - id
+browser-compat: api.Document.getElementById
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -137,7 +138,7 @@ var el = document.getElementById('testqq'); // el will be null!
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getElementById")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/getelementsbyclassname/index.html
+++ b/files/en-us/web/api/document/getelementsbyclassname/index.html
@@ -9,6 +9,7 @@ tags:
 - HTML5
 - Method
 - Reference
+browser-compat: api.Document.getElementsByClassName
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -156,4 +157,4 @@ document.getElementById("resultArea").value = result;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getElementsByClassName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/getelementsbyname/index.html
+++ b/files/en-us/web/api/document/getelementsbyname/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML
 - Method
 - Reference
+browser-compat: api.Document.getElementsByName
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getElementsByName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/getelementsbytagname/index.html
+++ b/files/en-us/web/api/document/getelementsbytagname/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Reference
+browser-compat: api.Document.getElementsByTagName
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -139,7 +140,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getElementsByTagName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.html
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsSpecTable
   - Reference
   - getElementsByTagNameNS
+browser-compat: api.Document.getElementsByTagNameNS
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -180,7 +181,7 @@ function div2ParaElems()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getElementsByTagNameNS")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/getselection/index.html
+++ b/files/en-us/web/api/document/getselection/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - getSelection
+browser-compat: api.Document.getSelection
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -80,4 +81,4 @@ console.log(selection); // Selection object
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.getSelection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/gotpointercapture_event/index.html
+++ b/files/en-us/web/api/document/gotpointercapture_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - gotpointercapture
+browser-compat: api.Document.gotpointercapture_event
 ---
 <div>{{APIRef}}</div>
 
@@ -84,7 +85,7 @@ para.addEventListener('pointerdown', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.gotpointercapture_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/hasfocus/index.html
+++ b/files/en-us/web/api/document/hasfocus/index.html
@@ -7,6 +7,7 @@ tags:
   - Focus
   - Method
   - Reference
+browser-compat: api.Document.hasFocus
 ---
 <div>{{APIRef}}</div>
 
@@ -93,7 +94,7 @@ setInterval(checkPageFocus, 300);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.hasFocus")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/hasstorageaccess/index.html
+++ b/files/en-us/web/api/document/hasstorageaccess/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Storage Access API
 - hasStorageAccess
+browser-compat: api.Document.hasStorageAccess
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.hasStorageAccess")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/head/index.html
+++ b/files/en-us/web/api/document/head/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.head
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.head")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/height/index.html
+++ b/files/en-us/web/api/document/height/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Deprecated
+browser-compat: api.Document.height
 ---
 <div>{{APIRef("DOM")}} {{deprecated_header}}</div>
 
@@ -46,7 +47,7 @@ document.documentElement.scrollHeight
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/hidden/index.html
+++ b/files/en-us/web/api/document/hidden/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - Web
+browser-compat: api.Document.hidden
 ---
 <p>{{ ApiRef("DOM") }}</p>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.hidden")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/images/index.html
+++ b/files/en-us/web/api/document/images/index.html
@@ -8,6 +8,7 @@ tags:
   - Images
   - Property
   - Reference
+browser-compat: api.Document.images
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,4 +77,4 @@ for(var i = 0; i &lt; ilist.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.images")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/implementation/index.html
+++ b/files/en-us/web/api/document/implementation/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsContent
 - Property
 - Reference
+browser-compat: api.Document.implementation
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -67,7 +68,7 @@ alert( "DOM " + modName + " " + modVer + " supported?: " + conformTest );
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.implementation")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Gecko-specific_notes">Gecko-specific notes</h3>
 

--- a/files/en-us/web/api/document/importnode/index.html
+++ b/files/en-us/web/api/document/importnode/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - copy
 - importNode
+browser-compat: api.Document.importNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -120,7 +121,7 @@ document.getElementById("container").appendChild(newNode);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.importNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/index.html
+++ b/files/en-us/web/api/document/index.html
@@ -7,6 +7,7 @@ tags:
   - Document
   - Interface
   - Reference
+browser-compat: api.Document
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -646,4 +647,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/keydown_event/index.html
+++ b/files/en-us/web/api/document/keydown_event/index.html
@@ -9,6 +9,7 @@ tags:
   - KeyboardEvent
   - Reference
   - keydown
+browser-compat: api.Document.keydown_event
 ---
 <div>{{APIRef}}</div>
 
@@ -89,7 +90,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.keydown_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/keypress_event/index.html
+++ b/files/en-us/web/api/document/keypress_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Event
   - KeyboardEvent
   - Reference
+browser-compat: api.Document.keypress_event
 ---
 <div>{{APIRef}} {{deprecated_header}}</div>
 
@@ -79,7 +80,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.keypress_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/keyup_event/index.html
+++ b/files/en-us/web/api/document/keyup_event/index.html
@@ -8,6 +8,7 @@ tags:
   - KeyboardEvent
   - Reference
   - keyup
+browser-compat: api.Document.keyup_event
 ---
 <div>{{APIRef}}</div>
 
@@ -92,7 +93,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.keyup_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/lastelementchild/index.html
+++ b/files/en-us/web/api/document/lastelementchild/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Element
   - Property
+browser-compat: api.Document.lastElementChild
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -47,7 +48,7 @@ document.lastElementChild;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.lastElementChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/lastmodified/index.html
+++ b/files/en-us/web/api/document/lastmodified/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsSpecTable
   - Property
   - Reference
+browser-compat: api.Document.lastModified
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -105,4 +106,4 @@ if (isNaN(nLastVisit) || nLastModif &gt; nLastVisit) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.lastModified")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/laststylesheetset/index.html
+++ b/files/en-us/web/api/document/laststylesheetset/index.html
@@ -11,6 +11,7 @@ tags:
   - Stylesheets
   - lastStyleSheetSet
   - Deprecated
+browser-compat: api.Document.lastStyleSheetSet
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -46,7 +47,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.lastStyleSheetSet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/linkcolor/index.html
+++ b/files/en-us/web/api/document/linkcolor/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+browser-compat: api.Document.linkColor
 ---
 <div>{{APIRef("DOM")}} {{Deprecated_header}}</div>
 
@@ -50,7 +51,7 @@ document.linkColor = <var>color</var>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.linkColor")}}</p>
+<p>{{Compat}}</p>
 
 <p>The default value for this property in Mozilla Firefox is blue (<code>#0000ee</code> in
   hexadecimal).</p>

--- a/files/en-us/web/api/document/links/index.html
+++ b/files/en-us/web/api/document/links/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+browser-compat: api.Document.links
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -56,4 +57,4 @@ for(var i = 0; i &lt; links.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.links")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/location/index.html
+++ b/files/en-us/web/api/document/location/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.Document.location
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -68,7 +69,7 @@ document.location = 'http://www.mozilla.org' // Equivalent to document.location.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.location")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/lostpointercapture_event/index.html
+++ b/files/en-us/web/api/document/lostpointercapture_event/index.html
@@ -8,6 +8,7 @@ tags:
   - PointerEvent
   - Reference
   - lostpointercapture
+browser-compat: api.Document.lostpointercapture_event
 ---
 <div>{{APIRef}}</div>
 
@@ -85,7 +86,7 @@ para.addEventListener('pointerdown', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.lostpointercapture_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/mozsetimageelement/index.html
+++ b/files/en-us/web/api/document/mozsetimageelement/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Non-standard
   - Reference
+browser-compat: api.Document.mozSetImageElement
 ---
 <p>{{ ApiRef("DOM") }}{{ non-standard_header() }}</p>
 
@@ -88,7 +89,7 @@ function clicked() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.mozSetImageElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/mozsyntheticdocument/index.html
+++ b/files/en-us/web/api/document/mozsyntheticdocument/index.html
@@ -7,6 +7,7 @@ tags:
 - Non-standard
 - Property
 - Reference
+browser-compat: api.Document.mozSyntheticDocument
 ---
 <p>{{ ApiRef("DOM") }}{{ non-standard_header() }}</p>
 
@@ -40,4 +41,4 @@ if (isSynthetic) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.mozSyntheticDocument")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/onafterscriptexecute/index.html
+++ b/files/en-us/web/api/document/onafterscriptexecute/index.html
@@ -7,6 +7,7 @@ tags:
   - Non-standard
   - Property
   - Reference
+browser-compat: api.Document.onafterscriptexecute
 ---
 <div>{{ApiRef("DOM")}}{{non-standard_header}}</div>
 
@@ -43,7 +44,7 @@ document.addEventListener('afterscriptexecute', finished, true);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.onafterscriptexecute")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/onbeforescriptexecute/index.html
+++ b/files/en-us/web/api/document/onbeforescriptexecute/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - element.onbeforescriptexecute
+browser-compat: api.Document.onbeforescriptexecute
 ---
 <div>{{ApiRef("DOM")}} {{non-standard_header }}</div>
 
@@ -43,7 +44,7 @@ document.addEventListener("beforescriptexecute", starting, true);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.onbeforescriptexecute")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/onfullscreenchange/index.html
+++ b/files/en-us/web/api/document/onfullscreenchange/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - fullscreen
 - onfullscreenchange
+browser-compat: api.Document.onfullscreenchange
 ---
 <div>{{APIRef("Fullscreen API")}}</div>
 
@@ -70,7 +71,7 @@ document.documentElement.onclick = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.onfullscreenchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/onfullscreenerror/index.html
+++ b/files/en-us/web/api/document/onfullscreenerror/index.html
@@ -13,6 +13,7 @@ tags:
 - fullscreen
 - onfullscreenerror
 - screen
+browser-compat: api.Document.onfullscreenerror
 ---
 <div>{{ApiRef("Fullscreen API")}}</div>
 
@@ -68,7 +69,7 @@ document.documentElement.requestFullscreen();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.onfullscreenerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/onvisibilitychange/index.html
+++ b/files/en-us/web/api/document/onvisibilitychange/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onvisibilitychange
+browser-compat: api.Document.onvisibilitychange
 ---
 <div>{{ApiRef('DOM')}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.onvisibilitychange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/open/index.html
+++ b/files/en-us/web/api/document/open/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - open
+browser-compat: api.Document.open
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -123,7 +124,7 @@ document.close();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.open")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/origin/index.html
+++ b/files/en-us/web/api/document/origin/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - Deprecated
+browser-compat: api.Document.origin
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -40,7 +41,7 @@ var origin = document.origin;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.origin")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/paste_event/index.html
+++ b/files/en-us/web/api/document/paste_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - paste
+browser-compat: api.Document.paste_event
 ---
 <div>{{APIRef}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.paste_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pictureinpictureelement/index.html
+++ b/files/en-us/web/api/document/pictureinpictureelement/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - pictureInPictureElement
   - pip
+browser-compat: api.Document.pictureInPictureElement
 ---
 <div>{{ApiRef("Fullscreen API")}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pictureInPictureElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.html
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - pip
+browser-compat: api.Document.pictureInPictureEnabled
 ---
 <div>{{APIRef("Picture-in-Picture API")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pictureInPictureEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/plugins/index.html
+++ b/files/en-us/web/api/document/plugins/index.html
@@ -7,6 +7,7 @@ tags:
 - NeedsMarkupWork
 - Property
 - Reference
+browser-compat: api.Document.plugins
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.plugins")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointercancel_event/index.html
+++ b/files/en-us/web/api/document/pointercancel_event/index.html
@@ -8,6 +8,7 @@ tags:
   - PointerEvent
   - onpointercancel
   - pointercancel
+browser-compat: api.Document.pointercancel_event
 ---
 <div>{{APIRef}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointercancel_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerdown_event/index.html
+++ b/files/en-us/web/api/document/pointerdown_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - onpointerdown
   - pointerdown
+browser-compat: api.Document.pointerdown_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerdown_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerenter_event/index.html
+++ b/files/en-us/web/api/document/pointerenter_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - onpointerenter
   - pointerenter
+browser-compat: api.Document.pointerenter_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerenter_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerleave_event/index.html
+++ b/files/en-us/web/api/document/pointerleave_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - onpointerleave
   - pointerleave
+browser-compat: api.Document.pointerleave_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerleave_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerlockchange_event/index.html
+++ b/files/en-us/web/api/document/pointerlockchange_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Web
   - pointerlockchange
+browser-compat: api.Document.pointerlockchange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerlockchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerlockelement/index.html
+++ b/files/en-us/web/api/document/pointerlockelement/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - mouse lock
+browser-compat: api.Document.pointerLockElement
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -60,7 +61,7 @@ if (document.pointerLockElement === canvasElement) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerLockElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerlockerror_event/index.html
+++ b/files/en-us/web/api/document/pointerlockerror_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Web
   - pointerlockerror
+browser-compat: api.Document.pointerlockerror_event
 ---
 <div>{{APIRef}}</div>
 
@@ -68,7 +69,7 @@ document.addEventListener('pointerlockerror', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerlockerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointermove_event/index.html
+++ b/files/en-us/web/api/document/pointermove_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Web
   - pointer
   - pointermove
+browser-compat: api.Document.pointermove_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointermove_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerout_event/index.html
+++ b/files/en-us/web/api/document/pointerout_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Web
   - onpointerout
   - pointerout
+browser-compat: api.Document.pointerout_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerout_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerover_event/index.html
+++ b/files/en-us/web/api/document/pointerover_event/index.html
@@ -10,6 +10,7 @@ tags:
   - onpointerover
   - pointer
   - pointerover
+browser-compat: api.Document.pointerover_event
 ---
 <div>{{APIRef}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerover_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/pointerup_event/index.html
+++ b/files/en-us/web/api/document/pointerup_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Web
   - onpointerup
   - pointerup
+browser-compat: api.Document.pointerup_event
 ---
 <div>{{APIRef}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.pointerup_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/popupnode/index.html
+++ b/files/en-us/web/api/document/popupnode/index.html
@@ -7,6 +7,7 @@ tags:
 - Deprecated
 - Property
 - Reference
+browser-compat: api.Document.popupNode
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.popupNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/preferredstylesheetset/index.html
+++ b/files/en-us/web/api/document/preferredstylesheetset/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Stylesheets
   - Deprecated
+browser-compat: api.Document.preferredStyleSheetSet
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.preferredStyleSheetSet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/prepend/index.html
+++ b/files/en-us/web/api/document/prepend/index.html
@@ -8,6 +8,7 @@ tags:
   - Node
   - Document
   - Reference
+browser-compat: api.Document.prepend
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -78,7 +79,7 @@ doc.children; // HTMLCollection [&lt;html&gt;]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.prepend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/querycommandenabled/index.html
+++ b/files/en-us/web/api/document/querycommandenabled/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - Deprecated
+browser-compat: api.Document.queryCommandEnabled
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
@@ -70,7 +71,7 @@ if(flg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.queryCommandEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/querycommandstate/index.html
+++ b/files/en-us/web/api/document/querycommandstate/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Reference
   - Deprecated
+browser-compat: api.Document.queryCommandState
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.queryCommandState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/querycommandsupported/index.html
+++ b/files/en-us/web/api/document/querycommandsupported/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - editor
 - Deprecated
+browser-compat: api.Document.queryCommandSupported
 ---
 <div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
@@ -70,7 +71,7 @@ if(flg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.queryCommandSupported")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/queryselector/index.html
+++ b/files/en-us/web/api/document/queryselector/index.html
@@ -12,6 +12,7 @@ tags:
 - Selector API
 - Selectors
 - querySelector
+browser-compat: api.Document.querySelector
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -152,7 +153,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.querySelector")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/queryselectorall/index.html
+++ b/files/en-us/web/api/document/queryselectorall/index.html
@@ -14,6 +14,7 @@ tags:
   - Selecting Elements
   - Selectors
   - querySelectorAll
+browser-compat: api.Document.querySelectorAll
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -195,7 +196,7 @@ inner.length; // 0
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.querySelectorAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/readystate/index.html
+++ b/files/en-us/web/api/document/readystate/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+browser-compat: api.Document.readyState
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -128,7 +129,7 @@ document.onreadystatechange = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.readyState")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/readystatechange_event/index.html
+++ b/files/en-us/web/api/document/readystatechange_event/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - XMLHttpRequest
   - interactive
+browser-compat: api.Document.readystatechange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -132,7 +133,7 @@ document.addEventListener('DOMContentLoaded', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.readystatechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/referrer/index.html
+++ b/files/en-us/web/api/document/referrer/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsSpecTable
   - Property
   - Reference
+browser-compat: api.Document.referrer
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.referrer")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/registerelement/index.html
+++ b/files/en-us/web/api/document/registerelement/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - Web Components
+browser-compat: api.Document.registerElement
 ---
 <div>{{APIRef("DOM")}}{{Deprecated_header}}
   <div class="warning overheadIndicator">
@@ -73,7 +74,7 @@ mytag.textContent = "I am a my-tag element.";
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.registerElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/releasecapture/index.html
+++ b/files/en-us/web/api/document/releasecapture/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Reference
+browser-compat: api.Document.releaseCapture
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.releaseCapture")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/replacechildren/index.html
+++ b/files/en-us/web/api/document/replacechildren/index.html
@@ -9,6 +9,7 @@ tags:
   - Document
   - Reference
   - replaceChildren
+browser-compat: api.Document.replaceChildren
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -65,7 +66,7 @@ document.children; // HTMLCollection []
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.replaceChildren")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/requeststorageaccess/index.html
+++ b/files/en-us/web/api/document/requeststorageaccess/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Storage Access API
   - requestStorageAccess
+browser-compat: api.Document.requestStorageAccess
 ---
 <div>{{APIRef}}</div>
 
@@ -175,7 +176,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.requestStorageAccess")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/scripts/index.html
+++ b/files/en-us/web/api/document/scripts/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.Document.scripts
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -57,4 +58,4 @@ if (scripts.length) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.scripts")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/document/scroll_event/index.html
+++ b/files/en-us/web/api/document/scroll_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Scroll
   - UIEvent
+browser-compat: api.Document.scroll_event
 ---
 <p>{{APIRef}}</p>
 
@@ -88,7 +89,7 @@ document.addEventListener('scroll', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.scroll_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/scrollingelement/index.html
+++ b/files/en-us/web/api/document/scrollingelement/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - scrollingElement
+browser-compat: api.Document.scrollingElement
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -51,4 +52,4 @@ scrollElm.scrollTop = 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.scrollingElement")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/selectedstylesheetset/index.html
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Stylesheets
   - Deprecated
+browser-compat: api.Document.selectedStyleSheetSet
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -44,7 +45,7 @@ document.selectedStyleSheetSet = 'Some other style sheet';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.selectedStyleSheetSet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/selectionchange_event/index.html
+++ b/files/en-us/web/api/document/selectionchange_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Selection
   - Selection API
   - selectionchange
+browser-compat: api.Document.selectionchange_event
 ---
 <p>{{APIRef}}</p>
 
@@ -68,7 +69,7 @@ document.onselectionchange = () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.selectionchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/selectstart_event/index.html
+++ b/files/en-us/web/api/document/selectstart_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Selection
   - Selection API
   - selectstart
+browser-compat: api.Document.selectstart_event
 ---
 <div>{{APIRef}}</div>
 
@@ -68,7 +69,7 @@ document.onselectstart = () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.selectstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/stylesheets/index.html
+++ b/files/en-us/web/api/document/stylesheets/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - Stylesheets
+browser-compat: api.Document.styleSheets
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.styleSheets")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/stylesheetsets/index.html
+++ b/files/en-us/web/api/document/stylesheetsets/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Stylesheets
   - Deprecated
+browser-compat: api.Document.styleSheetSets
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -50,7 +51,7 @@ for (let i = 0; i &lt; sheets.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.styleSheetSets")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/timeline/index.html
+++ b/files/en-us/web/api/document/timeline/index.html
@@ -14,6 +14,7 @@ tags:
   - timeline
   - waapi
   - web animations api
+browser-compat: api.Document.timeline
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</p>
 
@@ -55,7 +56,7 @@ var thisMoment = pageTimeline.currentTime;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.timeline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/title/index.html
+++ b/files/en-us/web/api/document/title/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+browser-compat: api.Document.title
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.title")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/tooltipnode/index.html
+++ b/files/en-us/web/api/document/tooltipnode/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Property
 - Reference
+browser-compat: api.Document.tooltipNode
 ---
 <p>{{APIRef("DOM")}}{{Draft}}{{Non-standard_Header}}</p>
 
@@ -28,4 +29,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.tooltipNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/touchcancel_event/index.html
+++ b/files/en-us/web/api/document/touchcancel_event/index.html
@@ -8,6 +8,7 @@ tags:
   - TouchEvent
   - Web
   - touchcancel
+browser-compat: api.Document.touchcancel_event
 ---
 <div>{{APIRef}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.touchcancel_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/touchend_event/index.html
+++ b/files/en-us/web/api/document/touchend_event/index.html
@@ -13,6 +13,7 @@ tags:
   - ontouchend
   - touch
   - touchend
+browser-compat: api.Document.touchend_event
 ---
 <div>{{APIRef}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.touchend_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/touchmove_event/index.html
+++ b/files/en-us/web/api/document/touchmove_event/index.html
@@ -14,6 +14,7 @@ tags:
   - UX
   - touch
   - touchmove
+browser-compat: api.Document.touchmove_event
 ---
 <div>{{APIRef}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.touchmove_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/touchstart_event/index.html
+++ b/files/en-us/web/api/document/touchstart_event/index.html
@@ -8,6 +8,7 @@ tags:
   - TouchEvent
   - Web
   - touchstart
+browser-compat: api.Document.touchstart_event
 ---
 <div>{{APIRef}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.touchstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/transitioncancel_event/index.html
+++ b/files/en-us/web/api/document/transitioncancel_event/index.html
@@ -10,6 +10,7 @@ tags:
   - TransitionEvent
   - Web
   - transitioncancel
+browser-compat: api.Document.transitioncancel_event
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.transitioncancel_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/transitionend_event/index.html
+++ b/files/en-us/web/api/document/transitionend_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - transitionend
+browser-compat: api.Document.transitionend_event
 ---
 <div>{{APIRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.transitionend_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/transitionrun_event/index.html
+++ b/files/en-us/web/api/document/transitionrun_event/index.html
@@ -8,6 +8,7 @@ tags:
   - TransitionEvent
   - Web
   - transitionrun
+browser-compat: api.Document.transitionrun_event
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.transitionrun_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/transitionstart_event/index.html
+++ b/files/en-us/web/api/document/transitionstart_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - transitionstart
+browser-compat: api.Document.transitionstart_event
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.transitionstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/url/index.html
+++ b/files/en-us/web/api/document/url/index.html
@@ -7,6 +7,7 @@ tags:
 - Document
 - Property
 - Reference
+browser-compat: api.Document.URL
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.URL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/visibilitychange_event/index.html
+++ b/files/en-us/web/api/document/visibilitychange_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Visibility
   - Web
   - visibilitychange
+browser-compat: api.Document.visibilitychange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.visibilitychange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/visibilitystate/index.html
+++ b/files/en-us/web/api/document/visibilitystate/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - Web
+browser-compat: api.Document.visibilityState
 ---
 <p>{{ ApiRef("DOM") }}</p>
 
@@ -82,4 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.visibilityState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/vlinkcolor/index.html
+++ b/files/en-us/web/api/document/vlinkcolor/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsSpecTable
 - Property
 - Reference
+browser-compat: api.Document.vlinkColor
 ---
 <div>{{APIRef("DOM")}} {{Deprecated_Header}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.vlinkColor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/wheel_event/index.html
+++ b/files/en-us/web/api/document/wheel_event/index.html
@@ -7,6 +7,7 @@ tags:
   - Event
   - Reference
   - wheel
+browser-compat: api.Document.wheel_event
 ---
 <div>{{APIRef}}</div>
 
@@ -112,7 +113,7 @@ document.onwheel = zoom;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.wheel_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/width/index.html
+++ b/files/en-us/web/api/document/width/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Deprecated
+browser-compat: api.Document.width
 ---
 <div>{{APIRef("DOM")}} {{deprecated_header}}</div>
 
@@ -49,7 +50,7 @@ window.innerWidth                      /* window's width */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/write/index.html
+++ b/files/en-us/web/api/document/write/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - write
+browser-compat: api.Document.write
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Document.write")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/document/writeln/index.html
+++ b/files/en-us/web/api/document/writeln/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Reference
+browser-compat: api.Document.writeln
 ---
 <p>{{ ApiRef("DOM") }}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.writeln")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/xmlencoding/index.html
+++ b/files/en-us/web/api/document/xmlencoding/index.html
@@ -8,6 +8,7 @@ tags:
   - MakeBrowserAgnostic
   - Property
   - Deprecated
+browser-compat: api.Document.xmlEncoding
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 
@@ -34,4 +35,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("api.Document.xmlEncoding")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/document/xmlversion/index.html
+++ b/files/en-us/web/api/document/xmlversion/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Deprecated
+browser-compat: api.Document.xmlVersion
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -29,4 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.xmlVersion")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/documentfragment/append/index.html
+++ b/files/en-us/web/api/documentfragment/append/index.html
@@ -8,6 +8,7 @@ tags:
   - Node
   - DocumentFragment
   - Reference
+browser-compat: api.DocumentFragment.append
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -67,7 +68,7 @@ fragment.children; // HTMLCollection [&lt;div&gt;]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.append")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/childelementcount/index.html
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.DocumentFragment.childElementCount
 ---
 <div>{{ APIRef("DOM") }}</div>
 
@@ -46,7 +47,7 @@ fragment.childElementCount; // 1
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.childElementCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/children/index.html
+++ b/files/en-us/web/api/documentfragment/children/index.html
@@ -8,6 +8,7 @@ tags:
   - HTMLCollection
   - Property
   - children
+browser-compat: api.DocumentFragment.children
 ---
 <div>{{ APIRef("DOM") }}</div>
 
@@ -63,7 +64,7 @@ fragment.children; // HTMLCollection [&lt;p&gt;]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.children")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/documentfragment/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - DocumentFragment
   - Experimental
+browser-compat: api.DocumentFragment.DocumentFragment
 ---
 <div>{{ApiRef("DOM")}}{{SeeCompatTable}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.DocumentFragment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/firstelementchild/index.html
+++ b/files/en-us/web/api/documentfragment/firstelementchild/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Element
   - Property
+browser-compat: api.DocumentFragment.firstElementChild
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -48,7 +49,7 @@ fragment.firstElementChild; // &lt;p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.firstElementChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/index.html
+++ b/files/en-us/web/api/documentfragment/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Web Components
+browser-compat: api.DocumentFragment
 ---
 <div>{{ APIRef("DOM") }}</div>
 
@@ -131,7 +132,7 @@ list.appendChild(fragment)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/lastelementchild/index.html
+++ b/files/en-us/web/api/documentfragment/lastelementchild/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Element
   - Property
+browser-compat: api.DocumentFragment.lastElementChild
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -48,7 +49,7 @@ fragment.lastElementChild; // &lt;p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.lastElementChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/prepend/index.html
+++ b/files/en-us/web/api/documentfragment/prepend/index.html
@@ -8,6 +8,7 @@ tags:
   - Node
   - DocumentFragment
   - Reference
+browser-compat: api.DocumentFragment.prepend
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -69,7 +70,7 @@ fragment.children; // HTMLCollection [&lt;div&gt;, &lt;p&gt;]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.prepend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/queryselector/index.html
+++ b/files/en-us/web/api/documentfragment/queryselector/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - DocumentFragment
 - Method
+browser-compat: api.DocumentFragment.querySelector
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -87,7 +88,7 @@ document.querySelector('#foo\\:bar')   // Match the second div
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.querySelector")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/queryselectorall/index.html
+++ b/files/en-us/web/api/documentfragment/queryselectorall/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - DocumentFragment
 - Method
+browser-compat: api.DocumentFragment.querySelectorAll
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.querySelectorAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documentfragment/replacechildren/index.html
+++ b/files/en-us/web/api/documentfragment/replacechildren/index.html
@@ -9,6 +9,7 @@ tags:
   - DocumentFragment
   - Reference
   - replaceChildren
+browser-compat: api.DocumentFragment.replaceChildren
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -75,7 +76,7 @@ fragment.children; // HTMLCollection []
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentFragment.replaceChildren")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.html
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - waapi
   - web animations api
+browser-compat: api.DocumentTimeline.DocumentTimeline
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -61,7 +62,7 @@ cats.forEach(function(cat) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentTimeline.DocumentTimeline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documenttimeline/index.html
+++ b/files/en-us/web/api/documenttimeline/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Animations
   - waapi
   - web animations api
+browser-compat: api.DocumentTimeline
 ---
 <p>{{ APIRef("Web Animations") }}{{ SeeCompatTable() }}</p>
 
@@ -65,7 +66,7 @@ for (const cat of cats) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentTimeline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documenttype/index.html
+++ b/files/en-us/web/api/documenttype/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - DocumentType
   - Interface
+browser-compat: api.DocumentType
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/documenttype/remove/index.html
+++ b/files/en-us/web/api/documenttype/remove/index.html
@@ -6,6 +6,7 @@ tags:
   - DocumentType
   - DOM
   - Method
+browser-compat: api.DocumentType.remove
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -52,7 +53,7 @@ document.doctype; // null
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DocumentType.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domerror/index.html
+++ b/files/en-us/web/api/domerror/index.html
@@ -8,6 +8,7 @@ tags:
   - Deprecated
   - Interface
   - Reference
+browser-compat: api.DOMError
 ---
 <p>{{ APIRef("DOM") }}{{deprecated_header}}</p>
 
@@ -121,7 +122,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMError")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domexception/code/index.html
+++ b/files/en-us/web/api/domexception/code/index.html
@@ -7,6 +7,7 @@ tags:
   - DOMException
   - Property
   - Reference
+browser-compat: api.DOMException.code
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMException.code")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domexception/domexception/index.html
+++ b/files/en-us/web/api/domexception/domexception/index.html
@@ -6,6 +6,7 @@ tags:
 - Constructor
 - DOMException
 - Reference
+browser-compat: api.DOMException.DOMException
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -59,4 +60,4 @@ var domException = new DOMException(message, name);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMException.DOMException")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domexception/index.html
+++ b/files/en-us/web/api/domexception/index.html
@@ -9,6 +9,7 @@ tags:
   - Error code
   - Exception
   - Reference
+browser-compat: api.DOMException
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -126,7 +127,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMException")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domexception/message/index.html
+++ b/files/en-us/web/api/domexception/message/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - message
+browser-compat: api.DOMException.message
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMException.message")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domexception/name/index.html
+++ b/files/en-us/web/api/domexception/name/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - name
+browser-compat: api.DOMException.name
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMException.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domhighrestimestamp/index.html
+++ b/files/en-us/web/api/domhighrestimestamp/index.html
@@ -12,6 +12,7 @@ tags:
   - Type
   - speed
   - timeStamp
+browser-compat: api.DOMHighResTimestamp
 ---
 <p>{{APIRef("High Resolution Time")}}</p>
 
@@ -113,7 +114,7 @@ let elapsedTime = performance.now() - startTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMHighResTimestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domimplementation/createdocument/index.html
+++ b/files/en-us/web/api/domimplementation/createdocument/index.html
@@ -7,6 +7,7 @@ tags:
 - DOMImplementation
 - Method
 - Reference
+browser-compat: api.DOMImplementation.createDocument
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -78,7 +79,7 @@ alert(doc.getElementById('abc')); // [object HTMLBodyElement]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMImplementation.createDocument")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domimplementation/createdocumenttype/index.html
+++ b/files/en-us/web/api/domimplementation/createdocumenttype/index.html
@@ -7,6 +7,7 @@ tags:
 - DOMImplementation
 - Method
 - Reference
+browser-compat: api.DOMImplementation.createDocumentType
 ---
 <p>{{ ApiRef("DOM")}}</p>
 
@@ -72,7 +73,7 @@ alert(d.doctype.publicId); // -//W3C//DTD SVG 1.1//EN
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMImplementation.createDocumentType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.html
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.html
@@ -8,6 +8,7 @@ tags:
   - DOMImplementation
   - Method
   - Reference
+browser-compat: api.DOMImplementation.createHTMLDocument
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -112,7 +113,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMImplementation.createHTMLDocument")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domimplementation/hasfeature/index.html
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.html
@@ -8,6 +8,7 @@ tags:
 - Deprecated
 - Method
 - Reference
+browser-compat: api.DOMImplementation.hasFeature
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMImplementation.hasFeature")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domimplementation/index.html
+++ b/files/en-us/web/api/domimplementation/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Interface
   - Reference
+browser-compat: api.DOMImplementation
 ---
 <p>{{ ApiRef("DOM") }}</p>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMImplementation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dommatrix/dommatrix/index.html
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.html
@@ -9,6 +9,7 @@ tags:
 - Geometry Interfaces
 - Reference
 - matrix
+browser-compat: api.DOMMatrix.DOMMatrix
 ---
 <p>{{APIRef("Geometry Interfaces")}}</p>
 
@@ -70,4 +71,4 @@ var transformedPoint = point.matrixTransform(matrix);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrix.DOMMatrix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.html
@@ -9,6 +9,7 @@ tags:
 - Geometry Interfaces
 - Reference
 - matrix
+browser-compat: api.DOMMatrixReadOnly.DOMMatrixReadOnly
 ---
 <p>{{APIRef("Geometry Interfaces")}}{{Non-standard_header}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrixReadOnly.DOMMatrixReadOnly")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dommatrixreadonly/flipx/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/flipx/index.html
@@ -13,6 +13,7 @@ tags:
   - Method
   - Reference
   - matrix
+browser-compat: api.DOMMatrixReadOnly.flipX
 ---
 <p>{{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}</p>
 
@@ -64,4 +65,4 @@ flipped.setAttribute('transform', flippedMatrix.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrixReadOnly.flipX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dommatrixreadonly/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/index.html
@@ -24,6 +24,7 @@ tags:
   - camera
   - matrix
   - transform
+browser-compat: api.DOMMatrixReadOnly
 ---
 <p>{{APIRef("Geometry Interfaces")}}</p>
 
@@ -168,7 +169,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrixReadOnly")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dommatrixreadonly/scale/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/scale/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - Scale
 - matrix
+browser-compat: api.DOMMatrixReadOnly.scale
 ---
 <p>{{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}</p>
 
@@ -138,4 +139,4 @@ document.querySelector('#transformedOrigin').setAttribute('transform', scaledMat
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrixReadOnly.scale")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dommatrixreadonly/translate/index.html
+++ b/files/en-us/web/api/dommatrixreadonly/translate/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - Translate
 - matrix
+browser-compat: api.DOMMatrixReadOnly.translate
 ---
 <p>{{APIRef("Geometry Interfaces")}}{{SeeCompatTable}}</p>
 
@@ -97,4 +98,4 @@ document.querySelector('#transformed').setAttribute('transform', matrix.toString
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrixReadOnly.translate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domparser/domparser/index.html
+++ b/files/en-us/web/api/domparser/domparser/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM Parsing
   - Parsing
   - Reference
+browser-compat: api.DOMParser.DOMParser
 ---
 <p>The <strong><code>DOMParser()</code></strong> constructor creates a new <code><a href="/en-US/docs/Web/API/DOMParser">DOMParser</a></code> object.</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMParser.DOMParser")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domparser/parsefromstring/index.html
+++ b/files/en-us/web/api/domparser/parsefromstring/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Method
   - Reference
+browser-compat: api.DOMParser.parseFromString
 ---
 <div>{{APIRef("DOMParser")}}</div>
 
@@ -117,7 +118,7 @@ console.log(doc.documentElement.textContent);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMParser.parseFromString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompoint/dompoint/index.html
+++ b/files/en-us/web/api/dompoint/dompoint/index.html
@@ -11,6 +11,7 @@ tags:
 - Geometry Interfaces
 - Point
 - Reference
+browser-compat: api.DOMPoint.DOMPoint
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -72,7 +73,7 @@ newTopLeft.y += 100;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPoint.DOMPoint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompoint/index.html
+++ b/files/en-us/web/api/dompoint/index.html
@@ -13,6 +13,7 @@ tags:
   - Point
   - Reference
   - VR
+browser-compat: api.DOMPoint
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPoint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompointinit/index.html
+++ b/files/en-us/web/api/dompointinit/index.html
@@ -12,6 +12,7 @@ tags:
   - Interface
   - Point
   - Reference
+browser-compat: api.DOMPointInit
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -65,4 +66,4 @@ const windTopLeft = DOMPoint.fromPoint(pointDesc)</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointInit")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointinit/w/index.html
+++ b/files/en-us/web/api/dompointinit/w/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - W
   - perspective
+browser-compat: api.DOMPointInit.w
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -72,4 +73,4 @@ var <em>wPerspective</em> = <em>DOMPointInit</em>.w;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointInit.w")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointinit/x/index.html
+++ b/files/en-us/web/api/dompointinit/x/index.html
@@ -12,6 +12,7 @@ tags:
   - Property
   - Reference
   - x
+browser-compat: api.DOMPointInit.x
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -68,4 +69,4 @@ var <em>xPos</em> = <em>DOMPointInit</em>.x;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointInit.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointinit/y/index.html
+++ b/files/en-us/web/api/dompointinit/y/index.html
@@ -12,6 +12,7 @@ tags:
   - Property
   - Reference
   - 'y'
+browser-compat: api.DOMPointInit.y
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,4 +77,4 @@ var <em>yPos</em> = <em>DOMPointInit</em>.y;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointInit.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointinit/z/index.html
+++ b/files/en-us/web/api/dompointinit/z/index.html
@@ -12,6 +12,7 @@ tags:
   - Property
   - Reference
   - z
+browser-compat: api.DOMPointInit.z
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -80,4 +81,4 @@ var <em>zPos</em> = <em>DOMPointInit</em>.z;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointInit.z")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointreadonly/dompointreadonly/index.html
+++ b/files/en-us/web/api/dompointreadonly/dompointreadonly/index.html
@@ -12,6 +12,7 @@ tags:
 - Point
 - Position
 - Reference
+browser-compat: api.DOMPointReadOnly.DOMPointReadOnly
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -80,4 +81,4 @@ var perspectivePoint3D = new DOMPointReadOnly(50, 50, 25, 0.5);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.DOMPointReadOnly")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointreadonly/frompoint/index.html
+++ b/files/en-us/web/api/dompointreadonly/frompoint/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - Static Method
 - fromPoint
+browser-compat: api.DOMPointReadOnly.fromPoint
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -90,4 +91,4 @@ const newPoint = DOMPointReadOnly.fromPoint(origPoint)</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.fromPoint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointreadonly/index.html
+++ b/files/en-us/web/api/dompointreadonly/index.html
@@ -12,6 +12,7 @@ tags:
   - Interface
   - Point
   - Reference
+browser-compat: api.DOMPointReadOnly
 ---
 <div>{{APIRef("Geometry Interfaces")}}</div>
 
@@ -91,7 +92,7 @@ const point = new DOMPointReadOnly(100, 100, 100, 1.0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompointreadonly/tojson/index.html
+++ b/files/en-us/web/api/dompointreadonly/tojson/index.html
@@ -13,6 +13,7 @@ tags:
 - Point
 - Reference
 - toJSON
+browser-compat: api.DOMPointReadOnly.toJSON
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -64,4 +65,4 @@ var pointJSON = topLeft.toJSON();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompointreadonly/w/index.html
+++ b/files/en-us/web/api/dompointreadonly/w/index.html
@@ -15,6 +15,7 @@ tags:
 - Reference
 - W
 - perspective
+browser-compat: api.DOMPointReadOnly.w
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.w")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompointreadonly/x/index.html
+++ b/files/en-us/web/api/dompointreadonly/x/index.html
@@ -13,6 +13,7 @@ tags:
 - Read-only
 - Reference
 - x
+browser-compat: api.DOMPointReadOnly.x
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompointreadonly/y/index.html
+++ b/files/en-us/web/api/dompointreadonly/y/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - Vertical
 - 'y'
+browser-compat: api.DOMPointReadOnly.y
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompointreadonly/z/index.html
+++ b/files/en-us/web/api/dompointreadonly/z/index.html
@@ -14,6 +14,7 @@ tags:
 - Read-only
 - Reference
 - z
+browser-compat: api.DOMPointReadOnly.z
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.z")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domquad/index.html
+++ b/files/en-us/web/api/domquad/index.html
@@ -8,6 +8,7 @@ tags:
   - DOMQuad
   - Experimental
   - Geometry
+browser-compat: api.DOMQuad
 ---
 <p>{{SeeCompatTable}}{{APIRef("Geometry Interfaces")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMQuad")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domrect/domrect/index.html
+++ b/files/en-us/web/api/domrect/domrect/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Geometry
   - Reference
+browser-compat: api.DOMRect.DOMRect
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRect.DOMRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrect/index.html
+++ b/files/en-us/web/api/domrect/index.html
@@ -11,6 +11,7 @@ tags:
   - Interface
   - Rectangle
   - Reference
+browser-compat: api.DOMRect
 ---
 <p>{{draft}}{{APIRef("Geometry Interfaces")}}</p>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/bottom/index.html
+++ b/files/en-us/web/api/domrectreadonly/bottom/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - bottom
+browser-compat: api.DOMRectReadOnly.bottom
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.bottom")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/domrectreadonly/index.html
+++ b/files/en-us/web/api/domrectreadonly/domrectreadonly/index.html
@@ -10,6 +10,7 @@ tags:
 - Experimental
 - Geometry
 - Reference
+browser-compat: api.DOMRectReadOnly.DOMRectReadOnly
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable }}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.DOMRectReadOnly")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/fromrect/index.html
+++ b/files/en-us/web/api/domrectreadonly/fromrect/index.html
@@ -11,6 +11,7 @@ tags:
 - Method
 - Reference
 - fromRect()
+browser-compat: api.DOMRectReadOnly.fromRect
 ---
 <p>{{APIRef("DOM")}}{{SeeCompatTable}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.fromRect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domrectreadonly/height/index.html
+++ b/files/en-us/web/api/domrectreadonly/height/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - height
+browser-compat: api.DOMRectReadOnly.height
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/index.html
+++ b/files/en-us/web/api/domrectreadonly/index.html
@@ -11,6 +11,7 @@ tags:
   - Read-only
   - Rectangle
   - Reference
+browser-compat: api.DOMRectReadOnly
 ---
 <p>{{APIRef("Geometry Interfaces")}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/left/index.html
+++ b/files/en-us/web/api/domrectreadonly/left/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - left
+browser-compat: api.DOMRectReadOnly.left
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.left")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/right/index.html
+++ b/files/en-us/web/api/domrectreadonly/right/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - right
+browser-compat: api.DOMRectReadOnly.right
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.right")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/top/index.html
+++ b/files/en-us/web/api/domrectreadonly/top/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - top
+browser-compat: api.DOMRectReadOnly.top
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.top")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/width/index.html
+++ b/files/en-us/web/api/domrectreadonly/width/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - width
+browser-compat: api.DOMRectReadOnly.width
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/x/index.html
+++ b/files/en-us/web/api/domrectreadonly/x/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - x
+browser-compat: api.DOMRectReadOnly.x
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domrectreadonly/y/index.html
+++ b/files/en-us/web/api/domrectreadonly/y/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - 'y'
+browser-compat: api.DOMRectReadOnly.y
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable() }}</p>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMRectReadOnly.y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domstringlist/index.html
+++ b/files/en-us/web/api/domstringlist/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - DOMStringList
   - Reference
+browser-compat: api.DOMStringList
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMStringList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domstringmap/index.html
+++ b/files/en-us/web/api/domstringmap/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsNewLayout
   - NeedsUpdate
   - Reference
+browser-compat: api.DOMStringMap
 ---
 <div>{{ APIRef("HTML DOM") }}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMStringMap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domtokenlist/add/index.html
+++ b/files/en-us/web/api/domtokenlist/add/index.html
@@ -8,6 +8,7 @@ tags:
 - DOMTokenList
 - Method
 - Reference
+browser-compat: api.DOMTokenList.add
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -80,4 +81,4 @@ span.textContent = classes;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.add")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/contains/index.html
+++ b/files/en-us/web/api/domtokenlist/contains/index.html
@@ -8,6 +8,7 @@ tags:
 - DOMTokenList
 - Method
 - Reference
+browser-compat: api.DOMTokenList.contains
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -81,4 +82,4 @@ if (result) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.contains")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/entries/index.html
+++ b/files/en-us/web/api/domtokenlist/entries/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - Web
+browser-compat: api.DOMTokenList.entries
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -73,7 +74,7 @@ for (let value of iterator) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.entries")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domtokenlist/foreach/index.html
+++ b/files/en-us/web/api/domtokenlist/foreach/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web
 - forEach
+browser-compat: api.DOMTokenList.forEach
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -110,7 +111,7 @@ classes.forEach(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.forEach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/domtokenlist/index.html
+++ b/files/en-us/web/api/domtokenlist/index.html
@@ -7,6 +7,7 @@ tags:
   - DOMTokenList
   - Interface
   - Reference
+browser-compat: api.DOMTokenList
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -103,4 +104,4 @@ span.textContent = `span classList is "${classes}"`;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/item/index.html
+++ b/files/en-us/web/api/domtokenlist/item/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - item
+browser-compat: api.DOMTokenList.item
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -77,4 +78,4 @@ span.textContent = item;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.item")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/keys/index.html
+++ b/files/en-us/web/api/domtokenlist/keys/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web
 - keys
+browser-compat: api.DOMTokenList.keys
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -78,4 +79,4 @@ for(var value of iterator) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.keys")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/length/index.html
+++ b/files/en-us/web/api/domtokenlist/length/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - length
+browser-compat: api.DOMTokenList.length
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -68,4 +69,4 @@ span.textContent = `classList length = ${length}`;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/remove/index.html
+++ b/files/en-us/web/api/domtokenlist/remove/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - remove
+browser-compat: api.DOMTokenList.remove
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -86,4 +87,4 @@ span2.textContent = classes2;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.remove")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/replace/index.html
+++ b/files/en-us/web/api/domtokenlist/replace/index.html
@@ -7,6 +7,7 @@ tags:
 - Document
 - Method
 - Reference
+browser-compat: api.DOMTokenList.replace
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -105,4 +106,4 @@ if (result) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.replace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/supports/index.html
+++ b/files/en-us/web/api/domtokenlist/supports/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Reference
+browser-compat: api.DOMTokenList.supports
 ---
 <p>{{APIRef("DOM")}}{{SeeCompatTable}}</p>
 
@@ -68,4 +69,4 @@ if (iframe.sandbox.supports('allow-scripts')) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.supports")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/toggle/index.html
+++ b/files/en-us/web/api/domtokenlist/toggle/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - toggle
+browser-compat: api.DOMTokenList.toggle
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -90,4 +91,4 @@ span.addEventListener('click', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.toggle")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/value/index.html
+++ b/files/en-us/web/api/domtokenlist/value/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - value
+browser-compat: api.DOMTokenList.value
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -66,4 +67,4 @@ span.textContent = classes.value;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.value")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/domtokenlist/values/index.html
+++ b/files/en-us/web/api/domtokenlist/values/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web
 - values
+browser-compat: api.DOMTokenList.values
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -76,4 +77,4 @@ for(var value of iterator) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMTokenList.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/doublerange/index.html
+++ b/files/en-us/web/api/doublerange/index.html
@@ -12,6 +12,7 @@ tags:
   - Media Streams API
   - Reference
   - WebRTC
+browser-compat: api.DoubleRange
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DoubleRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dragevent/datatransfer/index.html
+++ b/files/en-us/web/api/dragevent/datatransfer/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - drag and drop
+browser-compat: api.DragEvent.dataTransfer
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -71,4 +72,4 @@ dragTarget.addEventListener("dragend", function(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DragEvent.dataTransfer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dragevent/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/dragevent/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Reference
   - drag and drop
+browser-compat: api.DragEvent.DragEvent
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DragEvent.DragEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dragevent/index.html
+++ b/files/en-us/web/api/dragevent/index.html
@@ -6,6 +6,7 @@ tags:
   - DragEvent
   - Reference
   - drag and drop
+browser-compat: api.DragEvent
 ---
 <div>{{APIRef("HTML Drag and Drop API")}}</div>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DragEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Web Audio API
+browser-compat: api.DynamicsCompressorNode.attack
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -60,7 +61,7 @@ compressor.attack.value = 0;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.attack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.html
@@ -7,6 +7,7 @@ tags:
 - DynamicsCompressorNode
 - Media
 - Web Audio API
+browser-compat: api.DynamicsCompressorNode.DynamicsCompressorNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.DynamicsCompressorNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dynamicscompressornode/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/index.html
@@ -9,6 +9,7 @@ tags:
   - Media
   - Reference
   - Web Audio API
+browser-compat: api.DynamicsCompressorNode
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - knee
+browser-compat: api.DynamicsCompressorNode.knee
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,7 +62,7 @@ compressor.knee.value = 40;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.knee")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - ratio
+browser-compat: api.DynamicsCompressorNode.ratio
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -62,7 +63,7 @@ compressor.ratio.value = 12;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.ratio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/reduction/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/reduction/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - reduction
+browser-compat: api.DynamicsCompressorNode.reduction
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -51,7 +52,7 @@ var myReduction = compressor.reduction;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.reduction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/release/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Release
   - Web Audio API
+browser-compat: api.DynamicsCompressorNode.release
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -60,7 +61,7 @@ compressor.release.value = 0.25;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.release")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.html
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - threshold
+browser-compat: api.DynamicsCompressorNode.threshold
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -62,7 +63,7 @@ compressor.threshold.value = -50;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DynamicsCompressorNode.threshold")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/d* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

343 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
