### PR TITLE
Put browser-compat info in front-runner for api/i*

### DIFF
--- a/files/en-us/web/api/idbcursor/advance/index.html
+++ b/files/en-us/web/api/idbcursor/advance/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - advance
+browser-compat: api.IDBCursor.advance
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -121,7 +122,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.advance")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/continue/index.html
+++ b/files/en-us/web/api/idbcursor/continue/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - continue
+browser-compat: api.IDBCursor.continue
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -124,7 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.continue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/continueprimarykey/index.html
+++ b/files/en-us/web/api/idbcursor/continueprimarykey/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Storage
 - Web
+browser-compat: api.IDBCursor.continuePrimaryKey
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -130,7 +131,7 @@ request.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.continuePrimaryKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/delete/index.html
+++ b/files/en-us/web/api/idbcursor/delete/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - delete
+browser-compat: api.IDBCursor.delete
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -125,7 +126,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.delete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/direction/index.html
+++ b/files/en-us/web/api/idbcursor/direction/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - direction
+browser-compat: api.IDBCursor.direction
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -140,7 +141,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.direction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/index.html
+++ b/files/en-us/web/api/idbcursor/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBCursor
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -118,7 +119,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/key/index.html
+++ b/files/en-us/web/api/idbcursor/key/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Storage
+browser-compat: api.IDBCursor.key
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.key")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/primarykey/index.html
+++ b/files/en-us/web/api/idbcursor/primarykey/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - primaryKey
+browser-compat: api.IDBCursor.primaryKey
 ---
 <div>
   <p>{{APIRef("IDBCursor")}}</p>
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.primaryKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/request/index.html
+++ b/files/en-us/web/api/idbcursor/request/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - request
+browser-compat: api.IDBCursor.request
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.request")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/source/index.html
+++ b/files/en-us/web/api/idbcursor/source/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - source
+browser-compat: api.IDBCursor.source
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.source")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursor/update/index.html
+++ b/files/en-us/web/api/idbcursor/update/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - Update
+browser-compat: api.IDBCursor.update
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -162,7 +163,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursor.update")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursorwithvalue/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBCursorWithValue
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursorWithValue")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbcursorwithvalue/value/index.html
+++ b/files/en-us/web/api/idbcursorwithvalue/value/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - value
+browser-compat: api.IDBCursorWithValue.value
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBCursorWithValue.value")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/abort_event/index.html
+++ b/files/en-us/web/api/idbdatabase/abort_event/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'IDBDatabase: abort event'
 slug: Web/API/IDBDatabase/abort_event
+browser-compat: api.IDBDatabase.abort_event
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -100,7 +101,7 @@ dBOpenRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.abort_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/close/index.html
+++ b/files/en-us/web/api/idbdatabase/close/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - Storage
+browser-compat: api.IDBDatabase.close
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -74,7 +75,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/close_event/index.html
+++ b/files/en-us/web/api/idbdatabase/close_event/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'IDBDatabase: close event'
 slug: Web/API/IDBDatabase/close_event
+browser-compat: api.IDBDatabase.close_event
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -91,7 +92,7 @@ dBOpenRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.close_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Storage
+browser-compat: api.IDBDatabase.createObjectStore
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -182,7 +183,7 @@ request.onupgradeneeded = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.createObjectStore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.html
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Storage
+browser-compat: api.IDBDatabase.deleteObjectStore
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -116,7 +117,7 @@ request.onupgradeneeded = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.deleteObjectStore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/error_event/index.html
+++ b/files/en-us/web/api/idbdatabase/error_event/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'IDBDatabase: error event'
 slug: Web/API/IDBDatabase/error_event
+browser-compat: api.IDBDatabase.error_event
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -99,7 +100,7 @@ dBOpenRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/index.html
+++ b/files/en-us/web/api/idbdatabase/index.html
@@ -12,6 +12,7 @@ tags:
   - accessing data
   - asynchronous access
   - transactions
