### PR TITLE
Put browser-compat info in front-runner for api/[jkl]*

### DIFF
--- a/files/en-us/web/api/keyboard/getlayoutmap/index.html
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - getLayoutMap()
 - keyboard
+browser-compat: api.Keyboard.getLayoutMap
 ---
 <div>{{APIRef("Keyboard API")}}{{SeeCompatTable}}</div>
 
@@ -65,4 +66,4 @@ keyboard.getLayoutMap()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Keyboard.getLayoutMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboard/index.html
+++ b/files/en-us/web/api/keyboard/index.html
@@ -10,6 +10,7 @@ tags:
   - Keyboard Map
   - Reference
   - keyboard
+browser-compat: api.Keyboard
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Keyboard")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboard/lock/index.html
+++ b/files/en-us/web/api/keyboard/lock/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - keyboard
 - lock()
+browser-compat: api.Keyboard.lock
 ---
 <div>{{APIRef("Keyboard Map API")}}{{SeeCompatTable}}</div>
 
@@ -75,4 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Keyboard.lock")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardevent/altkey/index.html
+++ b/files/en-us/web/api/keyboardevent/altkey/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.altKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -73,7 +74,7 @@ You can also use the SHIFT key together with the ALT key.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.altKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/charcode/index.html
+++ b/files/en-us/web/api/keyboardevent/charcode/index.html
@@ -8,6 +8,7 @@ tags:
   - KeyboardEvent
   - Property
   - Reference
+browser-compat: api.KeyboardEvent.charCode
 ---
 <div>{{ ApiRef("DOM Events") }} {{non-standard_header}} {{deprecated_header}}</div>
 
