### PR TITLE
Put browser-compat info in front-runner for api/m*

### DIFF
--- a/files/en-us/web/api/magnetometer/index.html
+++ b/files/en-us/web/api/magnetometer/index.html
@@ -10,6 +10,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.Magnetometer
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -74,4 +75,4 @@ magSensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Magnetometer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/magnetometer/magnetometer/index.html
+++ b/files/en-us/web/api/magnetometer/magnetometer/index.html
@@ -10,6 +10,7 @@ tags:
 - Sensor
 - Sensor APIs
 - Sensors
+browser-compat: api.Magnetometer.Magnetometer
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Magnetometer.Magnetometer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/magnetometer/x/index.html
+++ b/files/en-us/web/api/magnetometer/x/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor APIs
 - Sensors
 - x
+browser-compat: api.Magnetometer.x
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -68,4 +69,4 @@ magSensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Magnetometer.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/magnetometer/y/index.html
+++ b/files/en-us/web/api/magnetometer/y/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor APIs
 - Sensors
 - 'y'
+browser-compat: api.Magnetometer.y
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -68,4 +69,4 @@ magSensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Magnetometer.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/magnetometer/z/index.html
+++ b/files/en-us/web/api/magnetometer/z/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor APIs
 - Sensors
 - z
+browser-compat: api.Magnetometer.z
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -69,4 +70,4 @@ magSensor.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Magnetometer.z")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mathmlelement/index.html
+++ b/files/en-us/web/api/mathmlelement/index.html
@@ -7,6 +7,7 @@ tags:
   - MathML
   - MathMLElement
   - Reference
+browser-compat: api.MathMLElement
 ---
 <div>{{APIRef("MathML")}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MathMLElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.html
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - decodingInfo()
+browser-compat: api.MediaCapabilities.decodingInfo
 ---
 <p>{{APIRef("MediaCapabilities")}}</p>
 
@@ -83,7 +84,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaCapabilities.decodingInfo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.html
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - encodingInfo
+browser-compat: api.MediaCapabilities.encodingInfo
 ---
 <p>{{APIRef("MediaCapabilities")}}</p>
 
@@ -102,7 +103,7 @@ navigator.mediaCapabilities.encodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaCapabilities.encodingInfo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediacapabilities/index.html
+++ b/files/en-us/web/api/mediacapabilities/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaCapabilities
   - Reference
   - Video
+browser-compat: api.MediaCapabilities
 ---
 <p>{{APIRef("Media Capabilities API")}}</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaCapabilities")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediacapabilitiesinfo/index.html
+++ b/files/en-us/web/api/mediacapabilitiesinfo/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaCapabilitiesInfo
   - Reference
   - Video
+browser-compat: api.MediaCapabilitiesInfo
 ---
 <p>{{APIRef("Media Capabilities API")}}</p>
 
@@ -69,7 +70,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; { // res
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaCapabilitiesInfo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaconfiguration/index.html
+++ b/files/en-us/web/api/mediaconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaConfiguration
   - Reference
   - Video
+browser-compat: api.MediaConfiguration
 ---
 <div>{{APIRef("Media Capabilities API")}}</div>
 
@@ -101,7 +102,7 @@ const audioEncoderConfig = {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadecodingconfiguration/index.html
+++ b/files/en-us/web/api/mediadecodingconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaDecodingConfiguration
   - Reference
   - Video
+browser-compat: api.MediaDecodingConfiguration
 ---
 <p>The <strong><code>MediaDecodingConfiguration</code></strong> dictionary of the <a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a> is used to define the type of media being tested when calling {{domxref("MediaCapabilities.decodingInfo()")}} to query whether a specific media configuration is supported, smooth, and/or power efficient.</p>
 
@@ -68,7 +69,7 @@ navigator.mediaCapabilities.decodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDecodingConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/deviceid/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/deviceid/index.html
@@ -8,6 +8,7 @@ tags:
 - MediaDevicesInfo
 - Property
 - deviceId
+browser-compat: api.MediaDeviceInfo.deviceId
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Capture")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDeviceInfo.deviceId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediadeviceinfo/groupid/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/groupid/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - groupId
 - output
+browser-compat: api.MediaDeviceInfo.groupId
 ---
 <p>{{APIRef("Media Capture")}}</p>
 
@@ -110,4 +111,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDeviceInfo.groupId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediadeviceinfo/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/index.html
@@ -13,6 +13,7 @@ tags:
   - Video
   - WebRTC
   - WebRTC API
+browser-compat: api.MediaDeviceInfo
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -94,7 +95,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDeviceInfo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadeviceinfo/kind/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/kind/index.html
@@ -8,6 +8,7 @@ tags:
 - MediaDevicesInfo
 - Property
 - kind
+browser-compat: api.MediaDeviceInfo.kind
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Capture")}}</p>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDeviceInfo.kind")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediadeviceinfo/label/index.html
+++ b/files/en-us/web/api/mediadeviceinfo/label/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - label
+browser-compat: api.MediaDeviceInfo.label
 ---
 <div>{{APIRef("Media Capture")}}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDeviceInfo.label")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.html
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - events
+browser-compat: api.MediaDevices.devicechange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices.devicechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.html
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Reference
   - WebRTC
+browser-compat: api.MediaDevices.enumerateDevices
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -89,7 +90,7 @@ audioinput: Built-in Microphone id=r2/xw1xUPIyZunfV1lGrKOma5wTOvCkWfZ368XCndm0=
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices.enumerateDevices")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.html
@@ -16,6 +16,7 @@ tags:
   - display
   - getDisplayMedia
   - screen
+browser-compat: api.MediaDevices.getDisplayMedia
 ---
 <div>{{DefaultAPISidebar("Screen Capture API")}}</div>
 
@@ -160,7 +161,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices.getDisplayMedia")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.html
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - getSupportedConstraints
+browser-compat: api.MediaDevices.getSupportedConstraints
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -94,4 +95,4 @@ for (let constraint in supportedConstraints) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices.getSupportedConstraints")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediadevices/getusermedia/index.html
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.html
@@ -15,6 +15,7 @@ tags:
 - Video
 - WebRTC
 - getusermedia
+browser-compat: api.MediaDevices.getUserMedia
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -486,7 +487,7 @@ var constraints = { video: { facingMode: (front? "user" : "environment") } };
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices.getUserMedia")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadevices/index.html
+++ b/files/en-us/web/api/mediadevices/index.html
@@ -17,6 +17,7 @@ tags:
   - Sharing
   - Video
   - WebRTC
+browser-compat: api.MediaDevices
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -112,7 +113,7 @@ function errorMsg(msg, error) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediadevices/ondevicechange/index.html
+++ b/files/en-us/web/api/mediadevices/ondevicechange/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - ondevicechanged
+browser-compat: api.MediaDevices.ondevicechange
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -250,7 +251,7 @@ let videoList = document.getElementById("videoList");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaDevices.ondevicechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.html
@@ -9,6 +9,7 @@ tags:
   - MediaElementAudioSourceNode
   - Reference
   - Web Audio API
+browser-compat: api.MediaElementAudioSourceNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaElementAudioSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Audio API
 - mediaElement
+browser-compat: api.MediaElementAudioSourceNode.mediaElement
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -61,4 +62,4 @@ console.log(source.mediaElement);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaElementAudioSourceNode.mediaElement")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.html
@@ -8,6 +8,7 @@ tags:
   - MediaElementAudioSourceNode
   - Reference
   - Web Audio API
+browser-compat: api.MediaElementAudioSourceNode.MediaElementAudioSourceNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -66,4 +67,4 @@ var myAudioSource = new MediaElementAudioSourceNode(ac, options);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaElementAudioSourceNode.MediaElementAudioSourceNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediaencodingconfiguration/index.html
+++ b/files/en-us/web/api/mediaencodingconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaEncodingConfiguration
   - Reference
   - Video
+browser-compat: api.MediaEncodingConfiguration
 ---
 <p>The <strong><code>MediaEncodingConfiguration</code></strong> dictionary of the <a href="/en-US/docs/Web/API/Media_Capabilities_API">Media Capabilities API</a> is used to define the type of media being tested when calling {{domxref("MediaCapabilities.encodingInfo()")}} to query whether a specific media configuration is supported, smooth, and/or power efficient.</p>
 
@@ -68,7 +69,7 @@ navigator.mediaCapabilities.encodingInfo(mediaConfig).then(result =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaEncodingConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaerror/code/index.html
+++ b/files/en-us/web/api/mediaerror/code/index.html
@@ -13,6 +13,7 @@ tags:
 - Read-only
 - Reference
 - Video
+browser-compat: api.MediaError.code
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -97,7 +98,7 @@ obj.src="https://example.com/blahblah.mp4";
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaError.code")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaerror/index.html
+++ b/files/en-us/web/api/mediaerror/index.html
@@ -11,6 +11,7 @@ tags:
   - MediaError
   - Reference
   - Video
+browser-compat: api.MediaError
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaError")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaerror/message/index.html
+++ b/files/en-us/web/api/mediaerror/message/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Video
 - message
+browser-compat: api.MediaError.message
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -118,7 +119,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaError.message")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaimage/index.html
+++ b/files/en-us/web/api/mediaimage/index.html
@@ -1,6 +1,7 @@
 ---
 title: MediaImage
 slug: Web/API/MediaImage
+browser-compat: api.MediaImage
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -38,7 +39,7 @@ slug: Web/API/MediaImage
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaImage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediakeymessageevent/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsContent
   - NeedsExample
   - Reference
+browser-compat: api.MediaKeyMessageEvent
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyMessageEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsContent
 - NeedsExample
 - Reference
+browser-compat: api.MediaKeyMessageEvent.MediaKeyMessageEvent
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}{{Non-standard_header}}</p>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyMessageEvent.MediaKeyMessageEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeymessageevent/message/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/message/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - message
+browser-compat: api.MediaKeyMessageEvent.message
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyMessageEvent.message")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeymessageevent/messagetype/index.html
+++ b/files/en-us/web/api/mediakeymessageevent/messagetype/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - messageType
+browser-compat: api.MediaKeyMessageEvent.messageType
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyMessageEvent.messageType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeys/createsession/index.html
+++ b/files/en-us/web/api/mediakeys/createsession/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - createSession
+browser-compat: api.MediaKeys.createSession
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeys.createSession")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeys/index.html
+++ b/files/en-us/web/api/mediakeys/index.html
@@ -11,6 +11,7 @@ tags:
   - NeedsExample
   - Reference
   - Video
+browser-compat: api.MediaKeys
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeys")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeys/setservercertificate/index.html
+++ b/files/en-us/web/api/mediakeys/setservercertificate/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - setServerCertificate
+browser-compat: api.MediaKeys.setServerCertificate
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -43,5 +44,5 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.MediaKeys.setServerCertificate")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/mediakeysession/close/index.html
+++ b/files/en-us/web/api/mediakeysession/close/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Reference
 - close
+browser-compat: api.MediaKeySession.close
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.close")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/closed/index.html
+++ b/files/en-us/web/api/mediakeysession/closed/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - closed
+browser-compat: api.MediaKeySession.closed
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.closed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/expiration/index.html
+++ b/files/en-us/web/api/mediakeysession/expiration/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - expiration
+browser-compat: api.MediaKeySession.expiration
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.expiration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.html
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Reference
 - generateRequest
+browser-compat: api.MediaKeySession.generateRequest
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}</p>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.generateRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/index.html
+++ b/files/en-us/web/api/mediakeysession/index.html
@@ -11,6 +11,7 @@ tags:
   - NeedsExample
   - Reference
   - Video
+browser-compat: api.MediaKeySession
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}</p>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/keystatuses/index.html
+++ b/files/en-us/web/api/mediakeysession/keystatuses/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - keyStatuses
+browser-compat: api.MediaKeySession.keyStatuses
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}</div>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.keyStatuses")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/load/index.html
+++ b/files/en-us/web/api/mediakeysession/load/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Reference
 - load
