### PR TITLE
Put browser-compat info in front-runner for api/f*

### DIFF
--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.html
@@ -8,6 +8,7 @@ tags:
 - Feature-Policy
 - FeaturePolicy
 - Reference
+browser-compat: api.FeaturePolicy.allowedFeatures
 ---
 <p>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</p>
 
@@ -68,4 +69,4 @@ for (const directive of allowed){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FeaturePolicy.allowedFeatures")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/featurepolicy/allowsfeature/index.html
+++ b/files/en-us/web/api/featurepolicy/allowsfeature/index.html
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy.allowsFeature()
 slug: Web/API/FeaturePolicy/allowsFeature
+browser-compat: api.FeaturePolicy.allowsFeature
 ---
 <div>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</div>
 
@@ -73,4 +74,4 @@ if (allowed){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FeaturePolicy.allowsFeature")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/featurepolicy/features/index.html
+++ b/files/en-us/web/api/featurepolicy/features/index.html
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy.features()
 slug: Web/API/FeaturePolicy/features
+browser-compat: api.FeaturePolicy.features
 ---
 <div>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</div>
 
@@ -59,4 +60,4 @@ for (const directive of supportedDirectives){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FeaturePolicy.features")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.html
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.html
@@ -6,6 +6,7 @@ tags:
 - Feature Policy
 - Feature-Policy
 - Reference
+browser-compat: api.FeaturePolicy.getAllowlistForFeature
 ---
 <div>{{APIRef("Feature Policy API")}}{{SeeCompatTable}}</div>
 
@@ -71,4 +72,4 @@ for (const origin of allowlist) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FeaturePolicy.getAllowlistForFeature")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/featurepolicy/index.html
+++ b/files/en-us/web/api/featurepolicy/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - access
   - delegation
+browser-compat: api.FeaturePolicy
 ---
 <p>{{APIRef("Feature Policy")}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FeaturePolicy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/federatedcredential/federatedcredential/index.html
+++ b/files/en-us/web/api/federatedcredential/federatedcredential/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - credential management
+browser-compat: api.FederatedCredential.FederatedCredential
 ---
 <p>{{APIRef("")}}{{Non-standard_header}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FederatedCredential.FederatedCredential")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/federatedcredential/index.html
+++ b/files/en-us/web/api/federatedcredential/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - credential management
+browser-compat: api.FederatedCredential
 ---
 <div>{{SeeCompatTable}}{{APIRef("Credential Management API")}}</div>
 
@@ -75,4 +76,4 @@ navigator.credentials.store(cred)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FederatedCredential")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/federatedcredential/protocol/index.html
+++ b/files/en-us/web/api/federatedcredential/protocol/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - credential management
+browser-compat: api.FederatedCredential.protocol
 ---
 <div>{{SeeCompatTable}}{{APIRef("")}}{{securecontext_header}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FederatedCredential.protocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/federatedcredential/provider/index.html
+++ b/files/en-us/web/api/federatedcredential/provider/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - credential management
+browser-compat: api.FederatedCredential.provider
 ---
 <p>{{SeeCompatTable}}{{APIRef("")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FederatedCredential.provider")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fetchevent/client/index.html
+++ b/files/en-us/web/api/fetchevent/client/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Service Workers
   - Workers
+browser-compat: api.FetchEvent.client
 ---
 <p>{{APIRef("Service Workers API")}}{{Deprecated_Header}}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.client")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/clientid/index.html
+++ b/files/en-us/web/api/fetchevent/clientid/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - clientId
+browser-compat: api.FetchEvent.clientId
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.clientId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/fetchevent/index.html
+++ b/files/en-us/web/api/fetchevent/fetchevent/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Service Workers
 - ServiceWorker
+browser-compat: api.FetchEvent.FetchEvent
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.FetchEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/index.html
+++ b/files/en-us/web/api/fetchevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Service Workers
   - Workers
+browser-compat: api.FetchEvent
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -97,7 +98,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/isreload/index.html
+++ b/files/en-us/web/api/fetchevent/isreload/index.html
@@ -12,6 +12,7 @@ tags:
   - Workers
   - isReload
   - Deprecated
+browser-compat: api.FetchEvent.isReload
 ---
 <div>{{APIRef("Service Workers API")}}{{deprecated_header}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.isReload")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/navigationpreload/index.html
+++ b/files/en-us/web/api/fetchevent/navigationpreload/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - Workers
+browser-compat: api.FetchEvent.navigationPreload
 ---
 <p>{{SeeCompatTable}}{{APIRef("Service Workers API")}}</p>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.navigationPreload")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fetchevent/preloadresponse/index.html
+++ b/files/en-us/web/api/fetchevent/preloadresponse/index.html
@@ -12,6 +12,7 @@ tags:
 - Web Performance
 - Workers
 - request
+browser-compat: api.FetchEvent.preloadResponse
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.preloadResponse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/replacesclientid/index.html
+++ b/files/en-us/web/api/fetchevent/replacesclientid/index.html
@@ -10,6 +10,7 @@ tags:
 - Service Workers
 - Workers
 - replacesClientId
+browser-compat: api.FetchEvent.replacesClientId
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.replacesClientId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/request/index.html
+++ b/files/en-us/web/api/fetchevent/request/index.html
@@ -11,6 +11,7 @@ tags:
   - Service Workers
   - Workers
   - request
+browser-compat: api.FetchEvent.request
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.request")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fetchevent/respondwith/index.html
+++ b/files/en-us/web/api/fetchevent/respondwith/index.html
@@ -11,6 +11,7 @@ tags:
 - Service Workers
 - Workers
 - respondWith
+browser-compat: api.FetchEvent.respondWith
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -162,7 +163,7 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.FetchEvent.respondWith")}}</p>
+	<p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/fetchevent/resultingclientid/index.html
+++ b/files/en-us/web/api/fetchevent/resultingclientid/index.html
@@ -10,6 +10,7 @@ tags:
 - Service Workers
 - Worker
 - resultingClientId
+browser-compat: api.FetchEvent.resultingClientId
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FetchEvent.resultingClientId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/file/index.html
+++ b/files/en-us/web/api/file/file/index.html
@@ -6,6 +6,7 @@ tags:
 - Constructor
 - File API
 - Reference
+browser-compat: api.File.File
 ---
 <div>{{APIRef("File")}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File.File")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/index.html
+++ b/files/en-us/web/api/file/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web
+browser-compat: api.File
 ---
 <div>{{APIRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/lastmodified/index.html
+++ b/files/en-us/web/api/file/lastmodified/index.html
@@ -7,6 +7,7 @@ tags:
 - Files
 - Property
 - Reference
+browser-compat: api.File.lastModified
 ---
 <div>{{APIRef("File")}}</div>
 
@@ -111,7 +112,7 @@ someFile.lastModified;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File.lastModified")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/lastmodifieddate/index.html
+++ b/files/en-us/web/api/file/lastmodifieddate/index.html
@@ -11,6 +11,7 @@ tags:
   - Read-only
   - Reference
   - lastModifiedDate
+browser-compat: api.File.lastModifiedDate
 ---
 <div>{{APIRef("File API") }} {{deprecated_header}}</div>
 
@@ -65,7 +66,7 @@ someFile.lastModifiedDate.getTime();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File.lastModifiedDate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/name/index.html
+++ b/files/en-us/web/api/file/name/index.html
@@ -7,6 +7,7 @@ tags:
   - Files
   - Property
   - Reference
+browser-compat: api.File.name
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/type/index.html
+++ b/files/en-us/web/api/file/type/index.html
@@ -8,6 +8,7 @@ tags:
   - Files
   - Property
   - Reference
+browser-compat: api.File.type
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/file/webkitrelativepath/index.html
+++ b/files/en-us/web/api/file/webkitrelativepath/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Web
 - webkitRelativePath
+browser-compat: api.File.webkitRelativePath
 ---
 <p>{{APIRef("File API")}}{{non-standard_header}}</p>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.File.webkitRelativePath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fileentrysync/index.html
+++ b/files/en-us/web/api/fileentrysync/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Non-standard
   - Reference
+browser-compat: api.FileEntrySync
 ---
 <p>{{APIRef("File System API")}} {{Non-standard_header}}</p>
 
@@ -124,7 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileEntrySync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fileerror/index.html
+++ b/files/en-us/web/api/fileerror/index.html
@@ -7,6 +7,7 @@ tags:
   - Files
   - Reference
   - Deprecated
+browser-compat: api.FileError
 ---
 <div>{{APIRef("File System API")}}{{deprecated_header}}</div>
 
@@ -131,7 +132,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileError")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fileexception/index.html
+++ b/files/en-us/web/api/fileexception/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - filesystem
   - Deprecated
+browser-compat: api.FileException
 ---
 <div>{{APIRef("File System API")}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -134,7 +135,7 @@ var fileEntry = fs.root.getFile('log.txt', {create: true, exclusive:true}0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileException")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filelist/index.html
+++ b/files/en-us/web/api/filelist/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - File API
   - Files
+browser-compat: api.FileList
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -163,7 +164,7 @@ document.querySelector("#myfiles").onchange=pullfiles;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileList")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/filereader/abort/index.html
+++ b/files/en-us/web/api/filereader/abort/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - abort
+browser-compat: api.FileReader.abort
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.abort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/abort_event/index.html
+++ b/files/en-us/web/api/filereader/abort_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - abort
+browser-compat: api.FileReader.abort_event
 ---
 <div>{{APIRef}}</div>
 
@@ -162,7 +163,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.abort_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/error/index.html
+++ b/files/en-us/web/api/filereader/error/index.html
@@ -7,6 +7,7 @@ tags:
 - Files
 - Property
 - Reference
+browser-compat: api.FileReader.error
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.error")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/error_event/index.html
+++ b/files/en-us/web/api/filereader/error_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - onerror
+browser-compat: api.FileReader.error_event
 ---
 <div>{{APIRef}}</div>
 
@@ -79,7 +80,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/index.html
+++ b/files/en-us/web/api/filereader/index.html
@@ -7,6 +7,7 @@ tags:
   - Files
   - Interface
   - Reference
+browser-compat: api.FileReader
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -140,7 +141,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/load_event/index.html
+++ b/files/en-us/web/api/filereader/load_event/index.html
@@ -7,6 +7,7 @@ tags:
   - FileReader
   - Web
   - load
+browser-compat: api.FileReader.load_event
 ---
 <div>{{APIRef}}</div>
 
@@ -159,7 +160,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.load_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/loadend_event/index.html
+++ b/files/en-us/web/api/filereader/loadend_event/index.html
@@ -8,6 +8,7 @@ tags:
   - ProgressiveEvent
   - Web
   - loadend
+browser-compat: api.FileReader.loadend_event
 ---
 <div>{{APIRef}}</div>
 
@@ -160,7 +161,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.loadend_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/loadstart_event/index.html
+++ b/files/en-us/web/api/filereader/loadstart_event/index.html
@@ -8,6 +8,7 @@ tags:
   - ProgressEvent
   - Web
   - loadstart
+browser-compat: api.FileReader.loadstart_event
 ---
 <div>{{APIRef}}</div>
 
@@ -160,7 +161,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.loadstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/onabort/index.html
+++ b/files/en-us/web/api/filereader/onabort/index.html
@@ -7,6 +7,7 @@ tags:
   - FileReader
   - Property
   - Reference
+browser-compat: api.FileReader.onabort
 ---
 <p>The <strong><code>FileReader.onabort</code></strong> property contains an event handler executed when the <code><a href="/en-US/docs/Web/API/HTMLMediaElement/abort_event">abort</a></code> event is fired, i.e. when the process of reading the file is aborted.</p>
 
@@ -16,4 +17,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.onabort")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/filereader/onerror/index.html
+++ b/files/en-us/web/api/filereader/onerror/index.html
@@ -1,6 +1,7 @@
 ---
 title: FileReader.onerror
 slug: Web/API/FileReader/onerror
+browser-compat: api.FileReader.onerror
 ---
 <p>The <a href="/en-US/docs/Web/API/FileReader">FileReader</a> onerror handler receives an Event object, not an Error object, as a parameter, but an error can be accessed from the FileReader object, as <code><a href="/en-US/docs/Web/API/FileReader/error">instanceOfFileReader.error</a></code></p>
 
@@ -19,4 +20,4 @@ function onChange(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.onerror")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/filereader/onload/index.html
+++ b/files/en-us/web/api/filereader/onload/index.html
@@ -7,6 +7,7 @@ tags:
   - FileReader
   - Property
   - Reference
+browser-compat: api.FileReader.onload
 ---
 <p>{{APIRef}}</p>
 
@@ -29,4 +30,4 @@ function onChange(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.onload")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/filereader/progress_event/index.html
+++ b/files/en-us/web/api/filereader/progress_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - progress
+browser-compat: api.FileReader.progress_event
 ---
 <div>{{APIRef}}</div>
 
@@ -161,7 +162,7 @@ fileInput.addEventListener('change', handleSelected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.progress_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereader/readasarraybuffer/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - readAsArrayBuffer
+browser-compat: api.FileReader.readAsArrayBuffer
 ---
 <p>{{APIRef("File API")}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.readAsArrayBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.html
@@ -7,6 +7,7 @@ tags:
 - Files
 - Method
 - Reference
+browser-compat: api.FileReader.readAsBinaryString
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -80,7 +81,7 @@ canvas.toBlob(function (blob) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.readAsBinaryString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/readasdataurl/index.html
+++ b/files/en-us/web/api/filereader/readasdataurl/index.html
@@ -9,6 +9,7 @@ tags:
 - Files
 - Method
 - Reference
+browser-compat: api.FileReader.readAsDataURL
 ---
 <p>The <code>readAsDataURL</code> method is used to read the contents of the specified
   {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is finished, the
@@ -136,7 +137,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.readAsDataURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/readastext/index.html
+++ b/files/en-us/web/api/filereader/readastext/index.html
@@ -7,6 +7,7 @@ tags:
 - Files
 - Method
 - Reference
+browser-compat: api.FileReader.readAsText
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.readAsText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/readystate/index.html
+++ b/files/en-us/web/api/filereader/readystate/index.html
@@ -7,6 +7,7 @@ tags:
   - Files
   - Property
   - Reference
+browser-compat: api.FileReader.readyState
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -84,7 +85,7 @@ reader.onloadend = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.readyState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereader/result/index.html
+++ b/files/en-us/web/api/filereader/result/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - result
+browser-compat: api.FileReader.result
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -106,7 +107,7 @@ function read(callback) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReader.result")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/index.html
+++ b/files/en-us/web/api/filereadersync/index.html
@@ -4,6 +4,7 @@ slug: Web/API/FileReaderSync
 tags:
   - API
   - NeedsMarkupWork
+browser-compat: api.FileReaderSync
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReaderSync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.html
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsArrayBuffer()
 slug: Web/API/FileReaderSync/readAsArrayBuffer
+browser-compat: api.FileReaderSync.readAsArrayBuffer
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -64,7 +65,7 @@ slug: Web/API/FileReaderSync/readAsArrayBuffer
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReaderSync.readAsArrayBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.html
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.html
@@ -4,6 +4,7 @@ slug: Web/API/FileReaderSync/readAsBinaryString
 tags:
   - Reference
   - Deprecated
+browser-compat: api.FileReaderSync.readAsBinaryString
 ---
 <div>{{APIRef("File API")}}{{deprecated_header}}</div>
 
@@ -53,7 +54,7 @@ readAsBinaryString(<em>Blob</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReaderSync.readAsBinaryString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.html
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.html
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsDataURL()
 slug: Web/API/FileReaderSync/readAsDataURL
+browser-compat: api.FileReaderSync.readAsDataURL
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -46,7 +47,7 @@ readAsDataURL(<em>Blob</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReaderSync.readAsDataURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filereadersync/readastext/index.html
+++ b/files/en-us/web/api/filereadersync/readastext/index.html
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsText()
 slug: Web/API/FileReaderSync/readAsText
+browser-compat: api.FileReaderSync.readAsText
 ---
 <div>{{APIRef("File API")}}</div>
 
@@ -50,7 +51,7 @@ readAsText(<em>Blob</em>, <em>encoding</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileReaderSync.readAsText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystem/index.html
+++ b/files/en-us/web/api/filesystem/index.html
@@ -10,6 +10,7 @@ tags:
   - Non-standard
   - Offline
   - filesystem
+browser-compat: api.FileSystem
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystem/name/index.html
+++ b/files/en-us/web/api/filesystem/name/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - filesystem
 - name
+browser-compat: api.FileSystem.name
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystem.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystem/root/index.html
+++ b/files/en-us/web/api/filesystem/root/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - filesystem
 - root
+browser-compat: api.FileSystem.root
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystem.root")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/createreader/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/createreader/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - createReader
+browser-compat: api.FileSystemDirectoryEntry.createReader
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryEntry.createReader")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - getDirectory
+browser-compat: api.FileSystemDirectoryEntry.getDirectory
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -139,7 +140,7 @@ function loadDictionaryForLanguage(appDataDirEntry, lang) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryEntry.getDirectory")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/getfile/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - getFile
+browser-compat: api.FileSystemDirectoryEntry.getFile
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -137,7 +138,7 @@ function loadDictionaryForLanguage(appDataDirEntry, lang) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryEntry.getFile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/index.html
@@ -13,6 +13,7 @@ tags:
   - Non-standard
   - Offline
   - Reference
+browser-compat: api.FileSystemDirectoryEntry
 ---
 <div>{{APIRef("File System API")}}{{SeeCompatTable}}</div>
 
@@ -91,7 +92,7 @@ window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, onFs, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.html
+++ b/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - removeRecursively
 - Deprecated
+browser-compat: api.FileSystemDirectoryEntry.removeRecursively
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}{{SeeCompatTable}}</p>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryEntry.removeRecursively")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.html
@@ -8,6 +8,7 @@ tags:
   - Files
   - Iterable
   - Method
+browser-compat: api.FileSystemDirectoryHandle.entries
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.entries")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.html
@@ -8,6 +8,7 @@ tags:
   - File System Access API
   - FileSystemDirectoryHandle
   - Method
+browser-compat: api.FileSystemDirectoryHandle.getDirectoryHandle
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -86,7 +87,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.getDirectoryHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.html
@@ -7,6 +7,7 @@ tags:
   - File System Access API
   - FileSystemDirectoryHandle
   - Method
+browser-compat: api.FileSystemDirectoryHandle.getFileHandle
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -85,7 +86,7 @@ const fileHandle = currentDirHandle.getFileHandle(fileName, {create: true});</pr
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.getFileHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.html
@@ -9,6 +9,7 @@ tags:
   - Files
   - Interface
   - working with directories
+browser-compat: api.FileSystemDirectoryHandle
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
@@ -94,7 +95,7 @@ const subDir = currentDirHandle.getDirectoryHandle(dirName, {create: true});</pr
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.html
@@ -8,6 +8,7 @@ tags:
   - Files
   - Iterable
   - Method
+browser-compat: api.FileSystemDirectoryHandle.keys
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.html
@@ -7,6 +7,7 @@ tags:
   - File System Access API
   - FileSystemDirectoryHandle
   - Method
+browser-compat: api.FileSystemDirectoryHandle.removeEntry
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -84,7 +85,7 @@ currentDirHandle.removeEntry(entryName).then( () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.removeEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.html
@@ -7,6 +7,7 @@ tags:
   - File System Access API
   - FileSystemDirectoryHandle
   - Method
+browser-compat: api.FileSystemDirectoryHandle.resolve
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.resolve")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.html
@@ -8,6 +8,7 @@ tags:
   - FileSystemDirectoryHandle
   - Iterable
   - Method
+browser-compat: api.FileSystemDirectoryHandle.values
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryHandle.values")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryreader/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/index.html
@@ -12,6 +12,7 @@ tags:
   - Offline
   - Reference
   - Deprecated
+browser-compat: api.FileSystemDirectoryReader
 ---
 <p>{{APIRef("File System API")}}{{Deprecated_Header}}{{Non-standard_header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryReader")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - readEntries
 - Deprecated
+browser-compat: api.FileSystemDirectoryReader.readEntries
 ---
 <div>{{APIRef("File System API")}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemDirectoryReader.readEntries")}}</p>
+<p>{{Compat}}</p>
 
 <p>On Chrome 77, <code>readEntries()</code> will only return the first
   100 <code>FileSystemEntry</code> instances. In order to obtain all of the

--- a/files/en-us/web/api/filesystementry/copyto/index.html
+++ b/files/en-us/web/api/filesystementry/copyto/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - copyTo
 - Deprecated
+browser-compat: api.FileSystemEntry.copyTo
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.copyTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/filesystem/index.html
+++ b/files/en-us/web/api/filesystementry/filesystem/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - filesystem
+browser-compat: api.FileSystemEntry.filesystem
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.filesystem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/fullpath/index.html
+++ b/files/en-us/web/api/filesystementry/fullpath/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - fullPath
+browser-compat: api.FileSystemEntry.fullPath
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.fullPath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/getmetadata/index.html
+++ b/files/en-us/web/api/filesystementry/getmetadata/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - getMetadata
 - Deprecated
+browser-compat: api.FileSystemEntry.getMetadata
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.getMetadata")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/getparent/index.html
+++ b/files/en-us/web/api/filesystementry/getparent/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - getParent
+browser-compat: api.FileSystemEntry.getParent
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.getParent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/index.html
+++ b/files/en-us/web/api/filesystementry/index.html
@@ -11,6 +11,7 @@ tags:
   - Non-standard
   - Offline
   - Reference
+browser-compat: api.FileSystemEntry
 ---
 <div>{{APIRef("File System API")}} {{non-standard_header}}</div>
 
@@ -107,7 +108,7 @@ window.requestFileSystem(TEMPORARY, 1024*1024 /*1MB*/, function(fs) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/isdirectory/index.html
+++ b/files/en-us/web/api/filesystementry/isdirectory/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - isDirectory
+browser-compat: api.FileSystemEntry.isDirectory
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.isDirectory")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/isfile/index.html
+++ b/files/en-us/web/api/filesystementry/isfile/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - isFile
+browser-compat: api.FileSystemEntry.isFile
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.isFile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/moveto/index.html
+++ b/files/en-us/web/api/filesystementry/moveto/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - moveTo
 - Deprecated
+browser-compat: api.FileSystemEntry.moveTo
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}{{deprecated_header}}</p>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.moveTo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/name/index.html
+++ b/files/en-us/web/api/filesystementry/name/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - name
+browser-compat: api.FileSystemEntry.name
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/remove/index.html
+++ b/files/en-us/web/api/filesystementry/remove/index.html
@@ -13,6 +13,7 @@ tags:
 - delete
 - remove
 - Deprecated
+browser-compat: api.FileSystemEntry.remove
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementry/tourl/index.html
+++ b/files/en-us/web/api/filesystementry/tourl/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Reference
 - toURL
+browser-compat: api.FileSystemEntry.toURL
 ---
 <p>{{APIRef("File System API")}}{{deprecated_header}}</p>
 
@@ -66,7 +67,7 @@ document.body.appendChild(img);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntry.toURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystementrysync/index.html
+++ b/files/en-us/web/api/filesystementrysync/index.html
@@ -13,6 +13,7 @@ tags:
   - Offline
   - Reference
   - filesystem
+browser-compat: api.FileSystemEntrySync
 ---
 <div>{{APIRef("File System API")}}{{Non-standard_header()}}</div>
 
@@ -373,7 +374,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemEntrySync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemfileentry/createwriter/index.html
+++ b/files/en-us/web/api/filesystemfileentry/createwriter/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - createWriter
 - Deprecated
+browser-compat: api.FileSystemFileEntry.createWriter
 ---
 <p>{{APIRef("File System
   API")}}{{SeeCompatTable}}{{deprecated_header}}{{Non-standard_header}}</p>
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFileEntry.createWriter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemfileentry/file/index.html
+++ b/files/en-us/web/api/filesystemfileentry/file/index.html
@@ -11,6 +11,7 @@ tags:
 - Method
 - Non-standard
 - Reference
+browser-compat: api.FileSystemFileEntry.file
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFileEntry.file")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemfileentry/index.html
+++ b/files/en-us/web/api/filesystemfileentry/index.html
@@ -11,6 +11,7 @@ tags:
   - Interface
   - Offline
   - Reference
+browser-compat: api.FileSystemFileEntry
 ---
 <div>{{APIRef("File System API")}}{{SeeCompatTable}}</div>
 
@@ -89,7 +90,7 @@ window.requestFileSystem(window.TEMPORARY, 1024*1024, onInitFs, errorHandler);</
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFileEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - stream
   - working with files
+browser-compat: api.FileSystemFileHandle.createWritable
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFileHandle.createWritable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - getFile
   - working with files
+browser-compat: api.FileSystemFileHandle.getFile
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFileHandle.getFile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemfilehandle/index.html
+++ b/files/en-us/web/api/filesystemfilehandle/index.html
@@ -8,6 +8,7 @@ tags:
   - FileSystemFileHandle
   - Interface
   - working with files
+browser-compat: api.FileSystemFileHandle
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFileHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemflags/create/index.html
+++ b/files/en-us/web/api/filesystemflags/create/index.html
@@ -13,6 +13,7 @@ tags:
 - Offline
 - Property
 - Reference
+browser-compat: api.FileSystemFlags.create
 ---
 <div>{{APIRef("File System API")}}{{SeeCompatTable}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFlags.create")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemflags/exclusive/index.html
+++ b/files/en-us/web/api/filesystemflags/exclusive/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - exclusive
+browser-compat: api.FileSystemFlags.exclusive
 ---
 <div>{{APIRef("File System API")}}{{SeeCompatTable}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFlags.exclusive")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemflags/index.html
+++ b/files/en-us/web/api/filesystemflags/index.html
@@ -12,6 +12,7 @@ tags:
   - Interface
   - Non-standard
   - Reference
+browser-compat: api.FileSystemFlags
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}</p>
 
@@ -114,7 +115,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemFlags")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemhandle/index.html
+++ b/files/en-us/web/api/filesystemhandle/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - handle
   - working with files
+browser-compat: api.FileSystemHandle
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
@@ -126,7 +127,7 @@ async function verifyPermission(fileHandle, withWrite) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemHandle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.html
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.html
@@ -7,6 +7,7 @@ tags:
   - File System Access API
   - FileSystemHandle
   - Method
+browser-compat: api.FileSystemHandle.isSameEntry
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemHandle.isSameEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemhandle/kind/index.html
+++ b/files/en-us/web/api/filesystemhandle/kind/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Read-only
   - handle
+browser-compat: api.FileSystemHandle.kind
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -77,7 +78,7 @@ async function getFile() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemHandle.kind")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemhandle/name/index.html
+++ b/files/en-us/web/api/filesystemhandle/name/index.html
@@ -8,6 +8,7 @@ tags:
   - FileSystemHandle
   - Property
   - Read-only
+browser-compat: api.FileSystemHandle.name
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -60,7 +61,7 @@ async function getFile() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemHandle.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.html
@@ -7,6 +7,7 @@ tags:
   - File System Access API
   - FileSystemHandle
   - Method
+browser-compat: api.FileSystemHandle.queryPermission
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -100,7 +101,7 @@ async function verifyPermission(fileHandle, withWrite) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemHandle.queryPermission")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.html
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.html
@@ -7,6 +7,7 @@ tags:
   - File System Access API
   - FileSystemHandle
   - Method
+browser-compat: api.FileSystemHandle.requestPermission
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -93,7 +94,7 @@ async function verifyPermission(fileHandle, withWrite) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemHandle.requestPermission")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemsync/index.html
+++ b/files/en-us/web/api/filesystemsync/index.html
@@ -8,6 +8,7 @@ tags:
   - Files
   - Offline
   - filesystem
+browser-compat: api.FileSystemSync
 ---
 <div>
 <p>{{APIRef("File System API")}} {{non-standard_header}}</p>
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemSync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - stream
   - write file
+browser-compat: api.FileSystemWritableFileStream
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}</div>
 
@@ -86,7 +87,7 @@ writableStream.write({ type: "truncate", size: size })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemWritableFileStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - stream
   - write
+browser-compat: api.FileSystemWritableFileStream.seek
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemWritableFileStream.seek")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - stream
   - write
+browser-compat: api.FileSystemWritableFileStream.truncate
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemWritableFileStream.truncate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.html
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.html
@@ -9,6 +9,7 @@ tags:
   - stream
   - working with files
   - write
+browser-compat: api.FileSystemWritableFileStream.write
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 </div>
@@ -128,7 +129,7 @@ writableStream.write({ type: "truncate", size: size })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FileSystemWritableFileStream.write")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/focusevent/focusevent/index.html
+++ b/files/en-us/web/api/focusevent/focusevent/index.html
@@ -7,6 +7,7 @@ tags:
 - Event
 - FocusEvent
 - Reference
+browser-compat: api.FocusEvent.FocusEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FocusEvent.FocusEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/focusevent/index.html
+++ b/files/en-us/web/api/focusevent/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM Events
   - Event
   - Reference
+browser-compat: api.FocusEvent
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FocusEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/focusevent/relatedtarget/index.html
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.html
@@ -8,6 +8,7 @@ tags:
 - FocusEvent
 - Property
 - Reference
+browser-compat: api.FocusEvent.relatedTarget
 ---
 <p>{{ apiref("DOM Events") }}</p>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FocusEvent.relatedTarget")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fontface/display/index.html
+++ b/files/en-us/web/api/fontface/display/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - display
+browser-compat: api.FontFace.display
 ---
 <p>{{SeeCompatTable}}{{APIRef("CSS Font Loading API")}}</p>
 
@@ -83,4 +84,4 @@ FontFace.display = <em>display</em></pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.display")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/family/index.html
+++ b/files/en-us/web/api/fontface/family/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - family
+browser-compat: api.FontFace.family
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -55,4 +56,4 @@ console.log(fontFace.family); // 'newRoboto'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.family")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/featuresettings/index.html
+++ b/files/en-us/web/api/fontface/featuresettings/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - featureSettings
+browser-compat: api.FontFace.featureSettings
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -46,4 +47,4 @@ FontFace.featureSettings = <em>featureSettingDescriptor</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.featureSettings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/fontface/index.html
+++ b/files/en-us/web/api/fontface/fontface/index.html
@@ -9,6 +9,7 @@ tags:
 - FontFace
 - Fonts
 - Reference
+browser-compat: api.FontFace.FontFace
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.FontFace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fontface/index.html
+++ b/files/en-us/web/api/fontface/index.html
@@ -9,6 +9,7 @@ tags:
   - Fonts
   - Interface
   - Reference
+browser-compat: api.FontFace
 ---
 <p>{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</p>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fontface/load/index.html
+++ b/files/en-us/web/api/fontface/load/index.html
@@ -10,6 +10,7 @@ tags:
   - Method
   - Reference
   - load
+browser-compat: api.FontFace.load
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.load")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/loaded/index.html
+++ b/files/en-us/web/api/fontface/loaded/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - loaded
+browser-compat: api.FontFace.loaded
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.loaded")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/status/index.html
+++ b/files/en-us/web/api/fontface/status/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - status
+browser-compat: api.FontFace.status
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.status")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/stretch/index.html
+++ b/files/en-us/web/api/fontface/stretch/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - stretch
+browser-compat: api.FontFace.stretch
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -46,4 +47,4 @@ FontFace.stretch = <em>stretchDescriptor</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.stretch")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/style/index.html
+++ b/files/en-us/web/api/fontface/style/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Style
+browser-compat: api.FontFace.style
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -46,4 +47,4 @@ FontFace.style = <em>value</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.style")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/unicoderange/index.html
+++ b/files/en-us/web/api/fontface/unicoderange/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - unicodeRange
+browser-compat: api.FontFace.unicodeRange
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -48,4 +49,4 @@ FontFace.unicodeRange = <em>unicodeRangeDescriptor</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.unicodeRange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/variant/index.html
+++ b/files/en-us/web/api/fontface/variant/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - variant
+browser-compat: api.FontFace.variant
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -47,4 +48,4 @@ FontFace.variant = <em>variantSubProperty</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.variant")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontface/weight/index.html
+++ b/files/en-us/web/api/fontface/weight/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - weight
+browser-compat: api.FontFace.weight
 ---
 <div>{{draft}}{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -46,4 +47,4 @@ FontFace.weight = <em>weightDescriptor</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFace.weight")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfaceset/check/index.html
+++ b/files/en-us/web/api/fontfaceset/check/index.html
@@ -9,6 +9,7 @@ tags:
 - FontFaceSet
 - Method
 - Reference
+browser-compat: api.FontFaceSet.check
 ---
 <p>{{APIRef()}}{{SeeCompatTable}}</p>
 
@@ -62,4 +63,4 @@ document.fonts.check("12px MyFont", "ß"); // returns true if the font 'MyFont' 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSet.check")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfaceset/index.html
+++ b/files/en-us/web/api/fontfaceset/index.html
@@ -9,6 +9,7 @@ tags:
   - Fonts
   - Interface
   - Reference
+browser-compat: api.FontFaceSet
 ---
 <div>{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSet")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfaceset/load/index.html
+++ b/files/en-us/web/api/fontfaceset/load/index.html
@@ -9,6 +9,7 @@ tags:
 - FontFaceSet
 - Method
 - Reference
+browser-compat: api.FontFaceSet.load
 ---
 <p>{{APIRef()}}{{SeeCompatTable}}</p>
 
@@ -66,4 +67,4 @@ document.fonts.load("12px MyFont", "ß").then(…);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSet.load")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfaceset/ready/index.html
+++ b/files/en-us/web/api/fontfaceset/ready/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Ready
 - Reference
+browser-compat: api.FontFaceSet.ready
 ---
 <p>{{APIRef("CSSFontLoading")}}{{SeeCompatTable}}{{draft}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSet.ready")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - fontfaces
+browser-compat: api.FontFaceSetLoadEvent.fontfaces
 ---
 <p>{{SeeCompatTable}}{{APIRef("CSS Font Loading API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSetLoadEvent.fontfaces")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.html
@@ -10,6 +10,7 @@ tags:
 - FontFaceLoadEvent
 - Fonts
 - Reference
+browser-compat: api.FontFaceSetLoadEvent.FontFaceSetLoadEvent
 ---
 <p>{{APIRef("CSS Font Loading API")}}{{SeeCompatTable}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSetLoadEvent.FontFaceSetLoadEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/fontfacesetloadevent/index.html
+++ b/files/en-us/web/api/fontfacesetloadevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Fonts
   - Interface
   - Reference
+browser-compat: api.FontFaceSetLoadEvent
 ---
 <p>{{SeeCompatTable}}{{APIRef("CSS Font Loading API")}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FontFaceSetLoadEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/formdata/append/index.html
+++ b/files/en-us/web/api/formdata/append/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - XHR
   - XMLHttpRequest
+browser-compat: api.FormData.append
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -92,7 +93,7 @@ formData.getAll('name'); // ["true", "74", "John"]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.append")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/delete/index.html
+++ b/files/en-us/web/api/formdata/delete/index.html
@@ -9,6 +9,7 @@ tags:
   - XHR
   - XMLHttpRequest
   - delete
+browser-compat: api.FormData.delete
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.delete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/entries/index.html
+++ b/files/en-us/web/api/formdata/entries/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - XMLHttpRequest API
+browser-compat: api.FormData.entries
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -67,7 +68,7 @@ key2, value2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.entries")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/formdata/index.html
+++ b/files/en-us/web/api/formdata/formdata/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - XHR
   - XMLHttpRequest
+browser-compat: api.FormData.FormData
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -84,7 +85,7 @@ let formData = new FormData(myForm);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.FormData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/get/index.html
+++ b/files/en-us/web/api/formdata/get/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - XHR
   - XMLHttpRequest
+browser-compat: api.FormData.get
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -73,7 +74,7 @@ formData.append('username', 'Bob');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/getall/index.html
+++ b/files/en-us/web/api/formdata/getall/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - XHR
   - XMLHttpRequest
+browser-compat: api.FormData.getAll
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -66,7 +67,7 @@ formData.append('username', 'Bob');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/has/index.html
+++ b/files/en-us/web/api/formdata/has/index.html
@@ -9,6 +9,7 @@ tags:
   - XHR
   - XMLHttpRequest
   - has
+browser-compat: api.FormData.has
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -66,7 +67,7 @@ formData.has('username'); // Returns true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.has")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/index.html
+++ b/files/en-us/web/api/formdata/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - XMLHttpRequest
+browser-compat: api.FormData
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/keys/index.html
+++ b/files/en-us/web/api/formdata/keys/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - XMLHttpRequest API
+browser-compat: api.FormData.keys
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -66,7 +67,7 @@ key2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/set/index.html
+++ b/files/en-us/web/api/formdata/set/index.html
@@ -9,6 +9,7 @@ tags:
   - XHR
   - XMLHttpRequest
   - set
+browser-compat: api.FormData.set
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -77,7 +78,7 @@ formData.get('name'); // "72"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.set")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdata/values/index.html
+++ b/files/en-us/web/api/formdata/values/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - XMLHttpRequest API
+browser-compat: api.FormData.values
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -67,7 +68,7 @@ value2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormData.values")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdataevent/formdata/index.html
+++ b/files/en-us/web/api/formdataevent/formdata/index.html
@@ -8,6 +8,7 @@ tags:
 - Forms
 - Property
 - Reference
+browser-compat: api.FormDataEvent.formData
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,7 +77,7 @@ formElem.addEventListener('formdata', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormDataEvent.formData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdataevent/formdataevent/index.html
+++ b/files/en-us/web/api/formdataevent/formdataevent/index.html
@@ -8,6 +8,7 @@ tags:
 - FormDataEvent
 - Forms
 - Reference
+browser-compat: api.FormDataEvent.FormDataEvent
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -74,7 +75,7 @@ for (let value of fdEv.formData.values()) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormDataEvent.FormDataEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/formdataevent/index.html
+++ b/files/en-us/web/api/formdataevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Forms
   - Landing
   - Reference
+browser-compat: api.FormDataEvent
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -87,7 +88,7 @@ formElem.addEventListener('formdata', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FormDataEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fullscreenoptions/index.html
+++ b/files/en-us/web/api/fullscreenoptions/index.html
@@ -15,6 +15,7 @@ tags:
   - UI
   - fullscreen
   - screen
+browser-compat: api.FullscreenOptions
 ---
 <p>{{APIRef("Fullscreen API")}}</p>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FullscreenOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/fullscreenoptions/navigationui/index.html
+++ b/files/en-us/web/api/fullscreenoptions/navigationui/index.html
@@ -14,6 +14,7 @@ tags:
 - fullscreen
 - navigationUI
 - screen
+browser-compat: api.FullscreenOptions.navigationUI
 ---
 <p>{{APIRef("Fullscreen API")}}</p>
 
@@ -87,7 +88,7 @@ elem.requestFullscreen({ navigationUI: "show" }).then({}).catch(err =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.FullscreenOptions.navigationUI")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/b* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

144 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