@@ -101,4 +102,4 @@ input.addEventListener('keypress', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.charCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardevent/code/index.html
+++ b/files/en-us/web/api/keyboardevent/code/index.html
@@ -11,6 +11,7 @@ tags:
   - Read-only
   - Reference
   - UI Events
+browser-compat: api.KeyboardEvent.code
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -209,4 +210,4 @@ let spaceship = document.getElementById("spaceship");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.code")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardevent/ctrlkey/index.html
+++ b/files/en-us/web/api/keyboardevent/ctrlkey/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.ctrlKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -68,7 +69,7 @@ You can also use the SHIFT key together with the CTRL key.&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.ctrlKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Reference
   - getModifierState
+browser-compat: api.KeyboardEvent.getModifierState
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -286,7 +287,7 @@ if ((event.getModifierState("ScrollLock") ||
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.getModifierState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/index.html
@@ -15,6 +15,7 @@ tags:
   - UI Events
   - keyboard
   - user input
+browser-compat: api.KeyboardEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -313,7 +314,7 @@ document.addEventListener('keyup', (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Compatibility_notes">Compatibility notes</h3>
 

--- a/files/en-us/web/api/keyboardevent/iscomposing/index.html
+++ b/files/en-us/web/api/keyboardevent/iscomposing/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.isComposing
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -54,7 +55,7 @@ console.log(kbdEvent.isComposing); // return false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.isComposing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/key/index.html
+++ b/files/en-us/web/api/keyboardevent/key/index.html
@@ -9,6 +9,7 @@ tags:
   - Read-only
   - Reference
   - UI Events
+browser-compat: api.KeyboardEvent.key
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -227,4 +228,4 @@ btnClearConsole.addEventListener('click', (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.key")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.html
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM
 - KeyboardEvent
 - Reference
+browser-compat: api.KeyboardEvent.KeyboardEvent
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.KeyboardEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/keycode/index.html
+++ b/files/en-us/web/api/keyboardevent/keycode/index.html
@@ -11,6 +11,7 @@ tags:
   - Read-only
   - Reference
   - keyCode
+browser-compat: api.KeyboardEvent.keyCode
 ---
 <p>{{APIRef("DOM Events")}}{{Deprecated_Header}}</p>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.keyCode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Value_of_keyCode">Value of keyCode</h2>
 

--- a/files/en-us/web/api/keyboardevent/keyidentifier/index.html
+++ b/files/en-us/web/api/keyboardevent/keyidentifier/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - events
+browser-compat: api.KeyboardEvent.keyIdentifier
 ---
 <p>{{ ApiRef("DOM Events") }}{{non-standard_header}}{{deprecated_header}}</p>
 
@@ -20,4 +21,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.keyIdentifier")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardevent/location/index.html
+++ b/files/en-us/web/api/keyboardevent/location/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Read-only
   - Reference
+browser-compat: api.KeyboardEvent.location
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -128,7 +129,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.location")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/metakey/index.html
+++ b/files/en-us/web/api/keyboardevent/metakey/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.metaKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.metaKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/repeat/index.html
+++ b/files/en-us/web/api/keyboardevent/repeat/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.repeat
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.repeat")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardevent/shiftkey/index.html
+++ b/files/en-us/web/api/keyboardevent/shiftkey/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.shiftKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -71,7 +72,7 @@ You can also use the SHIFT key together with the ALT key.&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.shiftKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardevent/which/index.html
+++ b/files/en-us/web/api/keyboardevent/which/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.KeyboardEvent.which
 ---
 <div>{{ APIRef("DOM Events") }} {{Deprecated_header}}</div>
 
@@ -91,7 +92,7 @@ alert("onkeydown handler: \n"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardEvent.which")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboardlayoutmap/entries/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/entries/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - keyboard
+browser-compat: api.KeyboardLayoutMap.entries
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.entries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/foreach/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/foreach/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - forEach()
 - keyboard
+browser-compat: api.KeyboardLayoutMap.forEach
 ---
 <div>{{APIRef("Keyboard API")}}{{SeeCompatTable}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.forEach")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/get/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/get/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - get()
 - keyboard
+browser-compat: api.KeyboardLayoutMap.get
 ---
 <div>{{APIRef("Keyboard API")}}{{SeeCompatTable}}</div>
 
@@ -68,4 +69,4 @@ keyboard.getLayoutMap()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/has/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/has/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - has()
 - keyboard
+browser-compat: api.KeyboardLayoutMap.has
 ---
 <div>{{APIRef("Keyboard API")}}{{SeeCompatTable}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.has")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/index.html
@@ -10,6 +10,7 @@ tags:
   - KeyboardLayoutMap
   - Reference
   - keyboard
+browser-compat: api.KeyboardLayoutMap
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -69,4 +70,4 @@ keyboard.getLayoutMap()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/keys/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/keys/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - keyboard
 - keys
+browser-compat: api.KeyboardLayoutMap.keys
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.keys")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/size/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/size/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - keyboard
 - size
+browser-compat: api.KeyboardLayoutMap.size
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.size")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyboardlayoutmap/values/index.html
+++ b/files/en-us/web/api/keyboardlayoutmap/values/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - keyboard
 - values
+browser-compat: api.KeyboardLayoutMap.values
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyboardLayoutMap.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/keyframeeffect/composite/index.html
+++ b/files/en-us/web/api/keyframeeffect/composite/index.html
@@ -11,6 +11,7 @@ tags:
   - composite
   - waapi
   - web animations api
+browser-compat: api.KeyframeEffect.composite
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -56,7 +57,7 @@ keyframeEffect.composite = 'accumulate';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect.composite")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffect/getkeyframes/index.html
+++ b/files/en-us/web/api/keyframeeffect/getkeyframes/index.html
@@ -11,6 +11,7 @@ tags:
   - getKeyframes
   - waapi
   - web animations api
+browser-compat: api.KeyframeEffect.getKeyframes
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -80,7 +81,7 @@ redQueen_alice.effect.getKeyframes();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect.getKeyframes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffect/index.html
+++ b/files/en-us/web/api/keyframeeffect/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Animations
   - web animations api
+browser-compat: api.KeyframeEffect
 ---
 <div>{{SeeCompatTable}}{{ APIRef("Web Animations") }}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffect/iterationcomposite/index.html
+++ b/files/en-us/web/api/keyframeeffect/iterationcomposite/index.html
@@ -11,6 +11,7 @@ tags:
   - iterationComposite
   - waapi
   - web animations api
+browser-compat: api.KeyframeEffect.iterationComposite
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -53,7 +54,7 @@ keyframeEffect.<em>iterationComposite</em> = 'replace';
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect.iterationComposite")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - waapi
   - web animations api
+browser-compat: api.KeyframeEffect.KeyframeEffect
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -89,7 +90,7 @@ var keyframes = new KeyframeEffect(<em>sourceKeyFrames</em>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect.KeyframeEffect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
+++ b/files/en-us/web/api/keyframeeffect/setkeyframes/index.html
@@ -11,6 +11,7 @@ tags:
   - setKeyframes
   - waapi
   - web animations api
+browser-compat: api.KeyframeEffect.setKeyframes
 ---
 <p>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</p>
 
@@ -98,7 +99,7 @@ existingKeyframeEffect.setKeyframes(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect.setKeyframes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffect/target/index.html
+++ b/files/en-us/web/api/keyframeeffect/target/index.html
@@ -11,6 +11,7 @@ tags:
   - target
   - waapi
   - web animations api
+browser-compat: api.KeyframeEffect.target
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}</div>
 
@@ -70,7 +71,7 @@ rabbitDownKeyframes.target;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffect.target")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyframeeffectoptions/index.html
+++ b/files/en-us/web/api/keyframeeffectoptions/index.html
@@ -12,6 +12,7 @@ tags:
   - NeedsCompatTable
   - Reference
   - Web Animations
+browser-compat: api.KeyframeEffectOptions
 ---
 <p>{{APIRef("Web Animations")}}{{Draft}}{{SeeCompatTable}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KeyframeEffectOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/khr_parallel_shader_compile/index.html
+++ b/files/en-us/web/api/khr_parallel_shader_compile/index.html
@@ -8,6 +8,7 @@ tags:
   - WebGL
   - WebGL extension
   - parallel shader compile
+browser-compat: api.KHR_parallel_shader_compile
 ---
 <div>{{draft}}{{APIRef("WebGL")}}</div>
 
@@ -77,7 +78,7 @@ function* linkingProgress(programs) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.KHR_parallel_shader_compile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/largestcontentfulpaint/index.html
+++ b/files/en-us/web/api/largestcontentfulpaint/index.html
@@ -9,6 +9,7 @@ tags:
   - Performance
   - Reference
   - Web Performance
+browser-compat: api.LargestContentfulPaint
 ---
 <div>{{SeeCompatTable}}</div>
 
@@ -94,4 +95,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LargestContentfulPaint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/layoutshift/index.html
+++ b/files/en-us/web/api/layoutshift/index.html
@@ -9,6 +9,7 @@ tags:
   - Performance
   - Reference
   - Web Performance
+browser-compat: api.LayoutShift
 ---
 <p>The <code>LayoutShift</code> interface of the Layout Instability API provides insights into the stability of web pages based on movements of the elements on the page.</p>
 
@@ -87,4 +88,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LayoutShift")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/layoutshiftattribution/index.html
+++ b/files/en-us/web/api/layoutshiftattribution/index.html
@@ -10,6 +10,7 @@ tags:
   - Performance
   - Reference
   - Web Performance
+browser-compat: api.LayoutShiftAttribution
 ---
 <p>The <code>LayoutShiftAttribution</code> interface of the Layout Instability API provides debugging information about elements which have shifted.</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LayoutShiftAttribution")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/linearaccelerationsensor/index.html
+++ b/files/en-us/web/api/linearaccelerationsensor/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.LinearAccelerationSensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -69,4 +70,4 @@ laSensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LinearAccelerationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.html
+++ b/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor
 - Sensor APIs
 - Sensors
+browser-compat: api.LinearAccelerationSensor.LinearAccelerationSensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LinearAccelerationSensor.LinearAccelerationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/linkstyle/index.html
+++ b/files/en-us/web/api/linkstyle/index.html
@@ -6,6 +6,7 @@ tags:
   - CSSOM
   - Interface
   - Reference
+browser-compat: api.LinkStyle
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LinkStyle")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/localfilesystem/index.html
+++ b/files/en-us/web/api/localfilesystem/index.html
@@ -8,6 +8,7 @@ tags:
   - Offline
   - Reference
   - filesystem
+browser-compat: api.LocalFileSystem
 ---
 <div>{{APIRef("File System API")}}{{non-standard_header()}}</div>
 
@@ -215,7 +216,7 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LocalFileSystem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/localfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/index.html
@@ -8,6 +8,7 @@ tags:
   - Offline
   - Reference
   - filesystem
+browser-compat: api.LocalFileSystemSync
 ---
 <div>{{APIRef("File System API")}}{{non-standard_header()}}</div>
 
@@ -174,7 +175,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LocalFileSystemSync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
+++ b/files/en-us/web/api/localfilesystemsync/requestfilesystemsync/index.html
@@ -1,6 +1,7 @@
 ---
 title: LocalFileSystemSync.requestFileSystemSync()
 slug: Web/API/LocalFileSystemSync/requestFileSystemSync
+browser-compat: api.LocalFileSystemSync.requestFileSystemSync
 ---
 <p>{{APIRef("File System API")}}{{SeeCompatTable}}{{deprecated_header}}{{Draft}}</p>
 
@@ -90,7 +91,7 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LocalFileSystemSync.requestFileSystemSync")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/localmediastream/index.html
+++ b/files/en-us/web/api/localmediastream/index.html
@@ -13,6 +13,7 @@ tags:
   - Deprecated
   - Reference
   - WebRTC
+browser-compat: api.LocalMediaStream
 ---
 <div>{{APIRef("Media Capture and Streams")}} {{deprecated_header}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LocalMediaStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/location/ancestororigins/index.html
+++ b/files/en-us/web/api/location/ancestororigins/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.ancestorOrigins
 ---
 <p>{{APIRef("Location")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.ancestorOrigins")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/assign/index.html
+++ b/files/en-us/web/api/location/assign/index.html
@@ -7,6 +7,7 @@ tags:
 - Location
 - Method
 - Reference
+browser-compat: api.Location.assign
 ---
 <div>{{ APIRef("HTML DOM") }}</div>
 
@@ -68,7 +69,7 @@ window.location.assign('https://developer.mozilla.org/en-US/docs/Web/API/Locatio
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.assign")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/location/hash/index.html
+++ b/files/en-us/web/api/location/hash/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.hash
 ---
 <div>{{ APIRef("Location") }}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.hash")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/host/index.html
+++ b/files/en-us/web/api/location/host/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.host
 ---
 <div>{{ApiRef("Location")}}</div>
 
@@ -54,4 +55,4 @@ anchor.host == "developer.mozilla.org:4097"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.host")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/hostname/index.html
+++ b/files/en-us/web/api/location/hostname/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.hostname
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -43,4 +44,4 @@ var result = anchor.hostname; // Returns:'developer.mozilla.org'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.hostname")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/href/index.html
+++ b/files/en-us/web/api/location/href/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.href
 ---
 <p>{{ApiRef("Location")}}</p>
 
@@ -48,4 +49,4 @@ var result = anchor.href; // Returns: 'https://developer.mozilla.org/en-US/Locat
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.href")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/index.html
+++ b/files/en-us/web/api/location/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Location
   - Reference
+browser-compat: api.Location
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -134,7 +135,7 @@ console.log(url.origin);    // https://developer.mozilla.org:8080
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/location/origin/index.html
+++ b/files/en-us/web/api/location/origin/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.origin
 ---
 <p>{{APIRef("Location")}}</p>
 
@@ -56,4 +57,4 @@ var result = window.location.origin; // Returns:'https://developer.mozilla.org'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.origin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/password/index.html
+++ b/files/en-us/web/api/location/password/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.password
 ---
 <div>{{deprecated_header}}</div>
 
@@ -32,4 +33,4 @@ var result = anchor.password; // Returns:'flabada'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.password")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/pathname/index.html
+++ b/files/en-us/web/api/location/pathname/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.pathname
 ---
 <p>{{ApiRef("Location")}}</p>
 
@@ -45,4 +46,4 @@ var result = anchor.pathname; // Returns:'/en-US/docs/Location.pathname'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.pathname")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/port/index.html
+++ b/files/en-us/web/api/location/port/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.port
 ---
 <p>{{ApiRef("Location")}}</p>
 
@@ -45,4 +46,4 @@ var result = anchor.port; // Returns:'443'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.port")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/protocol/index.html
+++ b/files/en-us/web/api/location/protocol/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.protocol
 ---
 <p>{{ApiRef("Location")}}</p>
 
@@ -45,4 +46,4 @@ var result = anchor.protocol; // Returns:'https:'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.protocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/reload/index.html
+++ b/files/en-us/web/api/location/reload/index.html
@@ -7,6 +7,7 @@ tags:
 - Location
 - Method
 - Reference
+browser-compat: api.Location.reload
 ---
 <div>{{ APIRef("HTML DOM") }}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.reload")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/location/replace/index.html
+++ b/files/en-us/web/api/location/replace/index.html
@@ -7,6 +7,7 @@ tags:
 - Location
 - Method
 - Reference
+browser-compat: api.Location.replace
 ---
 <p>{{ APIRef("HTML DOM") }}</p>
 
@@ -70,7 +71,7 @@ window.location.replace('https://developer.mozilla.org/en-US/docs/Web/API/Locati
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.replace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/location/search/index.html
+++ b/files/en-us/web/api/location/search/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Location
   - Property
+browser-compat: api.Location.search
 ---
 <div>{{ApiRef("Location")}}</div>
 
@@ -55,4 +56,4 @@ let q = parseInt(params.get("q")); // is the number 123
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.search")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/tostring/index.html
+++ b/files/en-us/web/api/location/tostring/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - Stringifier
+browser-compat: api.Location.toString
 ---
 <p>{{ApiRef("Location")}}</p>
 
@@ -44,4 +45,4 @@ var result = anchor.toString(); // Returns: 'https://developer.mozilla.org/en-US
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.toString")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/location/username/index.html
+++ b/files/en-us/web/api/location/username/index.html
@@ -6,6 +6,7 @@ tags:
 - Location
 - Property
 - Reference
+browser-compat: api.Location.username
 ---
 <div>{{deprecated_header}}</div>
 
@@ -28,4 +29,4 @@ var result = anchor.username; // Returns:'anonymous'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Location.username")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/lock/index.html
+++ b/files/en-us/web/api/lock/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Locks API
   - lock
+browser-compat: api.Lock
 ---
 <div>{{SeeCompatTable}}{{APIRef("Web Locks")}}</div>
 
@@ -53,4 +54,4 @@ function show_lock_properties(lock) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Lock")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/lock/mode/index.html
+++ b/files/en-us/web/api/lock/mode/index.html
@@ -9,6 +9,7 @@ tags:
 - Web Locks API
 - lock
 - mode
+browser-compat: api.Lock.mode
 ---
 <p>{{SeeCompatTable}}{{APIRef("Web Locks")}}</p>
 
@@ -66,4 +67,4 @@ function show_lock_properties(lock) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Lock.mode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/lock/name/index.html
+++ b/files/en-us/web/api/lock/name/index.html
@@ -10,6 +10,7 @@ tags:
 - lock
 - mode
 - name
+browser-compat: api.Lock.name
 ---
 <p>{{SeeCompatTable}}{{APIRef("Web Locks")}}</p>
 
@@ -65,4 +66,4 @@ function show_lock_properties(lock) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Lock.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/lockmanager/index.html
+++ b/files/en-us/web/api/lockmanager/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Locks API
   - lock
+browser-compat: api.LockManager
 ---
 <p>{{SeeCompatTable}}{{APIRef("Web Locks")}}</p>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LockManager")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/lockmanager/query/index.html
+++ b/files/en-us/web/api/lockmanager/query/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Locks API
 - query()
+browser-compat: api.LockManager.query
 ---
 <p>{{APIRef("Web Locks")}}{{SeeCompatTable}}</p>
 
@@ -66,4 +67,4 @@ for (const request of state.pending) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LockManager.query")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/lockmanager/request/index.html
+++ b/files/en-us/web/api/lockmanager/request/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Locks API
   - request()
+browser-compat: api.LockManager.request
 ---
 <p>{{APIRef("Web Locks")}}{{SeeCompatTable}}</p>
 
@@ -173,4 +174,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.LockManager.request")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/[jkl]* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

69 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