+browser-compat: api.MediaKeySession.load
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.load")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.html
+++ b/files/en-us/web/api/mediakeysession/onkeystatuseschange/index.html
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.onkeystatuseschange
 slug: Web/API/MediaKeySession/onkeystatuseschange
+browser-compat: api.MediaKeySession.onkeystatuseschange
 ---
 <p>{{APIRef("Encrypted Media Extensions")}}</p>
 
@@ -33,4 +34,4 @@ slug: Web/API/MediaKeySession/onkeystatuseschange
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.onkeystatuseschange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/onmessage/index.html
+++ b/files/en-us/web/api/mediakeysession/onmessage/index.html
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.onmessage
 slug: Web/API/MediaKeySession/onmessage
+browser-compat: api.MediaKeySession.onmessage
 ---
 <p>{{APIRef("Encrypted Media Extensions")}}</p>
 
@@ -39,5 +40,5 @@ slug: Web/API/MediaKeySession/onmessage
 
 <div>
 
-    <p>{{Compat("api.MediaKeySession.onmessage")}}</p>
+    <p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/mediakeysession/remove/index.html
+++ b/files/en-us/web/api/mediakeysession/remove/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsExample
   - Reference
   - remove
+browser-compat: api.MediaKeySession.remove
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}</p>
 
@@ -38,4 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.remove")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/sessionid/index.html
+++ b/files/en-us/web/api/mediakeysession/sessionid/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - sessionId
+browser-compat: api.MediaKeySession.sessionId
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}</p>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.sessionId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysession/update/index.html
+++ b/files/en-us/web/api/mediakeysession/update/index.html
@@ -10,6 +10,7 @@ tags:
 - NeedsExample
 - Reference
 - Update
