### PR TITLE
Put browser-compat info in front-runner for api/r*

### DIFF
--- a/files/en-us/web/api/radionodelist/index.html
+++ b/files/en-us/web/api/radionodelist/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML DOM
   - Interface
   - RadioNodeList
+browser-compat: api.RadioNodeList
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RadioNodeList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/radionodelist/value/index.html
+++ b/files/en-us/web/api/radionodelist/value/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - RadioNodeList
 - Reference
+browser-compat: api.RadioNodeList.value
 ---
 <div>{{ APIRef("HTML DOM") }}</div>
 
@@ -71,7 +72,7 @@ radios.value = 'red';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RadioNodeList.value")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/clonecontents/index.html
+++ b/files/en-us/web/api/range/clonecontents/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.cloneContents
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -59,7 +60,7 @@ document.body.appendChild(documentFragment);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.cloneContents")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/clonerange/index.html
+++ b/files/en-us/web/api/range/clonerange/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.cloneRange
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -53,7 +54,7 @@ clone = range.cloneRange();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.cloneRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/collapse/index.html
+++ b/files/en-us/web/api/range/collapse/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.collapse
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -64,7 +65,7 @@ range.collapse(true);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.collapse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/collapsed/index.html
+++ b/files/en-us/web/api/range/collapsed/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Range
   - Reference
+browser-compat: api.Range.collapsed
 ---
 <div>{{ APIRef("DOM") }}</div>
 
@@ -60,7 +61,7 @@ isCollapsed = range.collapsed;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.collapsed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/commonancestorcontainer/index.html
+++ b/files/en-us/web/api/range/commonancestorcontainer/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Range
+browser-compat: api.Range.commonAncestorContainer
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -134,7 +135,7 @@ function playAnimation(el) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.commonAncestorContainer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/compareboundarypoints/index.html
+++ b/files/en-us/web/api/range/compareboundarypoints/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.compareBoundaryPoints
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -87,7 +88,7 @@ compare = range.compareBoundaryPoints(Range.START_TO_END, sourceRange);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.compareBoundaryPoints")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/comparenode/index.html
+++ b/files/en-us/web/api/range/comparenode/index.html
@@ -11,6 +11,7 @@ tags:
   - Range
   - Reference
   - compareNode
+browser-compat: api.Range.compareNode
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_Header}}</p>
 
@@ -94,7 +95,7 @@ returnValue = range.compareNode(document.getElementsByTagName("p").item(0));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.compareNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/comparepoint/index.html
+++ b/files/en-us/web/api/range/comparepoint/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Range
   - Reference
+browser-compat: api.Range.comparePoint
 ---
 <div>{{ApiRef("DOM")}} {{SeeCompatTable}}</div>
 
@@ -64,7 +65,7 @@ returnValue = range.comparePoint(document.getElementsByTagName('p').item(0), 1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.comparePoint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/createcontextualfragment/index.html
+++ b/files/en-us/web/api/range/createcontextualfragment/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Range
   - Reference
+browser-compat: api.Range.createContextualFragment
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -62,7 +63,7 @@ document.body.appendChild(documentFragment);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.createContextualFragment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/deletecontents/index.html
+++ b/files/en-us/web/api/range/deletecontents/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.deleteContents
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -53,7 +54,7 @@ range.deleteContents();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.deleteContents")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/detach/index.html
+++ b/files/en-us/web/api/range/detach/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Range
+browser-compat: api.Range.detach
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -51,7 +52,7 @@ range.detach();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.detach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/endcontainer/index.html
+++ b/files/en-us/web/api/range/endcontainer/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Range
+browser-compat: api.Range.endContainer
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -53,7 +54,7 @@ endRangeNode = range.endContainer;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.endContainer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/endoffset/index.html
+++ b/files/en-us/web/api/range/endoffset/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Range
+browser-compat: api.Range.endOffset
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -60,7 +61,7 @@ endRangeOffset = range.endOffset;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.endOffset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/extractcontents/index.html
+++ b/files/en-us/web/api/range/extractcontents/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.extractContents
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -121,7 +122,7 @@ button.addEventListener('click', e =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.extractContents")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/getboundingclientrect/index.html
+++ b/files/en-us/web/api/range/getboundingclientrect/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - Range
 - Reference
+browser-compat: api.Range.getBoundingClientRect
 ---
 <div>{{ApiRef("DOM")}}{{SeeCompatTable}}</div>
 
@@ -81,7 +82,7 @@ highlight.style.height = `${clientRect.height}px`;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.getBoundingClientRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/getclientrects/index.html
+++ b/files/en-us/web/api/range/getclientrects/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Range
   - Reference
+browser-compat: api.Range.getClientRects
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -48,7 +49,7 @@ rectList = range.getClientRects();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.getClientRects")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/index.html
+++ b/files/en-us/web/api/range/index.html
@@ -4,6 +4,7 @@ slug: Web/API/Range
 tags:
   - API
   - DOM
+browser-compat: api.Range
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -135,7 +136,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/insertnode/index.html
+++ b/files/en-us/web/api/range/insertnode/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Method
 - Range
+browser-compat: api.Range.insertNode
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -65,7 +66,7 @@ range.insertNode(newNode);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.insertNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/intersectsnode/index.html
+++ b/files/en-us/web/api/range/intersectsnode/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Range
   - Reference
+browser-compat: api.Range.intersectsNode
 ---
 <div>{{ApiRef("DOM")}} {{SeeCompatTable}}</div>
 
@@ -54,7 +55,7 @@ var bool = range.intersectsNode(document.getElementsByTagName("p").item(0));</pr
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.intersectsNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/ispointinrange/index.html
+++ b/files/en-us/web/api/range/ispointinrange/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - Range
   - Reference
+browser-compat: api.Range.isPointInRange
 ---
 <p>{{ApiRef("DOM")}}{{SeeCompatTable}}</p>
 
@@ -58,7 +59,7 @@ bool = range.isPointInRange(document.getElementsByTagName("p").item(0),1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.isPointInRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/range/index.html
+++ b/files/en-us/web/api/range/range/index.html
@@ -9,6 +9,7 @@ tags:
   - Experimental
   - Range
   - Reference
+browser-compat: api.Range.Range
 ---
 <div>{{ APIRef("DOM") }} {{SeeCompatTable}}</div>
 
@@ -76,7 +77,7 @@ selection.addRange(range);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.Range")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/selectnode/index.html
+++ b/files/en-us/web/api/range/selectnode/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.selectNode
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -58,7 +59,7 @@ range.selectNode(referenceNode);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.selectNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/selectnodecontents/index.html
+++ b/files/en-us/web/api/range/selectnodecontents/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Range
   - Reference
+browser-compat: api.Range.selectNodeContents
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -106,7 +107,7 @@ deselectButton.addEventListener('click', e =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.selectNodeContents")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/setend/index.html
+++ b/files/en-us/web/api/range/setend/index.html
@@ -10,6 +10,7 @@ tags:
   - Range
   - Reference
   - setEnd
+browser-compat: api.Range.setEnd
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -98,7 +99,7 @@ range.setEnd(endNode, endOffset);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.setEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/setendafter/index.html
+++ b/files/en-us/web/api/range/setendafter/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.setEndAfter
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -58,7 +59,7 @@ range.setEndAfter(referenceNode);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.setEndAfter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/setendbefore/index.html
+++ b/files/en-us/web/api/range/setendbefore/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.setEndBefore
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -60,7 +61,7 @@ range.setEndBefore(referenceNode);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.setEndBefore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/setstart/index.html
+++ b/files/en-us/web/api/range/setstart/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.setStart
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -135,7 +136,7 @@ document.getElementById('log').textContent = range;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.setStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/setstartafter/index.html
+++ b/files/en-us/web/api/range/setstartafter/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.setStartAfter
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -60,7 +61,7 @@ range.setStartAfter(referenceNode);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.setStartAfter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/setstartbefore/index.html
+++ b/files/en-us/web/api/range/setstartbefore/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.setStartBefore
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -60,7 +61,7 @@ range.setStartBefore(referenceNode);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.setStartBefore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/startcontainer/index.html
+++ b/files/en-us/web/api/range/startcontainer/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Range
+browser-compat: api.Range.startContainer
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -52,7 +53,7 @@ startRangeNode = range.startContainer;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.startContainer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/startoffset/index.html
+++ b/files/en-us/web/api/range/startoffset/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Range
+browser-compat: api.Range.startOffset
 ---
 <p>{{ApiRef("DOM")}}</p>
 
@@ -60,7 +61,7 @@ var startRangeOffset = range.startOffset;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.startOffset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/surroundcontents/index.html
+++ b/files/en-us/web/api/range/surroundcontents/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Method
   - Range
+browser-compat: api.Range.surroundContents
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -81,7 +82,7 @@ range.surroundContents(newParent);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.surroundContents")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/range/tostring/index.html
+++ b/files/en-us/web/api/range/tostring/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Range
   - Stringifier
+browser-compat: api.Range.toString
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -66,7 +67,7 @@ document.getElementById('log').textContent = range.toString();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Range.toString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - byobRequest
+browser-compat: api.ReadableByteStreamController.byobRequest
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableByteStreamController.byobRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - close
+browser-compat: api.ReadableByteStreamController.close
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableByteStreamController.close")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - desiredSize
+browser-compat: api.ReadableByteStreamController.desiredSize
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableByteStreamController.desiredSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - enqueue
+browser-compat: api.ReadableByteStreamController.enqueue
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableByteStreamController.enqueue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/error/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/error/index.html
@@ -9,6 +9,7 @@ tags:
 - ReadableByteStreamController
 - Reference
 - Streams
+browser-compat: api.ReadableByteStreamController.error
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableByteStreamController.error")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablebytestreamcontroller/index.html
+++ b/files/en-us/web/api/readablebytestreamcontroller/index.html
@@ -9,6 +9,7 @@ tags:
   - ReadableByteStreamController
   - Reference
   - Streams
+browser-compat: api.ReadableByteStreamController
 ---
 <p>{{APIRef("Streams")}}{{SeeCompatTable}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableByteStreamController")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/cancel/index.html
+++ b/files/en-us/web/api/readablestream/cancel/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Streams
   - cancel
+browser-compat: api.ReadableStream.cancel
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -136,4 +137,4 @@ fetch(url).then(response =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.cancel")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/getreader/index.html
+++ b/files/en-us/web/api/readablestream/getreader/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - getReader
+browser-compat: api.ReadableStream.getReader
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -112,4 +113,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.getReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Streams
   - data
+browser-compat: api.ReadableStream
 ---
 <p>{{APIRef("Streams")}}</p>
 
@@ -134,7 +135,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/readablestream/locked/index.html
+++ b/files/en-us/web/api/readablestream/locked/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - locked
+browser-compat: api.ReadableStream.locked
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -55,4 +56,4 @@ stream.locked
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.locked")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/pipethrough/index.html
+++ b/files/en-us/web/api/readablestream/pipethrough/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - pipeThrough
+browser-compat: api.ReadableStream.pipeThrough
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -118,4 +119,4 @@ fetch('png-logo.png')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.pipeThrough")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/pipeto/index.html
+++ b/files/en-us/web/api/readablestream/pipeto/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Streams
   - pipeTo
+browser-compat: api.ReadableStream.pipeTo
 ---
 <div>{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -102,4 +103,4 @@ fetch('png-logo.png')
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.pipeTo")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/readablestream/index.html
+++ b/files/en-us/web/api/readablestream/readablestream/index.html
@@ -6,6 +6,7 @@ tags:
 - Constructor
 - ReadableStream
 - Reference
+browser-compat: api.ReadableStream.ReadableStream
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -163,4 +164,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.ReadableStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestream/tee/index.html
+++ b/files/en-us/web/api/readablestream/tee/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - tee
+browser-compat: api.ReadableStream.tee
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -108,4 +109,4 @@ function fetchStream(stream, list) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStream.tee")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - cancel
+browser-compat: api.ReadableStreamBYOBReader.cancel
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBReader.cancel")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/closed/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Streams
   - closed
+browser-compat: api.ReadableStreamBYOBReader.closed
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBReader.closed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/index.html
@@ -9,6 +9,7 @@ tags:
   - ReadableStreamBYOBReader
   - Reference
   - Streams
+browser-compat: api.ReadableStreamBYOBReader
 ---
 <p>{{APIRef("Streams")}}{{SeeCompatTable}}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/read/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Streams
   - read
+browser-compat: api.ReadableStreamBYOBReader.read
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBReader.read")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.html
@@ -8,6 +8,7 @@ tags:
 - ReadableStreamBYOBReader
 - Reference
 - Streams
+browser-compat: api.ReadableStreamBYOBReader.ReadableStreamBYOBReader
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBReader.ReadableStreamBYOBReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - releaseLock
+browser-compat: api.ReadableStreamBYOBReader.releaseLock
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBReader.releaseLock")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobrequest/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/index.html
@@ -9,6 +9,7 @@ tags:
   - ReadableStreamBYOBRequest
   - Reference
   - Steams
+browser-compat: api.ReadableStreamBYOBRequest
 ---
 <p>{{APIRef("Streams")}}{{SeeCompatTable}}{{draft}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobrequest/respond/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/respond/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - respond
+browser-compat: api.ReadableStreamBYOBRequest.respond
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBRequest.respond")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - respondWithNewView
+browser-compat: api.ReadableStreamBYOBRequest.respondWithNewView
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBRequest.respondWithNewView")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreambyobrequest/view/index.html
+++ b/files/en-us/web/api/readablestreambyobrequest/view/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Streams
 - View
+browser-compat: api.ReadableStreamBYOBRequest.view
 ---
 <div>{{draft}}{{SeeCompatTable}}{{APIRef("Streams")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamBYOBRequest.view")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/close/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/close/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - close
+browser-compat: api.ReadableStreamDefaultController.close
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -106,4 +107,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultController.close")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - desiredSize
+browser-compat: api.ReadableStreamDefaultController.desiredSize
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultController.desiredSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - enqueue
+browser-compat: api.ReadableStreamDefaultController.enqueue
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -102,4 +103,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultController.enqueue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/error/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/error/index.html
@@ -8,6 +8,7 @@ tags:
 - ReadableStreamDefaultController
 - Reference
 - Streams
+browser-compat: api.ReadableStreamDefaultController.error
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultController.error")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.html
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.html
@@ -8,6 +8,7 @@ tags:
   - ReadableStreamDefaultController
   - Reference
   - Streams
+browser-compat: api.ReadableStreamDefaultController
 ---
 <p>{{APIRef("Streams")}}</p>
 
@@ -92,4 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultController")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Streams
   - cancel
+browser-compat: api.ReadableStreamDefaultReader.cancel
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -113,4 +114,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultReader.cancel")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultreader/closed/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/closed/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Streams
   - closed
+browser-compat: api.ReadableStreamDefaultReader.closed
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultReader.closed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.html
@@ -8,6 +8,7 @@ tags:
   - ReadableStreamDefaultReader
   - Reference
   - Streams
+browser-compat: api.ReadableStreamDefaultReader
 ---
 <p>{{APIRef("Streams")}}</p>
 
@@ -92,4 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Streams
   - read
+browser-compat: api.ReadableStreamDefaultReader.read
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -154,4 +155,4 @@ for await (let line of makeTextFileLineIterator(urlOfFile)) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultReader.read")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.html
@@ -7,6 +7,7 @@ tags:
 - ReadableStreamDefaultReader
 - Reference
 - Streams
+browser-compat: api.ReadableStreamDefaultReader.ReadableStreamDefaultReader
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -104,4 +105,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultReader.ReadableStreamDefaultReader")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.html
+++ b/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Streams
 - releaseLock
+browser-compat: api.ReadableStreamDefaultReader.releaseLock
 ---
 <div>{{APIRef("Streams")}}</div>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReadableStreamDefaultReader.releaseLock")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.RelativeOrientationSensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -99,4 +100,4 @@ Promise.all([navigator.permissions.query({ name: "accelerometer" }),
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RelativeOrientationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
+++ b/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor
 - Sensor APIs
 - Sensors
+browser-compat: api.RelativeOrientationSensor.RelativeOrientationSensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RelativeOrientationSensor.RelativeOrientationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/report/body/index.html
+++ b/files/en-us/web/api/report/body/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Report
 - Reporting API
+browser-compat: api.Report.body
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -64,7 +65,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Report.body")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/report/index.html
+++ b/files/en-us/web/api/report/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Report
   - Reporting API
+browser-compat: api.Report
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
@@ -106,7 +107,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Report")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/report/url/index.html
+++ b/files/en-us/web/api/report/url/index.html
@@ -9,6 +9,7 @@ tags:
 - Report
 - Reporting API
 - URL
+browser-compat: api.Report.url
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -58,7 +59,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Report.url")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/reportingobserver/disconnect/index.html
+++ b/files/en-us/web/api/reportingobserver/disconnect/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Reporting API
 - ReportingObserver
+browser-compat: api.ReportingObserver.disconnect
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -63,7 +64,7 @@ observer.disconnect()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReportingObserver.disconnect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Reporting API
   - ReportingObserver
+browser-compat: api.ReportingObserver
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
@@ -97,7 +98,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReportingObserver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/reportingobserver/observe/index.html
+++ b/files/en-us/web/api/reportingobserver/observe/index.html
@@ -9,6 +9,7 @@ tags:
 - Reporting API
 - ReportingObserver
 - observe
+browser-compat: api.ReportingObserver.observe
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -54,7 +55,7 @@ observer.observe()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReportingObserver.observe")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/reportingobserver/reportingobserver/index.html
+++ b/files/en-us/web/api/reportingobserver/reportingobserver/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Reporting API
 - ReportingObserver
+browser-compat: api.ReportingObserver.ReportingObserver
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -81,7 +82,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReportingObserver.ReportingObserver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/reportingobserver/takerecords/index.html
+++ b/files/en-us/web/api/reportingobserver/takerecords/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Reporting API
 - ReportingObserver
+browser-compat: api.ReportingObserver.takeRecords
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -64,7 +65,7 @@ console.log(records);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReportingObserver.takeRecords")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/reportingobserveroptions/index.html
+++ b/files/en-us/web/api/reportingobserveroptions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Reporting API
   - ReportingObserverOptions
+browser-compat: api.ReportingObserverOptions
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
@@ -52,7 +53,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ReportingObserverOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/cache/index.html
+++ b/files/en-us/web/api/request/cache/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - request
+browser-compat: api.Request.cache
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -129,7 +130,7 @@ fetch("some.json", {cache: "only-if-cached", mode: "same-origin", signal: contro
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.cache")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/clone/index.html
+++ b/files/en-us/web/api/request/clone/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - clone
   - request
+browser-compat: api.Request.clone
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -56,7 +57,7 @@ var newRequest = myRequest.clone(); // a copy of the request is now stored in ne
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.clone")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/context/index.html
+++ b/files/en-us/web/api/request/context/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - request
+browser-compat: api.Request.context
 ---
 <div>{{APIRef("Fetch")}}{{Deprecated_Header}}</div>
 
@@ -50,7 +51,7 @@ var myContext = myRequest.context; // returns the empty string by default</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.context")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/credentials/index.html
+++ b/files/en-us/web/api/request/credentials/index.html
@@ -11,6 +11,7 @@ tags:
   - Security
   - credentials
   - request
+browser-compat: api.Request.credentials
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -58,7 +59,7 @@ var myCred = myRequest.credentials; // returns "same-origin" by default</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.credentials")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/destination/index.html
+++ b/files/en-us/web/api/request/destination/index.html
@@ -15,6 +15,7 @@ tags:
   - data
   - destination
   - request
+browser-compat: api.Request.destination
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -78,7 +79,7 @@ var myDestination = myRequest.destination; // returns the empty string by defaul
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.destination")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/headers/index.html
+++ b/files/en-us/web/api/request/headers/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - request
+browser-compat: api.Request.headers
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -71,7 +72,7 @@ myContentType = myRequest.headers.get('Content-Type'); // returns 'image/jpeg'</
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.headers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/index.html
+++ b/files/en-us/web/api/request/index.html
@@ -9,6 +9,7 @@ tags:
   - Networking
   - Reference
   - request
+browser-compat: api.Request
 ---
 <div>{{APIRef("Fetch API")}}</div>
 
@@ -158,7 +159,7 @@ const bodyUsed = request.bodyUsed;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/integrity/index.html
+++ b/files/en-us/web/api/request/integrity/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - integrity
   - request
+browser-compat: api.Request.integrity
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -50,7 +51,7 @@ var myIntegrity = myRequest.integrity;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.integrity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/method/index.html
+++ b/files/en-us/web/api/request/method/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - request
+browser-compat: api.Request.method
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -52,7 +53,7 @@ var myMethod = myRequest.method; // GET</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.method")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/mode/index.html
+++ b/files/en-us/web/api/request/mode/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - mode
   - request
+browser-compat: api.Request.mode
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -107,7 +108,7 @@ var myMode = myRequest.mode; // returns "cors" by default</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.mode")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/request/redirect/index.html
+++ b/files/en-us/web/api/request/redirect/index.html
@@ -9,6 +9,7 @@ tags:
   - Redirect
   - Reference
   - request
+browser-compat: api.Request.redirect
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -56,7 +57,7 @@ var myCred = myRequest.redirect;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.redirect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/referrer/index.html
+++ b/files/en-us/web/api/request/referrer/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - referrer
   - request
+browser-compat: api.Request.referrer
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -58,7 +59,7 @@ var myReferrer = myRequest.referrer; // returns "about:client" by default</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.referrer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/referrerpolicy/index.html
+++ b/files/en-us/web/api/request/referrerpolicy/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - referrerPolicy
   - request
+browser-compat: api.Request.referrerPolicy
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -56,7 +57,7 @@ var myReferrer = myRequest.referrerPolicy; // returns "" by default</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.referrerPolicy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/request/index.html
+++ b/files/en-us/web/api/request/request/index.html
@@ -8,6 +8,7 @@ tags:
   - Fetch
   - Reference
   - request
+browser-compat: api.Request.Request
 ---
 <div>{{APIRef("Fetch API")}}</div>
 
@@ -193,7 +194,7 @@ var myRequest = new Request('flowers.jpg', myInit);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.Request")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/request/url/index.html
+++ b/files/en-us/web/api/request/url/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - URL
   - request
+browser-compat: api.Request.url
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -53,7 +54,7 @@ var myURL = myRequest.url; // "https://mdn.github.io/fetch-examples/fetch-reques
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Request.url")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/requestdestination/index.html
+++ b/files/en-us/web/api/requestdestination/index.html
@@ -11,6 +11,7 @@ tags:
   - RequestDestination
   - Type
   - destination
+browser-compat: api.RequestDestination
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RequestDestination")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/resizeobserver/disconnect/index.html
+++ b/files/en-us/web/api/resizeobserver/disconnect/index.html
@@ -9,6 +9,7 @@ tags:
 - ResizeObserver
 - disconnect()
 - observers
+browser-compat: api.ResizeObserver.disconnect
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserver.disconnect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/index.html
@@ -11,6 +11,7 @@ tags:
   - ResizeObserver
   - content box
   - observers
+browser-compat: api.ResizeObserver
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -111,7 +112,7 @@ checkbox.addEventListener('change', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/resizeobserver/observe/index.html
+++ b/files/en-us/web/api/resizeobserver/observe/index.html
@@ -9,6 +9,7 @@ tags:
 - ResizeObserver
 - observe()
 - observers
+browser-compat: api.ResizeObserver.observe
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -100,4 +101,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserver.observe")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.html
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.html
@@ -8,6 +8,7 @@ tags:
 - Resize Observer API
 - ResizeObserver
 - observers
+browser-compat: api.ResizeObserver.ResizeObserver
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -99,4 +100,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserver.ResizeObserver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserver/unobserve/index.html
+++ b/files/en-us/web/api/resizeobserver/unobserve/index.html
@@ -9,6 +9,7 @@ tags:
 - ResizeObserver
 - observers
 - unobserve()
+browser-compat: api.ResizeObserver.unobserve
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -94,4 +95,4 @@ checkbox.addEventListener('change', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserver.unobserve")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/borderboxsize/index.html
@@ -9,6 +9,7 @@ tags:
 - Resize Observer API
 - ResizeObserverEntry
 - borderBoxSize
+browser-compat: api.ResizeObserverEntry.borderBoxSize
 ---
 <div>{{APIRef("Resize Observer API")}}{{SeeCompatTable}}</div>
 
@@ -82,4 +83,4 @@ resizeObserver.observe(document.querySelector('div'));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverEntry.borderBoxSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.html
@@ -9,6 +9,7 @@ tags:
 - Resize Observer API
 - ResizeObserverEntry
 - contentBoxSize
+browser-compat: api.ResizeObserverEntry.contentBoxSize
 ---
 <div>{{APIRef("Resize Observer API")}}{{SeeCompatTable}}</div>
 
@@ -92,4 +93,4 @@ resizeObserver.observe(document.querySelector('div'));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverEntry.contentBoxSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserverentry/contentrect/index.html
+++ b/files/en-us/web/api/resizeobserverentry/contentrect/index.html
@@ -11,6 +11,7 @@ tags:
 - ResizeObserverEntry
 - content box
 - observers
+browser-compat: api.ResizeObserverEntry.contentRect
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -83,4 +84,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverEntry.contentRect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserverentry/index.html
+++ b/files/en-us/web/api/resizeobserverentry/index.html
@@ -11,6 +11,7 @@ tags:
   - ResizeObserverEntry
   - content box
   - observers
+browser-compat: api.ResizeObserverEntry
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -76,4 +77,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverEntry")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserverentry/target/index.html
+++ b/files/en-us/web/api/resizeobserverentry/target/index.html
@@ -12,6 +12,7 @@ tags:
 - content box
 - observers
 - target
+browser-compat: api.ResizeObserverEntry.target
 ---
 <div>{{APIRef("Resize Observer API")}}</div>
 
@@ -81,4 +82,4 @@ resizeObserver.observe(document.querySelector('div'));</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverEntry.target")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.html
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - blockSize
   - ResizeObserverSize
+browser-compat: api.ResizeObserverSize.blockSize
 ---
 <div>{{DefaultAPISidebar("Resize Observer API")}}</div>
 
@@ -56,4 +57,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverSize.blockSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserversize/index.html
+++ b/files/en-us/web/api/resizeobserversize/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - ResizeObserverSize
+browser-compat: api.ResizeObserverSize
 ---
 <div>{{DefaultAPISidebar("Resize Observer API")}}</div>
 
@@ -63,4 +64,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.html
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - inlineSize
   - ResizeObserverSize
+browser-compat: api.ResizeObserverSize.inlineSize
 ---
 <div>{{DefaultAPISidebar("Resize Observer API")}}</div>
 
@@ -56,4 +57,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ResizeObserverSize.inlineSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/response/clone/index.html
+++ b/files/en-us/web/api/response/clone/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Response
   - clone
+browser-compat: api.Response.clone
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -86,7 +87,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.clone")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/error/index.html
+++ b/files/en-us/web/api/response/error/index.html
@@ -9,6 +9,7 @@ tags:
   - Method
   - Reference
   - Response
+browser-compat: api.Response.error
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.error")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/headers/index.html
+++ b/files/en-us/web/api/response/headers/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Response
+browser-compat: api.Response.headers
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -70,7 +71,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.headers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/index.html
+++ b/files/en-us/web/api/response/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - Response
+browser-compat: api.Response
 ---
 <div>{{APIRef("Fetch API")}}</div>
 
@@ -143,7 +144,7 @@ doAjax().then(console.log).catch(console.log);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/ok/index.html
+++ b/files/en-us/web/api/response/ok/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Response
   - ok
+browser-compat: api.Response.ok
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -72,7 +73,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.ok")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/redirect/index.html
+++ b/files/en-us/web/api/response/redirect/index.html
@@ -9,6 +9,7 @@ tags:
   - Redirect
   - Reference
   - Response
+browser-compat: api.Response.redirect
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.redirect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/redirected/index.html
+++ b/files/en-us/web/api/response/redirected/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Response
   - redirected
+browser-compat: api.Response.redirected
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.redirected")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/response/index.html
+++ b/files/en-us/web/api/response/response/index.html
@@ -8,6 +8,7 @@ tags:
   - Fetch
   - Reference
   - Response
+browser-compat: api.Response.Response
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -82,7 +83,7 @@ var myResponse = new Response(myBlob,init);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.Response")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/status/index.html
+++ b/files/en-us/web/api/response/status/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Response
   - status
+browser-compat: api.Response.status
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -70,7 +71,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.status")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/statustext/index.html
+++ b/files/en-us/web/api/response/statustext/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Response
   - statusText
+browser-compat: api.Response.statusText
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -75,7 +76,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.statusText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/type/index.html
+++ b/files/en-us/web/api/response/type/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Response
   - Type
+browser-compat: api.Response.type
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -71,7 +72,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/response/url/index.html
+++ b/files/en-us/web/api/response/url/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Response
   - URL
+browser-compat: api.Response.url
 ---
 <div>{{APIRef("Fetch")}}</div>
 
@@ -71,7 +72,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Response.url")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcansweroptions/index.html
+++ b/files/en-us/web/api/rtcansweroptions/index.html
@@ -13,6 +13,7 @@ tags:
   - answer
   - createAnswer
   - rtc
+browser-compat: api.RTCAnswerOptions
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCAnswerOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtccertificate/index.html
+++ b/files/en-us/web/api/rtccertificate/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebRTC
   - real-time communications
+browser-compat: api.RTCCertificate
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -39,4 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCCertificate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/bundlepolicy/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - bundlePolicy
+browser-compat: api.RTCConfiguration.bundlePolicy
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -133,7 +134,7 @@ let pc = new RTCPeerConnection(config);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCConfiguration.bundlePolicy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/certificates/index.html
+++ b/files/en-us/web/api/rtcconfiguration/certificates/index.html
@@ -81,7 +81,8 @@ let <em>certificates</em> = <em>rtcConfiguration</em>.certificates;
   for subsequent calls, the remote peer can tell you're the same caller. This also avoids
   the cost of generating new keys.</p>
 
-<p><strong>&lt;&lt;&lt;--- add link to information about identity ---&gt;&gt;&gt;</strong>
+<p><strong>&lt;&lt;&lt;--- add link to information about identity browser-compat: api.RTCConfiguration.certificates
+---&gt;&gt;&gt;</strong>
 </p>
 
 <h2 id="Examples">Examples</h2>
@@ -117,4 +118,4 @@ let <em>certificates</em> = <em>rtcConfiguration</em>.certificates;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCConfiguration.certificates")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcconfiguration/iceservers/index.html
+++ b/files/en-us/web/api/rtcconfiguration/iceservers/index.html
@@ -17,6 +17,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - iceServers
+browser-compat: api.RTCConfiguration.iceServers
 ---
   <p>{{DefaultAPISidebar("WebRTC API")}}</p>
 
@@ -103,7 +104,7 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
   <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-    <p>{{Compat("api.RTCConfiguration.iceServers")}}</p>
+    <p>{{Compat}}</p>
 
     <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
+++ b/files/en-us/web/api/rtcconfiguration/icetransportpolicy/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC API
 - WebRTC Device API\
 - iceTransportPolicy
+browser-compat: api.RTCConfiguration.iceTransportPolicy
 ---
 <p>{{DefaultAPISidebar("WebRTC API")}}</p>
 
@@ -98,4 +99,4 @@ let pc = new RTCPeerConnection(config);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCConfiguration.iceTransportPolicy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcconfiguration/index.html
+++ b/files/en-us/web/api/rtcconfiguration/index.html
@@ -11,6 +11,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - rtc
+browser-compat: api.RTCConfiguration
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -83,4 +84,4 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCConfiguration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcdatachannel/binarytype/index.html
+++ b/files/en-us/web/api/rtcdatachannel/binarytype/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebRTC
   - binaryType
+browser-compat: api.RTCDataChannel.binaryType
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}{{draft}}</p>
 
@@ -86,7 +87,7 @@ dc.onmessage = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.binaryType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamount/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - bufferedAmount
+browser-compat: api.RTCDataChannel.bufferedAmount
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -85,7 +86,7 @@ function showBufferedAmount(channel) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.bufferedAmount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.html
@@ -15,6 +15,7 @@ tags:
   - data
   - events
   - rtc
+browser-compat: api.RTCDataChannel.bufferedamountlow_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -88,7 +89,7 @@ pc.addEventListener("bufferedamountlow", ev =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.bufferedamountlow_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebRTC
   - bufferedAmountLowThreshold
+browser-compat: api.RTCDataChannel.bufferedAmountLowThreshold
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -81,7 +82,7 @@ dc.onbufferedamountlow = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.bufferedAmountLowThreshold")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/close/index.html
+++ b/files/en-us/web/api/rtcdatachannel/close/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC
   - WebRTC API
   - close
+browser-compat: api.RTCDataChannel.close
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -101,7 +102,7 @@ dc.onclose = function (
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/close_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/close_event/index.html
@@ -14,6 +14,7 @@ tags:
   - close
   - data
   - events
+browser-compat: api.RTCDataChannel.close_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.close_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/closing_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/closing_event/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC Device API
   - closing
   - events
+browser-compat: api.RTCDataChannel.closing_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.closing_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/error_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/error_event/index.html
@@ -16,6 +16,7 @@ tags:
   - data
   - events
   - rtc
+browser-compat: api.RTCDataChannel.error_event
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -145,7 +146,7 @@ dc.addEventListener("error", ev =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/id/index.html
+++ b/files/en-us/web/api/rtcdatachannel/id/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - id
+browser-compat: api.RTCDataChannel.id
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -74,7 +75,7 @@ console.log("Channel id: " + dc.id);</code></pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/index.html
+++ b/files/en-us/web/api/rtcdatachannel/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCDataChannel
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -80,7 +81,7 @@ dc.onclose = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/label/index.html
+++ b/files/en-us/web/api/rtcdatachannel/label/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - label
+browser-compat: api.RTCDataChannel.label
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -75,7 +76,7 @@ document.getElementById(&quot;channel-name&quot;).innerHTML =
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.label")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/maxpacketlifetime/index.html
+++ b/files/en-us/web/api/rtcdatachannel/maxpacketlifetime/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebRTC
   - maxPacketLifeTime
+browser-compat: api.RTCDataChannel.maxPacketLifeTime
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.maxPacketLifeTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/maxretransmits/index.html
+++ b/files/en-us/web/api/rtcdatachannel/maxretransmits/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebRTC
   - maxRetransmits
+browser-compat: api.RTCDataChannel.maxRetransmits
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.maxRetransmits")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/message_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/message_event/index.html
@@ -15,6 +15,7 @@ tags:
   - message
   - messaging
   - rtc
+browser-compat: api.RTCDataChannel.message_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.message_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/negotiated/index.html
+++ b/files/en-us/web/api/rtcdatachannel/negotiated/index.html
@@ -12,6 +12,7 @@ tags:
   - data
   - datachannel
   - negotiated
+browser-compat: api.RTCDataChannel.negotiated
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.negotiated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onbufferedamountlow/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC
 - buffering
 - onbufferedamountlow
+browser-compat: api.RTCDataChannel.onbufferedamountlow
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -76,4 +77,4 @@ dc.onbufferedamountlow = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.onbufferedamountlow")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcdatachannel/onclose/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclose/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - onclose
+browser-compat: api.RTCDataChannel.onclose
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -73,7 +74,7 @@ dc.onclose = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.onclose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onclosing/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onclosing/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - onclosing
+browser-compat: api.RTCDataChannel.onclosing
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}{{Draft}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.onclosing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onerror/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onerror/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - onerror
+browser-compat: api.RTCDataChannel.onerror
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -75,7 +76,7 @@ dc.onerror = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.onerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onmessage/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onmessage/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - onmessage
+browser-compat: api.RTCDataChannel.onmessage
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -70,7 +71,7 @@ dc.onmessage = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.onmessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/onopen/index.html
+++ b/files/en-us/web/api/rtcdatachannel/onopen/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - onopen
+browser-compat: api.RTCDataChannel.onopen
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -70,7 +71,7 @@ dc.onopen = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.onopen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/open_event/index.html
+++ b/files/en-us/web/api/rtcdatachannel/open_event/index.html
@@ -16,6 +16,7 @@ tags:
   - data
   - events
   - rtc
+browser-compat: api.RTCDataChannel.open_event
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.open_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/ordered/index.html
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - ordered
+browser-compat: api.RTCDataChannel.ordered
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -62,7 +63,7 @@ if (!dc.ordered) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.ordered")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/protocol/index.html
+++ b/files/en-us/web/api/rtcdatachannel/protocol/index.html
@@ -10,6 +10,7 @@ tags:
   - Read-only
   - Reference
   - WebRTC
+browser-compat: api.RTCDataChannel.protocol
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -77,7 +78,7 @@ function handleChannelMessage(dataChannel, msg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.protocol")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/readystate/index.html
+++ b/files/en-us/web/api/rtcdatachannel/readystate/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - readyState
+browser-compat: api.RTCDataChannel.readyState
 ---
 <div>{{APIRef("WebRTC")}}{{SeeCompatTable}}</div>
 
@@ -99,7 +100,7 @@ function sendMessage(msg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.readyState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/reliable/index.html
+++ b/files/en-us/web/api/rtcdatachannel/reliable/index.html
@@ -9,6 +9,7 @@ tags:
   - Read-only
   - WebRTC
   - reliable
+browser-compat: api.RTCDataChannel.reliable
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}{{deprecated_header}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.reliable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/send/index.html
+++ b/files/en-us/web/api/rtcdatachannel/send/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - datachannel
   - send
+browser-compat: api.RTCDataChannel.send
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -114,7 +115,7 @@ function sendMessage(msg) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.send")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannel/stream/index.html
+++ b/files/en-us/web/api/rtcdatachannel/stream/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebRTC
   - stream
+browser-compat: api.RTCDataChannel.stream
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}{{non-standard_header}}</p>
 
@@ -45,7 +46,7 @@ console.log("Data channel stream ID: " + </code>dataChannel.stream<code>);</code
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannel.stream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannelevent/channel/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/channel/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - channel
+browser-compat: api.RTCDataChannelEvent.channel
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannelEvent.channel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - datachannel
+browser-compat: api.RTCDataChannelEvent
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannelEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
+++ b/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.html
@@ -7,6 +7,7 @@ tags:
   - RTCDataChannelEvent
   - Reference
   - WebRTC
+browser-compat: api.RTCDataChannelEvent.RTCDataChannelEvent
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDataChannelEvent.RTCDataChannelEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - events
+browser-compat: api.RTCDtlsTransport.error_event
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDtlsTransport.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/icetransport/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/icetransport/index.html
@@ -12,6 +12,7 @@ tags:
 - Read-only
 - Reference
 - iceTransport
+browser-compat: api.RTCDtlsTransport.iceTransport
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}{{draft}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDtlsTransport.iceTransport")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsExample
   - RTCDtlsTransport
   - Reference
+browser-compat: api.RTCDtlsTransport
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -130,7 +131,7 @@ function tallySenders(pc) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDtlsTransport")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtlstransport/state/index.html
+++ b/files/en-us/web/api/rtcdtlstransport/state/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - WebRTC
 - state
+browser-compat: api.RTCDtlsTransport.state
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDtlsTransport.state")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/index.html
@@ -13,6 +13,7 @@ tags:
   - Touch-tone
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCDTMFSender
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFSender")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - insertDTMF
+browser-compat: api.RTCDTMFSender.insertDTMF
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFSender.insertDTMF")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/ontonechange/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/ontonechange/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC
 - WebRTC API
 - ontonechange
+browser-compat: api.RTCDTMFSender.ontonechange
 ---
 <div>{{ APIRef("WebRTC") }}{{draft}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFSender.ontonechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC
   - WebRTC API
   - toneBuffer
+browser-compat: api.RTCDTMFSender.toneBuffer
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -97,7 +98,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFSender.toneBuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.html
+++ b/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.html
@@ -10,6 +10,7 @@ tags:
   - WebRTC API
   - events
   - tonechange
+browser-compat: api.RTCDTMFSender.tonechange_event
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFSender.tonechange_event")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcdtmftonechangeevent/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/index.html
@@ -8,6 +8,7 @@ tags:
   - WebRTC
   - WebRTC API
   - events
+browser-compat: api.RTCDTMFToneChangeEvent
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFToneChangeEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCDTMFToneChangeEvent.RTCDTMFToneChangeEvent
 ---
 <div>{{APIRef("WebRTC")}}{{SeeCompatTable}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFToneChangeEvent.RTCDTMFToneChangeEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.html
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.html
@@ -10,6 +10,7 @@ tags:
 - WebRTC
 - WebRTC API
 - tone
+browser-compat: api.RTCDTMFToneChangeEvent.tone
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCDTMFToneChangeEvent.tone")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcerror/errordetail/index.html
+++ b/files/en-us/web/api/rtcerror/errordetail/index.html
@@ -19,6 +19,7 @@ tags:
 - details
 - errorDetail
 - rtc
+browser-compat: api.RTCError.errorDetail
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -96,4 +97,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCError.errorDetail")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerror/index.html
+++ b/files/en-us/web/api/rtcerror/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - WebRTC API
   - WebRTC Device API
+browser-compat: api.RTCError
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCError")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerror/receivedalert/index.html
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - receivedAlert
+browser-compat: api.RTCError.receivedAlert
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCError.receivedAlert")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.html
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - sctpCauseCode
+browser-compat: api.RTCError.sctpCauseCode
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCError.sctpCauseCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.html
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - sdpLineNumber
+browser-compat: api.RTCError.sdpLineNumber
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCError.sdpLineNumber")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerror/sentalert/index.html
+++ b/files/en-us/web/api/rtcerror/sentalert/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - sentAlert
+browser-compat: api.RTCError.sentAlert
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCError.sentAlert")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerrorevent/error/index.html
+++ b/files/en-us/web/api/rtcerrorevent/error/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - WebRTC Device API
+browser-compat: api.RTCErrorEvent.error
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -100,4 +101,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCErrorEvent.error")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcerrorevent/index.html
+++ b/files/en-us/web/api/rtcerrorevent/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - rtc
+browser-compat: api.RTCErrorEvent
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCErrorEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/address/index.html
+++ b/files/en-us/web/api/rtcicecandidate/address/index.html
@@ -15,6 +15,7 @@ tags:
 - SDP
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCIceCandidate.address
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -122,4 +123,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.address")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/candidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/candidate/index.html
@@ -15,6 +15,7 @@ tags:
   - WebRTC
   - WebRTC API
   - a-line
+browser-compat: api.RTCIceCandidate.candidate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -114,4 +115,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.candidate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/component/index.html
+++ b/files/en-us/web/api/rtcicecandidate/component/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - component
+browser-compat: api.RTCIceCandidate.component
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -82,4 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.component")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/foundation/index.html
+++ b/files/en-us/web/api/rtcicecandidate/foundation/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - foundation
+browser-compat: api.RTCIceCandidate.foundation
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.foundation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/index.html
@@ -15,6 +15,7 @@ tags:
   - Web RTC
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceCandidate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -98,4 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/port/index.html
+++ b/files/en-us/web/api/rtcicecandidate/port/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - WebRTC API
   - port
+browser-compat: api.RTCIceCandidate.port
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.port")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidate/priority/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - priority
+browser-compat: api.RTCIceCandidate.priority
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -103,4 +104,4 @@ function handleCandidate(candidateString) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.priority")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/protocol/index.html
+++ b/files/en-us/web/api/rtcicecandidate/protocol/index.html
@@ -12,6 +12,7 @@ tags:
 - SDP
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCIceCandidate.protocol
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -89,4 +90,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.protocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/relatedaddress/index.html
+++ b/files/en-us/web/api/rtcicecandidate/relatedaddress/index.html
@@ -15,6 +15,7 @@ tags:
   - WebRTC
   - WebRTC API
   - relatedAddress
+browser-compat: api.RTCIceCandidate.relatedAddress
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -114,7 +115,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.relatedAddress")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/relatedport/index.html
+++ b/files/en-us/web/api/rtcicecandidate/relatedport/index.html
@@ -15,6 +15,7 @@ tags:
   - WebRTC
   - WebRTC API
   - relatedPort
+browser-compat: api.RTCIceCandidate.relatedPort
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -106,7 +107,7 @@ if (relIP &amp;&amp; relPort) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.relatedPort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
+++ b/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC
   - WebRTC API
   - rtc
+browser-compat: api.RTCIceCandidate.RTCIceCandidate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.RTCIceCandidate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.html
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.html
@@ -15,6 +15,7 @@ tags:
 - identification-tag
 - sdpMid
 - stream
+browser-compat: api.RTCIceCandidate.sdpMid
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.sdpMid")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.html
+++ b/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - m-line
 - sdpMLineIndex
+browser-compat: api.RTCIceCandidate.sdpMLineIndex
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.sdpMLineIndex")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/tcptype/index.html
+++ b/files/en-us/web/api/rtcicecandidate/tcptype/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - tcpType
+browser-compat: api.RTCIceCandidate.tcpType
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.tcpType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/tojson/index.html
+++ b/files/en-us/web/api/rtcicecandidate/tojson/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - toJSON
+browser-compat: api.RTCIceCandidate.toJSON
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidate/type/index.html
+++ b/files/en-us/web/api/rtcicecandidate/type/index.html
@@ -13,6 +13,7 @@ tags:
   - Type
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceCandidate.type
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidate/usernamefragment/index.html
+++ b/files/en-us/web/api/rtcicecandidate/usernamefragment/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC API
   - ufrag
   - usernameFragment
+browser-compat: api.RTCIceCandidate.usernameFragment
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -138,4 +139,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidate.usernameFragment")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidateinit/candidate/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/candidate/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC
   - WebRTC API
   - candidate-attribute
+browser-compat: api.RTCIceCandidateInit.candidate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateInit.candidate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/index.html
@@ -12,6 +12,7 @@ tags:
   - SDP
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceCandidateInit
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateInit")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidateinit/sdpmid/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/sdpmid/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - m-line
   - sdpMid
+browser-compat: api.RTCIceCandidateInit.sdpMid
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateInit.sdpMid")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/sdpmlineindex/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/sdpmlineindex/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC API
   - m-line
   - sdpMLineIndex
+browser-compat: api.RTCIceCandidateInit.sdpMLineIndex
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateInit.sdpMLineIndex")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidateinit/usernamefragment/index.html
+++ b/files/en-us/web/api/rtcicecandidateinit/usernamefragment/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - ufrag
   - usernameFragment
+browser-compat: api.RTCIceCandidateInit.usernameFragment
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateInit.usernameFragment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidatepair/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceCandidatePair
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePair")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepair/local/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - local
 - rtc
+browser-compat: api.RTCIceCandidatePair.local
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -71,4 +72,4 @@ var localCandidate = candidatePair.local;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePair.local")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepair/remote/index.html
+++ b/files/en-us/web/api/rtcicecandidatepair/remote/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - rtc
+browser-compat: api.RTCIceCandidatePair.remote
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -71,4 +72,4 @@ var remoteCandidate = candidatePair.remote;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePair.remote")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableincomingbitrate/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableincomingbitrate/index.html
@@ -19,6 +19,7 @@ tags:
 - availableIncomingBitrate
 - priority
 - speed
+browser-compat: api.RTCIceCandidatePairStats.availableIncomingBitrate
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.availableIncomingBitrate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.html
@@ -18,6 +18,7 @@ tags:
 - Stats
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCIceCandidatePairStats.availableOutgoingBitrate
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.availableOutgoingBitrate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - bytesReceived
 - data
+browser-compat: api.RTCIceCandidatePairStats.bytesReceived
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.bytesReceived")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - bytesSent
 - rtc
+browser-compat: api.RTCIceCandidatePairStats.bytesSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.bytesSent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - circuitBreakerTriggerCount
+browser-compat: api.RTCIceCandidatePairStats.circuitBreakerTriggerCount
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.circuitBreakerTriggerCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.html
@@ -17,6 +17,7 @@ tags:
 - expiration
 - rtc
 - timeStamp
+browser-compat: api.RTCIceCandidatePairStats.consentExpiredTimestamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.consentExpiredTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentrequestssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentrequestssent/index.html
@@ -16,6 +16,7 @@ tags:
 - contentRequestsReceived
 - data
 - rtc
+browser-compat: api.RTCIceCandidatePairStats.consentRequestsSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.consentRequestsSent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.html
@@ -17,6 +17,7 @@ tags:
 - currentRoundTripTime
 - rtc
 - speed
+browser-compat: api.RTCIceCandidatePairStats.currentRoundTripTime
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.currentRoundTripTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - firstRequestTimestamp
 - timeStamp
+browser-compat: api.RTCIceCandidatePairStats.firstRequestTimeStamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -73,4 +74,4 @@ tags:
     updated.</p>
 </div>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.firstRequestTimeStamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/index.html
@@ -19,6 +19,7 @@ tags:
   - WebRTC API
   - candidate-pair
   - rtc
+browser-compat: api.RTCIceCandidatePairStats
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -148,4 +149,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - lastPacketReceivedTimestamp
 - timeStamp
+browser-compat: api.RTCIceCandidatePairStats.lastPacketReceivedTimestamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.lastPacketReceivedTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - lastPacketSentTImestamp
+browser-compat: api.RTCIceCandidatePairStats.lastPacketSentTimestamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.lastPacketSentTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - lastRequestTimestamp
 - timeStamp
+browser-compat: api.RTCIceCandidatePairStats.lastRequestTimestamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.lastRequestTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - lastResponseTimestamp
 - timeStamp
+browser-compat: api.RTCIceCandidatePairStats.lastResponseTimestamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.lastResponseTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - local
 - localCandidateId
+browser-compat: api.RTCIceCandidatePairStats.localCandidateId
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.localCandidateId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - nominated
+browser-compat: api.RTCIceCandidatePairStats.nominated
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.nominated")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - packetsReceived
+browser-compat: api.RTCIceCandidatePairStats.packetsReceived
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.packetsReceived")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.html
@@ -16,6 +16,7 @@ tags:
 - Stats
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCIceCandidatePairStats.packetsSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.packetsSent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/priority/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - priority
+browser-compat: api.RTCIceCandidatePairStats.priority
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.priority")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/readable/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/readable/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - readable
+browser-compat: api.RTCIceCandidatePairStats.readable
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.readable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - id
+browser-compat: api.RTCIceCandidatePairStats.remoteCandidateId
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.remoteCandidateId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - request
 - requestsReceived
+browser-compat: api.RTCIceCandidatePairStats.requestsReceived
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.requestsReceived")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - requestsSent
+browser-compat: api.RTCIceCandidatePairStats.requestsSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.requestsSent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC
 - WebRTC API
 - responsesReceived
+browser-compat: api.RTCIceCandidatePairStats.responsesReceived
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.responsesReceived")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - responsesSent
+browser-compat: api.RTCIceCandidatePairStats.responsesSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.responsesSent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC
 - WebRTC API
 - retransmissionsReceived
+browser-compat: api.RTCIceCandidatePairStats.retransmissionsReceived
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.retransmissionsReceived")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionssent/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionssent/index.html
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.retransmissionsSent
 slug: Web/API/RTCIceCandidatePairStats/retransmissionsSent
+browser-compat: api.RTCIceCandidatePairStats.retransmissionsSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -54,4 +55,4 @@ slug: Web/API/RTCIceCandidatePairStats/retransmissionsSent
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.retransmissionsSent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/selected/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/selected/index.html
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.selected
 slug: Web/API/RTCIceCandidatePairStats/selected
+browser-compat: api.RTCIceCandidatePairStats.selected
 ---
 <p>{{APIRef("WebRTC")}}{{non-standard_header}}</p>
 
@@ -47,4 +48,4 @@ slug: Web/API/RTCIceCandidatePairStats/selected
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.selected")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/state/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/state/index.html
@@ -17,6 +17,7 @@ tags:
   - WebRTC
   - WebRTC API
   - state
+browser-compat: api.RTCIceCandidatePairStats.state
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.state")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.html
@@ -18,6 +18,7 @@ tags:
 - rount trip time
 - rtt
 - totalRoundTripTime
+browser-compat: api.RTCIceCandidatePairStats.totalRoundTripTime
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.totalRoundTripTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - id
 - transportID
+browser-compat: api.RTCIceCandidatePairStats.transportId
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.transportId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatepairstats/writable/index.html
+++ b/files/en-us/web/api/rtcicecandidatepairstats/writable/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - writable
+browser-compat: api.RTCIceCandidatePairStats.writable
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidatePairStats.writable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/address/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/address/index.html
@@ -17,6 +17,7 @@ tags:
 - Stats
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCIceCandidateStats.address
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.address")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - candidateType
 - rtc
+browser-compat: api.RTCIceCandidateStats.candidateType
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.candidateType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/deleted/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/deleted/index.html
@@ -10,6 +10,7 @@ tags:
 - WebRTC
 - WebRTC API
 - deleted
+browser-compat: api.RTCIceCandidateStats.deleted
 ---
 <p>{{APIRef("WebRTC")}}<br>
   <span class="seoSummary">The {{domxref("RTCIceCandidateStats")}} dictionary's
@@ -97,4 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.deleted")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/index.html
@@ -14,6 +14,7 @@ tags:
   - Stats
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceCandidateStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -98,4 +99,4 @@ if (rtcStats &amp;&amp; rtcStats.type === "local-candidate") {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/networktype/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/networktype/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - networkType
+browser-compat: api.RTCIceCandidateStats.networkType
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.networkType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/port/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/port/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - port
+browser-compat: api.RTCIceCandidateStats.port
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.port")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/priority/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/priority/index.html
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.priority
 slug: Web/API/RTCIceCandidateStats/priority
+browser-compat: api.RTCIceCandidateStats.priority
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -108,7 +109,7 @@ slug: Web/API/RTCIceCandidateStats/priority
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.priority")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.html
@@ -15,6 +15,7 @@ tags:
 - Transport
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCIceCandidateStats.protocol
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.protocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - relayProtocol
 - rtc
+browser-compat: api.RTCIceCandidateStats.relayProtocol
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.relayProtocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/transportid/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/transportid/index.html
@@ -20,6 +20,7 @@ tags:
 - id
 - rtc
 - transportID
+browser-compat: api.RTCIceCandidateStats.transportId
 ---
 <p>{{APIRef("WebRTC")}}<br>
   <span class="seoSummary">The {{domxref("RTCIceCandidateStats")}} dictionary's
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.transportId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatestats/url/index.html
+++ b/files/en-us/web/api/rtcicecandidatestats/url/index.html
@@ -18,6 +18,7 @@ tags:
 - WebRTC
 - WebRTC API
 - rtc
+browser-compat: api.RTCIceCandidateStats.url
 ---
 <p>{{APIRef("WebRTC")}}<br>
   <span class="seoSummary">The {{domxref("RTCIceCandidateStats")}} dictionary's
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateStats.url")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecandidatetype/index.html
+++ b/files/en-us/web/api/rtcicecandidatetype/index.html
@@ -13,6 +13,7 @@ tags:
   - Type
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceCandidateType
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCandidateType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecomponent/index.html
+++ b/files/en-us/web/api/rtcicecomponent/index.html
@@ -15,6 +15,7 @@ tags:
   - Transport
   - Type
   - component
+browser-compat: api.RTCIceComponent
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceComponent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicecredentialtype/index.html
+++ b/files/en-us/web/api/rtcicecredentialtype/index.html
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCredentialType
 slug: Web/API/RTCIceCredentialType
+browser-compat: api.RTCIceCredentialType
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -45,7 +46,7 @@ slug: Web/API/RTCIceCredentialType
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceCredentialType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicegathererstate/index.html
+++ b/files/en-us/web/api/rtcicegathererstate/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - rtc
   - state
+browser-compat: api.RTCIceGathererState
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceGathererState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtciceparameters/index.html
+++ b/files/en-us/web/api/rtciceparameters/index.html
@@ -17,6 +17,7 @@ tags:
   - password
   - ufrag
   - username
+browser-compat: api.RTCIceParameters
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtciceparameters/password/index.html
+++ b/files/en-us/web/api/rtciceparameters/password/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - password
+browser-compat: api.RTCIceParameters.password
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceParameters.password")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtciceparameters/usernamefragment/index.html
+++ b/files/en-us/web/api/rtciceparameters/usernamefragment/index.html
@@ -17,6 +17,7 @@ tags:
 - ufrag
 - username
 - usernameFragment
+browser-compat: api.RTCIceParameters.usernameFragment
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceParameters.usernameFragment")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtciceprotocol/index.html
+++ b/files/en-us/web/api/rtciceprotocol/index.html
@@ -14,6 +14,7 @@ tags:
   - UDP
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceProtocol
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceProtocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicerole/index.html
+++ b/files/en-us/web/api/rtcicerole/index.html
@@ -17,6 +17,7 @@ tags:
   - WebRTC API
   - agent
   - rtc
+browser-compat: api.RTCIceRole
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceRole")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtciceserver/credential/index.html
+++ b/files/en-us/web/api/rtciceserver/credential/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - TURN
 - WebRTC
+browser-compat: api.RTCIceServer.credential
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -78,7 +79,7 @@ var <em>credential</em> = <em>iceServer</em>.credential;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceServer.credential")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtciceserver/credentialtype/index.html
+++ b/files/en-us/web/api/rtciceserver/credentialtype/index.html
@@ -13,6 +13,7 @@ tags:
 - credentialType
 - credentials
 - password
+browser-compat: api.RTCIceServer.credentialType
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -81,7 +82,7 @@ var <em>credentialType</em> = <em>iceServer</em>.credentialType;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceServer.credentialType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtciceserver/index.html
+++ b/files/en-us/web/api/rtciceserver/index.html
@@ -9,6 +9,7 @@ tags:
   - ICE
   - RTCIceServer
   - WebRTC
+browser-compat: api.RTCIceServer
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -64,7 +65,7 @@ var pc = new RTCPeerConnection(configuration);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceServer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtciceserver/url/index.html
+++ b/files/en-us/web/api/rtciceserver/url/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - URL
 - WebRTC
+browser-compat: api.RTCIceServer.url
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -66,7 +67,7 @@ var serverUrl = <em>iceServer</em>.url;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceServer.url")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtciceserver/urls/index.html
+++ b/files/en-us/web/api/rtciceserver/urls/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - WebRTC
 - urls
+browser-compat: api.RTCIceServer.urls
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -139,7 +140,7 @@ iceServers.push(iceServer);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceServer.urls")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtciceserver/username/index.html
+++ b/files/en-us/web/api/rtciceserver/username/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - WebRTC
 - username
+browser-compat: api.RTCIceServer.username
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -76,7 +77,7 @@ var <em>username</em> = <em>iceServer</em>.username;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceServer.username")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetcpcandidatetype/index.html
+++ b/files/en-us/web/api/rtcicetcpcandidatetype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIceTcpCandidateType
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTcpCandidateType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/component/index.html
+++ b/files/en-us/web/api/rtcicetransport/component/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - component
+browser-compat: api.RTCIceTransport.component
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.component")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/gatheringstate/index.html
+++ b/files/en-us/web/api/rtcicetransport/gatheringstate/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC API
 - gatheringState
 - state
+browser-compat: api.RTCIceTransport.gatheringState
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.gatheringState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.html
+++ b/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.html
@@ -15,6 +15,7 @@ tags:
   - events
   - gatheringSstate
   - gatheringstatechange
+browser-compat: api.RTCIceTransport.gatheringstatechange_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -89,7 +90,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.gatheringstatechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.html
+++ b/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - getLocalCandidates
 - rtc
+browser-compat: api.RTCIceTransport.getLocalCandidates
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -81,4 +82,4 @@ localCandidates.forEach(function(candidate, index)) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.getLocalCandidates")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/getlocalparameters/index.html
+++ b/files/en-us/web/api/rtcicetransport/getlocalparameters/index.html
@@ -18,6 +18,7 @@ tags:
 - ufrag
 - username
 - usernameFragment
+browser-compat: api.RTCIceTransport.getLocalParameters
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.getLocalParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/getremotecandidates/index.html
+++ b/files/en-us/web/api/rtcicetransport/getremotecandidates/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - getRemoteCandidates
 - rtc
+browser-compat: api.RTCIceTransport.getRemoteCandidates
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -80,4 +81,4 @@ remoteCandidates.forEach(function(candidate, index)) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.getRemoteCandidates")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/getremoteparameters/index.html
+++ b/files/en-us/web/api/rtcicetransport/getremoteparameters/index.html
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.getRemoteParameters()
 slug: Web/API/RTCIceTransport/getRemoteParameters
+browser-compat: api.RTCIceTransport.getRemoteParameters
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -53,4 +54,4 @@ slug: Web/API/RTCIceTransport/getRemoteParameters
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.getRemoteParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.html
+++ b/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - getSelectedCandidatePair
+browser-compat: api.RTCIceTransport.getSelectedCandidatePair
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -90,4 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.getSelectedCandidatePair")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/index.html
+++ b/files/en-us/web/api/rtcicetransport/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC
   - WebRTC API
   - rtc
+browser-compat: api.RTCIceTransport
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/ongatheringstatechange/index.html
+++ b/files/en-us/web/api/rtcicetransport/ongatheringstatechange/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - ongatheringstatechange
+browser-compat: api.RTCIceTransport.ongatheringstatechange
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -79,7 +80,7 @@ iceTransport.ongatheringstatechange = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.ongatheringstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetransport/onselectedcandidatepairchange/index.html
+++ b/files/en-us/web/api/rtcicetransport/onselectedcandidatepairchange/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - onselectedcandidatepairchange
 - selectedcandidatepairchange
+browser-compat: api.RTCIceTransport.onselectedcandidatepairchange
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -84,7 +85,7 @@ iceTransport.onselectedcandidatepairchange = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.onselectedcandidatepairchange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetransport/onstatechange/index.html
+++ b/files/en-us/web/api/rtcicetransport/onstatechange/index.html
@@ -17,6 +17,7 @@ tags:
 - rtc
 - state
 - statechange
+browser-compat: api.RTCIceTransport.onstatechange
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -78,7 +79,7 @@ iceTransport.onstatechange = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.onstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetransport/role/index.html
+++ b/files/en-us/web/api/rtcicetransport/role/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC
 - WebRTC API
 - rtc
+browser-compat: api.RTCIceTransport.role
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.role")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.html
+++ b/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.html
@@ -14,6 +14,7 @@ tags:
   - events
   - onselectedcandidatepairchange
   - selectedcandidatepairchange
+browser-compat: api.RTCIceTransport.selectedcandidatepairchange_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -88,7 +89,7 @@ iceTransport.onselectedcandidatepairchange = ev =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.selectedcandidatepairchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetransport/state/index.html
+++ b/files/en-us/web/api/rtcicetransport/state/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - state
+browser-compat: api.RTCIceTransport.state
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.state")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcicetransport/statechange_event/index.html
+++ b/files/en-us/web/api/rtcicetransport/statechange_event/index.html
@@ -14,6 +14,7 @@ tags:
   - rtc
   - state
   - statechange
+browser-compat: api.RTCIceTransport.statechange_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
@@ -83,7 +84,7 @@ iceTransport.onstatechange = ev =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceTransport.statechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcidentityassertion/index.html
+++ b/files/en-us/web/api/rtcidentityassertion/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIdentityAssertion
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityAssertion")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcidentityerrorevent/idp/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/idp/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - WebRTC
+browser-compat: api.RTCIdentityErrorEvent.idp
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityErrorEvent.idp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcidentityerrorevent/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - WebRTC
+browser-compat: api.RTCIdentityErrorEvent
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityErrorEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcidentityerrorevent/loginurl/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/loginurl/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - WebRTC
+browser-compat: api.RTCIdentityErrorEvent.loginUrl
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityErrorEvent.loginUrl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcidentityerrorevent/protocol/index.html
+++ b/files/en-us/web/api/rtcidentityerrorevent/protocol/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - WebRTC
+browser-compat: api.RTCIdentityErrorEvent.protocol
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityErrorEvent.protocol")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcidentityevent/assertion/index.html
+++ b/files/en-us/web/api/rtcidentityevent/assertion/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - WebRTC
+browser-compat: api.RTCIdentityEvent.assertion
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityEvent.assertion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcidentityevent/index.html
+++ b/files/en-us/web/api/rtcidentityevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCIdentityEvent
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIdentityEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - averageRtcpInterval
 - rate
+browser-compat: api.RTCInboundRtpStreamStats.averageRtcpInterval
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.averageRtcpInterval")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - bytesReceived
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.bytesReceived
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.bytesReceived")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - fecPacketsDiscarded
+browser-compat: api.RTCInboundRtpStreamStats.fecPacketsDiscarded
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.fecPacketsDiscarded")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.html
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.fecPacketsReceived
 slug: Web/API/RTCInboundRtpStreamStats/fecPacketsReceived
+browser-compat: api.RTCInboundRtpStreamStats.fecPacketsReceived
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -64,7 +65,7 @@ slug: Web/API/RTCInboundRtpStreamStats/fecPacketsReceived
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.fecPacketsReceived")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - firCount
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.firCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.firCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.html
@@ -18,6 +18,7 @@ tags:
 - decoding
 - framesDecoded
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.framesDecoded
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.framesDecoded")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/index.html
@@ -11,6 +11,7 @@ tags:
   - Stats
   - local
   - receiver
+browser-compat: api.RTCInboundRtpStreamStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.html
@@ -15,6 +15,7 @@ tags:
 - lastPacketReceivedTimestamp
 - stream
 - timeStamp
+browser-compat: api.RTCInboundRtpStreamStats.lastPacketReceivedTimestamp
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.lastPacketReceivedTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - nackCount
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.nackCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.nackCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - packetsDuplicated
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.packetsDuplicated
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.packetsDuplicated")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - packetsFailedDecryption
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.packetsFailedDecryption
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.packetsFailedDecryption")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - perDcspPacketsReceived
+browser-compat: api.RTCInboundRtpStreamStats.perDscpPacketsReceived
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.perDscpPacketsReceived")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - pliCount
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.pliCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.pliCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - qpSum
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.qpSum
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -115,4 +116,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.qpSum")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - receiver
 - receiverId
+browser-compat: api.RTCInboundRtpStreamStats.receiverId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.receiverId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.html
@@ -18,6 +18,7 @@ tags:
 - remoteId
 - sender
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.remoteId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.remoteId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.html
@@ -18,6 +18,7 @@ tags:
 - WebRTC API
 - sliCount
 - stream
+browser-compat: api.RTCInboundRtpStreamStats.sliCount
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.sliCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.html
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - trackId
+browser-compat: api.RTCInboundRtpStreamStats.trackId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCInboundRtpStreamStats.trackId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcnetworktype/index.html
+++ b/files/en-us/web/api/rtcnetworktype/index.html
@@ -17,6 +17,7 @@ tags:
   - WebRTC API
   - networkType
   - Deprecated
+browser-compat: api.RTCNetworkType
 ---
 <p>{{deprecated_header}}{{APIRef("WebRTC")}}</p>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCNetworkType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcofferansweroptions/index.html
+++ b/files/en-us/web/api/rtcofferansweroptions/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC API
   - createAnswer
   - createOffer
+browser-compat: api.RTCOfferAnswerOptions
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOfferAnswerOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcofferansweroptions/voiceactivitydetection/index.html
+++ b/files/en-us/web/api/rtcofferansweroptions/voiceactivitydetection/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - answer
 - detection
+browser-compat: api.RTCOfferAnswerOptions.voiceActivityDetection
 ---
 <div>{{APIRef("WebRTC")}}{{deprecated_header}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOfferAnswerOptions.voiceActivityDetection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcofferoptions/icerestart/index.html
+++ b/files/en-us/web/api/rtcofferoptions/icerestart/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - iceRestart
+browser-compat: api.RTCOfferOptions.iceRestart
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -103,4 +104,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOfferOptions.iceRestart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcofferoptions/index.html
+++ b/files/en-us/web/api/rtcofferoptions/index.html
@@ -11,6 +11,7 @@ tags:
   - WebRTC
   - WebRTC API
   - rtc
+browser-compat: api.RTCOfferOptions
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOfferOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.html
@@ -19,6 +19,7 @@ tags:
 - rate
 - sender
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.averageRtcpInterval
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.averageRtcpInterval")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC
 - WebRTC API
 - firCount
+browser-compat: api.RTCOutboundRtpStreamStats.firCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.firCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.html
@@ -17,6 +17,7 @@ tags:
 - encode
 - framesEncoded
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.framesEncoded
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.framesEncoded")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - WebRTC API
   - stream
+browser-compat: api.RTCOutboundRtpStreamStats
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - lastPacketSentTImestamp
 - timeStamp
+browser-compat: api.RTCOutboundRtpStreamStats.lastPacketSentTimestamp
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.lastPacketSentTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.html
@@ -19,6 +19,7 @@ tags:
 - WebRTC API
 - nackCount
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.nackCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.nackCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - perDscpPacketsSent
+browser-compat: api.RTCOutboundRtpStreamStats.perDscpPacketsSent
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.perDscpPacketsSent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - pliCount
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.pliCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.pliCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.html
@@ -19,6 +19,7 @@ tags:
 - compression
 - qpSum
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.qpSum
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -118,4 +119,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.qpSum")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.html
@@ -15,6 +15,7 @@ tags:
 - qualityLimitationReason
 - reason
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.qualityLimitationReason
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.qualityLimitationReason")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - id
 - remoteId
+browser-compat: api.RTCOutboundRtpStreamStats.remoteId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.remoteId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.html
@@ -18,6 +18,7 @@ tags:
 - WebRTC API
 - sliCount
 - stream
+browser-compat: api.RTCOutboundRtpStreamStats.sliCount
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.sliCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.html
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.html
@@ -20,6 +20,7 @@ tags:
 - stream
 - track
 - trackId
+browser-compat: api.RTCOutboundRtpStreamStats.trackId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCOutboundRtpStreamStats.trackId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - addIceCandidate
+browser-compat: api.RTCPeerConnection.addIceCandidate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -194,7 +195,7 @@ signalingChannel.onmessage = receivedString =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.addIceCandidate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addstream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addstream/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - addStream
+browser-compat: api.RTCPeerConnection.addStream
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -118,7 +119,7 @@ if (pc.removeTrack) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.addStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addstream_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addstream_event/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - addStream
   - events
+browser-compat: api.RTCPeerConnection.addstream_event
 ---
 <p>{{WebRTCSidebar}}{{deprecated_header}}</p>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.addstream_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.html
@@ -12,6 +12,7 @@ tags:
 - Video
 - WebRTC
 - addTrack
+browser-compat: api.RTCPeerConnection.addTrack
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -292,7 +293,7 @@ pc.setRemoteDescription(desc).then(function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.addTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.html
@@ -12,6 +12,7 @@ tags:
 - Transceivers
 - Video
 - addTransceiver
+browser-compat: api.RTCPeerConnection.addTransceiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.addTransceiver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - WebRTC API
 - canTrickleIceCandidates
+browser-compat: api.RTCPeerConnection.canTrickleIceCandidates
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -102,7 +103,7 @@ pc.addEventListener('icecandidate', e =&gt; (pc.canTrickleIceCandidates) &amp;&a
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.canTrickleIceCandidates")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/close/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/close/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - WebRTC
 - close
+browser-compat: api.RTCPeerConnection.close
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -75,7 +76,7 @@ dc.onclose = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.close")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/connectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstate/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - WebRTC
 - connectionState
+browser-compat: api.RTCPeerConnection.connectionState
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -62,7 +63,7 @@ var connectionState = pc.connectionState;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.connectionState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: connectionstatechange event'
 slug: Web/API/RTCPeerConnection/connectionstatechange_event
+browser-compat: api.RTCPeerConnection.connectionstatechange_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
@@ -86,7 +87,7 @@ slug: Web/API/RTCPeerConnection/connectionstatechange_event
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.connectionstatechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/createanswer/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createanswer/index.html
@@ -12,6 +12,7 @@ tags:
 - Web
 - WebRTC
 - createAnswer
+browser-compat: api.RTCPeerConnection.createAnswer
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -138,4 +139,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.createAnswer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - WebRTC
 - createDataChannel
+browser-compat: api.RTCPeerConnection.createDataChannel
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -184,7 +185,7 @@ channel.onmessage = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.createDataChannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.html
@@ -10,6 +10,7 @@ tags:
 - SDP
 - WebRTC
 - createOffer
+browser-compat: api.RTCPeerConnection.createOffer
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -216,4 +217,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.createOffer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.html
@@ -11,6 +11,7 @@ tags:
 - SDP
 - WebRTC
 - currentLocalConnection
+browser-compat: api.RTCPeerConnection.currentLocalDescription
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -88,7 +89,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.currentLocalDescription")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note">
   <p>The addition of <code>currentLocalDescription</code> and

--- a/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.html
@@ -11,6 +11,7 @@ tags:
 - SDP
 - WebRTC
 - currentRemoteDescription
+browser-compat: api.RTCPeerConnection.currentRemoteDescription
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -88,7 +89,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.currentRemoteDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.html
@@ -14,6 +14,7 @@ tags:
   - datachannel
   - events
   - rtc
+browser-compat: api.RTCPeerConnection.datachannel_event
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.datachannel_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - generateCertificate
+browser-compat: api.RTCPeerConnection.generateCertificate
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -140,7 +141,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.generateCertificate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - WebRTC
 - getConfiguration
+browser-compat: api.RTCPeerConnection.getConfiguration
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -90,7 +91,7 @@ if ((configuration.certificates != undefined) &amp;&amp; (!configuration.certifi
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getdefaulticeservers/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getdefaulticeservers/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - getDefaultIceServers
+browser-compat: api.RTCPeerConnection.getDefaultIceServers
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -63,7 +64,7 @@ if (iceServers.length === 0) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getDefaultIceServers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.html
@@ -7,6 +7,7 @@ tags:
 - RTCPeerConnection
 - Reference
 - WebRTC
+browser-compat: api.RTCPeerConnection.getIdentityAssertion
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -57,7 +58,7 @@ pc.getIdentityAssertion(); // Not mandatory, but we know that we will need it in
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getIdentityAssertion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getreceivers/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getreceivers/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC
 - WebRTC API
 - getReceivers
+browser-compat: api.RTCPeerConnection.getReceivers
 ---
 <div>{{APIRef("WebRTC")}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getReceivers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getsenders/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getsenders/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - getSenders
+browser-compat: api.RTCPeerConnection.getSenders
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getSenders")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC Stats
 - getStats
 - rtc
+browser-compat: api.RTCPeerConnection.getStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -149,4 +150,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getStats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnection/getstreambyid/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/getstreambyid/index.html
@@ -7,6 +7,7 @@ tags:
 - RTCPeerConnection
 - Reference
 - WebRTC
+browser-compat: api.RTCPeerConnection.getStreamById
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
@@ -72,7 +73,7 @@ RTCPeerConnection.prototype.getStreamById = function(id) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getStreamById")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/gettransceivers/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/gettransceivers/index.html
@@ -12,6 +12,7 @@ tags:
 - Transceiver
 - WebRTC
 - getTransceivers
+browser-compat: api.RTCPeerConnection.getTransceivers
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.getTransceivers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icecandidate_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidate_event/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC API
   - events
   - icecandidate
+browser-compat: api.RTCPeerConnection.icecandidate_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
@@ -139,7 +140,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.icecandidate_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.html
@@ -17,6 +17,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - icecandidateerror
+browser-compat: api.RTCPeerConnection.icecandidateerror_event
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.icecandidateerror_event")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - iceConnectionState
 - state
+browser-compat: api.RTCPeerConnection.iceConnectionState
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -68,7 +69,7 @@ var state = pc.iceConnectionState;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.iceConnectionState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.html
@@ -15,6 +15,7 @@ tags:
   - events
   - iceConnectionState
   - iceconnectionstatechange
+browser-compat: api.RTCPeerConnection.iceconnectionstatechange_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.iceconnectionstatechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - iceGatheringState
+browser-compat: api.RTCPeerConnection.iceGatheringState
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -60,7 +61,7 @@ var state = pc.iceGatheringState;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.iceGatheringState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.html
@@ -14,6 +14,7 @@ tags:
   - events
   - icegatheringstatechange
   - state
+browser-compat: api.RTCPeerConnection.icegatheringstatechange_event
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.icegatheringstatechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/identityresult_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/identityresult_event/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC
   - WebRTC API
   - identityresult
+browser-compat: api.RTCPeerConnection.identityresult_event
 ---
 <div>{{APIRef("WebRTC")}}{{deprecated_header}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.identityresult_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/idpassertionerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/idpassertionerror_event/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - events
   - idpassertionerror
+browser-compat: api.RTCPeerConnection.idpassertionerror_event
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.idpassertionerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/idpvalidationerror_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/idpvalidationerror_event/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC API
   - events
   - idpvalidationerror
+browser-compat: api.RTCPeerConnection.idpvalidationerror_event
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.idpvalidationerror_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/index.html
@@ -15,6 +15,7 @@ tags:
   - Video
   - WebRTC
   - WebRTC API
+browser-compat: api.RTCPeerConnection
 ---
 <p>{{APIRef('WebRTC')}}</p>
 
@@ -356,7 +357,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/localdescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/localdescription/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - localDescription
+browser-compat: api.RTCPeerConnection.localDescription
 ---
 <p>{{WebRTCSidebar}}{{SeeCompatTable}}</p>
 
@@ -69,7 +70,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.localDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - negotiationneeded
   - rtc
+browser-compat: api.RTCPeerConnection.negotiationneeded_event
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.negotiationneeded_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onaddstream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onaddstream/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC API
 - onaddstream
 - rtc
+browser-compat: api.RTCPeerConnection.onaddstream
 ---
 <p>{{WebRTCSidebar}}{{deprecated_header}}</p>
 
@@ -72,7 +73,7 @@ tags:
     existing code and understand existing samples, which may not be up-to-date yet.</p>
 </div>
 
-<p>{{Compat("api.RTCPeerConnection.onaddstream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onconnectionstatechange/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - onconnectionstatechange
+browser-compat: api.RTCPeerConnection.onconnectionstatechange
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onconnectionstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ondatachannel/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - ondatachannel
+browser-compat: api.RTCPeerConnection.ondatachannel
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.ondatachannel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidate/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - onicecandidate
+browser-compat: api.RTCPeerConnection.onicecandidate
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onicecandidate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicecandidateerror/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - WebRTC
 - onicecandidateerror
+browser-compat: api.RTCPeerConnection.onicecandidateerror
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onicecandidateerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/oniceconnectionstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/oniceconnectionstatechange/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - oniceconnectionstatechange
+browser-compat: api.RTCPeerConnection.oniceconnectionstatechange
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.oniceconnectionstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onicegatheringstatechange/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - WebRTC
 - onicegatheringstatechange
+browser-compat: api.RTCPeerConnection.onicegatheringstatechange
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onicegatheringstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onidentityresult/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onidentityresult/index.html
@@ -8,6 +8,7 @@ tags:
   - RTCPeerConnection
   - Reference
   - WebRTC
+browser-compat: api.RTCPeerConnection.onidentityresult
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onidentityresult")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onidpassertionerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onidpassertionerror/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCPeerConnection.onidpassertionerror
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onidpassertionerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onidpvalidationerror/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onidpvalidationerror/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC
 - WebRTC API
 - onidpvalidationerror
+browser-compat: api.RTCPeerConnection.onidpvalidationerror
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onidpvalidationerror")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onnegotiationneeded/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onnegotiationneeded/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - onnegotiationneeded
+browser-compat: api.RTCPeerConnection.onnegotiationneeded
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onnegotiationneeded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onpeeridentity/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onpeeridentity/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - onpeeridentity
+browser-compat: api.RTCPeerConnection.onpeeridentity
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onpeeridentity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onremovestream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onremovestream/index.html
@@ -8,6 +8,7 @@ tags:
   - RTCPeerConnection
   - Reference
   - WebRTC
+browser-compat: api.RTCPeerConnection.onremovestream
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}{{SeeCompatTable}}</p>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onremovestream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/onsignalingstatechange/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/onsignalingstatechange/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - answer
 - onsignalingstatechange
+browser-compat: api.RTCPeerConnection.onsignalingstatechange
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.onsignalingstatechange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/ontrack/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - ontrack
+browser-compat: api.RTCPeerConnection.ontrack
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.ontrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCPeerConnection.peerIdentity
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -92,7 +93,7 @@ async function getIdentityAssertion(pc) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.peerIdentity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity_event/index.html
@@ -10,6 +10,7 @@ tags:
   - WebRTC API
   - events
   - peeridentity
+browser-compat: api.RTCPeerConnection.peeridentity_event
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.peeridentity_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.html
@@ -11,6 +11,7 @@ tags:
 - SDP
 - WebRTC
 - pendingLocalDescription
+browser-compat: api.RTCPeerConnection.pendingLocalDescription
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -74,7 +75,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.pendingLocalDescription")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note">
   <p>The addition of <code>pendingLocalDescription</code> and

--- a/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.html
@@ -10,6 +10,7 @@ tags:
 - SDP
 - WebRTC
 - pendingRemoteDescription
+browser-compat: api.RTCPeerConnection.pendingRemoteDescription
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -73,7 +74,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.pendingRemoteDescription")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note">
   <p>The addition of <code>pendingRemoteDescription</code> and

--- a/files/en-us/web/api/rtcpeerconnection/remotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/remotedescription/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - remoteDescription
+browser-compat: api.RTCPeerConnection.remoteDescription
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -75,7 +76,7 @@ else {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.remoteDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/removestream/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removestream/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - WebRTC
 - removeStream
+browser-compat: api.RTCPeerConnection.removeStream
 ---
 <div>{{APIRef("WebRTC")}}{{deprecated_header}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ document.getElementById("closeButton").addEventListener("click", function(event)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.removeStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/removestream_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removestream_event/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - WebRTC API
   - removeStream
+browser-compat: api.RTCPeerConnection.removestream_event
 ---
 <p>{{APIRef("WebRTC")}}{{deprecated_header}}</p>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.removestream_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.html
@@ -11,6 +11,7 @@ tags:
 - Video
 - WebRTC
 - removeTrack
+browser-compat: api.RTCPeerConnection.removeTrack
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -92,7 +93,7 @@ document.getElementById("closeButton").addEventListener("click", function(event)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.removeTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/restartice/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/restartice/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - restartIce
+browser-compat: api.RTCPeerConnection.restartIce
 ---
 <p>{{APIRef("WebRTC API")}}</p>
 
@@ -113,7 +114,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.restartIce")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.html
@@ -8,6 +8,7 @@ tags:
 - RTCPeerConnection
 - Reference
 - WebRTC
+browser-compat: api.RTCPeerConnection.RTCPeerConnection
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.RTCPeerConnection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/sctp/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/sctp/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - SCTP
 - WebRTC
+browser-compat: api.RTCPeerConnection.sctp
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -70,7 +71,7 @@ var maxMessageSize = sctp.maxMessageSize;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.sctp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - setConfiguration
+browser-compat: api.RTCPeerConnection.setConfiguration
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -125,7 +126,7 @@ myPeerConnection.createOffer({"iceRestart": true}).then(function(offer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.setConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.html
@@ -7,6 +7,7 @@ tags:
 - RTCPeerConnection
 - Reference
 - WebRTC
+browser-compat: api.RTCPeerConnection.setIdentityProvider
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -68,7 +69,7 @@ pc.setIdentityAssertion("developer.mozilla.org");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.setIdentityProvider")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC
 - answer
 - setLocalDescription
+browser-compat: api.RTCPeerConnection.setLocalDescription
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -196,7 +197,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.setLocalDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - answer
 - setRemoteDescription
+browser-compat: api.RTCPeerConnection.setRemoteDescription
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -268,7 +269,7 @@ createMyStream();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.setRemoteDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - signalingState
 - state
+browser-compat: api.RTCPeerConnection.signalingState
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -80,7 +81,7 @@ var state = pc.signalingState;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.signalingState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/signalingstatechange_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstatechange_event/index.html
@@ -12,6 +12,7 @@ tags:
   - signalingState
   - signalingstatechange
   - state
+browser-compat: api.RTCPeerConnection.signalingstatechange_event
 ---
 <p>{{WebRTCSidebar}}</p>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.signalingstatechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnection/track_event/index.html
+++ b/files/en-us/web/api/rtcpeerconnection/track_event/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC API
   - events
   - track
+browser-compat: api.RTCPeerConnection.track_event
 ---
 <div>{{WebRTCSidebar}}</div>
 
@@ -91,4 +92,4 @@ pc.addEventListener("track", e =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnection.track_event")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC
 - WebRTC API
 - WebRTC Device API
+browser-compat: api.RTCPeerConnectionIceErrorEvent.address
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnectionIceErrorEvent.address")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.html
@@ -16,6 +16,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - rtc
+browser-compat: api.RTCPeerConnectionIceErrorEvent
 ---
 <p>{{DefaultAPISidebar("WebRTC API")}}</p>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnectionIceErrorEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - rtc
+browser-compat: api.RTCPeerConnectionIceEvent.candidate
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnectionIceEvent.candidate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/index.html
@@ -8,6 +8,7 @@ tags:
   - RTCIceCandidateEvent
   - Reference
   - WebRTC
+browser-compat: api.RTCPeerConnectionIceEvent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnectionIceEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.html
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.html
@@ -8,6 +8,7 @@ tags:
 - RTCPeerConnectionIceEvent
 - Reference
 - WebRTC
+browser-compat: api.RTCPeerConnectionIceEvent.RTCPeerConnectionIceEvent
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCPeerConnectionIceEvent.RTCPeerConnectionIceEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.html
@@ -18,6 +18,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - stream
+browser-compat: api.RTCRemoteOutboundRtpStreamStats
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRemoteOutboundRtpStreamStats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.html
@@ -18,6 +18,7 @@ tags:
   - WebRTC Device API
   - id
   - localId
+browser-compat: api.RTCRemoteOutboundRtpStreamStats.localId
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -282,4 +283,4 @@ async function networkTestStart(pc) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRemoteOutboundRtpStreamStats.localId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC Device API
 - remoteTimestamp
 - timeStamp
+browser-compat: api.RTCRemoteOutboundRtpStreamStats.remoteTimestamp
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRemoteOutboundRtpStreamStats.remoteTimestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/reportssent/index.html
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/reportssent/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC Device API
 - reportsSent
 - sender
+browser-compat: api.RTCRemoteOutboundRtpStreamStats.reportsSent
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRemoteOutboundRtpStreamStats.reportsSent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtcpparameters/index.html
+++ b/files/en-us/web/api/rtcrtcpparameters/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - parameters
+browser-compat: api.RTCRtcpParameters
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtcpParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.html
@@ -15,6 +15,7 @@ tags:
   - WebRTC
   - WebRTC API
   - WebRTC Device API
+browser-compat: api.RTCRtpCapabilities
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -77,4 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcodeccapability/index.html
+++ b/files/en-us/web/api/rtcrtpcodeccapability/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - WebRTC API
   - WebRTC Device API
+browser-compat: api.RTCRtpCodecCapability
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpCodecCapability")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - audioLevel
+browser-compat: api.RTCRtpContributingSource.audioLevel
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpContributingSource.audioLevel")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcontributingsource/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/index.html
@@ -11,6 +11,7 @@ tags:
   - RTP
   - Reference
   - WebRTC
+browser-compat: api.RTCRtpContributingSource
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpContributingSource")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.html
@@ -15,6 +15,7 @@ tags:
 - WebRTC API
 - receiver
 - rtpTimestamp
+browser-compat: api.RTCRtpContributingSource.rtpTimestamp
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpContributingSource.rtpTimestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/source/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - source
+browser-compat: api.RTCRtpContributingSource.source
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpContributingSource.source")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.html
+++ b/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebRTC
 - timeStamp
+browser-compat: api.RTCRtpContributingSource.timestamp
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpContributingSource.timestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpencodingparameters/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC
   - WebRTC API
   - parameters
+browser-compat: api.RTCRtpEncodingParameters
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpEncodingParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - maxBitrate
 - parameters
+browser-compat: api.RTCRtpEncodingParameters.maxBitrate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpEncodingParameters.maxBitrate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.html
+++ b/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.html
@@ -19,6 +19,7 @@ tags:
 - rtc
 - scaleResolutionDownBy
 - size
+browser-compat: api.RTCRtpEncodingParameters.scaleResolutionDownBy
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpEncodingParameters.scaleResolutionDownBy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpreceiveparameters/index.html
+++ b/files/en-us/web/api/rtcrtpreceiveparameters/index.html
@@ -14,6 +14,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - parameters
+browser-compat: api.RTCRtpReceiveParameters
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiveParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.html
@@ -19,6 +19,7 @@ tags:
 - WebRTC Device API
 - capabilities
 - getCapabilities
+browser-compat: api.RTCRtpReceiver.getCapabilities
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -116,4 +117,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.getCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - getContributingSources
+browser-compat: api.RTCRtpReceiver.getContributingSources
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.getContributingSources")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpreceiver/getparameters/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getparameters/index.html
@@ -16,6 +16,7 @@ tags:
 - getParameters
 - parameters
 - rtc
+browser-compat: api.RTCRtpReceiver.getParameters
 ---
 <p>{{APIRef("WebRTC API")}}</p>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.getParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC Statistics
 - WebRTC Statistics API
 - getStats
+browser-compat: api.RTCRtpReceiver.getStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.getStats")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/getsynchronizationsources/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/getsynchronizationsources/index.html
@@ -10,6 +10,7 @@ tags:
 - Web
 - WebRTC
 - getSynchronizationSources
+browser-compat: api.RTCRtpReceiver.getSynchronizationSources
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.getSynchronizationSources")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpreceiver/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/index.html
@@ -10,6 +10,7 @@ tags:
   - WebRTC
   - WebRTC Statistics
   - WebRTC Statistics API
+browser-compat: api.RTCRtpReceiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpreceiver/track/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/track/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - track
+browser-compat: api.RTCRtpReceiver.track
 ---
 <p>{{APIRef("WebRTC API")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.track")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpreceiver/transport/index.html
+++ b/files/en-us/web/api/rtcrtpreceiver/transport/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - receiver
+browser-compat: api.RTCRtpReceiver.transport
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiver.transport")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsender/dtmf/index.html
+++ b/files/en-us/web/api/rtcrtpsender/dtmf/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - WebRTC API
+browser-compat: api.RTCRtpSender.dtmf
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.dtmf")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC Device API
 - capabilities
 - getCapabilities
+browser-compat: api.RTCRtpSender.getCapabilities
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -113,4 +114,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.getCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC
 - WebRTC API
 - getParameters()
+browser-compat: api.RTCRtpSender.getParameters
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.getParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.html
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC Statistics
 - WebRTC Statistics API
 - getStats
+browser-compat: api.RTCRtpSender.getStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.getStats")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/index.html
+++ b/files/en-us/web/api/rtcrtpsender/index.html
@@ -16,6 +16,7 @@ tags:
   - WebRTC
   - WebRTC API
   - WebRTC Device API
+browser-compat: api.RTCRtpSender
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.html
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.html
@@ -14,6 +14,7 @@ tags:
 - replace
 - replaceTrack
 - track
+browser-compat: api.RTCRtpSender.replaceTrack
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -143,7 +144,7 @@ navigator.mediaDevices
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.replaceTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.html
@@ -15,6 +15,7 @@ tags:
 - parameters
 - sender
 - setParameters
+browser-compat: api.RTCRtpSender.setParameters
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -212,7 +213,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.setParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpsender/setstreams/index.html
+++ b/files/en-us/web/api/rtcrtpsender/setstreams/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - WebRTC API Reference
 - setStreams
+browser-compat: api.RTCRtpSender.setStreams
 ---
 <p>{{DefaultAPISidebar("WebRTC API")}}</p>
 
@@ -104,4 +105,4 @@ rtcRtpSender.setStreams([<em>mediaStream...</em>]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.setStreams")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsender/track/index.html
+++ b/files/en-us/web/api/rtcrtpsender/track/index.html
@@ -12,6 +12,7 @@ tags:
 - Web
 - WebRTC API
 - track
+browser-compat: api.RTCRtpSender.track
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.track")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsender/transport/index.html
+++ b/files/en-us/web/api/rtcrtpsender/transport/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - WebRTC Device API
 - sender
+browser-compat: api.RTCRtpSender.transport
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSender.transport")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsendparameters/encodings/index.html
+++ b/files/en-us/web/api/rtcrtpsendparameters/encodings/index.html
@@ -17,6 +17,7 @@ tags:
 - parameters
 - rtc
 - sender
+browser-compat: api.RTCRtpSendParameters.encodings
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSendParameters.encodings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsendparameters/index.html
+++ b/files/en-us/web/api/rtcrtpsendparameters/index.html
@@ -18,6 +18,7 @@ tags:
   - WebRTC API
   - parameters
   - sender
+browser-compat: api.RTCRtpSendParameters
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSendParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/codecid/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/codecid/index.html
@@ -17,6 +17,7 @@ tags:
 - codecId
 - id
 - rtc
+browser-compat: api.RTCRtpStreamStats.codecId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.codecId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/fircount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/fircount/index.html
@@ -17,6 +17,7 @@ tags:
 - firCount
 - rtc
 - stream
+browser-compat: api.RTCRtpStreamStats.firCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -75,4 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.firCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC
   - WebRTC API
   - rtc
+browser-compat: api.RTCRtpStreamStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -86,4 +87,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/kind/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/kind/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC API
 - kind
 - rtc
+browser-compat: api.RTCRtpStreamStats.kind
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.kind")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.html
@@ -17,6 +17,7 @@ tags:
 - WebRTC API
 - nackCount
 - rtc
+browser-compat: api.RTCRtpStreamStats.nackCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.nackCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/plicount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/plicount/index.html
@@ -19,6 +19,7 @@ tags:
 - WebRTC API
 - pliCount
 - rtc
+browser-compat: api.RTCRtpStreamStats.pliCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.pliCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.html
@@ -20,6 +20,7 @@ tags:
 - compression
 - qpSum
 - rtc
+browser-compat: api.RTCRtpStreamStats.qpSum
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -126,4 +127,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.qpSum")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/slicount/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/slicount/index.html
@@ -19,6 +19,7 @@ tags:
 - rtc
 - sliCount
 - slice
+browser-compat: api.RTCRtpStreamStats.sliCount
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.sliCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.html
@@ -14,6 +14,7 @@ tags:
 - rtc
 - source
 - ssrc
+browser-compat: api.RTCRtpStreamStats.ssrc
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.ssrc")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/trackid/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/trackid/index.html
@@ -15,6 +15,7 @@ tags:
 - rtc
 - track
 - trackId
+browser-compat: api.RTCRtpStreamStats.trackId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.trackId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpstreamstats/transportid/index.html
+++ b/files/en-us/web/api/rtcrtpstreamstats/transportid/index.html
@@ -13,6 +13,7 @@ tags:
 - id
 - rtc
 - transportID
+browser-compat: api.RTCRtpStreamStats.transportId
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpStreamStats.transportId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsynchronizationsource/index.html
+++ b/files/en-us/web/api/rtcrtpsynchronizationsource/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Synchronization Source
   - WebRTC
+browser-compat: api.RTCRtpSynchronizationSource
 ---
 <div>{{APIRef("WebRTC API")}}</div>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSynchronizationSource")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpsynchronizationsource/voiceactivityflag/index.html
+++ b/files/en-us/web/api/rtcrtpsynchronizationsource/voiceactivityflag/index.html
@@ -11,6 +11,7 @@ tags:
 - Voice Detection
 - WebRTC
 - voiceActivityFlag
+browser-compat: api.RTCRtpSynchronizationSource.voiceActivityFlag
 ---
 <div>{{APIRef("WebRTC API")}}{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpSynchronizationSource.voiceActivityFlag")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtptransceiver/currentdirection/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/currentdirection/index.html
@@ -12,6 +12,7 @@ tags:
 - Transceiver
 - WebRTC
 - currentDirection
+browser-compat: api.RTCRtpTransceiver.currentDirection
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.currentDirection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/direction/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/direction/index.html
@@ -12,6 +12,7 @@ tags:
 - Transceiver Direction
 - WebRTC
 - direction
+browser-compat: api.RTCRtpTransceiver.direction
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.direction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/index.html
@@ -12,6 +12,7 @@ tags:
   - SDP
   - Transceiver
   - WebRTC
+browser-compat: api.RTCRtpTransceiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/mid/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/mid/index.html
@@ -13,6 +13,7 @@ tags:
 - SDP
 - WebRTC
 - mid
+browser-compat: api.RTCRtpTransceiver.mid
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.mid")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/receiver/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/receiver/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - WebRTC
 - receiver
+browser-compat: api.RTCRtpTransceiver.receiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.receiver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/sender/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/sender/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - sender
+browser-compat: api.RTCRtpTransceiver.sender
 ---
 
 <div>{{APIRef("WebRTC")}}</div>
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.sender")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/setcodecpreferences/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/setcodecpreferences/index.html
@@ -14,6 +14,7 @@ tags:
 - Settings
 - WebRTC
 - setCodecPreferences
+browser-compat: api.RTCRtpTransceiver.setCodecPreferences
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -113,7 +114,7 @@ var availReceiveCodecs = transceiver.receiver.getCapabilities("video").codecs;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.setCodecPreferences")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/stop/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/stop/index.html
@@ -11,6 +11,7 @@ tags:
 - Stopping a Transceiver
 - WebRTC
 - stop
+browser-compat: api.RTCRtpTransceiver.stop
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.stop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
+++ b/files/en-us/web/api/rtcrtptransceiver/stopped/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - WebRTC
 - stopped
+browser-compat: api.RTCRtpTransceiver.stopped
 ---
 <div>{{APIRef("WebRTC")}}{{deprecated_header}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiver.stopped")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiverdirection/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverdirection/index.html
@@ -17,6 +17,7 @@ tags:
   - recvonly
   - sendonly
   - sendrecv
+browser-compat: api.RTCRtpTransceiverDirection
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiverDirection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcrtptransceiverinit/index.html
+++ b/files/en-us/web/api/rtcrtptransceiverinit/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Transceiver
   - WebRTC
+browser-compat: api.RTCRtpTransceiverInit
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpTransceiverInit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsctptransport/index.html
+++ b/files/en-us/web/api/rtcsctptransport/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Unimplemented
   - WebRTC
+browser-compat: api.RTCSctpTransport
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSctpTransport")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsctptransport/state/index.html
+++ b/files/en-us/web/api/rtcsctptransport/state/index.html
@@ -14,6 +14,7 @@ tags:
 - Reference
 - WebRTC
 - state
+browser-compat: api.RTCSctpTransport.state
 ---
 <p>{{APIRef("WebRTC")}}{{Draft}}{{SeeCompatTable}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSctpTransport.state")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/index.html
@@ -11,6 +11,7 @@ tags:
   - Video
   - Web
   - WebRTC
+browser-compat: api.RTCSessionDescription
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -111,7 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSessionDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - SDP
 - WebRTC
+browser-compat: api.RTCSessionDescription.RTCSessionDescription
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}{{deprecated_header}}</p>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSessionDescription.RTCSessionDescription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/sdp/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/sdp/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - SDP
 - WebRTC
+browser-compat: api.RTCSessionDescription.sdp
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -66,7 +67,7 @@ alert(pc.remoteDescription.sdp);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSessionDescription.sdp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/tojson/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/tojson/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Serializer
 - WebRTC
+browser-compat: api.RTCSessionDescription.toJSON
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -63,7 +64,7 @@ alert(JSON.stringify(sd)); // This call the toJSON() method behind the scene.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSessionDescription.toJSON")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsessiondescription/type/index.html
+++ b/files/en-us/web/api/rtcsessiondescription/type/index.html
@@ -9,6 +9,7 @@ tags:
 - SDP
 - Type
 - WebRTC
+browser-compat: api.RTCSessionDescription.type
 ---
 <p>{{APIRef("WebRTC")}}{{SeeCompatTable}}</p>
 
@@ -67,7 +68,7 @@ alert(pc.remoteDescription.type);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSessionDescription.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcsessiondescriptioncallback/index.html
+++ b/files/en-us/web/api/rtcsessiondescriptioncallback/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - SDP
 - WebRTC
+browser-compat: api.RTCSessionDescriptionCallback
 ---
 <div>{{APIRef("WebRTC")}}{{deprecated_header}}</div>
 
@@ -76,7 +77,7 @@ pc.createOffer(descriptionCallback);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCSessionDescriptionCallback")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcstats/id/index.html
+++ b/files/en-us/web/api/rtcstats/id/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC API
 - id
 - rtc
+browser-compat: api.RTCStats.id
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStats.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcstats/index.html
+++ b/files/en-us/web/api/rtcstats/index.html
@@ -11,6 +11,7 @@ tags:
   - Stats
   - WebRTC
   - rtc
+browser-compat: api.RTCStats
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStats")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcstats/timestamp/index.html
+++ b/files/en-us/web/api/rtcstats/timestamp/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC API
 - rtc
 - timeStamp
+browser-compat: api.RTCStats.timestamp
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStats.timestamp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcstats/type/index.html
+++ b/files/en-us/web/api/rtcstats/type/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - rtc
+browser-compat: api.RTCStats.type
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStats.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcstatsicecandidatepairstate/index.html
+++ b/files/en-us/web/api/rtcstatsicecandidatepairstate/index.html
@@ -15,6 +15,7 @@ tags:
   - WebRTC
   - WebRTC API
   - state
+browser-compat: api.RTCStatsIceCandidatePairState
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStatsIceCandidatePairState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcstatsreport/index.html
+++ b/files/en-us/web/api/rtcstatsreport/index.html
@@ -11,6 +11,7 @@ tags:
   - RTCStatsReport
   - Reference
   - WebRTC
+browser-compat: api.RTCStatsReport
 ---
 <p>{{APIRef("WebRTC")}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStatsReport")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcstatstype/index.html
+++ b/files/en-us/web/api/rtcstatstype/index.html
@@ -13,6 +13,7 @@ tags:
   - WebRTC API
   - WebRTC Statistics Identifiers
   - rtc
+browser-compat: api.RTCStatsType
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCStatsType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackevent/index.html
+++ b/files/en-us/web/api/rtctrackevent/index.html
@@ -12,6 +12,7 @@ tags:
   - events
   - rtc
   - track
+browser-compat: api.RTCTrackEvent
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackevent/receiver/index.html
+++ b/files/en-us/web/api/rtctrackevent/receiver/index.html
@@ -15,6 +15,7 @@ tags:
 - events
 - receiver
 - track
+browser-compat: api.RTCTrackEvent.receiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEvent.receiver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackevent/rtctrackevent/index.html
+++ b/files/en-us/web/api/rtctrackevent/rtctrackevent/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC API
 - events
 - track
+browser-compat: api.RTCTrackEvent.RTCTrackEvent
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEvent.RTCTrackEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackevent/streams/index.html
+++ b/files/en-us/web/api/rtctrackevent/streams/index.html
@@ -13,6 +13,7 @@ tags:
 - WebRTC API
 - events
 - track
+browser-compat: api.RTCTrackEvent.streams
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEvent.streams")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackevent/track/index.html
+++ b/files/en-us/web/api/rtctrackevent/track/index.html
@@ -14,6 +14,7 @@ tags:
 - WebRTC API
 - events
 - track
+browser-compat: api.RTCTrackEvent.track
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEvent.track")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackevent/transceiver/index.html
+++ b/files/en-us/web/api/rtctrackevent/transceiver/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC
 - WebRTC API
 - events
+browser-compat: api.RTCTrackEvent.transceiver
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEvent.transceiver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackeventinit/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/index.html
@@ -12,6 +12,7 @@ tags:
   - WebRTC API
   - events
   - track
+browser-compat: api.RTCTrackEventInit
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEventInit")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackeventinit/receiver/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/receiver/index.html
@@ -12,6 +12,7 @@ tags:
 - events
 - receiver
 - track
+browser-compat: api.RTCTrackEventInit.receiver
 ---
 <div>{{APIRef("WebAPI")}}</div>
 
@@ -56,4 +57,4 @@ var <em>rtpReceiver</em> = <em>trackEventInit</em>.receiver;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEventInit.receiver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackeventinit/streams/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/streams/index.html
@@ -12,6 +12,7 @@ tags:
 - WebRTC API
 - events
 - track
+browser-compat: api.RTCTrackEventInit.streams
 ---
 <div>{{APIRef("WebAPI")}}</div>
 
@@ -60,4 +61,4 @@ var <em>streamList</em> = <em>trackEventInit</em>.streams;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEventInit.streams")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackeventinit/track/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/track/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC API
 - events
 - track
+browser-compat: api.RTCTrackEventInit.track
 ---
 <div>{{APIRef("WebAPI")}}</div>
 
@@ -58,4 +59,4 @@ var <em>track</em> = <em>trackEventInit</em>.track;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEventInit.track")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtctrackeventinit/transceiver/index.html
+++ b/files/en-us/web/api/rtctrackeventinit/transceiver/index.html
@@ -11,6 +11,7 @@ tags:
 - WebRTC
 - WebRTC API
 - events
+browser-compat: api.RTCTrackEventInit.transceiver
 ---
 <div>{{APIRef("WebAPI")}}</div>
 
@@ -57,4 +58,4 @@ var <em>rtpTransceiver</em> = <em>trackEventInit</em>.transceiver;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCTrackEventInit.transceiver")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/r* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

483 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
