### PR TITLE
Put browser-compat info in front-runner for api/n*

### DIFF
--- a/files/en-us/web/api/namednodemap/getnameditem/index.html
+++ b/files/en-us/web/api/namednodemap/getnameditem/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - NamedNodeMap
 - Reference
+browser-compat: api.NamedNodeMap.getNamedItem
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -26,4 +27,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NamedNodeMap.getNamedItem")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/namednodemap/index.html
+++ b/files/en-us/web/api/namednodemap/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Interface
   - Reference
+browser-compat: api.NamedNodeMap
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NamedNodeMap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigationpreloadmanager/index.html
+++ b/files/en-us/web/api/navigationpreloadmanager/index.html
@@ -9,6 +9,7 @@ tags:
   - Offline
   - Reference
   - Service Workers
+browser-compat: api.NavigationPreloadManager
 ---
 <p>{{APIRef("Service Workers API")}}</p>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigationPreloadManager")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/activevrdisplays/index.html
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.html
@@ -12,6 +12,7 @@ tags:
 - Virtual Reality
 - WebVR
 - activeVRDisplays
+browser-compat: api.Navigator.activeVRDisplays
 ---
 <div>{{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.activeVRDisplays")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/battery/index.html
+++ b/files/en-us/web/api/navigator/battery/index.html
@@ -11,6 +11,7 @@ tags:
 - Non-standard
 - Property
 - Reference
+browser-compat: api.Navigator.battery
 ---
 <div>{{ApiRef("Battery API")}}{{deprecated_header}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.battery")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/buildid/index.html
+++ b/files/en-us/web/api/navigator/buildid/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML DOM
   - Navigator
   - Property
+browser-compat: api.Navigator.buildID
 ---
 <p>{{ ApiRef("HTML DOM") }}</p>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.buildID")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/canshare/index.html
+++ b/files/en-us/web/api/navigator/canshare/index.html
@@ -7,6 +7,7 @@ tags:
 - Navigator
 - Reference
 - Share
+browser-compat: api.Navigator.canShare
 ---
 <div>{{APIRef("HTML
   DOM")}}{{Non-standard_Header}}{{SeeCompatTable}}{{securecontext_header}}</div>
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.canShare")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/clearappbadge/index.html
+++ b/files/en-us/web/api/navigator/clearappbadge/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - clearAppBadge
   - Navigator
+browser-compat: api.Navigator.clearAppBadge
 ---
 <div>{{DefaultAPISidebar("Badging API")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.clearAppBadge")}}</p>
+<p>{{Compat}}</p>
 
 <h2>See also</h2>
 

--- a/files/en-us/web/api/navigator/clipboard/index.html
+++ b/files/en-us/web/api/navigator/clipboard/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - copy
 - paste
+browser-compat: api.Navigator.clipboard
 ---
 <p><span class="seoSummary">The <a href="/en-US/docs/Web/API/Clipboard_API">Clipboard
       API</a> adds to the <strong>{{domxref("Navigator")}}</strong> interface the
@@ -74,6 +75,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.clipboard")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{APIRef("Clipboard API")}}</div>

--- a/files/en-us/web/api/navigator/connection/index.html
+++ b/files/en-us/web/api/navigator/connection/index.html
@@ -9,6 +9,7 @@ tags:
 - Network Information API
 - Property
 - Reference
+browser-compat: api.Navigator.connection
 ---
 <div>{{APIRef("Network Information API")}}{{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.connection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/contacts/index.html
+++ b/files/en-us/web/api/navigator/contacts/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - contact picker
+browser-compat: api.Navigator.contacts
 ---
 <div>{{draft}}{{DefaultAPISidebar("Contact Picker API")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.contacts")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/cookieenabled/index.html
+++ b/files/en-us/web/api/navigator/cookieenabled/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML DOM
   - Navigator
   - Property
+browser-compat: api.Navigator.cookieEnabled
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.cookieEnabled")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/credentials/index.html
+++ b/files/en-us/web/api/navigator/credentials/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Reference
 - credentials
+browser-compat: api.Navigator.credentials
 ---
 <div>{{securecontext_header}}{{APIRef("")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.credentials")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/devicememory/index.html
+++ b/files/en-us/web/api/navigator/devicememory/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - deviceMemory
 - memory
+browser-compat: api.Navigator.deviceMemory
 ---
 <div>{{APIRef("Device Memory")}}{{securecontext_header}}{{SeeCompatTable}}</div>
 
@@ -57,7 +58,7 @@ console.log (`This device has at least ${memory}GiB of RAM.`)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.deviceMemory")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/donottrack/index.html
+++ b/files/en-us/web/api/navigator/donottrack/index.html
@@ -8,6 +8,7 @@ tags:
   - Navigator
   - Property
   - Reference
+browser-compat: api.Navigator.doNotTrack
 ---
 <div>{{ApiRef("HTML DOM")}}{{Deprecated_header}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.doNotTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/geolocation/index.html
+++ b/files/en-us/web/api/navigator/geolocation/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - Secure context
+browser-compat: api.Navigator.geolocation
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.geolocation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/getbattery/index.html
+++ b/files/en-us/web/api/navigator/getbattery/index.html
@@ -9,6 +9,7 @@ tags:
   - Navigator
   - Reference
   - getBattery
+browser-compat: api.Navigator.getBattery
 ---
 <div>{{ ApiRef("Battery API") }}</div>
 
@@ -98,7 +99,7 @@ navigator.getBattery().then(function(battery) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.getBattery")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/getgamepads/index.html
+++ b/files/en-us/web/api/navigator/getgamepads/index.html
@@ -9,6 +9,7 @@ tags:
 - Method
 - Navigator
 - Reference
+browser-compat: api.Navigator.getGamepads
 ---
 <p>{{APIRef("Gamepad API")}}{{SeeCompatTable}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.getGamepads")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/getusermedia/index.html
+++ b/files/en-us/web/api/navigator/getusermedia/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - getusermedia
+browser-compat: api.Navigator.getUserMedia
 ---
 <div>{{APIRef("Media Capture and Streams")}}{{deprecated_header}}</div>
 
@@ -134,7 +135,7 @@ if (navigator.getUserMedia) {
    </p>
 </div>
 
-<p>{{Compat("api.Navigator.getUserMedia")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/getvrdisplays/index.html
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.html
@@ -13,6 +13,7 @@ tags:
 - Virtual Reality
 - WebVR
 - getVRDisplays()
+browser-compat: api.Navigator.getVRDisplays
 ---
 <div>{{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.getVRDisplays")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/hid/index.html
+++ b/files/en-us/web/api/navigator/hid/index.html
@@ -8,6 +8,7 @@ tags:
 - WebHID API
 - Property
 - Reference
+browser-compat: api.Navigator.hid
 ---
 <div>{{APIRef("WebHID API")}}{{SeeCompatTable}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.hid")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/index.html
+++ b/files/en-us/web/api/navigator/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - Web Performance
+browser-compat: api.Navigator
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -184,4 +185,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Navigator")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/navigator/keyboard/index.html
+++ b/files/en-us/web/api/navigator/keyboard/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - keyboard
+browser-compat: api.Navigator.keyboard
 ---
 <div>{{SeeCompatTable}}{{APIRef("Keyboard API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.keyboard")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/locks/index.html
+++ b/files/en-us/web/api/navigator/locks/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Locks API
 - locks
+browser-compat: api.Navigator.locks
 ---
 <p>{{SeeCompatTable}}{{APIRef("Web Locks")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.locks")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/maxtouchpoints/index.html
+++ b/files/en-us/web/api/navigator/maxtouchpoints/index.html
@@ -7,6 +7,7 @@ tags:
 - Navigator
 - Property
 - Reference
+browser-compat: api.Navigator.maxTouchPoints
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Navigator.maxTouchPoints")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/navigator/mediacapabilities/index.html
+++ b/files/en-us/web/api/navigator/mediacapabilities/index.html
@@ -8,6 +8,7 @@ tags:
 - Media Capabilities API
 - MediaCapabilities
 - Navigator
+browser-compat: api.Navigator.mediaCapabilities
 ---
 <p>{{SeeCompatTable}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.mediaCapabilities")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/mediadevices/index.html
+++ b/files/en-us/web/api/navigator/mediadevices/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - Web
+browser-compat: api.Navigator.mediaDevices
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.mediaDevices")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/mediasession/index.html
+++ b/files/en-us/web/api/navigator/mediasession/index.html
@@ -15,6 +15,7 @@ tags:
 - UX
 - Video
 - metadata
+browser-compat: api.Navigator.mediaSession
 ---
 <p>{{APIRef}}</p>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.mediaSession")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/mozislocallyavailable/index.html
+++ b/files/en-us/web/api/navigator/mozislocallyavailable/index.html
@@ -7,6 +7,7 @@ tags:
 - Navigator
 - Non-standard
 - Deprecated
+browser-compat: api.Navigator.mozIsLocallyAvailable
 ---
 <div>{{APIRef("HTML DOM")}} {{non-standard_header}}{{deprecated_header}}</div>
 
@@ -51,4 +52,4 @@ if (available) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.mozIsLocallyAvailable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/mssaveblob/index.html
+++ b/files/en-us/web/api/navigator/mssaveblob/index.html
@@ -1,6 +1,7 @@
 ---
 title: Navigator.msSaveBlob
 slug: Web/API/Navigator/msSaveBlob
+browser-compat: api.Navigator.msSaveBlob
 ---
 <div>{{APIRef("HTML DOM")}}{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -49,4 +50,4 @@ X-Download-Options: noopen
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.msSaveBlob")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/mssaveoropenblob/index.html
+++ b/files/en-us/web/api/navigator/mssaveoropenblob/index.html
@@ -1,6 +1,7 @@
 ---
 title: Navigator.msSaveOrOpenBlob
 slug: Web/API/Navigator/msSaveOrOpenBlob
+browser-compat: api.Navigator.msSaveOrOpenBlob
 ---
 <div>{{APIRef("HTML DOM")}}{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -46,4 +47,4 @@ Content-Disposition: attachment;filename=&lt;defaultName&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.msSaveOrOpenBlob")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/oscpu/index.html
+++ b/files/en-us/web/api/navigator/oscpu/index.html
@@ -9,6 +9,7 @@ tags:
   - NavigatorID
   - Property
   - Reference
+browser-compat: api.Navigator.oscpu
 ---
 <p>{{ ApiRef("HTML DOM") }} {{Deprecated_Header}}</p>
 
@@ -106,4 +107,4 @@ osInfo(); // alerts "Windows NT 6.0" for example
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.oscpu")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/permissions/index.html
+++ b/files/en-us/web/api/navigator/permissions/index.html
@@ -8,6 +8,7 @@ tags:
 - Permissions
 - Property
 - Reference
+browser-compat: api.Navigator.permissions
 ---
 <p>{{APIRef("HTML DOM")}}{{SeeCompatTable}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.permissions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/presentation/index.html
+++ b/files/en-us/web/api/navigator/presentation/index.html
@@ -1,6 +1,7 @@
 ---
 title: Navigator.presentation
 slug: Web/API/Navigator/presentation
+browser-compat: api.Navigator.presentation
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{APIRef("Presentation API")}}</p>
 
@@ -37,7 +38,7 @@ slug: Web/API/Navigator/presentation
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.presentation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/productsub/index.html
+++ b/files/en-us/web/api/navigator/productsub/index.html
@@ -8,6 +8,7 @@ tags:
 - Navigator
 - Property
 - Read-only
+browser-compat: api.Navigator.productSub
 ---
 <div>{{ ApiRef("HTML DOM") }} {{Deprecated_Header}}</div>
 
@@ -62,4 +63,4 @@ function prodsub() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.productSub")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/registercontenthandler/index.html
+++ b/files/en-us/web/api/navigator/registercontenthandler/index.html
@@ -9,6 +9,7 @@ tags:
   - Deprecated
   - Web-Based Protocol Handlers
   - registerContentHandler
+browser-compat: api.Navigator.registerContentHandler
 ---
 <div>{{ApiRef("HTML DOM")}}{{deprecated_header}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.registerContentHandler")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.html
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web-Based Protocol Handlers
   - registerProtocolHandler
+browser-compat: api.Navigator.registerProtocolHandler
 ---
 <div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
 
@@ -172,7 +173,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.registerProtocolHandler")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.html
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - Video
 - requestMediaKeySystemAccess
+browser-compat: api.Navigator.requestMediaKeySystemAccess
 ---
 <div>{{APIRef("Encrypted Media Extensions")}}</div>
 
@@ -98,7 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.requestMediaKeySystemAccess")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Firefox_compatibility_notes">Firefox compatibility notes</h3>
 

--- a/files/en-us/web/api/navigator/sendbeacon/index.html
+++ b/files/en-us/web/api/navigator/sendbeacon/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Performance
 - sendBeacon
+browser-compat: api.Navigator.sendBeacon
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -145,7 +146,7 @@ navigator.sendBeacon(<var>url</var>, <var>data</var>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.sendBeacon")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/serial/index.html
+++ b/files/en-us/web/api/navigator/serial/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - serial
   - Navigator
+browser-compat: api.Navigator.serial
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.serial")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/serviceworker/index.html
+++ b/files/en-us/web/api/navigator/serviceworker/index.html
@@ -9,6 +9,7 @@ tags:
 - Service Workers
 - Service worker API
 - ServiceWorker
+browser-compat: api.Navigator.serviceWorker
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.serviceWorker")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/setappbadge/index.html
+++ b/files/en-us/web/api/navigator/setappbadge/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - setAppBadge
   - Navigator
+browser-compat: api.Navigator.setAppBadge
 ---
 <div>{{DefaultAPISidebar("Badging API")}}</div>
 
@@ -61,7 +62,7 @@ navigator.setAppBadge(unread);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.setAppBadge")}}</p>
+<p>{{Compat}}</p>
 
 <h2>See also</h2>
 

--- a/files/en-us/web/api/navigator/share/index.html
+++ b/files/en-us/web/api/navigator/share/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - Share
 - Web
+browser-compat: api.Navigator.share
 ---
 <div>{{APIRef("HTML DOM")}}{{securecontext_header}}</div>
 
@@ -111,7 +112,7 @@ btn.addEventListener('click', async () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.share")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/vendor/index.html
+++ b/files/en-us/web/api/navigator/vendor/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML DOM
   - Property
   - Read-only
+browser-compat: api.Navigator.vendor
 ---
 <p>{{ APIRef("HTML DOM") }}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.vendor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/vendorsub/index.html
+++ b/files/en-us/web/api/navigator/vendorsub/index.html
@@ -7,6 +7,7 @@ tags:
 - HTML DOM
 - Property
 - Read-only
+browser-compat: api.Navigator.vendorSub
 ---
 <div>{{ApiRef}} {{Deprecated_Header}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.vendorSub")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigator/vibrate/index.html
+++ b/files/en-us/web/api/navigator/vibrate/index.html
@@ -7,6 +7,7 @@ tags:
 - Navigator
 - Reference
 - Vibration API
+browser-compat: api.Navigator.vibrate
 ---
 <div>{{APIRef("Vibration API")}}</div>
 
@@ -64,7 +65,7 @@ window.navigator.vibrate([100,30,100,30,100,30,200,30,200,30,200,30,100,30,100,3
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.vibrate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/wakelock/index.html
+++ b/files/en-us/web/api/navigator/wakelock/index.html
@@ -5,6 +5,7 @@ tags:
 - API
 - Reference
 - Screen Wake Lock API
+browser-compat: api.Navigator.wakeLock
 ---
 <p>{{ApiRef("Screen Wake Lock API")}}{{SeeCompatTable}}{{securecontext_header}}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.wakeLock")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigator/webdriver/index.html
+++ b/files/en-us/web/api/navigator/webdriver/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - WebDriver
 - weblock
+browser-compat: api.Navigator.webdriver
 ---
 <div>{{SeeCompatTable}}{{APIRef("WebDriver")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Navigator.webdriver")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/navigator/xr/index.html
+++ b/files/en-us/web/api/navigator/xr/index.html
@@ -14,6 +14,7 @@ tags:
 - Virtual Reality
 - WebXR
 - XR
+browser-compat: api.Navigator.xr
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Navigator.xr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.html
+++ b/files/en-us/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.html
@@ -11,6 +11,7 @@ tags:
 - Worker
 - WorkerNavigator
 - hardwareConcurrency
+browser-compat: api.NavigatorConcurrentHardware.hardwareConcurrency
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -79,7 +80,7 @@ for (let i = 0; i &lt; window.navigator.hardwareConcurrency; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorConcurrentHardware.hardwareConcurrency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorconcurrenthardware/index.html
+++ b/files/en-us/web/api/navigatorconcurrenthardware/index.html
@@ -15,6 +15,7 @@ tags:
   - Threads
   - WorkerNavigator
   - Workers
+browser-compat: api.NavigatorConcurrentHardware
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorConcurrentHardware")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorid/appcodename/index.html
+++ b/files/en-us/web/api/navigatorid/appcodename/index.html
@@ -8,6 +8,7 @@ tags:
 - NavigatorID
 - Property
 - Reference
+browser-compat: api.NavigatorID.appCodeName
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.appCodeName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorid/appname/index.html
+++ b/files/en-us/web/api/navigatorid/appname/index.html
@@ -8,6 +8,7 @@ tags:
 - NavigatorID
 - Property
 - Reference
+browser-compat: api.NavigatorID.appName
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.appName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorid/appversion/index.html
+++ b/files/en-us/web/api/navigatorid/appversion/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - appVersion
+browser-compat: api.NavigatorID.appVersion
 ---
 <p>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.appVersion")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigatorid/index.html
+++ b/files/en-us/web/api/navigatorid/index.html
@@ -8,6 +8,7 @@ tags:
   - Navigator
   - NavigatorID
   - Reference
+browser-compat: api.NavigatorID
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorid/platform/index.html
+++ b/files/en-us/web/api/navigatorid/platform/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - platform
+browser-compat: api.NavigatorID.platform
 ---
 <p>{{ APIRef("HTML DOM") }} {{Deprecated_Header}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.platform")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigatorid/product/index.html
+++ b/files/en-us/web/api/navigatorid/product/index.html
@@ -7,6 +7,7 @@ tags:
 - NavigatorID
 - Property
 - Reference
+browser-compat: api.NavigatorID.product
 ---
 <div>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.product")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorid/taintenabled/index.html
+++ b/files/en-us/web/api/navigatorid/taintenabled/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - NavigatorID
 - Reference
+browser-compat: api.NavigatorID.taintEnabled
 ---
 <div>{{APIRef("HTML DOM")}} {{deprecated_header}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.taintEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorid/useragent/index.html
+++ b/files/en-us/web/api/navigatorid/useragent/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.NavigatorID.userAgent
 ---
 <p>{{ApiRef("HTML DOM")}}</p>
 
@@ -90,7 +91,7 @@ Application-Name Application-Name-version
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorID.userAgent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorlanguage/index.html
+++ b/files/en-us/web/api/navigatorlanguage/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - HTML-DOM
   - Reference
+browser-compat: api.NavigatorLanguage
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorLanguage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorlanguage/language/index.html
+++ b/files/en-us/web/api/navigatorlanguage/language/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.NavigatorLanguage.language
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorLanguage.language")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorlanguage/languages/index.html
+++ b/files/en-us/web/api/navigatorlanguage/languages/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - languages
+browser-compat: api.NavigatorLanguage.languages
 ---
 <p>{{APIRef("HTML DOM")}}{{SeeCompatTable}}</p>
 
@@ -61,7 +62,7 @@ navigator.languages  //["en-US", "zh-CN", "ja-JP"]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorLanguage.languages")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatoronline/index.html
+++ b/files/en-us/web/api/navigatoronline/index.html
@@ -4,6 +4,7 @@ slug: Web/API/NavigatorOnLine
 tags:
   - API
   - HTML-DOM
+browser-compat: api.NavigatorOnLine
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorOnLine")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatoronline/online/index.html
+++ b/files/en-us/web/api/navigatoronline/online/index.html
@@ -8,6 +8,7 @@ tags:
 - Online
 - Property
 - Reference
+browser-compat: api.NavigatorOnLine.onLine
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -100,7 +101,7 @@ window.addEventListener('online', function(e) { console.log('online'); });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorOnLine.onLine")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/api/navigatorplugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/index.html
@@ -11,6 +11,7 @@ tags:
   - NavigatorPlugins
   - Plugins
   - Reference
+browser-compat: api.NavigatorPlugins
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorPlugins")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorplugins/javaenabled/index.html
+++ b/files/en-us/web/api/navigatorplugins/javaenabled/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Method
   - Reference
+browser-compat: api.NavigatorPlugins.javaEnabled
 ---
 <p>{{ APIRef("HTML DOM") }}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorPlugins.javaEnabled")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigatorplugins/mimetypes/index.html
+++ b/files/en-us/web/api/navigatorplugins/mimetypes/index.html
@@ -5,6 +5,7 @@ tags:
 - API
 - Property
 - Reference
+browser-compat: api.NavigatorPlugins.mimeTypes
 ---
 <div>{{ ApiRef("HTML DOM") }}{{deprecated_header}}</div>
 
@@ -64,4 +65,4 @@ function getJavaPluginDescription() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorPlugins.mimeTypes")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/navigatorplugins/plugins/index.html
+++ b/files/en-us/web/api/navigatorplugins/plugins/index.html
@@ -9,6 +9,7 @@ tags:
 - Plugins
 - Property
 - Reference
+browser-compat: api.NavigatorPlugins.plugins
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
@@ -105,7 +106,7 @@ for(var i = 0; i &lt; pluginsLength; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorPlugins.plugins")}}</p>
+<p>{{Compat}}</p>
 
 <p>In addition to listing each plugin as a pseudo-array by zero-indexed numeric
   properties, Firefox provides properties that are the plugin name directly on the <a

--- a/files/en-us/web/api/navigatorstorage/index.html
+++ b/files/en-us/web/api/navigatorstorage/index.html
@@ -12,6 +12,7 @@ tags:
   - Storage
   - Storage Standard
   - WorkerNavigator
+browser-compat: api.NavigatorStorage
 ---
 <p>{{securecontext_header}}{{APIRef("Storage")}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorStorage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/navigatorstorage/storage/index.html
+++ b/files/en-us/web/api/navigatorstorage/storage/index.html
@@ -10,6 +10,7 @@ tags:
 - Secure context
 - Storage
 - WorkerNavigator
+browser-compat: api.NavigatorStorage.storage
 ---
 <p>{{securecontext_header}}{{APIRef("Storage")}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NavigatorStorage.storage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/ndefmessage/index.html
+++ b/files/en-us/web/api/ndefmessage/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFMessage
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFMessage")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefmessage/records/index.html
+++ b/files/en-us/web/api/ndefmessage/records/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFMessage.records
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFMessage.records")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFReader
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefreader/ndefreader/index.html
+++ b/files/en-us/web/api/ndefreader/ndefreader/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFReader.NDEFReader
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef()}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReader.NDEFReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefreader/onreading/index.html
+++ b/files/en-us/web/api/ndefreader/onreading/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFReader.onreading
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReader.onreading")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/ndefreader/onreadingerror/index.html
+++ b/files/en-us/web/api/ndefreader/onreadingerror/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFReader.onreadingerror
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -25,4 +26,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReader.onreadingerror")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefreader/scan/index.html
+++ b/files/en-us/web/api/ndefreader/scan/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFReader.scan
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReader.scan")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefreader/write/index.html
+++ b/files/en-us/web/api/ndefreader/write/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFReader.write
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -82,4 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReader.write")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefreadingevent/index.html
+++ b/files/en-us/web/api/ndefreadingevent/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFReadingEvent
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFReadingEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/ndefrecord/data/index.html
+++ b/files/en-us/web/api/ndefrecord/data/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.data
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.data")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/encoding/index.html
+++ b/files/en-us/web/api/ndefrecord/encoding/index.html
@@ -6,6 +6,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.encoding
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.encoding")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/id/index.html
+++ b/files/en-us/web/api/ndefrecord/id/index.html
@@ -6,6 +6,7 @@ tags:
 - NDEFRecord
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.id
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/index.html
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFRecord
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/lang/index.html
+++ b/files/en-us/web/api/ndefrecord/lang/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.lang
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.lang")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/ndefrecord/mediatype/index.html
+++ b/files/en-us/web/api/ndefrecord/mediatype/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.mediaType
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.mediaType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/ndefrecord/index.html
+++ b/files/en-us/web/api/ndefrecord/ndefrecord/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.NDEFRecord
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.NDEFRecord")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/recordtype/index.html
+++ b/files/en-us/web/api/ndefrecord/recordtype/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.recordType
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.recordType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ndefrecord/torecords/index.html
+++ b/files/en-us/web/api/ndefrecord/torecords/index.html
@@ -5,6 +5,7 @@ tags:
 - NDEF
 - Reference
 - Web NFC
+browser-compat: api.NDEFRecord.toRecords
 ---
 <p>{{Draft}}{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NDEFRecord.toRecords")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/networkinformation/downlink/index.html
+++ b/files/en-us/web/api/networkinformation/downlink/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - downlink
+browser-compat: api.NetworkInformation.downlink
 ---
 <p>{{SeeCompatTable}}{{APIRef("Network Information API")}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.downlink")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/networkinformation/downlinkmax/index.html
+++ b/files/en-us/web/api/networkinformation/downlinkmax/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.NetworkInformation.downlinkMax
 ---
 <p>{{APIRef("Network Information API")}}{{SeeCompatTable}}</p>
 
@@ -76,4 +77,4 @@ navigator.connection.addEventListener('change', logConnectionType);</code></pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.downlinkMax")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/networkinformation/effectivetype/index.html
+++ b/files/en-us/web/api/networkinformation/effectivetype/index.html
@@ -8,6 +8,7 @@ tags:
 - NetworkInformation
 - Reference
 - effectiveType
+browser-compat: api.NetworkInformation.effectiveType
 ---
 <p>{{SeeCompatTable}}{{APIRef("Network Information API")}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.effectiveType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/networkinformation/index.html
+++ b/files/en-us/web/api/networkinformation/index.html
@@ -8,6 +8,7 @@ tags:
   - Network Information API
   - NetworkInformation
   - Reference
+browser-compat: api.NetworkInformation
 ---
 <div>{{APIRef("Network Information API")}}{{SeeCompatTable}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/networkinformation/onchange/index.html
+++ b/files/en-us/web/api/networkinformation/onchange/index.html
@@ -9,6 +9,7 @@ tags:
 - NetworkInformation
 - Property
 - Reference
+browser-compat: api.NetworkInformation.onchange
 ---
 <p>{{apiref("Network Information API")}}{{SeeCompatTable}}</p>
 
@@ -56,4 +57,4 @@ navigator.connection.onchange = changeHandler;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/networkinformation/rtt/index.html
+++ b/files/en-us/web/api/networkinformation/rtt/index.html
@@ -10,6 +10,7 @@ tags:
 - Read-only
 - Reference
 - rtt
+browser-compat: api.NetworkInformation.rtt
 ---
 <p>{{apiref("Network Information API")}}{{SeeCompatTable}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.rtt")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/networkinformation/savedata/index.html
+++ b/files/en-us/web/api/networkinformation/savedata/index.html
@@ -10,6 +10,7 @@ tags:
 - Read-only
 - Reference
 - saveData
+browser-compat: api.NetworkInformation.saveData
 ---
 <div>{{APIRef("Network Information API")}}{{SeeCompatTable}}</div>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.saveData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/networkinformation/type/index.html
+++ b/files/en-us/web/api/networkinformation/type/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.NetworkInformation.type
 ---
 <p>{{apiref("Network Information API")}}{{SeeCompatTable}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NetworkInformation.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/appendchild/index.html
+++ b/files/en-us/web/api/node/appendchild/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.Node.appendChild
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -103,7 +104,7 @@ document.body.appendChild(p);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.appendChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/baseuri/index.html
+++ b/files/en-us/web/api/node/baseuri/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Property
 - Read-only
+browser-compat: api.Node.baseURI
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.baseURI")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/childnodes/index.html
+++ b/files/en-us/web/api/node/childnodes/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Property
 - Reference
+browser-compat: api.Node.childNodes
 ---
 <div>
   <div>{{APIRef("DOM")}}</div>
@@ -99,7 +100,7 @@ while (box.firstChild) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.childNodes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/clonenode/index.html
+++ b/files/en-us/web/api/node/clonenode/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - NeedsBrowserCompatibility
 - Reference
+browser-compat: api.Node.cloneNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -127,4 +128,4 @@ let p_prime = p.cloneNode(true)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.cloneNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/comparedocumentposition/index.html
+++ b/files/en-us/web/api/node/comparedocumentposition/index.html
@@ -10,6 +10,7 @@ tags:
 - Position
 - Reference
 - compareDocumentPosition
+browser-compat: api.Node.compareDocumentPosition
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -127,7 +128,7 @@ if (head.compareDocumentPosition(body) &amp; Node.DOCUMENT_POSITION_FOLLOWING) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.compareDocumentPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/contains/index.html
+++ b/files/en-us/web/api/node/contains/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Node
+browser-compat: api.Node.contains
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.contains")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/firstchild/index.html
+++ b/files/en-us/web/api/node/firstchild/index.html
@@ -7,6 +7,7 @@ tags:
 - Node
 - Property
 - Reference
+browser-compat: api.Node.firstChild
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -98,4 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.firstChild")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/getrootnode/index.html
+++ b/files/en-us/web/api/node/getrootnode/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Reference
 - getRootNode
+browser-compat: api.Node.getRootNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -104,4 +105,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.getRootNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/getuserdata/index.html
+++ b/files/en-us/web/api/node/getuserdata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Deprecated
 - Reference
+browser-compat: api.Node.getUserData
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -62,7 +63,7 @@ console.log(document.getUserData('key')); // 15</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.getUserData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/haschildnodes/index.html
+++ b/files/en-us/web/api/node/haschildnodes/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsSpecTable
 - Node
 - Reference
+browser-compat: api.Node.hasChildNodes
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,7 +77,7 @@ if (foo.hasChildNodes()) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.hasChildNodes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/index.html
+++ b/files/en-us/web/api/node/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Structure
 - hierarchy
+browser-compat: api.Node
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -447,4 +448,4 @@ console.log(mistakes)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/insertbefore/index.html
+++ b/files/en-us/web/api/node/insertbefore/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.Node.insertBefore
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -197,7 +198,7 @@ parentElement.insertBefore(newElement, theFirstChild)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.insertBefore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/isconnected/index.html
+++ b/files/en-us/web/api/node/isconnected/index.html
@@ -7,6 +7,7 @@ tags:
 - Node
 - Property
 - Reference
+browser-compat: api.Node.isConnected
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -94,7 +95,7 @@ console.log(style.isConnected); // Returns true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.isConnected")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="see_also">See also</h2>
 

--- a/files/en-us/web/api/node/isdefaultnamespace/index.html
+++ b/files/en-us/web/api/node/isdefaultnamespace/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsSpecTable
 - Node
 - Reference
+browser-compat: api.Node.isDefaultNamespace
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -60,4 +61,4 @@ alert(el.isDefaultNamespace(XULNS)); // true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.isDefaultNamespace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/isequalnode/index.html
+++ b/files/en-us/web/api/node/isequalnode/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.Node.isEqualNode
 ---
 <div>
   <div>{{APIRef("DOM")}}</div>
@@ -90,7 +91,7 @@ output.innerHTML += "div 0 equals div 2: " + divList[0].isEqualNode(divList[2]) 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.isEqualNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/issamenode/index.html
+++ b/files/en-us/web/api/node/issamenode/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.Node.isSameNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -94,7 +95,7 @@ output.innerHTML += "div 0 same as div 2: " + divList[0].isSameNode(divList[2]) 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.isSameNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/issupported/index.html
+++ b/files/en-us/web/api/node/issupported/index.html
@@ -10,6 +10,7 @@ tags:
 - Node
 - Deprecated
 - Reference
+browser-compat: api.Node.isSupported
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.isSupported")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/lastchild/index.html
+++ b/files/en-us/web/api/node/lastchild/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - Reference
+browser-compat: api.Node.lastChild
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -61,4 +62,4 @@ var corner_td = tr.lastChild;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.lastChild")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/lookupnamespaceuri/index.html
+++ b/files/en-us/web/api/node/lookupnamespaceuri/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsSpecTable
 - Node
 - Reference
+browser-compat: api.Node.lookupNamespaceURI
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.lookupNamespaceURI")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/lookupprefix/index.html
+++ b/files/en-us/web/api/node/lookupprefix/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Node
   - Reference
+browser-compat: api.Node.lookupPrefix
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -14,7 +15,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.lookupPrefix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/nextsibling/index.html
+++ b/files/en-us/web/api/node/nextsibling/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Node
 - Property
+browser-compat: api.Node.nextSibling
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -115,7 +116,7 @@ console.groupEnd();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.nextSibling")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/nodename/index.html
+++ b/files/en-us/web/api/node/nodename/index.html
@@ -9,6 +9,7 @@ tags:
 - Node
 - Property
 - Read-only
+browser-compat: api.Node.nodeName
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -128,4 +129,4 @@ text_field.value = div1.nodeName;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.nodeName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/nodetype/index.html
+++ b/files/en-us/web/api/node/nodetype/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - Reference
+browser-compat: api.Node.nodeType
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -185,4 +186,4 @@ if (node.nodeType !== Node.COMMENT_NODE) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.nodeType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/nodevalue/index.html
+++ b/files/en-us/web/api/node/nodevalue/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Property
 - Reference
+browser-compat: api.Node.nodeValue
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -110,4 +111,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.nodeValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/normalize/index.html
+++ b/files/en-us/web/api/node/normalize/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsSpecTable
   - Node
   - Reference
+browser-compat: api.Node.normalize
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,7 +56,7 @@ wrapper.normalize();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.normalize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/ownerdocument/index.html
+++ b/files/en-us/web/api/node/ownerdocument/index.html
@@ -7,6 +7,7 @@ tags:
 - Node
 - Property
 - Reference
+browser-compat: api.Node.ownerDocument
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -53,4 +54,4 @@ var html = d.documentElement;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.ownerDocument")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/node/parentelement/index.html
+++ b/files/en-us/web/api/node/parentelement/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsBrowserCompatibility
 - Node
 - Property
+browser-compat: api.Node.parentElement
 ---
 <div>
   <div>{{APIRef("DOM")}}</div>
@@ -59,7 +60,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.Node.parentElement")}}</p>
+  <p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/node/parentnode/index.html
+++ b/files/en-us/web/api/node/parentnode/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Gecko
 - Property
+browser-compat: api.Node.parentNode
 ---
 <div>
   <div>{{APIRef("DOM")}}</div>
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.parentNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/previoussibling/index.html
+++ b/files/en-us/web/api/node/previoussibling/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Gecko
 - Property
+browser-compat: api.Node.previousSibling
 ---
 <div>
   <div>{{APIRef("DOM")}}</div>
@@ -112,7 +113,7 @@ document.getElementById("b2").previousSibling.id;              // undefined
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.previousSibling")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/removechild/index.html
+++ b/files/en-us/web/api/node/removechild/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsSpecTable
 - Node
 - Reference
+browser-compat: api.Node.removeChild
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -161,7 +162,7 @@ while (element.firstChild) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.removeChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/replacechild/index.html
+++ b/files/en-us/web/api/node/replacechild/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Node
 - Reference
+browser-compat: api.Node.replaceChild
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -92,7 +93,7 @@ parentDiv.replaceChild(sp1, sp2);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.replaceChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/setuserdata/index.html
+++ b/files/en-us/web/api/node/setuserdata/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - Deprecated
 - Reference
+browser-compat: api.Node.setUserData
 ---
 <div>{{APIRef("DOM")}}{{deprecated_header}}</div>
 
@@ -85,7 +86,7 @@ console.log(e.getUserData('key')); // null since user data is not copied
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.setUserData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/node/textcontent/index.html
+++ b/files/en-us/web/api/node/textcontent/index.html
@@ -7,6 +7,7 @@ tags:
 - Node
 - Property
 - Reference
+browser-compat: api.Node.textContent
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -134,7 +135,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Node.textContent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodefilter/acceptnode/index.html
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - NodeFilter
+browser-compat: api.NodeFilter.acceptNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -122,7 +123,7 @@ while ((node = iterator.nextNode())) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeFilter.acceptNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodefilter/index.html
+++ b/files/en-us/web/api/nodefilter/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - DOM
   - DOM Reference
+browser-compat: api.NodeFilter
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -120,7 +121,7 @@ while ((node = nodeIterator.nextNode())) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeFilter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/detach/index.html
+++ b/files/en-us/web/api/nodeiterator/detach/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - NodeIterator
 - Deprecated
+browser-compat: api.NodeIterator.detach
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 
@@ -64,7 +65,7 @@ nodeIterator.nextNode(); // throws an INVALID_STATE_ERR exception
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.detach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
+++ b/files/en-us/web/api/nodeiterator/expandentityreferences/index.html
@@ -7,6 +7,7 @@ tags:
 - Deprecated
 - NodeIterator
 - Property
+browser-compat: api.NodeIterator.expandEntityReferences
 ---
 <p>{{APIRef("DOM")}} {{deprecated_header}}</p>
 
@@ -54,7 +55,7 @@ expand = nodeIterator.expandEntityReferences;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.expandEntityReferences")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/filter/index.html
+++ b/files/en-us/web/api/nodeiterator/filter/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - NodeIterator
 - Property
+browser-compat: api.NodeIterator.filter
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -64,7 +65,7 @@ nodeFilter = nodeIterator.filter;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.filter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/index.html
+++ b/files/en-us/web/api/nodeiterator/index.html
@@ -4,6 +4,7 @@ slug: Web/API/NodeIterator
 tags:
 - API
 - DOM
+browser-compat: api.NodeIterator
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -200,7 +201,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/nextnode/index.html
+++ b/files/en-us/web/api/nodeiterator/nextnode/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - NodeIterator
+browser-compat: api.NodeIterator.nextNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -65,7 +66,7 @@ currentNode = nodeIterator.nextNode(); // returns the next node
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.nextNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.html
@@ -7,6 +7,7 @@ tags:
 - Experimental
 - NodeIterator
 - Property
+browser-compat: api.NodeIterator.pointerBeforeReferenceNode
 ---
 <p>{{APIRef("DOM")}} {{SeeCompatTable}}</p>
 
@@ -51,7 +52,7 @@ flag = nodeIterator.pointerBeforeReferenceNode;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.pointerBeforeReferenceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/previousnode/index.html
+++ b/files/en-us/web/api/nodeiterator/previousnode/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - NodeIterator
+browser-compat: api.NodeIterator.previousNode
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -66,7 +67,7 @@ previousNode = nodeIterator.previousNode(); // same result, since we backtracked
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.previousNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/referencenode/index.html
+++ b/files/en-us/web/api/nodeiterator/referencenode/index.html
@@ -7,6 +7,7 @@ tags:
 - Experimental
 - NodeIterator
 - Property
+browser-compat: api.NodeIterator.referenceNode
 ---
 <p>{{APIRef("DOM")}}{{ SeeCompatTable }}</p>
 
@@ -50,7 +51,7 @@ node = nodeIterator.referenceNode;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.referenceNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/root/index.html
+++ b/files/en-us/web/api/nodeiterator/root/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - NodeIterator
 - Property
+browser-compat: api.NodeIterator.root
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -55,7 +56,7 @@ root = nodeIterator.root; // document.body in this case
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.root")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.html
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - NodeIterator
 - Property
+browser-compat: api.NodeIterator.whatToShow
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -151,7 +152,7 @@ if( (nodeIterator.whatToShow == NodeFilter.SHOW_ALL) ||
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeIterator.whatToShow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodelist/entries/index.html
+++ b/files/en-us/web/api/nodelist/entries/index.html
@@ -8,6 +8,7 @@ tags:
 - Node
 - NodeList
 - Polyfill
+browser-compat: api.NodeList.entries
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -49,7 +50,7 @@ Array [ 2, &lt;span&gt; ]</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList.entries")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodelist/foreach/index.html
+++ b/files/en-us/web/api/nodelist/foreach/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web
 - Polyfill
+browser-compat: api.NodeList.forEach
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -121,7 +122,7 @@ list.forEach(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList.forEach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodelist/index.html
+++ b/files/en-us/web/api/nodelist/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Interface
   - NodeList
+browser-compat: api.NodeList
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -126,4 +127,4 @@ Array.prototype.forEach.call(list, function (checkbox) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/nodelist/item/index.html
+++ b/files/en-us/web/api/nodelist/item/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - NodeList
 - Reference
+browser-compat: api.NodeList.item
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -66,4 +67,4 @@ var firstTable = tables.item(1); // or tables[1] - returns the <strong>second</s
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList.item")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/nodelist/keys/index.html
+++ b/files/en-us/web/api/nodelist/keys/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web
 - Polyfill
+browser-compat: api.NodeList.keys
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -52,7 +53,7 @@ for(var key of list.keys()) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/nodelist/length/index.html
+++ b/files/en-us/web/api/nodelist/length/index.html
@@ -9,6 +9,7 @@ tags:
 - NodeList
 - Property
 - Reference
+browser-compat: api.NodeList.length
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -65,4 +66,4 @@ for (let i = 0; i &lt; items.length; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/nodelist/values/index.html
+++ b/files/en-us/web/api/nodelist/values/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web
 - Polyfill
+browser-compat: api.NodeList.values
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -52,7 +53,7 @@ for(var value of list.values()) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NodeList.values")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/actions/index.html
+++ b/files/en-us/web/api/notification/actions/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - actions
+browser-compat: api.Notification.actions
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.actions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/badge/index.html
+++ b/files/en-us/web/api/notification/badge/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - badge
+browser-compat: api.Notification.badge
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.badge")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/notification/body/index.html
+++ b/files/en-us/web/api/notification/body/index.html
@@ -9,6 +9,7 @@ tags:
 - Notifications API
 - Property
 - Reference
+browser-compat: api.Notification.body
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.body")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/close/index.html
+++ b/files/en-us/web/api/notification/close/index.html
@@ -9,6 +9,7 @@ tags:
 - Notifications API
 - Reference
 - close
+browser-compat: api.Notification.close
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/data/index.html
+++ b/files/en-us/web/api/notification/data/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - data
+browser-compat: api.Notification.data
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -63,7 +64,7 @@ console.log(n.data) // should return 'I like peas.'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/dir/index.html
+++ b/files/en-us/web/api/notification/dir/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - dir
+browser-compat: api.Notification.dir
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -66,7 +67,7 @@ console.log(n.dir) // should return 'rtl'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.dir")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/icon/index.html
+++ b/files/en-us/web/api/notification/icon/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - icon
+browser-compat: api.Notification.icon
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.icon")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/image/index.html
+++ b/files/en-us/web/api/notification/image/index.html
@@ -9,6 +9,7 @@ tags:
 - Notifications API
 - Property
 - Reference
+browser-compat: api.Notification.image
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.image")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/index.html
+++ b/files/en-us/web/api/notification/index.html
@@ -7,6 +7,7 @@ tags:
   - Notifications
   - Notifications API
   - Reference
+browser-compat: api.Notification
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -167,7 +168,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/lang/index.html
+++ b/files/en-us/web/api/notification/lang/index.html
@@ -8,6 +8,7 @@ tags:
 - Notifications API
 - Property
 - Reference
+browser-compat: api.Notification.lang
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -65,7 +66,7 @@ console.log(n.lang) // should return 'en-US'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.lang")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/maxactions/index.html
+++ b/files/en-us/web/api/notification/maxactions/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - actions
+browser-compat: api.Notification.maxActions
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -56,7 +57,7 @@ console.log('This device can display at most ' + maxActions + ' actions on each 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.maxActions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/notification/index.html
+++ b/files/en-us/web/api/notification/notification/index.html
@@ -8,6 +8,7 @@ tags:
 - Notifications
 - Notifications API
 - Reference
+browser-compat: api.Notification.Notification
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -114,7 +115,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.Notification")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Chrome_notes">Chrome notes</h3>
 

--- a/files/en-us/web/api/notification/onclick/index.html
+++ b/files/en-us/web/api/notification/onclick/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onclick
+browser-compat: api.Notification.onclick
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.onclick")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/onclose/index.html
+++ b/files/en-us/web/api/notification/onclose/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onclose
+browser-compat: api.Notification.onclose
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -24,7 +25,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.onclose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/onerror/index.html
+++ b/files/en-us/web/api/notification/onerror/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onerror
+browser-compat: api.Notification.onerror
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/onshow/index.html
+++ b/files/en-us/web/api/notification/onshow/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - onshow
+browser-compat: api.Notification.onshow
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -24,7 +25,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.onshow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/permission/index.html
+++ b/files/en-us/web/api/notification/permission/index.html
@@ -8,6 +8,7 @@ tags:
 - Notifications API
 - Property
 - Reference
+browser-compat: api.Notification.permission
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.permission")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/renotify/index.html
+++ b/files/en-us/web/api/notification/renotify/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - renotify
+browser-compat: api.Notification.renotify
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -62,7 +63,7 @@ console.log(n.renotify) // should log true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.renotify")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/requestpermission/index.html
+++ b/files/en-us/web/api/notification/requestpermission/index.html
@@ -8,6 +8,7 @@ tags:
   - Notifications
   - Notifications API
   - Reference
+browser-compat: api.Notification.requestPermission
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.requestPermission")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/requireinteraction/index.html
+++ b/files/en-us/web/api/notification/requireinteraction/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - requireInteraction
+browser-compat: api.Notification.requireInteraction
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.requireInteraction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/silent/index.html
+++ b/files/en-us/web/api/notification/silent/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - silent
+browser-compat: api.Notification.silent
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -62,7 +63,7 @@ console.log(n.silent) // should log true</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.silent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/tag/index.html
+++ b/files/en-us/web/api/notification/tag/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - tag
+browser-compat: api.Notification.tag
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.tag")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/timestamp/index.html
+++ b/files/en-us/web/api/notification/timestamp/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - timeStamp
+browser-compat: api.Notification.timestamp
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -68,7 +69,7 @@ console.log(n.timestamp) // should log original timestamp</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.timestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/title/index.html
+++ b/files/en-us/web/api/notification/title/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - Title
+browser-compat: api.Notification.title
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.title")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notification/vibrate/index.html
+++ b/files/en-us/web/api/notification/vibrate/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - vibrate
+browser-compat: api.Notification.vibrate
 ---
 <p>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</p>
 
@@ -65,7 +66,7 @@ console.log(n.vibrate) // should log [200,100,200]</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification.vibrate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/notificationevent/action/index.html
+++ b/files/en-us/web/api/notificationevent/action/index.html
@@ -11,6 +11,7 @@ tags:
   - Service Workers
   - ServiceWorker
   - action
+browser-compat: api.NotificationEvent.action
 ---
 <p>{{APIRef("Web Notifications")}}</p>
 
@@ -56,4 +57,4 @@ self.addEventListener('notificationclick', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NotificationEvent.action")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Service Workers
   - ServiceWorker
+browser-compat: api.NotificationEvent
 ---
 <p>{{APIRef("Web Notifications")}}</p>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NotificationEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/notificationevent/notification/index.html
+++ b/files/en-us/web/api/notificationevent/notification/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Service Workers
   - ServiceWorker
+browser-compat: api.NotificationEvent.notification
 ---
 <p>{{APIRef("Web Notifications")}}</p>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NotificationEvent.notification")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/notificationevent/notificationevent/index.html
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - ServiceWorker
+browser-compat: api.NotificationEvent.NotificationEvent
 ---
 <p>{{APIRef("Web Notifications")}}{{draft}}</p>
 
@@ -60,4 +61,4 @@ var myNotificationEvent = new NotificationEvent(type, init);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.NotificationEvent.NotificationEvent")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/n* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

177 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
