### PR TITLE
Put browser-compat info in front-runner for api/g*

### DIFF
--- a/files/en-us/web/api/gainnode/gain/index.html
+++ b/files/en-us/web/api/gainnode/gain/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Web Audio API
+browser-compat: api.GainNode.gain
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -53,7 +54,7 @@ gainNode.gain.value = 0.5;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GainNode.gain")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gainnode/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/gainnode/index.html
@@ -9,6 +9,7 @@ tags:
   - Media
   - Reference
   - Web Audio API
+browser-compat: api.GainNode.GainNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -68,5 +69,5 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.GainNode.GainNode")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/gainnode/index.html
+++ b/files/en-us/web/api/gainnode/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.GainNode
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GainNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/axes/index.html
+++ b/files/en-us/web/api/gamepad/axes/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.axes
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.axes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/buttons/index.html
+++ b/files/en-us/web/api/gamepad/buttons/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.buttons
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -104,7 +105,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.buttons")}}</p>
+<p>{{Compat}}</p>
 
 <div id="compat-mobile"> </div>
 

--- a/files/en-us/web/api/gamepad/connected/index.html
+++ b/files/en-us/web/api/gamepad/connected/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.connected
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -53,7 +54,7 @@ console.log(gp.connected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.connected")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/displayid/index.html
+++ b/files/en-us/web/api/gamepad/displayid/index.html
@@ -12,6 +12,7 @@ tags:
   - WebVR
   - displayId
   - Deprecated
+browser-compat: api.Gamepad.displayId
 ---
 <p>{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.displayId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/hand/index.html
+++ b/files/en-us/web/api/gamepad/hand/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - hand
+browser-compat: api.Gamepad.hand
 ---
 <div>{{APIRef("Gamepad")}}{{SeeCompatTable}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.hand")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/hapticactuators/index.html
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - hapticActuators
+browser-compat: api.Gamepad.hapticActuators
 ---
 <div>{{APIRef("Gamepad")}}{{SeeCompatTable}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.hapticActuators")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/id/index.html
+++ b/files/en-us/web/api/gamepad/id/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.id
 ---
 <div>{{APIRef("Gamepad API")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/index.html
+++ b/files/en-us/web/api/gamepad/index.html
@@ -7,6 +7,7 @@ tags:
   - Games
   - Interface
   - Reference
+browser-compat: api.Gamepad
 ---
 <div>{{APIRef("Gamepad API")}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/index/index.html
+++ b/files/en-us/web/api/gamepad/index/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.index
 ---
 <div>{{APIRef("Gamepad API")}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.index")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/mapping/index.html
+++ b/files/en-us/web/api/gamepad/mapping/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.mapping
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -54,7 +55,7 @@ console.log(gp.mapping);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.mapping")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/pose/index.html
+++ b/files/en-us/web/api/gamepad/pose/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - pose
+browser-compat: api.Gamepad.pose
 ---
 <div>{{APIRef("Gamepad")}}{{SeeCompatTable}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.pose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepad/timestamp/index.html
+++ b/files/en-us/web/api/gamepad/timestamp/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.Gamepad.timestamp
 ---
 <div>{{APIRef("Gamepad API")}}</div>
 
@@ -61,7 +62,7 @@ console.log(gp.timestamp);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gamepad.timestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadbutton/index.html
+++ b/files/en-us/web/api/gamepadbutton/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsBetterSpecLink
   - NeedsMarkupWork
   - Reference
+browser-compat: api.GamepadButton
 ---
 <div>{{APIRef("Gamepad API")}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadButton")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadbutton/pressed/index.html
+++ b/files/en-us/web/api/gamepadbutton/pressed/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.GamepadButton.pressed
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -53,7 +54,7 @@ if(gp.buttons[0].pressed == true) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadButton.pressed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadbutton/value/index.html
+++ b/files/en-us/web/api/gamepadbutton/value/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMarkupWork
   - Property
   - Reference
+browser-compat: api.GamepadButton.value
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -57,7 +58,7 @@ if(gp.buttons[0].value &gt; 0) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadButton.value")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadevent/gamepad/index.html
+++ b/files/en-us/web/api/gamepadevent/gamepad/index.html
@@ -6,6 +6,7 @@ tags:
   - Gamepad API
   - Property
   - Reference
+browser-compat: api.GamepadEvent.gamepad
 ---
 <div>{{APIRef("Gamepad API")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadEvent.gamepad")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadevent/gamepadevent/index.html
+++ b/files/en-us/web/api/gamepadevent/gamepadevent/index.html
@@ -7,6 +7,7 @@ tags:
 - Gamepad API
 - Games
 - Reference
+browser-compat: api.GamepadEvent.GamepadEvent
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadEvent.GamepadEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gamepadevent/index.html
+++ b/files/en-us/web/api/gamepadevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Games
   - Interface
   - Reference
+browser-compat: api.GamepadEvent
 ---
 <p>{{APIRef("Gamepad API")}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadhapticactuator/index.html
+++ b/files/en-us/web/api/gamepadhapticactuator/index.html
@@ -11,6 +11,7 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+browser-compat: api.GamepadHapticActuator
 ---
 <div>{{APIRef("Gamepad API")}}{{SeeCompatTable}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadHapticActuator")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.html
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.html
@@ -10,6 +10,7 @@ tags:
   - Method
   - Reference
   - pulse
+browser-compat: api.GamepadHapticActuator.pulse
 ---
 <div>{{APIRef("Gamepad")}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadHapticActuator.pulse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadhapticactuator/type/index.html
+++ b/files/en-us/web/api/gamepadhapticactuator/type/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - Type
+browser-compat: api.GamepadHapticActuator.type
 ---
 <div>{{APIRef("Gamepad")}}{{SeeCompatTable}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadHapticActuator.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/angularacceleration/index.html
+++ b/files/en-us/web/api/gamepadpose/angularacceleration/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - angularAcceleration
+browser-compat: api.GamepadPose.angularAcceleration
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.angularAcceleration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/angularvelocity/index.html
+++ b/files/en-us/web/api/gamepadpose/angularvelocity/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - angularVelocity
+browser-compat: api.GamepadPose.angularVelocity
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.angularVelocity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasorientation/index.html
+++ b/files/en-us/web/api/gamepadpose/hasorientation/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasOrientation
+browser-compat: api.GamepadPose.hasOrientation
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.hasOrientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/hasposition/index.html
+++ b/files/en-us/web/api/gamepadpose/hasposition/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasPosition
+browser-compat: api.GamepadPose.hasPosition
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.hasPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/index.html
+++ b/files/en-us/web/api/gamepadpose/index.html
@@ -11,6 +11,7 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+browser-compat: api.GamepadPose
 ---
 <div>{{APIRef("Gamepad API")}}{{SeeCompatTable}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/linearacceleration/index.html
+++ b/files/en-us/web/api/gamepadpose/linearacceleration/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - linearAcceleration
+browser-compat: api.GamepadPose.linearAcceleration
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.linearAcceleration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/linearvelocity/index.html
+++ b/files/en-us/web/api/gamepadpose/linearvelocity/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - linearVelocity
+browser-compat: api.GamepadPose.linearVelocity
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.linearVelocity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/orientation/index.html
+++ b/files/en-us/web/api/gamepadpose/orientation/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Virtual Reality
   - WebVR
+browser-compat: api.GamepadPose.orientation
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.orientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gamepadpose/position/index.html
+++ b/files/en-us/web/api/gamepadpose/position/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Virtual Reality
   - WebVR
+browser-compat: api.GamepadPose.position
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GamepadPose.position")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocation/clearwatch/index.html
+++ b/files/en-us/web/api/geolocation/clearwatch/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - Secure context
+browser-compat: api.Geolocation.clearWatch
 ---
 <p>{{securecontext_header}}{{ APIref("Geolocation API") }}</p>
 
@@ -80,7 +81,7 @@ id = navigator.geolocation.watchPosition(success, error, options);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Geolocation.clearWatch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocation/getcurrentposition/index.html
+++ b/files/en-us/web/api/geolocation/getcurrentposition/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Secure context
 - getCurrentPosition
+browser-compat: api.Geolocation.getCurrentPosition
 ---
 <p>{{securecontext_header}}{{ APIRef("Geolocation API") }}</p>
 
@@ -88,7 +89,7 @@ navigator.geolocation.getCurrentPosition(success, error, options);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Geolocation.getCurrentPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocation/index.html
+++ b/files/en-us/web/api/geolocation/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Secure context
+browser-compat: api.Geolocation
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Geolocation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocation/watchposition/index.html
+++ b/files/en-us/web/api/geolocation/watchposition/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - Secure context
+browser-compat: api.Geolocation.watchPosition
 ---
 <p>{{securecontext_header}}{{ APIref("Geolocation API") }}</p>
 
@@ -94,7 +95,7 @@ id = navigator.geolocation.watchPosition(success, error, options);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Geolocation.watchPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/accuracy/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/accuracy/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - accuracy
+browser-compat: api.GeolocationCoordinates.accuracy
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.accuracy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/altitude/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/altitude/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - altitude
+browser-compat: api.GeolocationCoordinates.altitude
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.altitude")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - altitudeAccuracy
+browser-compat: api.GeolocationCoordinates.altitudeAccuracy
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.altitudeAccuracy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/heading/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/heading/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - heading
+browser-compat: api.GeolocationCoordinates.heading
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.heading")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/index.html
@@ -7,6 +7,7 @@ tags:
   - GeolocationCoordinates
   - Interface
   - Secure context
+browser-compat: api.GeolocationCoordinates
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/latitude/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/latitude/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - latitude
+browser-compat: api.GeolocationCoordinates.latitude
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.latitude")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/longitude/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/longitude/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Secure context
   - longitude
+browser-compat: api.GeolocationCoordinates.longitude
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -127,7 +128,7 @@ button.addEventListener("click", function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.longitude")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationcoordinates/speed/index.html
+++ b/files/en-us/web/api/geolocationcoordinates/speed/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - speed
+browser-compat: api.GeolocationCoordinates.speed
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationCoordinates.speed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationposition/coords/index.html
+++ b/files/en-us/web/api/geolocationposition/coords/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - coords
+browser-compat: api.GeolocationPosition.coords
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationPosition.coords")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationposition/index.html
+++ b/files/en-us/web/api/geolocationposition/index.html
@@ -7,6 +7,7 @@ tags:
   - GeolocationPosition
   - Interface
   - Secure context
+browser-compat: api.GeolocationPosition
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationposition/timestamp/index.html
+++ b/files/en-us/web/api/geolocationposition/timestamp/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - timeStamp
+browser-compat: api.GeolocationPosition.timestamp
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationPosition.timestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationpositionerror/code/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/code/index.html
@@ -8,6 +8,7 @@ tags:
   - GeolocationPositionError
   - Property
   - Secure context
+browser-compat: api.GeolocationPositionError.code
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationPositionError.code")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationpositionerror/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/index.html
@@ -7,6 +7,7 @@ tags:
   - GeolocationPositionError
   - Interface
   - Secure context
+browser-compat: api.GeolocationPositionError
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationPositionError")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geolocationpositionerror/message/index.html
+++ b/files/en-us/web/api/geolocationpositionerror/message/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Secure context
   - message
+browser-compat: api.GeolocationPositionError.message
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeolocationPositionError.message")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/geometryutils/index.html
+++ b/files/en-us/web/api/geometryutils/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM View
   - Experimental
   - Interface
+browser-compat: api.GeometryUtils
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GeometryUtils")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gestureevent/index.html
+++ b/files/en-us/web/api/gestureevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Non-standard
   - Reference
+browser-compat: api.GestureEvent
 ---
 <p id="Summary">{{APIRef("DOM Events")}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GestureEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/index.html
+++ b/files/en-us/web/api/globaleventhandlers/index.html
@@ -8,6 +8,7 @@ tags:
   - Mixin
   - Reference
   - events
+browser-compat: api.GlobalEventHandlers
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -255,7 +256,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onabort/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - Window
+browser-compat: api.GlobalEventHandlers.onabort
 ---
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}} {{draft}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.GlobalEventHandlers.onabort")}}</p>
+  <p>{{Compat}}</p>
 
   <p>This property is not available with Firefox 2 or Safari.</p>
 </div>

--- a/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationcancel/index.html
@@ -15,6 +15,7 @@ tags:
 - Window
 - onanimationcancel
 - web animations api
+browser-compat: api.GlobalEventHandlers.onanimationcancel
 ---
 <div>{{APIRef("CSS3 Animations")}}</div>
 
@@ -220,7 +221,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onanimationcancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationend/index.html
@@ -17,6 +17,7 @@ tags:
 - Window
 - onanimationend
 - web animations api
+browser-compat: api.GlobalEventHandlers.onanimationend
 ---
 <div>{{APIRef("CSS3 Animations")}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onanimationend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationiteration/index.html
@@ -17,6 +17,7 @@ tags:
 - animationiteration
 - onanimationiteration
 - web animations api
+browser-compat: api.GlobalEventHandlers.onanimationiteration
 ---
 <div>{{APIRef("CSS3 Animations")}} {{Draft}}</div>
 
@@ -204,7 +205,7 @@ box.onanimationiteration = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onanimationiteration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onanimationstart/index.html
@@ -14,6 +14,7 @@ tags:
 - Window
 - onanimationstart
 - onwebkitanimationstart
+browser-compat: api.GlobalEventHandlers.onanimationstart
 ---
 <div>{{APIRef("CSS3 Animations")}}</div>
 
@@ -216,7 +217,7 @@ box.onanimationend = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onanimationstart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onauxclick/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - auxclick
+browser-compat: api.GlobalEventHandlers.onauxclick
 ---
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
@@ -101,7 +102,7 @@ button.onauxclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onauxclick")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onblur/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onblur/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onblur
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -86,7 +87,7 @@ function inputFocus() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onblur")}}</p>
+<p>{{Compat}}</p>
 
 <p>In contrast to IE, in which almost all kinds of elements receive the <code>blur</code>
   event, only a few kinds of elements on Gecko browsers work with this event.</p>

--- a/files/en-us/web/api/globaleventhandlers/oncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncancel/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.oncancel
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.oncancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplay/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.oncanplay
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -47,7 +48,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncanplay;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.oncanplay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncanplaythrough/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.oncanplaythrough
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -47,7 +48,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncanplaythrough;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.oncanplaythrough")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onchange/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onchange
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -80,7 +81,7 @@ function handleChange(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onclick
 ---
 <p>{{ ApiRef("HTML DOM") }}</p>
 
@@ -110,7 +111,7 @@ function inputChange(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onclick")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onclose/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onclose/index.html
@@ -11,6 +11,7 @@ tags:
 - NeedsExample
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onclose
 ---
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onclose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncontextmenu/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.oncontextmenu
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -141,7 +142,7 @@ window.onpointerdown = play;</pre>
 
 <div>
 
-  <p>{{Compat("api.GlobalEventHandlers.oncontextmenu")}}</p>
+  <p>{{Compat}}</p>
 
   <p>Unless the default behavior is prevented, the browser context menu will activate upon
     right-click. However, IE8 has a bug with this and will not activate the context menu

--- a/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oncuechange/index.html
@@ -12,6 +12,7 @@ tags:
 - text track
 - track
 - vtt
+browser-compat: api.GlobalEventHandlers.oncuechange
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -53,7 +54,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.oncuechange;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.oncuechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondblclick/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.ondblclick
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -79,7 +80,7 @@ function logDoubleClick(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondblclick")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondrag/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondrag/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondrag
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -106,7 +107,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondrag")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragend/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondragend
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -141,7 +142,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondragend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragenter/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondragenter
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -142,7 +143,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondragenter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragleave/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondragleave
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -143,7 +144,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondragleave")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragover/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondragover
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -108,7 +109,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondragover")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondragstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondragstart/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondragstart
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -108,7 +109,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondragstart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondrop/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondrop/index.html
@@ -6,6 +6,7 @@ tags:
 - HTML DOM
 - Reference
 - drag and drop
+browser-compat: api.GlobalEventHandlers.ondrop
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -107,7 +108,7 @@ function dragover_handler(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondrop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ondurationchange/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.ondurationchange
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -46,7 +47,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.ondurationchange;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ondurationchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onemptied/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onemptied/index.html
@@ -1,6 +1,7 @@
 ---
 title: GlobalEventHandlers.onemptied
 slug: Web/API/GlobalEventHandlers/onemptied
+browser-compat: api.GlobalEventHandlers.onemptied
 ---
 <div>
     <div>{{ ApiRef("HTML DOM") }}</div>
@@ -51,4 +52,4 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onemptied;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onemptied")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/globaleventhandlers/onended/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onended/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onended
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -46,7 +47,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onended;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onended")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onerror/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onerror/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+browser-compat: api.GlobalEventHandlers.onerror
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onfocus/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onfocus/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+browser-compat: api.GlobalEventHandlers.onfocus
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -90,7 +91,7 @@ function inputFocus() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onfocus")}}</p>
+<p>{{Compat}}</p>
 
 <p>In contrast to IE, in which almost all kinds of elements receive the <code>focus</code>
   event, almost all kinds of elements on Gecko browsers do NOT work with this event.</p>

--- a/files/en-us/web/api/globaleventhandlers/onformdata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onformdata/index.html
@@ -9,6 +9,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onformdata
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -84,7 +85,7 @@ formElem.onformdata = (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onformdata")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - events
 - ongotpointercapture
+browser-compat: api.GlobalEventHandlers.ongotpointercapture
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -63,7 +64,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ongotpointercapture")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/oninput/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninput/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.oninput
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -84,7 +85,7 @@ function handleInput(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.oninput")}}</p>
+<p>{{Compat}}</p>
 
 <p>The following links discuss compatibility issues and fixes that may be helpful when
   working with older browsers:</p>

--- a/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
+++ b/files/en-us/web/api/globaleventhandlers/oninvalid/index.html
@@ -7,6 +7,7 @@ tags:
   - GlobalEventHandlers
   - Property
   - Reference
+browser-compat: api.GlobalEventHandlers.oninvalid
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -95,7 +96,7 @@ function submit(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.oninvalid")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeydown/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - events
+browser-compat: api.GlobalEventHandlers.onkeydown
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -76,7 +77,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onkeydown")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Compatibility_notes">Compatibility notes</h3>
 

--- a/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeypress/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Deprecated
+browser-compat: api.GlobalEventHandlers.onkeypress
 ---
 <div>{{ApiRef("HTML DOM")}} {{deprecated_header}}</div>
 
@@ -157,7 +158,7 @@ input.onpaste = event =&gt; false;</pre>
 
 <div>
 
-  <p>{{Compat("api.GlobalEventHandlers.onkeypress")}}</p>
+  <p>{{Compat}}</p>
 
   <h3 id="Browser_compatibility_notes">Browser compatibility notes</h3>
 

--- a/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onkeyup/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML DOM
   - Property
   - Reference
+browser-compat: api.GlobalEventHandlers.onkeyup
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -74,7 +75,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onkeyup")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Compatibility_notes">Compatibility notes</h3>
 

--- a/files/en-us/web/api/globaleventhandlers/onload/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onload/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onload
+browser-compat: api.GlobalEventHandlers.onload
 ---
 <div>{{ApiRef()}}</div>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onload")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadeddata/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onloadeddata
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -46,7 +47,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadeddata;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onloadeddata")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadedmetadata/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onloadedmetadata
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -45,7 +46,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onloadedmetadata;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onloadedmetadata")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onloadend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadend/index.html
@@ -11,6 +11,7 @@ tags:
 - Web
 - events
 - onloadend
+browser-compat: api.GlobalEventHandlers.onloadend
 ---
 <div>{{ApiRef}}</div>
 
@@ -53,4 +54,4 @@ image.addEventListener('loadend', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onloadend")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/globaleventhandlers/onloadstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onloadstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Web
 - events
 - onloadstart
+browser-compat: api.GlobalEventHandlers.onloadstart
 ---
 <div>{{ApiRef}}</div>
 
@@ -73,4 +74,4 @@ image.addEventListener('loadend', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onloadstart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - events
 - onlostpointercapture
+browser-compat: api.GlobalEventHandlers.onlostpointercapture
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -62,7 +63,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onlostpointercapture")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousedown/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmousedown
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -116,7 +117,7 @@ document.onmouseup = hideView;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmousedown")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseenter/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmouseenter
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -46,7 +47,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmouseenter;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmouseenter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseleave/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmouseleave
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -46,7 +47,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmouseleave;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmouseleave")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousemove/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmousemove
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -116,7 +117,7 @@ links.forEach(link =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmousemove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseout/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmouseout
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -71,4 +72,4 @@ function logMouseOut() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmouseout")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseover/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmouseover
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -70,4 +71,4 @@ function logMouseOut() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmouseover")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmouseup/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onmouseup
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -120,7 +121,7 @@ document.onmouseup = release;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmouseup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onmousewheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onmousewheel/index.html
@@ -3,6 +3,7 @@ title: GlobalEventHandlers.onmousewheel
 slug: Web/API/GlobalEventHandlers/onmousewheel
 tags:
   - Deprecated
+browser-compat: api.GlobalEventHandlers.onmousewheel
 ---
 <p>{{ ApiRef("HTML DOM") }}{{Deprecated_Header}}{{ Non-standard_header() }}</p>
 
@@ -42,4 +43,4 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onmousewheel;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onmousewheel")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/globaleventhandlers/onpause/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpause/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpause
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -45,7 +46,7 @@ var <em>handlerFunction</em> = <em><var>element</var></em>.onpause;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpause")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onplay/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplay/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onplay
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -62,7 +63,7 @@ function alertPlay() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onplay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onplaying/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onplaying/index.html
@@ -7,6 +7,7 @@ tags:
 - GlobalEventHandlers
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onplaying
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -48,7 +49,7 @@ var <var>handlerFunction</var> = <var>element</var>.onplaying;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onplaying")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointercancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointercancel/index.html
@@ -9,6 +9,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpointercancel
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -82,7 +83,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointercancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerdown/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerdown/index.html
@@ -13,6 +13,7 @@ tags:
 - Property
 - Reference
 - Window
+browser-compat: api.GlobalEventHandlers.onpointerdown
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -183,7 +184,7 @@ function handleUp(evt) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointerdown")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerenter/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerenter/index.html
@@ -9,6 +9,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpointerenter
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -82,7 +83,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointerenter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerleave/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerleave/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - onpointerleave
+browser-compat: api.GlobalEventHandlers.onpointerleave
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -89,7 +90,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointerleave")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointermove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointermove/index.html
@@ -9,6 +9,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpointermove
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -82,7 +83,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointermove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerout/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerout/index.html
@@ -9,6 +9,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpointerout
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -82,7 +83,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointerout")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerover/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerover/index.html
@@ -9,6 +9,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpointerover
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -82,7 +83,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointerover")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerup/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onpointerup/index.html
@@ -9,6 +9,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onpointerup
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -82,7 +83,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onpointerup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onreset/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onreset/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onreset
 ---
 <div>{{ ApiRef() }}</div>
 
@@ -77,7 +78,7 @@ form.onreset = logReset;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onreset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onresize/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onresize/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onresize
+browser-compat: api.GlobalEventHandlers.onresize
 ---
 <div>{{ ApiRef() }}</div>
 
@@ -70,7 +71,7 @@ window.onresize = resize;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onresize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onscroll/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onscroll/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onscroll
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -106,7 +107,7 @@ function logScroll(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onscroll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselect/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselect/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onselect
 ---
 <div>{{ ApiRef("HTML DOM") }}</div>
 
@@ -75,7 +76,7 @@ textarea.onselect = logSelection;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onselect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.html
@@ -11,6 +11,7 @@ tags:
   - Selection
   - Selection API
   - onselectionchange
+browser-compat: api.GlobalEventHandlers.onselectionchange
 ---
 <div>{{ApiRef('DOM')}} {{SeeCompatTable}}</div>
 
@@ -57,7 +58,7 @@ document.onselectionchange = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onselectionchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onselectstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Selection
 - Selection API
 - onselectstart
+browser-compat: api.GlobalEventHandlers.onselectstart
 ---
 <div>{{ApiRef('DOM')}}{{SeeCompatTable}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onselectstart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onsubmit/index.html
@@ -8,6 +8,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.onsubmit
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -91,7 +92,7 @@ function submit(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onsubmit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchcancel/index.html
@@ -9,6 +9,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.ontouchcancel
 ---
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
@@ -80,7 +81,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ontouchcancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchend/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Reference
 - TouchEvent
+browser-compat: api.GlobalEventHandlers.ontouchend
 ---
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
@@ -78,7 +79,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ontouchend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchmove/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchmove/index.html
@@ -6,6 +6,7 @@ tags:
   - Experimental
   - HTML DOM
   - Reference
+browser-compat: api.GlobalEventHandlers.ontouchmove
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -75,7 +76,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ontouchmove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontouchstart/index.html
@@ -9,6 +9,7 @@ tags:
 - HTML DOM
 - Property
 - Reference
+browser-compat: api.GlobalEventHandlers.ontouchstart
 ---
 <div>{{ApiRef("HTML DOM")}} {{SeeCompatTable}}</div>
 
@@ -77,7 +78,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ontouchstart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitioncancel/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - ontransitioncancel
+browser-compat: api.GlobalEventHandlers.ontransitioncancel
 ---
 <div>{{APIRef("CSS3 Transitions")}}</div>
 
@@ -164,7 +165,7 @@ box.ontransitioncancel = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ontransitioncancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
+++ b/files/en-us/web/api/globaleventhandlers/ontransitionend/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - Window
 - ontransitionend
+browser-compat: api.GlobalEventHandlers.ontransitionend
 ---
 <div>{{APIRef("CSS3 Transitions")}}</div>
 
@@ -144,7 +145,7 @@ box.ontransitionend = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.ontransitionend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/globaleventhandlers/onwheel/index.html
+++ b/files/en-us/web/api/globaleventhandlers/onwheel/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onwheel
+browser-compat: api.GlobalEventHandlers.onwheel
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
@@ -115,7 +116,7 @@ document.onwheel = zoom;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onwheel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/gravitysensor/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/gravitysensor/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor
 - Sensor APIs
 - Sensors
+browser-compat: api.GravitySensor.GravitySensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -77,4 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GravitySensor.GravitySensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gravitysensor/index.html
+++ b/files/en-us/web/api/gravitysensor/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.GravitySensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -68,4 +69,4 @@ gravitySensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.GravitySensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gyroscope/gyroscope/index.html
+++ b/files/en-us/web/api/gyroscope/gyroscope/index.html
@@ -10,6 +10,7 @@ tags:
 - Sensor
 - Sensor APIs
 - Sensors
+browser-compat: api.Gyroscope.Gyroscope
 ---
 <div>{{APIRef("Gyroscope")}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gyroscope.Gyroscope")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gyroscope/index.html
+++ b/files/en-us/web/api/gyroscope/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.Gyroscope
 ---
 <div>{{APIRef("Gyroscope")}}</div>
 
@@ -75,4 +76,4 @@ gyroscope.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gyroscope")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gyroscope/x/index.html
+++ b/files/en-us/web/api/gyroscope/x/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor APIs
 - Sensors
 - x
+browser-compat: api.Gyroscope.x
 ---
 <div>{{APIRef("Gyroscope")}}</div>
 
@@ -68,4 +69,4 @@ gyroscope.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gyroscope.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gyroscope/y/index.html
+++ b/files/en-us/web/api/gyroscope/y/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor APIs
 - Sensors
 - 'y'
+browser-compat: api.Gyroscope.y
 ---
 <div>{{APIRef("Gyroscope")}}</div>
 
@@ -68,4 +69,4 @@ gyroscope.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gyroscope.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/gyroscope/z/index.html
+++ b/files/en-us/web/api/gyroscope/z/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor APIs
 - Sensors
 - z
+browser-compat: api.Gyroscope.z
 ---
 <div>{{APIRef("Gyroscope")}}</div>
 
@@ -68,4 +69,4 @@ gyroscope.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Gyroscope.z")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/b* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

135 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