+browser-compat: api.MediaKeySession.update
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySession.update")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/entries/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/entries/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - entries()
+browser-compat: api.MediaKeyStatusMap.entries
 ---
 <p>{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.entries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/foreach/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/foreach/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - forEach()
+browser-compat: api.MediaKeyStatusMap.forEach
 ---
 <p>{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.forEach")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/get/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - get()
+browser-compat: api.MediaKeyStatusMap.get
 ---
 <p>{{APIRef("MediaKeyStatusMap")}}{{SeeCompatTable}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/has/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/has/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - has()
+browser-compat: api.MediaKeyStatusMap.has
 ---
 <p>{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.has")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/index.html
@@ -7,6 +7,7 @@ tags:
   - MediaKeyStatusMap
   - NeedsContent
   - Reference
+browser-compat: api.MediaKeyStatusMap
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/keys/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/keys/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - keys()
+browser-compat: api.MediaKeyStatusMap.keys
 ---
 <p>{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.keys")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/size/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/size/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - size
+browser-compat: api.MediaKeyStatusMap.size
 ---
 <p>{{SeeCompatTable}}{{APIRef("EncryptedMediaExtensions API")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.size")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeystatusmap/values/index.html
+++ b/files/en-us/web/api/mediakeystatusmap/values/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - values()
+browser-compat: api.MediaKeyStatusMap.values
 ---
 <p>{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeyStatusMap.values")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - createMediaKeys
+browser-compat: api.MediaKeySystemAccess.createMediaKeys
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemAccess.createMediaKeys")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - getConfiguration
+browser-compat: api.MediaKeySystemAccess.getConfiguration
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemAccess.getConfiguration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemaccess/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/index.html
@@ -11,6 +11,7 @@ tags:
   - NeedsExample
   - Reference
   - Video
+browser-compat: api.MediaKeySystemAccess
 ---
 <p>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemAccess")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemaccess/keysystem/index.html
+++ b/files/en-us/web/api/mediakeysystemaccess/keysystem/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - keySystem
+browser-compat: api.MediaKeySystemAccess.keySystem
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemAccess.keySystem")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemconfiguration/audiocapabilities/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/audiocapabilities/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - initDataTypes
+browser-compat: api.MediaKeySystemConfiguration.audioCapabilities
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemConfiguration.audioCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemconfiguration/distinctiveidentifier/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/distinctiveidentifier/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - distinctiveIdentifier
+browser-compat: api.MediaKeySystemConfiguration.distinctiveIdentifier
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemConfiguration.distinctiveIdentifier")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemconfiguration/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/index.html
@@ -12,6 +12,7 @@ tags:
   - NeedsContent
   - NeedsExample
   - Reference
+browser-compat: api.MediaKeySystemConfiguration
 ---
 <div>{{APIRef("Encrypted Media Extensions")}}{{SeeCompatTable}}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemConfiguration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemconfiguration/initdatatypes/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/initdatatypes/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - initDataTypes
+browser-compat: api.MediaKeySystemConfiguration.initDataTypes
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemConfiguration.initDataTypes")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemconfiguration/persistentstate/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/persistentstate/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - persistentState
+browser-compat: api.MediaKeySystemConfiguration.persistentState
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemConfiguration.persistentState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediakeysystemconfiguration/videocapabilities/index.html
+++ b/files/en-us/web/api/mediakeysystemconfiguration/videocapabilities/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - initDataTypes
+browser-compat: api.MediaKeySystemConfiguration.videoCapabilities
 ---
 <div>{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}</div>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaKeySystemConfiguration.videoCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/medialist/index.html
+++ b/files/en-us/web/api/medialist/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - MediaList
   - Reference
+browser-compat: api.MediaList
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -63,4 +64,4 @@ console.log(stylesheet.media.mediaText);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/medialist/mediatext/index.html
+++ b/files/en-us/web/api/medialist/mediatext/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - mediaText
+browser-compat: api.MediaList.mediaText
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -71,4 +72,4 @@ console.log(stylesheet.media.mediaText);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaList.mediaText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediametadata/album/index.html
+++ b/files/en-us/web/api/mediametadata/album/index.html
@@ -6,6 +6,7 @@ tags:
   - MediaMetadata
   - Property
   - Reference
+browser-compat: api.MediaMetadata.album
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -62,4 +63,4 @@ mediaMetaData.album = album</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaMetadata.album")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediametadata/artist/index.html
+++ b/files/en-us/web/api/mediametadata/artist/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Video
   - artist
+browser-compat: api.MediaMetadata.artist
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -66,4 +67,4 @@ mediaMetadata.artist = artist</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaMetadata.artist")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediametadata/artwork/index.html
+++ b/files/en-us/web/api/mediametadata/artwork/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - artwork
+browser-compat: api.MediaMetadata.artwork
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -70,7 +71,7 @@ mediaMetadata.artwork = artwork[]</pre>
 
 <div>
 
-  <p>{{Compat("api.MediaMetadata.artwork")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaSession
   - Reference
   - Video
+browser-compat: api.MediaMetadata
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaMetadata")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediametadata/mediametadata/index.html
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Video
 - artwork
+browser-compat: api.MediaMetadata.MediaMetadata
 ---
 <p>{{APIRef("Media Session API")}}{{SeeCompatTable}}</p>
 
@@ -77,4 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaMetadata.MediaMetadata")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediametadata/title/index.html
+++ b/files/en-us/web/api/mediametadata/title/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Title
   - Video
+browser-compat: api.MediaMetadata.title
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -67,4 +68,4 @@ mediaMetaData.title = title</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaMetadata.title")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediapositionstate/duration/index.html
+++ b/files/en-us/web/api/mediapositionstate/duration/index.html
@@ -15,6 +15,7 @@ tags:
 - Video
 - duration
 - length
+browser-compat: api.MediaPositionState.duration
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -86,4 +87,4 @@ navigator.mediaSession.setPositionState(positionState);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaPositionState.duration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediapositionstate/index.html
+++ b/files/en-us/web/api/mediapositionstate/index.html
@@ -16,6 +16,7 @@ tags:
   - direction
   - rate
   - speed
+browser-compat: api.MediaPositionState
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaPositionState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediapositionstate/playbackrate/index.html
+++ b/files/en-us/web/api/mediapositionstate/playbackrate/index.html
@@ -17,6 +17,7 @@ tags:
 - playbackRate
 - rate
 - speed
+browser-compat: api.MediaPositionState.playbackRate
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -96,4 +97,4 @@ navigator.mediaSession.setPositionState(positionState);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaPositionState.playbackRate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediapositionstate/position/index.html
+++ b/files/en-us/web/api/mediapositionstate/position/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - Time
 - Video
+browser-compat: api.MediaPositionState.position
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -90,4 +91,4 @@ let <em>duration</em> = <em>positionState</em>.duration;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaPositionState.position")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediaquerylist/addlistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - addListener
+browser-compat: api.MediaQueryList.addListener
 ---
 <p>{{APIRef("CSSOM")}}{{Deprecated_Header}}</p>
 
@@ -77,7 +78,7 @@ mediaQueryList.addListener(screenTest);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryList.addListener")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylist/index.html
+++ b/files/en-us/web/api/mediaquerylist/index.html
@@ -11,6 +11,7 @@ tags:
   - MediaQueryList
   - Reference
   - query
+browser-compat: api.MediaQueryList
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -98,7 +99,7 @@ mql.addEventListener('change', screenTest);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylist/matches/index.html
+++ b/files/en-us/web/api/mediaquerylist/matches/index.html
@@ -12,6 +12,7 @@ tags:
   - Property
   - Reference
   - matches
+browser-compat: api.MediaQueryList.matches
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -80,7 +81,7 @@ addMQListener(window.matchMedia("(orientation:landscape)"),
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryList.matches")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylist/media/index.html
+++ b/files/en-us/web/api/mediaquerylist/media/index.html
@@ -9,6 +9,7 @@ tags:
   - MediaQueryList
   - Property
   - Reference
+browser-compat: api.MediaQueryList.media
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -87,7 +88,7 @@ document.querySelector(".mq-value").innerText = mql.media;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryList.media")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylist/onchange/index.html
+++ b/files/en-us/web/api/mediaquerylist/onchange/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - onchange
+browser-compat: api.MediaQueryList.onchange
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -62,7 +63,7 @@ mql.addEventListener( "change", (e) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryList.onchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.html
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - removeListener
+browser-compat: api.MediaQueryList.removeListener
 ---
 <p>{{APIRef("CSSOM")}}{{Deprecated_Header}}</p>
 
@@ -79,7 +80,7 @@ mediaQueryList.removeListener(screenTest);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryList.removeListener")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Media Queries
   - MediaQueryListEvent
   - Reference
+browser-compat: api.MediaQueryListEvent
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -72,7 +73,7 @@ mql.addListener(screenTest);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryListEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/matches/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/matches/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - matches
+browser-compat: api.MediaQueryListEvent.matches
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -65,7 +66,7 @@ mql.addListener(screenTest);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryListEvent.matches")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/media/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/media/index.html
@@ -9,6 +9,7 @@ tags:
   - MediaQueryListEvent
   - Property
   - Reference
+browser-compat: api.MediaQueryListEvent.media
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -65,7 +66,7 @@ mql.addListener(screenTest);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryListEvent.media")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Media Queries
   - MediaQueryListEvent
   - Reference
+browser-compat: api.MediaQueryListEvent.MediaQueryListEvent
 ---
 <p>{{APIRef("CSSOM")}}</p>
 
@@ -65,7 +66,7 @@ var myMediaQueryListEvent = new MediaQueryListEvent({media, matches});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaQueryListEvent.MediaQueryListEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.html
@@ -8,6 +8,7 @@ tags:
 - MediaRecorder
 - Property
 - Reference
+browser-compat: api.MediaRecorder.audioBitsPerSecond
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Recording")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.audioBitsPerSecond")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediarecorder/error_event/index.html
+++ b/files/en-us/web/api/mediarecorder/error_event/index.html
@@ -3,6 +3,7 @@ title: 'MediaRecorder: error event'
 slug: Web/API/MediaRecorder/error_event
 tags:
   - Event
+browser-compat: api.MediaRecorder.error_event
 ---
 <div>{{APIRef}}</div>
 
@@ -76,7 +77,7 @@ record();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/ignoremutedmedia/index.html
+++ b/files/en-us/web/api/mediarecorder/ignoremutedmedia/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - Video
+browser-compat: api.MediaRecorder.ignoreMutedMedia
 ---
 <p>{{deprecated_header}}{{APIRef("MediaStream Recording")}}</p>
 
@@ -29,4 +30,4 @@ MediaRecorder.ignoreMutedMedia = boolean</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.ignoreMutedMedia")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/index.html
@@ -12,6 +12,7 @@ tags:
   - MediaRecorder
   - Reference
   - Video
+browser-compat: api.MediaRecorder
 ---
 <div>{{APIRef("Media Recorder API")}}</div>
 
@@ -195,7 +196,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/istypesupported/index.html
+++ b/files/en-us/web/api/mediarecorder/istypesupported/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - canRecordMimeType
+browser-compat: api.MediaRecorder.isTypeSupported
 ---
 <p>{{APIRef("MediaStream Recording")}}</p>
 
@@ -75,7 +76,7 @@ for (var i in types) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.isTypeSupported")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.html
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.html
@@ -11,6 +11,7 @@ tags:
   - MediaRecorder
   - Reference
   - Video
+browser-compat: api.MediaRecorder.MediaRecorder
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -126,7 +127,7 @@ if (navigator.mediaDevices.getUserMedia) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.MediaRecorder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/mimetype/index.html
+++ b/files/en-us/web/api/mediarecorder/mimetype/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - mimeType
+browser-compat: api.MediaRecorder.mimeType
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -111,7 +112,7 @@ if (navigator.mediaDevices) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.mimeType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/ondataavailable/index.html
+++ b/files/en-us/web/api/mediarecorder/ondataavailable/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - ondataavailable
+browser-compat: api.MediaRecorder.ondataavailable
 ---
 <p>{{APIRef("MediaStream Recording")}}</p>
 
@@ -101,7 +102,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.ondataavailable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/onerror/index.html
+++ b/files/en-us/web/api/mediarecorder/onerror/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - onerror
+browser-compat: api.MediaRecorder.onerror
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -138,7 +139,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/onpause/index.html
+++ b/files/en-us/web/api/mediarecorder/onpause/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - onpause
+browser-compat: api.MediaRecorder.onpause
 ---
 <p>{{APIRef("Media Recorder API")}}</p>
 
@@ -78,7 +79,7 @@ MediaRecorder.addEventListener('pause', function(event) { ... })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.onpause")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/onresume/index.html
+++ b/files/en-us/web/api/mediarecorder/onresume/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - onresume
+browser-compat: api.MediaRecorder.onresume
 ---
 <p>{{APIRef("Media Recorder API")}}</p>
 
@@ -78,7 +79,7 @@ MediaRecorder.addEventListener('resume', function(event) { ... })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.onresume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/onstart/index.html
+++ b/files/en-us/web/api/mediarecorder/onstart/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - onstart
+browser-compat: api.MediaRecorder.onstart
 ---
 <div>{{APIRef("Media Recorder API")}}</div>
 
@@ -68,7 +69,7 @@ MediaRecorder.addEventListener('start', function(event) { ... })</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.onstart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/onstop/index.html
+++ b/files/en-us/web/api/mediarecorder/onstop/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - onstop
+browser-compat: api.MediaRecorder.onstop
 ---
 <div>{{APIRef("Media Recorder API")}}</div>
 
@@ -71,7 +72,7 @@ MediaRecorder.addEventListener('stop', function(event) { ... })</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.onstop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/onwarning/index.html
+++ b/files/en-us/web/api/mediarecorder/onwarning/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - onwarning
+browser-compat: api.MediaRecorder.onwarning
 ---
 <div>{{Deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.onwarning")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/pause/index.html
+++ b/files/en-us/web/api/mediarecorder/pause/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - pause
+browser-compat: api.MediaRecorder.pause
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.pause")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/requestdata/index.html
+++ b/files/en-us/web/api/mediarecorder/requestdata/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Video
   - requestData
+browser-compat: api.MediaRecorder.requestData
 ---
 <p>{{APIRef("MediaStream Recording")}}</p>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.requestData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/resume/index.html
+++ b/files/en-us/web/api/mediarecorder/resume/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - resume
+browser-compat: api.MediaRecorder.resume
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.resume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/start/index.html
+++ b/files/en-us/web/api/mediarecorder/start/index.html
@@ -15,6 +15,7 @@ tags:
   - Reference
   - Video
   - start
+browser-compat: api.MediaRecorder.start
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -131,7 +132,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.start")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/state/index.html
+++ b/files/en-us/web/api/mediarecorder/state/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - state
+browser-compat: api.MediaRecorder.state
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.state")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/stop/index.html
+++ b/files/en-us/web/api/mediarecorder/stop/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - stop
+browser-compat: api.MediaRecorder.stop
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.stop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/stream/index.html
+++ b/files/en-us/web/api/mediarecorder/stream/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - stream
+browser-compat: api.MediaRecorder.stream
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorder.stream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecorder/videobitspersecond/index.html
+++ b/files/en-us/web/api/mediarecorder/videobitspersecond/index.html
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.videoBitsPerSecond
 slug: Web/API/MediaRecorder/videoBitsPerSecond
+browser-compat: api.MediaRecorder.videoBitsPerSecond
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Recording")}}</p>
 
@@ -44,5 +45,5 @@ slug: Web/API/MediaRecorder/videoBitsPerSecond
 
 <div>
 
-    <p>{{Compat("api.MediaRecorder.videoBitsPerSecond")}}</p>
+    <p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/mediarecordererrorevent/error/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/error/index.html
@@ -10,6 +10,7 @@ tags:
 - MediaStream Recording API
 - Property
 - Reference
+browser-compat: api.MediaRecorderErrorEvent.error
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -116,7 +117,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorderErrorEvent.error")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/index.html
@@ -17,6 +17,7 @@ tags:
   - Recording Video
   - Video
   - WebRTC
+browser-compat: api.MediaRecorderErrorEvent
 ---
 <div>{{APIRef("MediaStream Recording")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.MediaRecorderErrorEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
+++ b/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.html
@@ -13,6 +13,7 @@ tags:
 - MediaStream Recording API
 - Recording
 - Video
+browser-compat: api.MediaRecorderErrorEvent.MediaRecorderErrorEvent
 ---
 <p>{{APIRef("MediaStream Recording")}}</p>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaRecorderErrorEvent.MediaRecorderErrorEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasession/index.html
+++ b/files/en-us/web/api/mediasession/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaSession
   - Reference
   - Video
+browser-compat: api.MediaSession
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -122,4 +123,4 @@ for (const [action, handler] of actionHandlers) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSession")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasession/metadata/index.html
+++ b/files/en-us/web/api/mediasession/metadata/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Video
 - metadata
+browser-compat: api.MediaSession.metadata
 ---
 <p>{{SeeCompatTable}}{{APIRef("Media Session API")}}</p>
 
@@ -70,4 +71,4 @@ navigator.mediaSession.metadata = <em>mediaMetadata</em>;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSession.metadata")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasession/playbackstate/index.html
+++ b/files/en-us/web/api/mediasession/playbackstate/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Video
   - playbackState
+browser-compat: api.MediaSession.playbackState
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -98,4 +99,4 @@ for (const [action, handler] of actionHandlers) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSession.playbackState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasession/setactionhandler/index.html
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.html
@@ -12,6 +12,7 @@ tags:
   - UX
   - Video
   - setActionHandler
+browser-compat: api.MediaSession.setActionHandler
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -191,4 +192,4 @@ function handleSeek(details) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSession.setActionHandler")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasession/setpositionstate/index.html
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.html
@@ -16,6 +16,7 @@ tags:
 - rate
 - setPositionState
 - speed
+browser-compat: api.MediaSession.setPositionState
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -117,4 +118,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSession.setPositionState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasessionaction/index.html
+++ b/files/en-us/web/api/mediasessionaction/index.html
@@ -12,6 +12,7 @@ tags:
   - MediaSessionAction
   - Reference
   - Type
+browser-compat: api.MediaSessionAction
 ---
 <p>To support an action on a media session, such as seeking, pausing, or changing tracks, you need to call the {{domxref("MediaSession")}} interface's {{domxref("MediaSession.setActionHandler", "setActionHandler()")}} method to establish a handler for that action. <span class="seoSummary">The specific type of media session action to be handled on a <code>MediaSession</code> is identified using a string from the <code>MediaSessionAction</code> enumerated type.</span></p>
 
@@ -133,4 +134,4 @@ function handleSeek(details) {
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.MediaSessionAction")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasessionactiondetails/action/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/action/index.html
@@ -12,6 +12,7 @@ tags:
 - Session
 - action
 - details
+browser-compat: api.MediaSessionActionDetails.action
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -56,7 +57,7 @@ let <em>actionType</em> = <em>mediaSessionActionDetails</em>.action;
 
 <div>
 
-  <p>{{Compat("api.MediaSessionActionDetails.action")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/fastseek/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/fastseek/index.html
@@ -14,6 +14,7 @@ tags:
 - action
 - fastSeek
 - seek
+browser-compat: api.MediaSessionActionDetails.fastSeek
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -62,7 +63,7 @@ let <em>shouldFastSeek</em> = <em>mediaSessionActionDetails</em>.fastSeek;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSessionActionDetails.fastSeek")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/index.html
@@ -16,6 +16,7 @@ tags:
   - play
   - reverse
   - seek
+browser-compat: api.MediaSessionActionDetails
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSessionActionDetails")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasessionactiondetails/seekoffset/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/seekoffset/index.html
@@ -20,6 +20,7 @@ tags:
 - reverse
 - seek
 - seekOffset
+browser-compat: api.MediaSessionActionDetails.seekOffset
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -63,7 +64,7 @@ let <em>deltaTime</em> = <em>mediaSessionActionDetails</em>.seekOffset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSessionActionDetails.seekOffset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasessionactiondetails/seektime/index.html
+++ b/files/en-us/web/api/mediasessionactiondetails/seektime/index.html
@@ -18,6 +18,7 @@ tags:
 - reverse
 - seek
 - seekTime
+browser-compat: api.MediaSessionActionDetails.seekTime
 ---
 <p>{{APIRef("Media Session API")}}</p>
 
@@ -77,7 +78,7 @@ let <em>absTime</em> = <em>mediaSessionActionDetails</em>.seekTime;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSessionActionDetails.seekTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasettingsrange/index.html
+++ b/files/en-us/web/api/mediasettingsrange/index.html
@@ -10,6 +10,7 @@ tags:
   - MediaStream
   - MediaStream Image Capture API
   - Refernce
+browser-compat: api.MediaSettingsRange
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Image")}}</p>
 
@@ -76,4 +77,4 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSettingsRange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasettingsrange/max/index.html
+++ b/files/en-us/web/api/mediasettingsrange/max/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - max
+browser-compat: api.MediaSettingsRange.max
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Image")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSettingsRange.max")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasettingsrange/min/index.html
+++ b/files/en-us/web/api/mediasettingsrange/min/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - min
+browser-compat: api.MediaSettingsRange.min
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Image")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSettingsRange.min")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasettingsrange/step/index.html
+++ b/files/en-us/web/api/mediasettingsrange/step/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - step
+browser-compat: api.MediaSettingsRange.step
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Image")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSettingsRange.step")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasource/activesourcebuffers/index.html
+++ b/files/en-us/web/api/mediasource/activesourcebuffers/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - activeSourceBuffers
+browser-compat: api.MediaSource.activeSourceBuffers
 ---
 <div>{{APIRef("Media Source Extensions")}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.activeSourceBuffers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/addsourcebuffer/index.html
+++ b/files/en-us/web/api/mediasource/addsourcebuffer/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - addSourceBuffer
+browser-compat: api.MediaSource.addSourceBuffer
 ---
 <div>{{APIRef("Media Source Extensions")}}</div>
 
@@ -118,7 +119,7 @@ function sourceOpen (_) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.addSourceBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/clearliveseekablerange/index.html
+++ b/files/en-us/web/api/mediasource/clearliveseekablerange/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - clearLiveSeekableRange()
+browser-compat: api.MediaSource.clearLiveSeekableRange
 ---
 <p>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</p>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.clearLiveSeekableRange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasource/duration/index.html
+++ b/files/en-us/web/api/mediasource/duration/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - duration
+browser-compat: api.MediaSource.duration
 ---
 <div>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</div>
 
@@ -100,7 +101,7 @@ var <em>myDuration</em> = <em>mediaSource</em>.duration;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.duration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/endofstream/index.html
+++ b/files/en-us/web/api/mediasource/endofstream/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - endOfStream
+browser-compat: api.MediaSource.endOfStream
 ---
 <div>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</div>
 
@@ -128,7 +129,7 @@ function sourceOpen (_) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.endOfStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/index.html
@@ -13,6 +13,7 @@ tags:
   - MediaSource Extensions
   - Reference
   - Video
+browser-compat: api.MediaSource
 ---
 <p>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</p>
 
@@ -139,7 +140,7 @@ function fetchAB (url, cb) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/istypesupported/index.html
+++ b/files/en-us/web/api/mediasource/istypesupported/index.html
@@ -14,6 +14,7 @@ tags:
   - Static Method
   - Video
   - isTypeSupported
+browser-compat: api.MediaSource.isTypeSupported
 ---
 <div>{{APIRef("Media Source Extensions")}}</div>
 
@@ -109,7 +110,7 @@ function sourceOpen (_) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.isTypeSupported")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/mediasource/index.html
+++ b/files/en-us/web/api/mediasource/mediasource/index.html
@@ -11,6 +11,7 @@ tags:
 - MediaSource
 - Reference
 - Video
+browser-compat: api.MediaSource.MediaSource
 ---
 <div>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</div>
 
@@ -56,7 +57,7 @@ if ('MediaSource' in window &amp;&amp; MediaSource.isTypeSupported(mimeCodec)) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.MediaSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/readystate/index.html
+++ b/files/en-us/web/api/mediasource/readystate/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - readyState
+browser-compat: api.MediaSource.readyState
 ---
 <div>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</div>
 
@@ -88,7 +89,7 @@ function sourceOpen (_) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.readyState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/removesourcebuffer/index.html
+++ b/files/en-us/web/api/mediasource/removesourcebuffer/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - removeSourceBuffer
+browser-compat: api.MediaSource.removeSourceBuffer
 ---
 <div>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</div>
 
@@ -83,7 +84,7 @@ mediaSource.removeSourceBuffer(mediaSource.sourceBuffers[0]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.removeSourceBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediasource/setliveseekablerange/index.html
+++ b/files/en-us/web/api/mediasource/setliveseekablerange/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - setLiveSeekableRange()
+browser-compat: api.MediaSource.setLiveSeekableRange
 ---
 <p>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</p>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.setLiveSeekableRange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediasource/sourcebuffers/index.html
+++ b/files/en-us/web/api/mediasource/sourcebuffers/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - sourceBuffers
+browser-compat: api.MediaSource.sourceBuffers
 ---
 <div>{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaSource.sourceBuffers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/active/index.html
+++ b/files/en-us/web/api/mediastream/active/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - active
+browser-compat: api.MediaStream.active
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -67,4 +68,4 @@ promise.then((stream) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.active")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastream/addtrack/index.html
+++ b/files/en-us/web/api/mediastream/addtrack/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsExample
 - Reference
 - addTrack
+browser-compat: api.MediaStream.addTrack
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.addTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/addtrack_event/index.html
+++ b/files/en-us/web/api/mediastream/addtrack_event/index.html
@@ -3,6 +3,7 @@ title: 'MediaStream: addtrack event'
 slug: Web/API/MediaStream/addtrack_event
 tags:
   - Event
+browser-compat: api.MediaStream.addtrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -64,7 +65,7 @@ stream.onaddtrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.addtrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/clone/index.html
+++ b/files/en-us/web/api/mediastream/clone/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - clone
+browser-compat: api.MediaStream.clone
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.clone")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastream/ended/index.html
+++ b/files/en-us/web/api/mediastream/ended/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - ended
+browser-compat: api.MediaStream.ended
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.ended")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.html
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - getAudioTracks
 - track
+browser-compat: api.MediaStream.getAudioTracks
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.getAudioTracks")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastream/gettrackbyid/index.html
+++ b/files/en-us/web/api/mediastream/gettrackbyid/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - getTrackById
+browser-compat: api.MediaStream.getTrackById
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -65,7 +66,7 @@ stream.getTrackById("commentary-track").enabled = true;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.getTrackById")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/gettracks/index.html
+++ b/files/en-us/web/api/mediastream/gettracks/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - getTracks
+browser-compat: api.MediaStream.getTracks
 ---
 <p>{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}</p>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.getTracks")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastream/getvideotracks/index.html
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.html
@@ -13,6 +13,7 @@ tags:
 - getVideoTracks
 - stream
 - track
+browser-compat: api.MediaStream.getVideoTracks
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -87,4 +88,4 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.getVideoTracks")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastream/id/index.html
+++ b/files/en-us/web/api/mediastream/id/index.html
@@ -7,6 +7,7 @@ tags:
   - Read-only
   - Reference
   - Web
+browser-compat: api.MediaStream.id
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -48,7 +49,7 @@ p.then(function(stream) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/index.html
@@ -8,6 +8,7 @@ tags:
   - MediaStream
   - Reference
   - WebRTC
+browser-compat: api.MediaStream
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -125,7 +126,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/mediastream/index.html
+++ b/files/en-us/web/api/mediastream/mediastream/index.html
@@ -15,6 +15,7 @@ tags:
 - Video
 - WebRTC
 - streaming
+browser-compat: api.MediaStream.MediaStream
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.MediaStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/onaddtrack/index.html
+++ b/files/en-us/web/api/mediastream/onaddtrack/index.html
@@ -8,6 +8,7 @@ tags:
 - MediaStream
 - Property
 - Reference
+browser-compat: api.MediaStream.onaddtrack
 ---
 <p>{{APIRef("Media Streams API")}}</p>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.onaddtrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/onremovetrack/index.html
+++ b/files/en-us/web/api/mediastream/onremovetrack/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onremovetrack
+browser-compat: api.MediaStream.onremovetrack
 ---
 <p>{{APIRef("Media Streams API")}}</p>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.onremovetrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastream/removetrack_event/index.html
+++ b/files/en-us/web/api/mediastream/removetrack_event/index.html
@@ -3,6 +3,7 @@ title: 'MediaStream: removetrack event'
 slug: Web/API/MediaStream/removetrack_event
 tags:
   - Event
+browser-compat: api.MediaStream.removetrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -64,7 +65,7 @@ stream.onremovetrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStream.removetrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.html
@@ -7,6 +7,7 @@ tags:
   - MediaStreamAudioDestinationNode
   - Reference
   - Web Audio API
+browser-compat: api.MediaStreamAudioDestinationNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioDestinationNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.html
@@ -8,6 +8,7 @@ tags:
   - MediaStreamAudioDestinationNode
   - Reference
   - Web Audio API
+browser-compat: api.MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -57,4 +58,4 @@ var myDestination = new MediaStreamAudioDestinationNode(<em>ac</em>);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - stream
+browser-compat: api.MediaStreamAudioDestinationNode.stream
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -52,7 +53,7 @@ var myStream = destination.stream;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioDestinationNode.stream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.html
@@ -18,6 +18,7 @@ tags:
   - sound
   - stream
   - track
+browser-compat: api.MediaStreamAudioSourceNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.html
@@ -12,6 +12,7 @@ tags:
 - Web Audio
 - Web Audio API
 - stream
+browser-compat: api.MediaStreamAudioSourceNode.mediaStream
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -69,4 +70,4 @@ console.log(source.mediaStream);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioSourceNode.mediaStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.html
@@ -8,6 +8,7 @@ tags:
 - MediaStreamAudioSourceNode
 - Reference
 - Web Audio API
+browser-compat: api.MediaStreamAudioSourceNode.MediaStreamAudioSourceNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -106,4 +107,4 @@ if (navigator.mediaDevices.getUserMedia) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioSourceNode.MediaStreamAudioSourceNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamaudiosourceoptions/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourceoptions/index.html
@@ -15,6 +15,7 @@ tags:
   - Web Audio
   - Web Audio API
   - stream
+browser-compat: api.MediaStreamAudioSourceOptions
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioSourceOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamaudiosourceoptions/mediastream/index.html
+++ b/files/en-us/web/api/mediastreamaudiosourceoptions/mediastream/index.html
@@ -14,6 +14,7 @@ tags:
 - Web
 - Web Audio
 - Web Audio API
+browser-compat: api.MediaStreamAudioSourceOptions.mediaStream
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamAudioSourceOptions.mediaStream")}} </p>
+<p>{{Compat}} </p>

--- a/files/en-us/web/api/mediastreamconstraints/audio/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/audio/index.html
@@ -15,6 +15,7 @@ tags:
 - Web
 - WebRTC
 - getusermedia
+browser-compat: api.MediaStreamConstraints.audio
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -219,7 +220,7 @@ function log(msg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamConstraints.audio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamconstraints/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/index.html
@@ -15,6 +15,7 @@ tags:
   - Video
   - WebRTC
   - getusermedia
+browser-compat: api.MediaStreamConstraints
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamConstraints")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamconstraints/video/index.html
+++ b/files/en-us/web/api/mediastreamconstraints/video/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - Video
 - getusermedia
+browser-compat: api.MediaStreamConstraints.video
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -212,7 +213,7 @@ function log(msg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamConstraints.video")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamevent/index.html
+++ b/files/en-us/web/api/mediastreamevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - WebRTC
+browser-compat: api.MediaStreamEvent
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamevent/mediastreamevent/index.html
+++ b/files/en-us/web/api/mediastreamevent/mediastreamevent/index.html
@@ -7,6 +7,7 @@ tags:
   - MediaStreamEvent
   - Reference
   - WebRTC
+browser-compat: api.MediaStreamEvent.MediaStreamEvent
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -45,7 +46,7 @@ var event = new MediaStreamEvent("addstream", {"stream": s});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamEvent.MediaStreamEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamevent/stream/index.html
+++ b/files/en-us/web/api/mediastreamevent/stream/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - WebRTC
+browser-compat: api.MediaStreamEvent.stream
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamEvent.stream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/applyconstraints/index.html
+++ b/files/en-us/web/api/mediastreamtrack/applyconstraints/index.html
@@ -9,6 +9,7 @@ tags:
   - MediaStreamTrack
   - Method
   - applyConstraints
+browser-compat: api.MediaStreamTrack.applyConstraints
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -112,7 +113,7 @@ navigator.mediaDevices.getUserMedia({ video: true })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.applyConstraints")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/clone/index.html
+++ b/files/en-us/web/api/mediastreamtrack/clone/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - clone
+browser-compat: api.MediaStreamTrack.clone
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.clone")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrack/enabled/index.html
+++ b/files/en-us/web/api/mediastreamtrack/enabled/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebRTC
   - enabled
+browser-compat: api.MediaStreamTrack.enabled
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -102,7 +103,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.enabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/ended_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/ended_event/index.html
@@ -12,6 +12,7 @@ tags:
   - Video
   - Web Audio API
   - ended
+browser-compat: api.MediaStreamTrack.ended_event
 ---
 <div>{{DefaultAPISidebar("Media Capture and Streams")}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.ended_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.html
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - getCapabilities
+browser-compat: api.MediaStreamTrack.getCapabilities
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.getCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrack/getconstraints/index.html
+++ b/files/en-us/web/api/mediastreamtrack/getconstraints/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Reference
 - getConstraints
+browser-compat: api.MediaStreamTrack.getConstraints
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.getConstraints")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrack/getsettings/index.html
+++ b/files/en-us/web/api/mediastreamtrack/getsettings/index.html
@@ -8,6 +8,7 @@ tags:
 - MediaStreamTrack
 - Method
 - Reference
+browser-compat: api.MediaStreamTrack.getSettings
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.getSettings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrack/id/index.html
+++ b/files/en-us/web/api/mediastreamtrack/id/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - WebRTC
+browser-compat: api.MediaStreamTrack.id
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/index.html
+++ b/files/en-us/web/api/mediastreamtrack/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - WebRTC
+browser-compat: api.MediaStreamTrack
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -118,7 +119,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/kind/index.html
+++ b/files/en-us/web/api/mediastreamtrack/kind/index.html
@@ -9,6 +9,7 @@ tags:
   - Read-only
   - Reference
   - WebRTC
+browser-compat: api.MediaStreamTrack.kind
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.kind")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/label/index.html
+++ b/files/en-us/web/api/mediastreamtrack/label/index.html
@@ -9,6 +9,7 @@ tags:
   - Read-only
   - Reference
   - WebRTC
+browser-compat: api.MediaStreamTrack.label
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.label")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - mute
+browser-compat: api.MediaStreamTrack.mute_event
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -90,7 +91,7 @@ musicTrack.onunmute = event = &gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.mute_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/muted/index.html
+++ b/files/en-us/web/api/mediastreamtrack/muted/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - muted
+browser-compat: api.MediaStreamTrack.muted
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -72,4 +73,4 @@ trackList.forEach((track) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.muted")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrack/onended/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onended/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onended
+browser-compat: api.MediaStreamTrack.onended
 ---
 <p>{{ APIRef("Media Capture and Streams") }}</p>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.onended")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/onmute/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onmute/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC
 - mute
 - onmute
+browser-compat: api.MediaStreamTrack.onmute
 ---
 <div>{{ APIRef("Media Capture and Streams") }}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.onmute")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/onoverconstrained/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onoverconstrained/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - WebRTC
+browser-compat: api.MediaStreamTrack.onoverconstrained
 ---
 <div>{{ APIRef("Media Capture and Streams") }}{{deprecated_header}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.onoverconstrained")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/onunmute/index.html
+++ b/files/en-us/web/api/mediastreamtrack/onunmute/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC
   - onunmute
   - unmute
+browser-compat: api.MediaStreamTrack.onunmute
 ---
 <div>{{ APIRef("Media Capture and Streams") }}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.onunmute")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/readystate/index.html
+++ b/files/en-us/web/api/mediastreamtrack/readystate/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MediaStreamTrack.readyState
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.readyState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/remote/index.html
+++ b/files/en-us/web/api/mediastreamtrack/remote/index.html
@@ -8,6 +8,7 @@ tags:
   - Read-only
   - Reference
   - WebRTC
+browser-compat: api.MediaStreamTrack.remote
 ---
 <div>{{APIRef("Media Capture and Streams")}}{{deprecated_header}}</div>
 
@@ -24,7 +25,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.remote")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/stop/index.html
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.html
@@ -12,6 +12,7 @@ tags:
 - Streams
 - WebRTC
 - stop
+browser-compat: api.MediaStreamTrack.stop
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.stop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.html
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Video
   - unmute
+browser-compat: api.MediaStreamTrack.unmute_event
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -88,7 +89,7 @@ musicTrack.mute = event = &gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrack.unmute_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.html
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackAudioSourceNode
 slug: Web/API/MediaStreamTrackAudioSourceNode
+browser-compat: api.MediaStreamTrackAudioSourceNode
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -63,7 +64,7 @@ slug: Web/API/MediaStreamTrackAudioSourceNode
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrackAudioSourceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.html
@@ -16,6 +16,7 @@ tags:
 - sound
 - source
 - track
+browser-compat: api.MediaStreamTrackAudioSourceNode.MediaStreamTrackAudioSourceNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -113,4 +114,4 @@ if (navigator.mediaDevices.getUserMedia) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrackAudioSourceNode.MediaStreamTrackAudioSourceNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrackaudiosourceoptions/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourceoptions/index.html
@@ -14,6 +14,7 @@ tags:
   - Web Audio
   - Web Audio API
   - sound
+browser-compat: api.MediaStreamTrackAudioSourceOptions
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrackAudioSourceOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mediastreamtrackaudiosourceoptions/mediastreamtrack/index.html
+++ b/files/en-us/web/api/mediastreamtrackaudiosourceoptions/mediastreamtrack/index.html
@@ -16,6 +16,7 @@ tags:
 - sound
 - source
 - track
+browser-compat: api.MediaStreamTrackAudioSourceOptions.mediaStreamTrack
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrackAudioSourceOptions.mediaStreamTrack")}} </p>
+<p>{{Compat}} </p>

--- a/files/en-us/web/api/mediastreamtrackevent/index.html
+++ b/files/en-us/web/api/mediastreamtrackevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Streams
   - track
+browser-compat: api.MediaStreamTrackEvent
 ---
 <div>{{APIRef("Media Streams API")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrackEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediastreamtrackevent/mediastreamtrackevent/index.html
+++ b/files/en-us/web/api/mediastreamtrackevent/mediastreamtrackevent/index.html
@@ -7,6 +7,7 @@ tags:
 - Media Streams API
 - MediaStreamTrackEvent
 - Reference
+browser-compat: api.MediaStreamTrackEvent.MediaStreamTrackEvent
 ---
 <p>{{APIRef("Media Streams API")}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaStreamTrackEvent.MediaStreamTrackEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/aspectratio/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/aspectratio/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - aspectRatio
 - getusermedia
+browser-compat: api.MediaTrackConstraints.aspectRatio
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.aspectRatio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Web
 - autoGainControl
+browser-compat: api.MediaTrackConstraints.autoGainControl
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.autoGainControl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/channelcount/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/channelcount/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - channelCount
+browser-compat: api.MediaTrackConstraints.channelCount
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.channelCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/cursor/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/cursor/index.html
@@ -17,6 +17,7 @@ tags:
 - Video
 - display
 - screen
+browser-compat: api.MediaTrackConstraints.cursor
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -133,7 +134,7 @@ if (displayStream.getVideoTracks()[0].getSettings().cursor === "never") {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.cursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/deviceid/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/deviceid/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - deviceId
 - getusermedia
+browser-compat: api.MediaTrackConstraints.deviceId
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -89,7 +90,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.deviceId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/displaysurface/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/displaysurface/index.html
@@ -18,6 +18,7 @@ tags:
 - display
 - displaySurface
 - screen
+browser-compat: api.MediaTrackConstraints.displaySurface
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -109,7 +110,7 @@ if (displaySurface === "monitor" || displaySurface ==="application") {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.displaySurface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - echoCancellation
+browser-compat: api.MediaTrackConstraints.echoCancellation
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.echoCancellation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - facingMode
 - getusermedia
+browser-compat: api.MediaTrackConstraints.facingMode
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.facingMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/framerate/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/framerate/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - WebRTC
 - frameRate
+browser-compat: api.MediaTrackConstraints.frameRate
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.frameRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/groupid/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/groupid/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - getusermedia
 - groupId
+browser-compat: api.MediaTrackConstraints.groupId
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.groupId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/height/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/height/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - height
+browser-compat: api.MediaTrackConstraints.height
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/index.html
@@ -16,6 +16,7 @@ tags:
   - Sharing
   - WebRTC
   - screen
+browser-compat: api.MediaTrackConstraints
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -170,7 +171,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/latency/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/latency/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - getusermedia
 - latency
+browser-compat: api.MediaTrackConstraints.latency
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.latency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.html
@@ -18,6 +18,7 @@ tags:
 - display
 - logicalSurface
 - screen
+browser-compat: api.MediaTrackConstraints.logicalSurface
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.logicalSurface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Web
 - noiseSuppression
+browser-compat: api.MediaTrackConstraints.noiseSuppression
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.noiseSuppression")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/samplerate/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/samplerate/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - WebRTC
 - sampleRate
+browser-compat: api.MediaTrackConstraints.sampleRate
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.sampleRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/samplesize/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/samplesize/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - sampleSize
+browser-compat: api.MediaTrackConstraints.sampleSize
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.sampleSize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/volume/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/volume/index.html
@@ -14,6 +14,7 @@ tags:
 - Volume
 - WebRTC
 - getusermedia
+browser-compat: api.MediaTrackConstraints.volume
 ---
 <div>{{APIRef("Media Capture and Streams")}}{{deprecated_header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.volume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatrackconstraints/width/index.html
+++ b/files/en-us/web/api/mediatrackconstraints/width/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - width
+browser-compat: api.MediaTrackConstraints.width
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackConstraints.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.html
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - WebRTC
 - aspectRatio
+browser-compat: api.MediaTrackSettings.aspectRatio
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.aspectRatio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.html
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Web
 - autoGainControl
+browser-compat: api.MediaTrackSettings.autoGainControl
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.autoGainControl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.html
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.html
@@ -13,6 +13,7 @@ tags:
 - Settings
 - WebRTC
 - channelCount
+browser-compat: api.MediaTrackSettings.channelCount
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.channelCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/cursor/index.html
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.html
@@ -17,6 +17,7 @@ tags:
 - Settings
 - display
 - screen
+browser-compat: api.MediaTrackSettings.cursor
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.cursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.html
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.html
@@ -12,6 +12,7 @@ tags:
 - Settings
 - WebRTC
 - deviceId
+browser-compat: api.MediaTrackSettings.deviceId
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.deviceId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.html
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.html
@@ -19,6 +19,7 @@ tags:
 - display
 - displaySurface
 - screen
+browser-compat: api.MediaTrackSettings.displaySurface
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.displaySurface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.html
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Settings
 - echoCancellation
+browser-compat: api.MediaTrackSettings.echoCancellation
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.echoCancellation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.html
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - WebRTC
 - facingMode
+browser-compat: api.MediaTrackSettings.facingMode
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.facingMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/framerate/index.html
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - WebRTC
 - frameRate
+browser-compat: api.MediaTrackSettings.frameRate
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.frameRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/groupid/index.html
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.html
@@ -12,6 +12,7 @@ tags:
 - Settings
 - WebRTC
 - groupId
+browser-compat: api.MediaTrackSettings.groupId
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.groupId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/height/index.html
+++ b/files/en-us/web/api/mediatracksettings/height/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - WebRTC
 - height
+browser-compat: api.MediaTrackSettings.height
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/index.html
+++ b/files/en-us/web/api/mediatracksettings/index.html
@@ -14,6 +14,7 @@ tags:
   - NeedsExample
   - Reference
   - Video
+browser-compat: api.MediaTrackSettings
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -151,7 +152,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/latency/index.html
+++ b/files/en-us/web/api/mediatracksettings/latency/index.html
@@ -13,6 +13,7 @@ tags:
 - Settings
 - WebRTC
 - latency
+browser-compat: api.MediaTrackSettings.latency
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.latency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/logicalsurface/index.html
+++ b/files/en-us/web/api/mediatracksettings/logicalsurface/index.html
@@ -18,6 +18,7 @@ tags:
 - display
 - logicalSurface
 - screen
+browser-compat: api.MediaTrackSettings.logicalSurface
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.logicalSurface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.html
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Web
 - noiseSuppression
+browser-compat: api.MediaTrackSettings.noiseSuppression
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.noiseSuppression")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.html
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.html
@@ -13,6 +13,7 @@ tags:
 - Settings
 - WebRTC
 - sampleRate
+browser-compat: api.MediaTrackSettings.sampleRate
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.sampleRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.html
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.html
@@ -13,6 +13,7 @@ tags:
 - Settings
 - WebRTC
 - sampleSize
+browser-compat: api.MediaTrackSettings.sampleSize
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.sampleSize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/volume/index.html
+++ b/files/en-us/web/api/mediatracksettings/volume/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Volume
 - WebRTC
+browser-compat: api.MediaTrackSettings.volume
 ---
 <div>{{APIRef("Media Capture and Streams")}}{{deprecated_header}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.volume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksettings/width/index.html
+++ b/files/en-us/web/api/mediatracksettings/width/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - WebRTC
 - width
+browser-compat: api.MediaTrackSettings.width
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSettings.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.html
@@ -13,6 +13,7 @@ tags:
 - Web
 - WebRTC
 - aspectRatio
+browser-compat: api.MediaTrackSupportedConstraints.aspectRatio
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -90,7 +91,7 @@ if (navigator.mediaDevices.getSupportedConstraints().aspectRatio) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.aspectRatio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.html
@@ -15,6 +15,7 @@ tags:
 - Volume
 - Web
 - autoGainControl
+browser-compat: api.MediaTrackSupportedConstraints.autoGainControl
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -100,7 +101,7 @@ if (navigator.mediaDevices.getSupportedConstraints().autoGainControl) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.autoGainControl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.html
@@ -13,6 +13,7 @@ tags:
 - Web
 - WebRTC
 - channelCount
+browser-compat: api.MediaTrackSupportedConstraints.channelCount
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -90,7 +91,7 @@ if (navigator.mediaDevices.getSupportedConstraints().channelCount) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.channelCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/cursor/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/cursor/index.html
@@ -18,6 +18,7 @@ tags:
 - Video
 - display
 - screen
+browser-compat: api.MediaTrackSupportedConstraints.cursor
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.cursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.html
@@ -13,6 +13,7 @@ tags:
 - Web
 - WebRTC
 - deviceId
+browser-compat: api.MediaTrackSupportedConstraints.deviceId
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -90,7 +91,7 @@ if (navigator.mediaDevices.getSupportedConstraints().deviceId) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.deviceId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.html
@@ -18,6 +18,7 @@ tags:
 - display
 - displaySurface
 - screen
+browser-compat: api.MediaTrackSupportedConstraints.displaySurface
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.displaySurface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.html
@@ -12,6 +12,7 @@ tags:
 - Web
 - WebRTC
 - echoCancellation
+browser-compat: api.MediaTrackSupportedConstraints.echoCancellation
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -90,7 +91,7 @@ if (navigator.mediaDevices.getSupportedConstraints().echoCancellation) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.echoCancellation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.html
@@ -12,6 +12,7 @@ tags:
 - Web
 - WebRTC
 - facingMode
+browser-compat: api.MediaTrackSupportedConstraints.facingMode
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -89,7 +90,7 @@ if (navigator.mediaDevices.getSupportedConstraints().facingMode) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.facingMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.html
@@ -13,6 +13,7 @@ tags:
 - Web
 - WebRTC
 - frameRate
+browser-compat: api.MediaTrackSupportedConstraints.frameRate
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -113,7 +114,7 @@ if (navigator.mediaDevices.getSupportedConstraints().frameRate) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.frameRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.html
@@ -12,6 +12,7 @@ tags:
 - Web
 - WebRTC
 - groupId
+browser-compat: api.MediaTrackSupportedConstraints.groupId
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -89,7 +90,7 @@ if (navigator.mediaDevices.getSupportedConstraints().groupId) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.groupId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.html
@@ -12,6 +12,7 @@ tags:
 - Web
 - WebRTC
 - height
+browser-compat: api.MediaTrackSupportedConstraints.height
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -89,7 +90,7 @@ if (navigator.mediaDevices.getSupportedConstraints().height) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.html
@@ -14,6 +14,7 @@ tags:
   - Screen Capture
   - Screen Capture API
   - screen
+browser-compat: api.MediaTrackSupportedConstraints
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.html
@@ -13,6 +13,7 @@ tags:
 - Web
 - WebRTC
 - latency
+browser-compat: api.MediaTrackSupportedConstraints.latency
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -90,7 +91,7 @@ if (navigator.mediaDevices.getSupportedConstraints().latency) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.latency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.html
@@ -16,6 +16,7 @@ tags:
 - Video
 - display
 - screen
+browser-compat: api.MediaTrackSupportedConstraints.logicalSurface
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.logicalSurface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.html
@@ -12,6 +12,7 @@ tags:
 - MediaStreamTrackSupportedConstraints
 - Property
 - noiseSuppression
+browser-compat: api.MediaTrackSupportedConstraints.noiseSuppression
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -99,7 +100,7 @@ if (navigator.mediaDevices.getSupportedConstraints().noiseSuppression) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.noiseSuppression")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Web
 - sampleRate
+browser-compat: api.MediaTrackSupportedConstraints.sampleRate
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -89,7 +90,7 @@ if (navigator.mediaDevices.getSupportedConstraints().sampleRate) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.sampleRate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - sampleSize
+browser-compat: api.MediaTrackSupportedConstraints.sampleSize
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -89,7 +90,7 @@ if (navigator.mediaDevices.getSupportedConstraints().sampleSize) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.sampleSize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/volume/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/volume/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Volume
 - WebRTC
+browser-compat: api.MediaTrackSupportedConstraints.volume
 ---
 <p>{{APIRef("Media Capture and Streams")}}{{deprecated_header}}</p>
 
@@ -69,7 +70,7 @@ if (navigator.mediaDevices.getSupportedConstraints().volume) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.volume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/width/index.html
+++ b/files/en-us/web/api/mediatracksupportedconstraints/width/index.html
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.width
 slug: Web/API/MediaTrackSupportedConstraints/width
+browser-compat: api.MediaTrackSupportedConstraints.width
 ---
 <p>{{APIRef("Media Capture and Streams")}}</p>
 
@@ -78,7 +79,7 @@ if (navigator.mediaDevices.getSupportedConstraints().width) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MediaTrackSupportedConstraints.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/merchantvalidationevent/complete/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/complete/index.html
@@ -13,6 +13,7 @@ tags:
   - Payments
   - Reference
   - complete
+browser-compat: api.MerchantValidationEvent.complete
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</p>
 
@@ -62,7 +63,7 @@ function getValidationData(url) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MerchantValidationEvent.complete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/merchantvalidationevent/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/index.html
@@ -14,6 +14,7 @@ tags:
   - Payments
   - Reference
   - Secure context
+browser-compat: api.MerchantValidationEvent
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MerchantValidationEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.html
@@ -12,6 +12,7 @@ tags:
   - Payment Requests
   - Payments
   - Reference
+browser-compat: api.MerchantValidationEvent.MerchantValidationEvent
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MerchantValidationEvent.MerchantValidationEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/merchantvalidationevent/methodname/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/methodname/index.html
@@ -17,6 +17,7 @@ tags:
 - Validation
 - methodName
 - payment
+browser-compat: api.MerchantValidationEvent.methodName
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</p>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MerchantValidationEvent.methodName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/merchantvalidationevent/validationurl/index.html
+++ b/files/en-us/web/api/merchantvalidationevent/validationurl/index.html
@@ -14,6 +14,7 @@ tags:
 - Property
 - Reference
 - validationURL
+browser-compat: api.MerchantValidationEvent.validationURL
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MerchantValidationEvent.validationURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messagechannel/index.html
+++ b/files/en-us/web/api/messagechannel/index.html
@@ -8,6 +8,7 @@ tags:
   - MessageChannel
   - Reference
   - web messaging
+browser-compat: api.MessageChannel
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -83,7 +84,7 @@ function onMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messagechannel/messagechannel/index.html
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.html
@@ -7,6 +7,7 @@ tags:
 - Constructor
 - MessageChannel
 - Reference
+browser-compat: api.MessageChannel.MessageChannel
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -78,7 +79,7 @@ function handleMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageChannel.MessageChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messagechannel/port1/index.html
+++ b/files/en-us/web/api/messagechannel/port1/index.html
@@ -9,6 +9,7 @@ tags:
 - MessageChannel
 - Property
 - Reference
+browser-compat: api.MessageChannel.port1
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -78,7 +79,7 @@ function handleMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageChannel.port1")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messagechannel/port2/index.html
+++ b/files/en-us/web/api/messagechannel/port2/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - port2
+browser-compat: api.MessageChannel.port2
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -82,7 +83,7 @@ function handleMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageChannel.port2")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/data/index.html
+++ b/files/en-us/web/api/messageevent/data/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - data
 - messaging
+browser-compat: api.MessageEvent.data
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/index.html
+++ b/files/en-us/web/api/messageevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Window
   - Workers
   - messaging
+browser-compat: api.MessageEvent
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -127,7 +128,7 @@ myWorker.port.onmessage = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/lasteventid/index.html
+++ b/files/en-us/web/api/messageevent/lasteventid/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - lastEventID
 - messaging
+browser-compat: api.MessageEvent.lastEventId
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent.lastEventId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/messageevent/index.html
+++ b/files/en-us/web/api/messageevent/messageevent/index.html
@@ -8,6 +8,7 @@ tags:
 - MessageEvent
 - Reference
 - messaging
+browser-compat: api.MessageEvent.MessageEvent
 ---
 <div>{{APIRef("HTML DOM")}}{{draft}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent.MessageEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/origin/index.html
+++ b/files/en-us/web/api/messageevent/origin/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - messaging
 - origin
+browser-compat: api.MessageEvent.origin
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent.origin")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/ports/index.html
+++ b/files/en-us/web/api/messageevent/ports/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - messaging
   - ports
+browser-compat: api.MessageEvent.ports
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent.ports")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageevent/source/index.html
+++ b/files/en-us/web/api/messageevent/source/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - messaging
 - source
+browser-compat: api.MessageEvent.source
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessageEvent.source")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/close/index.html
+++ b/files/en-us/web/api/messageport/close/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - close
+browser-compat: api.MessagePort.close
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -68,7 +69,7 @@ channel.port1.start();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/index.html
+++ b/files/en-us/web/api/messageport/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - MessagePort
   - Reference
+browser-compat: api.MessagePort
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -100,7 +101,7 @@ function onMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/message_event/index.html
+++ b/files/en-us/web/api/messageport/message_event/index.html
@@ -3,6 +3,7 @@ title: 'MessagePort: message event'
 slug: Web/API/MessagePort/message_event
 tags:
   - Event
+browser-compat: api.MessagePort.message_event
 ---
 <div>{{APIRef}}</div>
 
@@ -86,7 +87,7 @@ targetFrame.postMessage('init', targetOrigin, [channel.port2]);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.message_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/messageerror_event/index.html
+++ b/files/en-us/web/api/messageport/messageerror_event/index.html
@@ -3,6 +3,7 @@ title: 'MessagePort: messageerror event'
 slug: Web/API/MessagePort/messageerror_event
 tags:
   - Event
+browser-compat: api.MessagePort.messageerror_event
 ---
 <div>{{APIRef}}</div>
 
@@ -95,7 +96,7 @@ targetFrame.postMessage('init', targetOrigin, [channel.port2]);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.messageerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/onmessage/index.html
+++ b/files/en-us/web/api/messageport/onmessage/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - onmessage
+browser-compat: api.MessagePort.onmessage
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -75,7 +76,7 @@ function handleMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.onmessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/onmessageerror/index.html
+++ b/files/en-us/web/api/messageport/onmessageerror/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - events
 - onmessageerror
+browser-compat: api.MessagePort.onmessageerror
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.onmessageerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/postmessage/index.html
+++ b/files/en-us/web/api/messageport/postmessage/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - postMessage
+browser-compat: api.MessagePort.postMessage
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -91,7 +92,7 @@ function handleMessage(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.postMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/messageport/start/index.html
+++ b/files/en-us/web/api/messageport/start/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Reference
 - start
+browser-compat: api.MessagePort.start
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -72,7 +73,7 @@ channel.port1.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MessagePort.start")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/metadata/index.html
+++ b/files/en-us/web/api/metadata/index.html
@@ -11,6 +11,7 @@ tags:
   - Offline
   - Reference
   - metadata
+browser-compat: api.Metadata
 ---
 <p>{{ APIRef("File System API") }}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Metadata")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/metadata/modificationtime/index.html
+++ b/files/en-us/web/api/metadata/modificationtime/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - metadata
 - modificationTime
+browser-compat: api.Metadata.modificationTime
 ---
 <p>{{APIRef("File System API")}}{{Non-standard_header}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Metadata.modificationTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/metadata/size/index.html
+++ b/files/en-us/web/api/metadata/size/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - metadata
 - size
+browser-compat: api.Metadata.size
 ---
 <p>{{APIRef("File System API")}}{{Non-standard_header}}</p>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Metadata.size")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/midiaccess/index.html
+++ b/files/en-us/web/api/midiaccess/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - Web MIDI API
+browser-compat: api.MIDIAccess
 ---
 <p>{{SeeCompatTable}}{{APIRef("Web MIDI API")}} </p>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MIDIAccess")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midiconnectionevent/index.html
+++ b/files/en-us/web/api/midiconnectionevent/index.html
@@ -9,6 +9,7 @@ tags:
   - MIDIConnectionEvent
   - Reference
   - Web MIDI API
+browser-compat: api.MIDIConnectionEvent
 ---
 <p>{{APIRef("Web MIDI API")}}{{SeeCompatTable}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MIDIConnectionEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midiinput/index.html
+++ b/files/en-us/web/api/midiinput/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - Reference
   - Web MIDI API
+browser-compat: api.MIDIInput
 ---
 <div>{{APIRef("Web MIDI API")}}{{SeeCompatTable}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MIDIInput")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midiinputmap/index.html
+++ b/files/en-us/web/api/midiinputmap/index.html
@@ -3,6 +3,7 @@ title: MIDIInputMap
 slug: Web/API/MIDIInputMap
 tags:
   - NeedsContent
+browser-compat: api.MIDIInputMap
 ---
 <p>{{APIRef("Web MIDI API")}} {{draft}} {{SeeCompatTable}}</p>
 
@@ -27,4 +28,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MIDIInputMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midimessageevent/index.html
+++ b/files/en-us/web/api/midimessageevent/index.html
@@ -8,6 +8,7 @@ tags:
   - MIDIMessageEvent
   - Reference
   - Web MIDI API
+browser-compat: api.MIDIMessageEvent
 ---
 <p>{{APIRef("Web MIDI API")}}{{SeeCompatTable}}</p>
 
@@ -58,4 +59,4 @@ navigator.requestMIDIAccess().then(midiAccess =&gt; {
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.MIDIMessageEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/midioutputmap/index.html
+++ b/files/en-us/web/api/midioutputmap/index.html
@@ -3,6 +3,7 @@ title: MIDIOutputMap
 slug: Web/API/MIDIOutputMap
 tags:
   - API
+browser-compat: api.MIDIOutputMap
 ---
 <p>{{APIRef("Web MIDI API")}} {{draft}} {{SeeCompatTable}}</p>
 
@@ -27,4 +28,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MIDIOutputMap")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mimetype/index.html
+++ b/files/en-us/web/api/mimetype/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Plugins
   - Reference
+browser-compat: api.MimeType
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MimeType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mimetypearray/index.html
+++ b/files/en-us/web/api/mimetypearray/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - mimeType
+browser-compat: api.MimeTypeArray
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
@@ -61,4 +62,4 @@ if (typeof flashPlugin === "undefined") {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MimeTypeArray")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mouseevent/altkey/index.html
+++ b/files/en-us/web/api/mouseevent/altkey/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.altKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -82,7 +83,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.altKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/button/index.html
+++ b/files/en-us/web/api/mouseevent/button/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.button
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -115,7 +116,7 @@ function logMouseButton(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.button")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/buttons/index.html
+++ b/files/en-us/web/api/mouseevent/buttons/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - UIEvent
+browser-compat: api.MouseEvent.buttons
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -105,7 +106,7 @@ document.querySelector('#log').appendChild(log)</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.buttons")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Firefox_notes">Firefox notes</h3>
 

--- a/files/en-us/web/api/mouseevent/clientx/index.html
+++ b/files/en-us/web/api/mouseevent/clientx/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.clientX
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -88,7 +89,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.clientX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/clienty/index.html
+++ b/files/en-us/web/api/mouseevent/clienty/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.clientY
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -87,7 +88,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.clientY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.html
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.ctrlKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -78,7 +79,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.ctrlKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.html
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.html
@@ -9,6 +9,7 @@ tags:
   - MouseEvent
   - Reference
   - getModifierState
+browser-compat: api.MouseEvent.getModifierState
 ---
 <p id="Summary">{{APIRef("DOM Events")}}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.getModifierState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - events
   - mouse
+browser-compat: api.MouseEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -184,7 +185,7 @@ document.getElementById("button").addEventListener('click', simulateClick);</pre
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - MouseEvent
   - Reference
+browser-compat: api.MouseEvent.initMouseEvent
 ---
 <p>{{APIRef("DOM Events")}}{{deprecated_header}}</p>
 
@@ -143,7 +144,7 @@ simulateClick();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.initMouseEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/metakey/index.html
+++ b/files/en-us/web/api/mouseevent/metakey/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.metaKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -82,7 +83,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.metaKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/mouseevent/index.html
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.html
@@ -8,6 +8,7 @@ tags:
 - MouseEvent
 - Reference
 - events
+browser-compat: api.MouseEvent.MouseEvent
 ---
 <p id="Summary">{{APIRef("DOM Events")}}</p>
 
@@ -158,7 +159,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.MouseEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/api/mouseevent/movementx/index.html
+++ b/files/en-us/web/api/mouseevent/movementx/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - mouse lock
   - pointer lock
+browser-compat: api.MouseEvent.movementX
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -73,7 +74,7 @@ document.addEventListener('mousemove', logMovement);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.movementX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/movementy/index.html
+++ b/files/en-us/web/api/mouseevent/movementy/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - mouse lock
   - pointer lock
+browser-compat: api.MouseEvent.movementY
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -72,7 +73,7 @@ document.addEventListener('mousemove', logMovement);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.movementY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/offsetx/index.html
+++ b/files/en-us/web/api/mouseevent/offsetx/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.offsetX
 ---
 <div>{{APIRef("DOM Events")}}{{SeeCompatTable}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.offsetX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/offsety/index.html
+++ b/files/en-us/web/api/mouseevent/offsety/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.offsetY
 ---
 <div>{{APIRef("DOM Events")}}{{SeeCompatTable}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.offsetY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/pagex/index.html
+++ b/files/en-us/web/api/mouseevent/pagex/index.html
@@ -13,6 +13,7 @@ tags:
   - UI Events
   - events
   - pageX
+browser-compat: api.MouseEvent.pageX
 ---
 <div>{{APIRef("CSSOM View")}}</div>
 
@@ -161,7 +162,7 @@ box.addEventListener("mouseleave", updateDisplay, false);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.pageX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/pagey/index.html
+++ b/files/en-us/web/api/mouseevent/pagey/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.pageY
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.pageY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/region/index.html
+++ b/files/en-us/web/api/mouseevent/region/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Read-only
   - Reference
+browser-compat: api.MouseEvent.region
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -53,7 +54,7 @@ canvas.addEventListener("mousemove", function(event){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.region")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.html
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Read-only
   - Reference
+browser-compat: api.MouseEvent.relatedTarget
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -163,7 +164,7 @@ function overListener(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.relatedTarget")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/screenx/index.html
+++ b/files/en-us/web/api/mouseevent/screenx/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.screenX
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -94,7 +95,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.screenX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/screeny/index.html
+++ b/files/en-us/web/api/mouseevent/screeny/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.screenY
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -80,7 +81,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.screenY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/shiftkey/index.html
+++ b/files/en-us/web/api/mouseevent/shiftkey/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.shiftKey
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -74,7 +75,7 @@ function logKey(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.shiftKey")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/which/index.html
+++ b/files/en-us/web/api/mouseevent/which/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.MouseEvent.which
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.which")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mouseevent/x/index.html
+++ b/files/en-us/web/api/mouseevent/x/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Property
   - Reference
+browser-compat: api.MouseEvent.x
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.x")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mouseevent/y/index.html
+++ b/files/en-us/web/api/mouseevent/y/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Property
   - Reference
+browser-compat: api.MouseEvent.y
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseEvent.y")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mousescrollevent/index.html
+++ b/files/en-us/web/api/mousescrollevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Event
   - Interface
   - Reference
+browser-compat: api.MouseScrollEvent
 ---
 <div>{{APIRef("DOM Events")}}{{ non-standard_header() }}{{deprecated_header}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseScrollEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mousewheelevent/index.html
+++ b/files/en-us/web/api/mousewheelevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Interface
   - Reference
+browser-compat: api.MouseWheelEvent
 ---
 <div>{{APIRef("DOM Events")}}{{ Non-standard_header() }}{{deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MouseWheelEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/msgestureevent/index.html
+++ b/files/en-us/web/api/msgestureevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Non-standard
   - Reference
+browser-compat: api.MSGestureEvent
 ---
 <p id="Summary">{{APIRef("DOM Events")}}</p>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MSGestureEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mutationevent/index.html
+++ b/files/en-us/web/api/mutationevent/index.html
@@ -8,6 +8,7 @@ tags:
   - MutationEvent
   - Reference
   - events
+browser-compat: api.MutationEvent
 ---
 <div>{{APIRef("DOM Events")}}{{Deprecated_Header}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mutationobserver/disconnect/index.html
+++ b/files/en-us/web/api/mutationobserver/disconnect/index.html
@@ -18,6 +18,7 @@ tags:
 - Watching
 - mutation
 - stop
+browser-compat: api.MutationObserver.disconnect
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -90,4 +91,4 @@ observer.disconnect();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserver.disconnect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserver/index.html
+++ b/files/en-us/web/api/mutationobserver/index.html
@@ -13,6 +13,7 @@ tags:
   - mutation
   - observers
   - resize
+browser-compat: api.MutationObserver
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -93,7 +94,7 @@ observer.disconnect();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/mutationobserver/mutationobserver/index.html
+++ b/files/en-us/web/api/mutationobserver/mutationobserver/index.html
@@ -13,6 +13,7 @@ tags:
 - MutationObserver
 - Observing
 - Reference
+browser-compat: api.MutationObserver.MutationObserver
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -145,4 +146,4 @@ observer.observe(targetNode, observerOptions);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserver.MutationObserver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserver/observe/index.html
+++ b/files/en-us/web/api/mutationobserver/observe/index.html
@@ -16,6 +16,7 @@ tags:
 - Node Changes
 - Reference
 - observe
+browser-compat: api.MutationObserver.observe
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -201,4 +202,4 @@ observer.observe(elementToObserve, {subtree: true, childList: true});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserver.observe")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserver/takerecords/index.html
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.html
@@ -15,6 +15,7 @@ tags:
 - Observer
 - mutation
 - takeRecords
+browser-compat: api.MutationObserver.takeRecords
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -101,4 +102,4 @@ if (mutations) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserver.takeRecords")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/attributefilter/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributefilter/index.html
@@ -13,6 +13,7 @@ tags:
 - Property
 - atttributeFilter
 - mutation
+browser-compat: api.MutationObserverInit.attributeFilter
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -122,4 +123,4 @@ observer.observe(userListElement, {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.attributeFilter")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/attributeoldvalue/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributeoldvalue/index.html
@@ -14,6 +14,7 @@ tags:
 - Property
 - Reference
 - value
+browser-compat: api.MutationObserverInit.attributeOldValue
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.attributeOldValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/attributes/index.html
+++ b/files/en-us/web/api/mutationobserverinit/attributes/index.html
@@ -13,6 +13,7 @@ tags:
 - Property
 - Reference
 - mutation
+browser-compat: api.MutationObserverInit.attributes
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -123,4 +124,4 @@ observer.observe(targetNode, {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.attributes")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/characterdata/index.html
+++ b/files/en-us/web/api/mutationobserverinit/characterdata/index.html
@@ -15,6 +15,7 @@ tags:
 - Text
 - Watching
 - characterData
+browser-compat: api.MutationObserverInit.characterData
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -91,4 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.characterData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/characterdataoldvalue/index.html
+++ b/files/en-us/web/api/mutationobserverinit/characterdataoldvalue/index.html
@@ -14,6 +14,7 @@ tags:
 - characterDataOldValue
 - mutation
 - value
+browser-compat: api.MutationObserverInit.characterDataOldValue
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.characterDataOldValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/childlist/index.html
+++ b/files/en-us/web/api/mutationobserverinit/childlist/index.html
@@ -15,6 +15,7 @@ tags:
 - childList
 - children
 - mutation
+browser-compat: api.MutationObserverInit.childList
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.childList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/index.html
+++ b/files/en-us/web/api/mutationobserverinit/index.html
@@ -14,6 +14,7 @@ tags:
   - MutationObserverInit
   - Observer
   - mutation
+browser-compat: api.MutationObserverInit
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationobserverinit/subtree/index.html
+++ b/files/en-us/web/api/mutationobserverinit/subtree/index.html
@@ -15,6 +15,7 @@ tags:
 - Watching
 - mutation
 - subtree
+browser-compat: api.MutationObserverInit.subtree
 ---
 <div>{{APIRef("DOM WHATWG")}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationObserverInit.subtree")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/mutationrecord/index.html
+++ b/files/en-us/web/api/mutationrecord/index.html
@@ -8,6 +8,7 @@ tags:
   - DOM Reference
   - NeedsContent
   - Reference
+browser-compat: api.MutationRecord
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -105,4 +106,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.MutationRecord")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/m* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

334 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