+browser-compat: api.IDBDatabase
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -154,7 +155,7 @@ DBOpenRequest.onupgradeneeded = function(event) {
 <div>
 <div>
 
-<p>{{Compat("api.IDBDatabase")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/idbdatabase/name/index.html
+++ b/files/en-us/web/api/idbdatabase/name/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - name
+browser-compat: api.IDBDatabase.name
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -84,7 +85,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.html
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - objectStoreNames
+browser-compat: api.IDBDatabase.objectStoreNames
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -81,7 +82,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.objectStoreNames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/onabort/index.html
+++ b/files/en-us/web/api/idbdatabase/onabort/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - onabort
+browser-compat: api.IDBDatabase.onabort
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.onabort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/onclose/index.html
+++ b/files/en-us/web/api/idbdatabase/onclose/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onclose
+browser-compat: api.IDBDatabase.onclose
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.onclose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/onerror/index.html
+++ b/files/en-us/web/api/idbdatabase/onerror/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - onerror
+browser-compat: api.IDBDatabase.onerror
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/onversionchange/index.html
+++ b/files/en-us/web/api/idbdatabase/onversionchange/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - onversionchange
+browser-compat: api.IDBDatabase.onversionchange
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.onversionchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/transaction/index.html
+++ b/files/en-us/web/api/idbdatabase/transaction/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Storage
+browser-compat: api.IDBDatabase.transaction
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -207,7 +208,7 @@ var objectStore = transaction.objectStore("toDoList");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.transaction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/version/index.html
+++ b/files/en-us/web/api/idbdatabase/version/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - version
+browser-compat: api.IDBDatabase.version
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -77,7 +78,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.version")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabase/versionchange_event/index.html
+++ b/files/en-us/web/api/idbdatabase/versionchange_event/index.html
@@ -6,6 +6,7 @@ tags:
   - IDBDatabase
   - Reference
   - versionchange
+browser-compat: api.IDBDatabase.versionchange_event
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -88,7 +89,7 @@ dBOpenRequest.onsuccess = event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabase.versionchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbdatabaseexception/index.html
+++ b/files/en-us/web/api/idbdatabaseexception/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Deprecated
   - Reference
+browser-compat: api.IDBDatabaseException
 ---
 
 <div>{{APIRef("IndexedDB")}}{{Deprecated_Header}}</div>
@@ -125,4 +126,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBDatabaseException")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/idbenvironment/index.html
+++ b/files/en-us/web/api/idbenvironment/index.html
@@ -14,6 +14,7 @@ tags:
   - access
   - asynchronous
   - client-side
+browser-compat: api.IDBEnvironment
 ---
 <p>{{APIRef()}}{{deprecated_header}}</p>
 
@@ -47,7 +48,7 @@ function openDB() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBEnvironment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbfactory/cmp/index.html
+++ b/files/en-us/web/api/idbfactory/cmp/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - cmp
+browser-compat: api.IDBFactory.cmp
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -118,7 +119,7 @@ console.log( "Comparison results: " + result );</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBFactory.cmp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbfactory/databases/index.html
+++ b/files/en-us/web/api/idbfactory/databases/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Storage
   - databases
+browser-compat: api.IDBFactory.databases
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -89,7 +90,7 @@ promise.then(databases =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBFactory.databases")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.html
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - deleteDatabase
+browser-compat: api.IDBFactory.deleteDatabase
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -104,7 +105,7 @@ DBDeleteRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBFactory.deleteDatabase")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbfactory/index.html
+++ b/files/en-us/web/api/idbfactory/index.html
@@ -9,6 +9,7 @@ tags:
   - Offline
   - Reference
   - Storage
+browser-compat: api.IDBFactory
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -78,7 +79,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBFactory")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbfactory/open/index.html
+++ b/files/en-us/web/api/idbfactory/open/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - open
+browser-compat: api.IDBFactory.open
 ---
   <p>{{APIRef("IndexedDB")}}</p>
   <p>The <strong><code>open()</code></strong> method of the {{domxref("IDBFactory")}}
@@ -163,7 +164,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBFactory.open")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/count/index.html
+++ b/files/en-us/web/api/idbindex/count/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - count
+browser-compat: api.IDBIndex.count
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -142,7 +143,7 @@ var <em>request</em> = <em>myIndex</em>.count(<em>key</em>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.count")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/get/index.html
+++ b/files/en-us/web/api/idbindex/get/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - Storage
+browser-compat: api.IDBIndex.get
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -143,7 +144,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/getall/index.html
+++ b/files/en-us/web/api/idbindex/getall/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - Storage
+browser-compat: api.IDBIndex.getAll
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -101,7 +102,7 @@ getAllRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/getallkeys/index.html
+++ b/files/en-us/web/api/idbindex/getallkeys/index.html
@@ -7,6 +7,7 @@ tags:
 - IndexedDB
 - Method
 - Reference
+browser-compat: api.IDBIndex.getAllKeys
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -101,7 +102,7 @@ getAllKeysRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.getAllKeys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/getkey/index.html
+++ b/files/en-us/web/api/idbindex/getkey/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - Storage
+browser-compat: api.IDBIndex.getKey
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -147,7 +148,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.getKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/index.html
+++ b/files/en-us/web/api/idbindex/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBIndex
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -119,7 +120,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/isautolocale/index.html
+++ b/files/en-us/web/api/idbindex/isautolocale/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Storage
   - isAutoLocale
+browser-compat: api.IDBIndex.isAutoLocale
 ---
 <div>{{APIRef("IndexedDB")}}{{SeeCompatTable}}</div>
 
@@ -66,7 +67,7 @@ console.log(myIndex.isAutoLocale);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.isAutoLocale")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/keypath/index.html
+++ b/files/en-us/web/api/idbindex/keypath/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - keyPath
+browser-compat: api.IDBIndex.keyPath
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -105,7 +106,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.keyPath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/locale/index.html
+++ b/files/en-us/web/api/idbindex/locale/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - Storage
+browser-compat: api.IDBIndex.locale
 ---
 <div>{{APIRef("IndexedDB")}}{{SeeCompatTable}}</div>
 
@@ -66,7 +67,7 @@ console.log(myIndex.locale);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.locale")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/multientry/index.html
+++ b/files/en-us/web/api/idbindex/multientry/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - multiEntry
+browser-compat: api.IDBIndex.multiEntry
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -125,7 +126,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.multiEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/name/index.html
+++ b/files/en-us/web/api/idbindex/name/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - name
+browser-compat: api.IDBIndex.name
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -116,7 +117,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/objectstore/index.html
+++ b/files/en-us/web/api/idbindex/objectstore/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - objectStore
+browser-compat: api.IDBIndex.objectStore
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -103,7 +104,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.objectStore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/opencursor/index.html
+++ b/files/en-us/web/api/idbindex/opencursor/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - openCursor
+browser-compat: api.IDBIndex.openCursor
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -150,7 +151,7 @@ var <em>request</em> = <em>myIndex</em>.openCursor(range, direction);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.openCursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/openkeycursor/index.html
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - openKeyCursor
+browser-compat: api.IDBIndex.openKeyCursor
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -153,7 +154,7 @@ var <em>request</em> = <em>myIndex</em>.openKeyCursor(<em>range</em>, <em>direct
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.openKeyCursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbindex/unique/index.html
+++ b/files/en-us/web/api/idbindex/unique/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - unique
+browser-compat: api.IDBIndex.unique
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -124,7 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBIndex.unique")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/bound/index.html
+++ b/files/en-us/web/api/idbkeyrange/bound/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - bound
+browser-compat: api.IDBKeyRange.bound
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -145,7 +146,7 @@ var <em>myIDBKeyRange</em> = <em>IDBKeyRange</em>.bound(<em>lower</em>, <em>uppe
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.bound")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/includes/index.html
+++ b/files/en-us/web/api/idbkeyrange/includes/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - includes
+browser-compat: api.IDBKeyRange.includes
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -107,7 +108,7 @@ var myResult = keyRangeValue.includes('W');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.includes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/index.html
+++ b/files/en-us/web/api/idbkeyrange/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBKeyRange
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -171,7 +172,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/lower/index.html
+++ b/files/en-us/web/api/idbkeyrange/lower/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - lower
+browser-compat: api.IDBKeyRange.lower
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.lower")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/lowerbound/index.html
+++ b/files/en-us/web/api/idbkeyrange/lowerbound/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - lowerBound
+browser-compat: api.IDBKeyRange.lowerBound
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -126,7 +127,7 @@ var <em>myIDBKeyRange</em> = <em>IDBKeyRange</em>.lowerBound(<em>lower</em>, <em
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.lowerBound")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/loweropen/index.html
+++ b/files/en-us/web/api/idbkeyrange/loweropen/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - lowerOpen
+browser-compat: api.IDBKeyRange.lowerOpen
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -116,7 +117,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.lowerOpen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/only/index.html
+++ b/files/en-us/web/api/idbkeyrange/only/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - only
+browser-compat: api.IDBKeyRange.only
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -116,7 +117,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.only")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/upper/index.html
+++ b/files/en-us/web/api/idbkeyrange/upper/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - upper
+browser-compat: api.IDBKeyRange.upper
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.upper")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/upperbound/index.html
+++ b/files/en-us/web/api/idbkeyrange/upperbound/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - upperBound
+browser-compat: api.IDBKeyRange.upperBound
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -124,7 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.upperBound")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbkeyrange/upperopen/index.html
+++ b/files/en-us/web/api/idbkeyrange/upperopen/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - upperOpen
+browser-compat: api.IDBKeyRange.upperOpen
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -117,7 +118,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBKeyRange.upperOpen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idblocaleawarekeyrange/index.html
+++ b/files/en-us/web/api/idblocaleawarekeyrange/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBLocaleAwareKeyRange
 ---
 <div>{{non-standard_header}}{{APIRef("IndexedDB")}}{{SeeCompatTable}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBLocaleAwareKeyRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/add/index.html
+++ b/files/en-us/web/api/idbobjectstore/add/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Storage
+browser-compat: api.IDBObjectStore.add
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -185,7 +186,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.add")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/autoincrement/index.html
+++ b/files/en-us/web/api/idbobjectstore/autoincrement/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - autoIncrement
+browser-compat: api.IDBObjectStore.autoIncrement
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -134,7 +135,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.autoIncrement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/clear/index.html
+++ b/files/en-us/web/api/idbobjectstore/clear/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - clear
+browser-compat: api.IDBObjectStore.clear
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -135,7 +136,7 @@ function clearData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.clear")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/count/index.html
+++ b/files/en-us/web/api/idbobjectstore/count/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - count
   - data
+browser-compat: api.IDBObjectStore.count
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -108,7 +109,7 @@ countRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.count")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/createindex/index.html
+++ b/files/en-us/web/api/idbobjectstore/createindex/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - createIndex
+browser-compat: api.IDBObjectStore.createIndex
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -234,7 +235,7 @@ DBOpenRequest.onupgradeneeded = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.createIndex")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/delete/index.html
+++ b/files/en-us/web/api/idbobjectstore/delete/index.html
@@ -6,6 +6,7 @@ tags:
   - IndexedDB
   - Method
   - Reference
+browser-compat: api.IDBObjectStore.delete
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -154,7 +155,7 @@ function deleteData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.delete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/deleteindex/index.html
+++ b/files/en-us/web/api/idbobjectstore/deleteindex/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - deleteIndex
+browser-compat: api.IDBObjectStore.deleteIndex
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -161,7 +162,7 @@ DBOpenRequest.onupgradeneeded = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.deleteIndex")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/get/index.html
+++ b/files/en-us/web/api/idbobjectstore/get/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Storage
+browser-compat: api.IDBObjectStore.get
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -157,7 +158,7 @@ function getData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/getall/index.html
+++ b/files/en-us/web/api/idbobjectstore/getall/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - getAll
+browser-compat: api.IDBObjectStore.getAll
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -115,7 +116,7 @@ var request = <em>objectStore</em>.getAll(<em>query</em>, <em>count</em>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.getAll")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/idbobjectstore/getallkeys/index.html
+++ b/files/en-us/web/api/idbobjectstore/getallkeys/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - Storage
+browser-compat: api.IDBObjectStore.getAllKeys
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -104,7 +105,7 @@ var request = <em>objectStore</em>.getAllKeys(<em>query</em>, <em>count</em>);</
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.getAllKeys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/getkey/index.html
+++ b/files/en-us/web/api/idbobjectstore/getkey/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Storage
 - Web API
+browser-compat: api.IDBObjectStore.getKey
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -106,7 +107,7 @@ openRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.getKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/index.html
+++ b/files/en-us/web/api/idbobjectstore/index.html
@@ -7,6 +7,7 @@ tags:
   - IndexedDB
   - Interface
   - Reference
+browser-compat: api.IDBObjectStore
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -156,7 +157,7 @@ objectStoreRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/index/index.html
+++ b/files/en-us/web/api/idbobjectstore/index/index.html
@@ -11,6 +11,7 @@ tags:
 - NeedsExample
 - Reference
 - Storage
+browser-compat: api.IDBObjectStore.index
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -129,7 +130,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.index")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/indexnames/index.html
+++ b/files/en-us/web/api/idbobjectstore/indexnames/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - indexNames
+browser-compat: api.IDBObjectStore.indexNames
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -111,7 +112,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.indexNames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/keypath/index.html
+++ b/files/en-us/web/api/idbobjectstore/keypath/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - keyPath
+browser-compat: api.IDBObjectStore.keyPath
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -114,7 +115,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.keyPath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/name/index.html
+++ b/files/en-us/web/api/idbobjectstore/name/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - name
+browser-compat: api.IDBObjectStore.name
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -127,7 +128,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/opencursor/index.html
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - openCursor
+browser-compat: api.IDBObjectStore.openCursor
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -124,7 +125,7 @@ request.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.openCursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/openkeycursor/index.html
+++ b/files/en-us/web/api/idbobjectstore/openkeycursor/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Storage
 - openKeyCursor
+browser-compat: api.IDBObjectStore.openKeyCursor
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -123,7 +124,7 @@ request.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.openKeyCursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/put/index.html
+++ b/files/en-us/web/api/idbobjectstore/put/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - put
+browser-compat: api.IDBObjectStore.put
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -176,7 +177,7 @@ objectStoreTitleRequest.onsuccess = () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.put")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbobjectstore/transaction/index.html
+++ b/files/en-us/web/api/idbobjectstore/transaction/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - transaction
+browser-compat: api.IDBObjectStore.transaction
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -111,7 +112,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBObjectStore.transaction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbopendbrequest/blocked_event/index.html
+++ b/files/en-us/web/api/idbopendbrequest/blocked_event/index.html
@@ -6,6 +6,7 @@ tags:
   - IDBOpenDBRequest
   - Reference
   - blocked
+browser-compat: api.IDBOpenDBRequest.blocked_event
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -104,7 +105,7 @@ DBOpenRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBOpenDBRequest.blocked_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbopendbrequest/index.html
+++ b/files/en-us/web/api/idbopendbrequest/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBOpenDBRequest
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -115,7 +116,7 @@ DBOpenRequest.onupgradeneeded = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBOpenDBRequest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbopendbrequest/onblocked/index.html
+++ b/files/en-us/web/api/idbopendbrequest/onblocked/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - onblocked
+browser-compat: api.IDBOpenDBRequest.onblocked
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -97,7 +98,7 @@ request.onblocked = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBOpenDBRequest.onblocked")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbopendbrequest/onupgradeneeded/index.html
+++ b/files/en-us/web/api/idbopendbrequest/onupgradeneeded/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - onupgradeneeded
+browser-compat: api.IDBOpenDBRequest.onupgradeneeded
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -114,7 +115,7 @@ request.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBOpenDBRequest.onupgradeneeded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbopendbrequest/upgradeneeded_event/index.html
+++ b/files/en-us/web/api/idbopendbrequest/upgradeneeded_event/index.html
@@ -6,6 +6,7 @@ tags:
   - IDBOpenDBRequest
   - Reference
   - upgradeneeded
+browser-compat: api.IDBOpenDBRequest.upgradeneeded_event
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -76,7 +77,7 @@ dBOpenRequest.onupgradeneeded = event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBOpenDBRequest.upgradeneeded_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/error/index.html
+++ b/files/en-us/web/api/idbrequest/error/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Storage
+browser-compat: api.IDBRequest.error
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -150,7 +151,7 @@ objectStoreTitleRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.error")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/error_event/index.html
+++ b/files/en-us/web/api/idbrequest/error_event/index.html
@@ -6,6 +6,7 @@ tags:
   - Event
   - IDBRequest
   - Reference
+browser-compat: api.IDBRequest.error_event
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -111,7 +112,7 @@ DBOpenRequest.onsuccess = event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/index.html
+++ b/files/en-us/web/api/idbrequest/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBRequest
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -113,7 +114,7 @@ DBOpenRequest.onsuccess = function(event) {
 <div>
 <div>
 
-<p>{{Compat("api.IDBRequest")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/idbrequest/onerror/index.html
+++ b/files/en-us/web/api/idbrequest/onerror/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - onerror
+browser-compat: api.IDBRequest.onerror
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -99,7 +100,7 @@ objectStoreTitleRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/onsuccess/index.html
+++ b/files/en-us/web/api/idbrequest/onsuccess/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - onsuccess
+browser-compat: api.IDBRequest.onsuccess
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -91,7 +92,7 @@ objectStoreTitleRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.onsuccess")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/readystate/index.html
+++ b/files/en-us/web/api/idbrequest/readystate/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - readyState
+browser-compat: api.IDBRequest.readyState
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -123,7 +124,7 @@ objectStoreTitleRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.readyState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/result/index.html
+++ b/files/en-us/web/api/idbrequest/result/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - result
+browser-compat: api.IDBRequest.result
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -93,7 +94,7 @@ objectStoreTitleRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.result")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/source/index.html
+++ b/files/en-us/web/api/idbrequest/source/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - source
+browser-compat: api.IDBRequest.source
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -99,7 +100,7 @@ objectStoreTitleRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.source")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/success_event/index.html
+++ b/files/en-us/web/api/idbrequest/success_event/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'IDBRequest: success event'
 slug: Web/API/IDBRequest/success_event
+browser-compat: api.IDBRequest.success_event
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -88,7 +89,7 @@ openRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.success_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbrequest/transaction/index.html
+++ b/files/en-us/web/api/idbrequest/transaction/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - transaction
+browser-compat: api.IDBRequest.transaction
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -136,7 +137,7 @@ openRequest.onsuccess = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBRequest.transaction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/abort/index.html
+++ b/files/en-us/web/api/idbtransaction/abort/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - abort
+browser-compat: api.IDBTransaction.abort
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -126,7 +127,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.abort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/abort_event/index.html
+++ b/files/en-us/web/api/idbtransaction/abort_event/index.html
@@ -6,6 +6,7 @@ tags:
   - IDBTransaction
   - Reference
   - abort
+browser-compat: api.IDBTransaction.abort_event
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -124,7 +125,7 @@ DBOpenRequest.onsuccess = event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.abort_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/commit/index.html
+++ b/files/en-us/web/api/idbtransaction/commit/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - commit
+browser-compat: api.IDBTransaction.commit
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -97,7 +98,7 @@ transaction.commit();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.commit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/complete_event/index.html
+++ b/files/en-us/web/api/idbtransaction/complete_event/index.html
@@ -6,6 +6,7 @@ tags:
   - IDBTransaction
   - Reference
   - complete
+browser-compat: api.IDBTransaction.complete_event
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -116,7 +117,7 @@ DBOpenRequest.onsuccess = event =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.complete_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/db/index.html
+++ b/files/en-us/web/api/idbtransaction/db/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - db
+browser-compat: api.IDBTransaction.db
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -112,7 +113,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.db")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/durability/index.html
+++ b/files/en-us/web/api/idbtransaction/durability/index.html
@@ -10,6 +10,7 @@ tags:
 - IndexedDB
 - Database
 - Storage
+browser-compat: api.IDBTransaction.durability
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("IndexedDB")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.durability")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/idbtransaction/error/index.html
+++ b/files/en-us/web/api/idbtransaction/error/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Storage
+browser-compat: api.IDBTransaction.error
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -119,7 +120,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.error")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/error_event/index.html
+++ b/files/en-us/web/api/idbtransaction/error_event/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'IDBTransaction: error event'
 slug: Web/API/IDBTransaction/error_event
+browser-compat: api.IDBTransaction.error_event
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -102,7 +103,7 @@ dBOpenRequest.onsuccess = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/index.html
+++ b/files/en-us/web/api/idbtransaction/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Storage
+browser-compat: api.IDBTransaction
 ---
 <div>{{APIRef("IndexedDB")}}</div>
 
@@ -222,7 +223,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/mode/index.html
+++ b/files/en-us/web/api/idbtransaction/mode/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - mode
+browser-compat: api.IDBTransaction.mode
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -142,7 +143,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.mode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/objectstore/index.html
+++ b/files/en-us/web/api/idbtransaction/objectstore/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - objectStore
+browser-compat: api.IDBTransaction.objectStore
 ---
 <div>{{ APIRef("IndexedDB") }}</div>
 
@@ -143,7 +144,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.objectStore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/objectstorenames/index.html
+++ b/files/en-us/web/api/idbtransaction/objectstorenames/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - db
+browser-compat: api.IDBTransaction.objectStoreNames
 ---
 <p>{{ APIRef("IndexedDB") }} {{SeeCompatTable}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.objectStoreNames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/onabort/index.html
+++ b/files/en-us/web/api/idbtransaction/onabort/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - onabort
+browser-compat: api.IDBTransaction.onabort
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -113,7 +114,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.onabort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/oncomplete/index.html
+++ b/files/en-us/web/api/idbtransaction/oncomplete/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - oncomplete
+browser-compat: api.IDBTransaction.oncomplete
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -126,7 +127,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.oncomplete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbtransaction/onerror/index.html
+++ b/files/en-us/web/api/idbtransaction/onerror/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - onerror
+browser-compat: api.IDBTransaction.onerror
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -109,7 +110,7 @@ function addData() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBTransaction.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.html
@@ -9,6 +9,7 @@ tags:
 - IndexedDB
 - Storage
 - Database
+browser-compat: api.IDBVersionChangeEvent.IDBVersionChangeEvent
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("IndexedDB")}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBVersionChangeEvent.IDBVersionChangeEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/idbversionchangeevent/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/index.html
@@ -11,6 +11,7 @@ tags:
   - JavaScript
   - Reference
   - Storage
+browser-compat: api.IDBVersionChangeEvent
 ---
 <p>{{APIRef("IndexedDB")}}</p>
 
@@ -106,7 +107,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBVersionChangeEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbversionchangeevent/newversion/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/newversion/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - newVersion
+browser-compat: api.IDBVersionChangeEvent.newVersion
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -95,7 +96,7 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBVersionChangeEvent.newVersion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbversionchangeevent/oldversion/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/oldversion/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Storage
 - oldVersion
+browser-compat: api.IDBVersionChangeEvent.oldVersion
 ---
 <p>{{ APIRef("IndexedDB") }}</p>
 
@@ -80,7 +81,7 @@ request.onupgradeneeded = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBVersionChangeEvent.oldVersion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idbversionchangeevent/version/index.html
+++ b/files/en-us/web/api/idbversionchangeevent/version/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsExample
   - Property
   - Reference
+browser-compat: api.IDBVersionChangeEvent.version
 ---
 <p>{{ APIRef("IndexedDB") }} {{Deprecated_Header}}</p>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IDBVersionChangeEvent.version")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idledeadline/didtimeout/index.html
+++ b/files/en-us/web/api/idledeadline/didtimeout/index.html
@@ -12,6 +12,7 @@ tags:
   - Window
   - didTimeout
   - requestIdleCallback
+browser-compat: api.IdleDeadline.didTimeout
 ---
 <div>{{APIRef("Background Tasks")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IdleDeadline.didTimeout")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idledeadline/index.html
+++ b/files/en-us/web/api/idledeadline/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - requestIdleCallback
+browser-compat: api.IdleDeadline
 ---
 <div>{{APIRef("Background Tasks")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IdleDeadline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/idledeadline/timeremaining/index.html
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - timeRemaining
+browser-compat: api.IdleDeadline.timeRemaining
 ---
 <p>{{APIRef("Background Tasks")}}{{SeeCompatTable}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IdleDeadline.timeRemaining")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/iirfilternode/getfrequencyresponse/index.html
+++ b/files/en-us/web/api/iirfilternode/getfrequencyresponse/index.html
@@ -10,6 +10,7 @@ tags:
   - Web Audio API
   - filter
   - getFrequencyResponse
+browser-compat: api.IIRFilterNode.getFrequencyResponse
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -127,7 +128,7 @@ calcFrequencyResponse();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IIRFilterNode.getFrequencyResponse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/iirfilternode/iirfilternode/index.html
+++ b/files/en-us/web/api/iirfilternode/iirfilternode/index.html
@@ -9,6 +9,7 @@ tags:
 - Media
 - Reference
 - Web Audio API
+browser-compat: api.IIRFilterNode.IIRFilterNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -78,5 +79,5 @@ const iirFilter = new IIRFilterNode(audioCtx, { feedforward: feedForward, feedba
 
 <div>
 
-	<p>{{Compat("api.IIRFilterNode.IIRFilterNode")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/iirfilternode/index.html
+++ b/files/en-us/web/api/iirfilternode/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - Web Audio API
+browser-compat: api.IIRFilterNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IIRFilterNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagebitmap/close/index.html
+++ b/files/en-us/web/api/imagebitmap/close/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - OffscreenCanvas
 - Reference
+browser-compat: api.ImageBitmap.close
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -55,7 +56,7 @@ bitmap.close();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageBitmap.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagebitmap/height/index.html
+++ b/files/en-us/web/api/imagebitmap/height/index.html
@@ -7,6 +7,7 @@ tags:
   - ImageBitmap
   - Property
   - Reference
+browser-compat: api.ImageBitmap.height
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageBitmap.height")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagebitmap/index.html
+++ b/files/en-us/web/api/imagebitmap/index.html
@@ -7,6 +7,7 @@ tags:
   - ImageBitmap
   - Interface
   - Reference
+browser-compat: api.ImageBitmap
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageBitmap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagebitmap/width/index.html
+++ b/files/en-us/web/api/imagebitmap/width/index.html
@@ -7,6 +7,7 @@ tags:
   - ImageBitmap
   - Property
   - Reference
+browser-compat: api.ImageBitmap.width
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageBitmap.width")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagebitmaprenderingcontext/index.html
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - OffscreenCanvas
   - Reference
+browser-compat: api.ImageBitmapRenderingContext
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageBitmapRenderingContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.html
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.html
@@ -9,6 +9,7 @@ tags:
 - OffscreenCanvas
 - Reference
 - transferFromImageBitmap
+browser-compat: api.ImageBitmapRenderingContext.transferFromImageBitmap
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -74,7 +75,7 @@ htmlCanvas.transferFromImageBitmap(bitmap);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageBitmapRenderingContext.transferFromImageBitmap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.html
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.html
@@ -12,6 +12,7 @@ tags:
 - Method
 - Reference
 - getPhotoCapabilities
+browser-compat: api.ImageCapture.getPhotoCapabilities
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -88,4 +89,4 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture.getPhotoCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.html
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.html
@@ -12,6 +12,7 @@ tags:
   - Method
   - Reference
   - getPhotoSettings
+browser-compat: api.ImageCapture.getPhotoSettings
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -101,4 +102,4 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture.getPhotoSettings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagecapture/grabframe/index.html
+++ b/files/en-us/web/api/imagecapture/grabframe/index.html
@@ -12,6 +12,7 @@ tags:
 - Method
 - Reference
 - grapFrame
+browser-compat: api.ImageCapture.grabFrame
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -79,4 +80,4 @@ function grabFrame() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture.grabFrame")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagecapture/imagecapture/index.html
+++ b/files/en-us/web/api/imagecapture/imagecapture/index.html
@@ -11,6 +11,7 @@ tags:
 - Media
 - MediaStream Image Capture API
 - Reference
+browser-compat: api.ImageCapture.ImageCapture
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture.ImageCapture")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagecapture/index.html
+++ b/files/en-us/web/api/imagecapture/index.html
@@ -11,6 +11,7 @@ tags:
   - Media
   - MediaStream Image Capture API
   - Reference
+browser-compat: api.ImageCapture
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -120,4 +121,4 @@ document.querySelector('video').addEventListener('play', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagecapture/takephoto/index.html
+++ b/files/en-us/web/api/imagecapture/takephoto/index.html
@@ -11,6 +11,7 @@ tags:
 - Method
 - Reference
 - takePhoto
+browser-compat: api.ImageCapture.takePhoto
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -94,4 +95,4 @@ function takePhoto() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture.takePhoto")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagecapture/track/index.html
+++ b/files/en-us/web/api/imagecapture/track/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.ImageCapture.track
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageCapture.track")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/imagedata/data/index.html
+++ b/files/en-us/web/api/imagedata/data/index.html
@@ -7,6 +7,7 @@ tags:
 - ImageData
 - Property
 - Reference
+browser-compat: api.ImageData.data
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -103,7 +104,7 @@ ctx.putImageData(imageData, 20, 20);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageData.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagedata/height/index.html
+++ b/files/en-us/web/api/imagedata/height/index.html
@@ -7,6 +7,7 @@ tags:
 - ImageData
 - Property
 - Reference
+browser-compat: api.ImageData.height
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -47,7 +48,7 @@ console.log(imageData.height);  // 100
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageData.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagedata/imagedata/index.html
+++ b/files/en-us/web/api/imagedata/imagedata/index.html
@@ -7,6 +7,7 @@ tags:
 - Constructor
 - ImageData
 - Reference
+browser-compat: api.ImageData.ImageData
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -118,7 +119,7 @@ ctx.putImageData(imageData, 20, 20);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageData.ImageData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagedata/index.html
+++ b/files/en-us/web/api/imagedata/index.html
@@ -6,6 +6,7 @@ tags:
   - Canvas
   - ImageData
   - Images
+browser-compat: api.ImageData
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/imagedata/width/index.html
+++ b/files/en-us/web/api/imagedata/width/index.html
@@ -7,6 +7,7 @@ tags:
 - ImageData
 - Property
 - Reference
+browser-compat: api.ImageData.width
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -47,7 +48,7 @@ console.log(imageData.width);  // 200
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ImageData.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/inputdevicecapabilities/firestouchevents/index.html
+++ b/files/en-us/web/api/inputdevicecapabilities/firestouchevents/index.html
@@ -3,6 +3,7 @@ title: InputDeviceCapabilities.firesTouchEvents
 slug: Web/API/InputDeviceCapabilities/firesTouchEvents
 tags:
   - needsTags
+browser-compat: api.InputDeviceCapabilities.firesTouchEvents
 ---
 <p>{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputDeviceCapabilities.firesTouchEvents")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputdevicecapabilities/index.html
+++ b/files/en-us/web/api/inputdevicecapabilities/index.html
@@ -7,6 +7,7 @@ tags:
   - InputDeviceCapabilities
   - Interface
   - Reference
+browser-compat: api.InputDeviceCapabilities
 ---
 <p>{{APIRef("InputDeviceCapabilities API")}}{{SeeCompatTable}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputDeviceCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputdevicecapabilities/inputdevicecapabilities/index.html
+++ b/files/en-us/web/api/inputdevicecapabilities/inputdevicecapabilities/index.html
@@ -1,6 +1,7 @@
 ---
 title: InputDeviceCapabilities
 slug: Web/API/InputDeviceCapabilities/InputDeviceCapabilities
+browser-compat: api.InputDeviceCapabilities.InputDeviceCapabilities
 ---
 <p>The <code>InputDeviceCapabilities()</code> constructor creates a new
 	{{domxref("InputDeviceCapabilities")}} object provides information about the physical
@@ -47,4 +48,4 @@ slug: Web/API/InputDeviceCapabilities/InputDeviceCapabilities
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputDeviceCapabilities.InputDeviceCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - getCapabilities
   - InputDeviceInfo
+browser-compat: api.InputDeviceInfo.getCapabilities
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
@@ -100,4 +101,4 @@ navigator.mediaDevices.enumerateDevices()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputDeviceInfo.getCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputdeviceinfo/index.html
+++ b/files/en-us/web/api/inputdeviceinfo/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - InputDeviceInfo
+browser-compat: api.InputDeviceInfo
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputDeviceInfo")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputevent/data/index.html
+++ b/files/en-us/web/api/inputevent/data/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - data
 - events
+browser-compat: api.InputEvent.data
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -70,4 +71,4 @@ editable.addEventListener('input', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent.data")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputevent/datatransfer/index.html
+++ b/files/en-us/web/api/inputevent/datatransfer/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - events
+browser-compat: api.InputEvent.dataTransfer
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -78,4 +79,4 @@ editable.addEventListener('input', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent.dataTransfer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputevent/gettargetranges/index.html
+++ b/files/en-us/web/api/inputevent/gettargetranges/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - events
 - getTargetRanges()
+browser-compat: api.InputEvent.getTargetRanges
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -77,4 +78,4 @@ editableElem.addEventListener('beforeinput', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent.getTargetRanges")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputevent/index.html
+++ b/files/en-us/web/api/inputevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - events
+browser-compat: api.InputEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/inputevent/inputevent/index.html
+++ b/files/en-us/web/api/inputevent/inputevent/index.html
@@ -11,6 +11,7 @@ tags:
 - InputEvent
 - Reference
 - events
+browser-compat: api.InputEvent.InputEvent
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent.InputEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/inputevent/inputtype/index.html
+++ b/files/en-us/web/api/inputevent/inputtype/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - events
 - inputType
+browser-compat: api.InputEvent.inputType
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -94,4 +95,4 @@ function logInputType(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent.inputType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/inputevent/iscomposing/index.html
+++ b/files/en-us/web/api/inputevent/iscomposing/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.InputEvent.isComposing
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -46,7 +47,7 @@ console.log(inputEvent.isComposing); // return false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InputEvent.isComposing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/installevent/activeworker/index.html
+++ b/files/en-us/web/api/installevent/activeworker/index.html
@@ -9,6 +9,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - activeWorker
+browser-compat: api.InstallEvent.activeWorker
 ---
 <div>{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InstallEvent.activeWorker")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/installevent/index.html
+++ b/files/en-us/web/api/installevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Service worker API
   - ServiceWorker
   - Workers
+browser-compat: api.InstallEvent
 ---
 <div>{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -79,7 +80,7 @@ console.log('Handling install event. Resources to pre-fetch:', urlsToPrefetch);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InstallEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/installevent/installevent/index.html
+++ b/files/en-us/web/api/installevent/installevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Service Workers
   - ServiceWorker
+browser-compat: api.InstallEvent.InstallEvent
 ---
 <div>{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.InstallEvent.InstallEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/disconnect/index.html
+++ b/files/en-us/web/api/intersectionobserver/disconnect/index.html
@@ -9,6 +9,7 @@ tags:
 - IntersectionObserver
 - Method
 - Reference
+browser-compat: api.IntersectionObserver.disconnect
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.disconnect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/index.html
+++ b/files/en-us/web/api/intersectionobserver/index.html
@@ -8,6 +8,7 @@ tags:
   - IntersectionObserver
   - Reference
   - observers
+browser-compat: api.IntersectionObserver
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -80,7 +81,7 @@ intersectionObserver.observe(document.querySelector('.scrollerFooter'));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Visibility
 - Visible
+browser-compat: api.IntersectionObserver.IntersectionObserver
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -118,4 +119,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.IntersectionObserver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserver/observe/index.html
+++ b/files/en-us/web/api/intersectionobserver/observe/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - observe
+browser-compat: api.IntersectionObserver.observe
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.observe")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/root/index.html
+++ b/files/en-us/web/api/intersectionobserver/root/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - root
+browser-compat: api.IntersectionObserver.root
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.root")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/rootmargin/index.html
+++ b/files/en-us/web/api/intersectionobserver/rootmargin/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - rootMargin
+browser-compat: api.IntersectionObserver.rootMargin
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.rootMargin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserver/takerecords/index.html
+++ b/files/en-us/web/api/intersectionobserver/takerecords/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Reference
 - takeRecords
+browser-compat: api.IntersectionObserver.takeRecords
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.takeRecords")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserver/thresholds/index.html
+++ b/files/en-us/web/api/intersectionobserver/thresholds/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Property
 - Reference
+browser-compat: api.IntersectionObserver.thresholds
 ---
 <div>{{APIRef("Intersection Observer API")}}{{draft}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.thresholds")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserver/unobserve/index.html
+++ b/files/en-us/web/api/intersectionobserver/unobserve/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - unobserve
+browser-compat: api.IntersectionObserver.unobserve
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -67,7 +68,7 @@ observer.unobserve(document.getElementById("elementToObserve"));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserver.unobserve")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/boundingclientrect/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - boundingClientRect
+browser-compat: api.IntersectionObserverEntry.boundingClientRect
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.boundingClientRect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/index.html
@@ -8,6 +8,7 @@ tags:
   - Intersection Observer API
   - IntersectionObserverEntry
   - Reference
+browser-compat: api.IntersectionObserverEntry
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/intersectionratio/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/intersectionratio/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - intersectionRatio
+browser-compat: api.IntersectionObserverEntry.intersectionRatio
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.intersectionRatio")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/intersectionrect/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/intersectionrect/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - intersectionRect
+browser-compat: api.IntersectionObserverEntry.intersectionRect
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.intersectionRect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/isintersecting/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/isintersecting/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - isIntersecting
+browser-compat: api.IntersectionObserverEntry.isIntersecting
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.isIntersecting")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/rootbounds/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/rootbounds/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - rootBounds
+browser-compat: api.IntersectionObserverEntry.rootBounds
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.rootBounds")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/target/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/target/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - target
+browser-compat: api.IntersectionObserverEntry.target
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.target")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/intersectionobserverentry/time/index.html
+++ b/files/en-us/web/api/intersectionobserverentry/time/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Time
+browser-compat: api.IntersectionObserverEntry.time
 ---
 <div>{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.IntersectionObserverEntry.time")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/i* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

173 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
