### PR TITLE
Fix typo in “Handling text — strings in JavaScript” doc

### DIFF
--- a/files/en-us/learn/javascript/first_steps/strings/index.html
+++ b/files/en-us/learn/javascript/first_steps/strings/index.html
@@ -196,7 +196,7 @@ examReport = `You scored ${ examScore }/${ examHighestScore } (${ Math.round(exa
 <ul>
  <li>The first two placeholders here are pretty simple, only including a simple value in the string.</li>
  <li>The third one calculates a percentage result and rounds it to the nearest integer.</li>
- <li>The fourth one includes uses a ternary operator to check whether the score is above a certain mark and print a pass or fail message depending on the result.</li>
+ <li>The fourth one includes a ternary operator to check whether the score is above a certain mark and print a pass or fail message depending on the result.</li>
 </ul>
 
 <p>Another point to note is that if you want to split a traditional string over multiple lines, you need to include a newline character, <code>\n</code>:</p>


### PR DESCRIPTION

> What was wrong/why is this fix needed? (quick summary only)
There is an extra word .

> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings

