### PR TITLE
Put browser-compat info in front-runner for api/t*

### DIFF
--- a/files/en-us/web/api/taskattributiontiming/containerid/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - TaskAttributionTiming
+browser-compat: api.TaskAttributionTiming.containerId
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TaskAttributionTiming.containerId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/taskattributiontiming/containername/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - TaskAttributionTiming
+browser-compat: api.TaskAttributionTiming.containerName
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TaskAttributionTiming.containerName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - TaskAttributionTiming
+browser-compat: api.TaskAttributionTiming.containerSrc
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TaskAttributionTiming.containerSrc")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.html
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - TaskAttributionTiming
+browser-compat: api.TaskAttributionTiming.containerType
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TaskAttributionTiming.containerType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/taskattributiontiming/index.html
+++ b/files/en-us/web/api/taskattributiontiming/index.html
@@ -8,6 +8,7 @@ tags:
   - Long Tasks API
   - Performance
   - TaskAttributionTiming
+browser-compat: api.TaskAttributionTiming
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TaskAttributionTiming")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/text/assignedslot/index.html
+++ b/files/en-us/web/api/text/assignedslot/index.html
@@ -8,6 +8,7 @@ tags:
 - Text
 - assignedSlot
 - shadow dom
+browser-compat: api.Text.assignedSlot
 ---
 <p>{{APIRef("Shadow DOM")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text.assignedSlot")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/text/index.html
+++ b/files/en-us/web/api/text/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Interface
   - Reference
+browser-compat: api.Text
 ---
 <div>{{ApiRef("DOM")}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/text/iselementcontentwhitespace/index.html
+++ b/files/en-us/web/api/text/iselementcontentwhitespace/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Property
   - Text
+browser-compat: api.Text.isElementContentWhitespace
 ---
 <p>{{ApiRef("DOM")}}{{deprecated_header}}</p>
 
@@ -36,7 +37,7 @@ ws.isElementContentWhitespace; /* evaluates to true */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text.isElementContentWhitespace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/text/replacewholetext/index.html
+++ b/files/en-us/web/api/text/replacewholetext/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Deprecated
 - Text
+browser-compat: api.Text.replaceWholeText
 ---
 <p>{{ApiRef("DOM")}}{{deprecated_header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text.replaceWholeText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/text/splittext/index.html
+++ b/files/en-us/web/api/text/splittext/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Text
 - splitText
+browser-compat: api.Text.splitText
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -116,7 +117,7 @@ p.insertBefore(u, bar);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text.splitText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/text/text/index.html
+++ b/files/en-us/web/api/text/text/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Reference
   - Text
+browser-compat: api.Text.Text
 ---
 <div>{{ Apiref("DOM")}}{{SeeCompatTable}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text.Text")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/text/wholetext/index.html
+++ b/files/en-us/web/api/text/wholetext/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - Text
+browser-compat: api.Text.wholeText
 ---
 <p>{{ apiref("DOM") }}</p>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Text.wholeText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textdecoder/decode/index.html
+++ b/files/en-us/web/api/textdecoder/decode/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Method
   - TextDecoder
+browser-compat: api.TextDecoder.decode
 ---
 <div>{{APIRef("Encoding API")}}{{SeeCompatTable}}</div>
 
@@ -84,7 +85,7 @@ document.getElementById('decoded-value').textContent = str;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoder.decode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textdecoder/encoding/index.html
+++ b/files/en-us/web/api/textdecoder/encoding/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Read-only
 - TextDecoder
+browser-compat: api.TextDecoder.encoding
 ---
 <p>{{APIRef("Encoding API")}}{{SeeCompatTable}}</p>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoder.encoding")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - TextDecoder
+browser-compat: api.TextDecoder
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -96,7 +97,7 @@ console.log(win1251decoder.decode(bytes)); // Привет, мир!
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textdecoder/textdecoder/index.html
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Reference
   - TextDecoder
+browser-compat: api.TextDecoder.TextDecoder
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -71,7 +72,7 @@ var textDecoder4 = new TextDecoder(&quot;iso-2022-cn&quot;); // Throw a TypeErro
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoder.TextDecoder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.html
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - encoding
   - TextDecoderStream
+browser-compat: api.TextDecoderStream.encoding
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -46,4 +47,4 @@ console.log(stream.encoding); // returns the default "utf-8"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream.encoding")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textdecoderstream/fatal/index.html
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - fatal
   - TextDecoderStream
+browser-compat: api.TextDecoderStream.fatal
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -45,4 +46,4 @@ console.log(stream.fatal); // returns false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream.fatal")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.html
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - ignoreBOM
   - TextDecoderStream
+browser-compat: api.TextDecoderStream.ignoreBOM
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -44,4 +45,4 @@ console.log(stream.ignoreBOM); // returns false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream.ignoreBOM")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TextDecoderStream
+browser-compat: api.TextDecoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textdecoderstream/readable/index.html
+++ b/files/en-us/web/api/textdecoderstream/readable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - readable
   - TextDecoderStream
+browser-compat: api.TextDecoderStream.readable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -45,4 +46,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream.readable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - TextDecoderStream
+browser-compat: api.TextDecoderStream.TextDecoderStream
 ---
 
 <p>{{APIRef("Encoding API")}}</p>
@@ -55,4 +56,4 @@ const stream = response.body.pipeThrough(new TextDecoderStream());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream.TextDecoderStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textdecoderstream/writable/index.html
+++ b/files/en-us/web/api/textdecoderstream/writable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - writable
   - TextDecoderStream
+browser-compat: api.TextDecoderStream.writable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -46,4 +47,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextDecoderStream.writable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textencoder/encode/index.html
+++ b/files/en-us/web/api/textencoder/encode/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - TextEncoder
 - encode
+browser-compat: api.TextEncoder.encode
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -68,7 +69,7 @@ resultPara.textContent += encoded;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoder.encode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textencoder/encodeinto/index.html
+++ b/files/en-us/web/api/textencoder/encodeinto/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - TextEncoder
   - encodeInto
+browser-compat: api.TextEncoder.encodeInto
 ---
 <p>{{APIRef("Encoding API")}}{{SeeCompatTable}}</p>
 
@@ -302,7 +303,7 @@ resultPara.textContent += 'Bytes read: ' + encodedResults.read +
 
 <div>
 
-    <p>{{Compat("api.TextEncoder.encodeInto")}}</p>
+    <p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/textencoder/encoding/index.html
+++ b/files/en-us/web/api/textencoder/encoding/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - TextEncoder
+browser-compat: api.TextEncoder.encoding
 ---
 <div>{{APIRef("Encoding API")}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoder.encoding")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textencoder/index.html
+++ b/files/en-us/web/api/textencoder/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - Reference
   - TextEncoder
+browser-compat: api.TextEncoder
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -136,7 +137,7 @@ console.log(view); // Uint8Array(3) [226, 130, 172]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textencoder/textencoder/index.html
+++ b/files/en-us/web/api/textencoder/textencoder/index.html
@@ -7,6 +7,7 @@ tags:
 - Encoding
 - Reference
 - TextEncoder
+browser-compat: api.TextEncoder.TextEncoder
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoder.TextEncoder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textencoderstream/encoding/index.html
+++ b/files/en-us/web/api/textencoderstream/encoding/index.html
@@ -8,6 +8,7 @@ tags:
   - encoding
   - TextEncoderStream
   - Read-only
+browser-compat: api.TextEncoderStream.encoding
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -47,4 +48,4 @@ console.log(stream.encoding);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoderStream.encoding")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/index.html
@@ -7,6 +7,7 @@ tags:
   - Encoding
   - Reference
   - TextEncoderStream
+browser-compat: api.TextEncoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoderStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textencoderstream/readable/index.html
+++ b/files/en-us/web/api/textencoderstream/readable/index.html
@@ -8,6 +8,7 @@ tags:
   - readable
   - TextEncoderStream
   - Read-only
+browser-compat: api.TextEncoderStream.readable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -46,4 +47,4 @@ console.log(stream.readable); //a ReadableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoderStream.readable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textencoderstream/textencoderstream/index.html
+++ b/files/en-us/web/api/textencoderstream/textencoderstream/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - TextEncoderStream
+browser-compat: api.TextEncoderStream.TextEncoderStream
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -41,4 +42,4 @@ fetch('/dest', { method: 'POST', body, headers: {'Content-Type': 'text/plain; ch
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoderStream.TextEncoderStream")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textencoderstream/writable/index.html
+++ b/files/en-us/web/api/textencoderstream/writable/index.html
@@ -8,6 +8,7 @@ tags:
   - writable
   - TextEncoderStream
   - Read-only
+browser-compat: api.TextEncoderStream.writable
 ---
 <p>{{APIRef("Encoding API")}}</p>
 
@@ -46,4 +47,4 @@ console.log(stream.writeable); //a WritableStream</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextEncoderStream.writable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/textmetrics/actualboundingboxascent/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxascent/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.actualBoundingBoxAscent
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.actualBoundingBoxAscent; // 8;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.actualBoundingBoxAscent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxdescent/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxdescent/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.actualBoundingBoxDescent
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.actualBoundingBoxDescent; // 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.actualBoundingBoxDescent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxleft/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxleft/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.actualBoundingBoxLeft
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.actualBoundingBoxLeft; // 0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.actualBoundingBoxLeft")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/actualboundingboxright/index.html
+++ b/files/en-us/web/api/textmetrics/actualboundingboxright/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.actualBoundingBoxRight
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.actualBoundingBoxRight; // 15.633333333333333;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.actualBoundingBoxRight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/alphabeticbaseline/index.html
+++ b/files/en-us/web/api/textmetrics/alphabeticbaseline/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.alphabeticBaseline
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.alphabeticBaseline; // -0;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.alphabeticBaseline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/emheightascent/index.html
+++ b/files/en-us/web/api/textmetrics/emheightascent/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.emHeightAscent
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.emHeightAscent; // 7.59765625;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.emHeightAscent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/emheightdescent/index.html
+++ b/files/en-us/web/api/textmetrics/emheightdescent/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.emHeightDescent
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.emHeightDescent; // -2.40234375;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.emHeightDescent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/fontboundingboxascent/index.html
+++ b/files/en-us/web/api/textmetrics/fontboundingboxascent/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.fontBoundingBoxAscent
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.fontBoundingBoxAscent; // 10;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.fontBoundingBoxAscent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/fontboundingboxdescent/index.html
+++ b/files/en-us/web/api/textmetrics/fontboundingboxdescent/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.fontBoundingBoxDescent
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.fontBoundingBoxDescent; // 3;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.fontBoundingBoxDescent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/hangingbaseline/index.html
+++ b/files/en-us/web/api/textmetrics/hangingbaseline/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.hangingBaseline
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.hangingBaseline; // 6.078125;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.hangingBaseline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/ideographicbaseline/index.html
+++ b/files/en-us/web/api/textmetrics/ideographicbaseline/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.ideographicBaseline
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -36,7 +37,7 @@ text.ideographicBaseline; // -1.201171875;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.ideographicBaseline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/index.html
+++ b/files/en-us/web/api/textmetrics/index.html
@@ -6,6 +6,7 @@ tags:
   - Canvas
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -121,7 +122,7 @@ console.log(Math.abs(textMetrics.actualBoundingBoxLeft) +
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/textmetrics/width/index.html
+++ b/files/en-us/web/api/textmetrics/width/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - TextMetrics
+browser-compat: api.TextMetrics.width
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -43,7 +44,7 @@ text.width; // 16;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextMetrics.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/texttrack/cuechange_event/index.html
+++ b/files/en-us/web/api/texttrack/cuechange_event/index.html
@@ -10,6 +10,7 @@ tags:
   - cuechange
   - oncuechange
   - track
+browser-compat: api.TextTrack.cuechange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -93,7 +94,7 @@ textTrackElem.oncuechange = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrack.cuechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/texttrack/index.html
+++ b/files/en-us/web/api/texttrack/index.html
@@ -9,6 +9,7 @@ tags:
   - TextTrack
   - Web
   - WebVTT
+browser-compat: api.TextTrack
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/texttrack/mode/index.html
+++ b/files/en-us/web/api/texttrack/mode/index.html
@@ -9,6 +9,7 @@ tags:
 - Web
 - WebVTT
 - mode
+browser-compat: api.TextTrack.mode
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
@@ -136,7 +137,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrack.mode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/texttrackcue/index.html
+++ b/files/en-us/web/api/texttrackcue/index.html
@@ -16,6 +16,7 @@ tags:
   - cue
   - track
   - vtt
+browser-compat: api.TextTrackCue
 ---
 <p>{{APIRef("WebVTT")}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackCue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.html
@@ -9,6 +9,7 @@ tags:
   - TextTrackCueList
   - WebVTT
   - Media
+browser-compat: api.TextTrackCueList.getCueById
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
@@ -68,4 +69,4 @@ video.onplay = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackCueList.getCueById")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttrackcuelist/index.html
+++ b/files/en-us/web/api/texttrackcuelist/index.html
@@ -8,6 +8,7 @@ tags:
   - TextTrackCueList
   - WebVTT
   - Media
+browser-compat: api.TextTrackCueList
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
@@ -57,4 +58,4 @@ video.onplay = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackCueList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttrackcuelist/length/index.html
+++ b/files/en-us/web/api/texttrackcuelist/length/index.html
@@ -9,6 +9,7 @@ tags:
   - TextTrackCueList
   - WebVTT
   - Media
+browser-compat: api.TextTrackCueList.length
 ---
 <div>{{APIRef("WebVTT")}}</div>
 
@@ -72,4 +73,4 @@ video.onplay = function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackCueList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/addtrack_event/index.html
+++ b/files/en-us/web/api/texttracklist/addtrack_event/index.html
@@ -9,6 +9,7 @@ tags:
   - addTrack
   - addTrack Event
   - events
+browser-compat: api.TextTrackList.addTrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -70,7 +71,7 @@ mediaElement.textTracks.onaddtrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.addTrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/texttracklist/change_event/index.html
+++ b/files/en-us/web/api/texttracklist/change_event/index.html
@@ -6,6 +6,7 @@ tags:
   - TextTrack
   - TextTrackList
   - change event
+browser-compat: api.TextTrackList.change_event
 ---
 <div>{{APIRef}}</div>
 
@@ -67,7 +68,7 @@ mediaElement.textTracks.onchange = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.change_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/texttracklist/gettrackbyid/index.html
+++ b/files/en-us/web/api/texttracklist/gettrackbyid/index.html
@@ -16,6 +16,7 @@ tags:
 - getTrackById
 - id
 - track
+browser-compat: api.TextTrackList.getTrackById
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.getTrackById")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/index.html
+++ b/files/en-us/web/api/texttracklist/index.html
@@ -12,6 +12,7 @@ tags:
   - Track List
   - Tracks
   - list
+browser-compat: api.TextTrackList
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -108,4 +109,4 @@ function updateTrackCount(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/length/index.html
+++ b/files/en-us/web/api/texttracklist/length/index.html
@@ -12,6 +12,7 @@ tags:
 - length
 - list
 - track
+browser-compat: api.TextTrackList.length
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -69,4 +70,4 @@ if (mediaElem.textTracks) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/texttracklist/onaddtrack/index.html
@@ -13,6 +13,7 @@ tags:
 - addTrack
 - onaddtrack
 - track
+browser-compat: api.TextTrackList.onaddtrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.onaddtrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/onchange/index.html
+++ b/files/en-us/web/api/texttracklist/onchange/index.html
@@ -16,6 +16,7 @@ tags:
 - onchange
 - text track
 - track
+browser-compat: api.TextTrackList.onchange
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -68,4 +69,4 @@ trackList.onchange = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/texttracklist/onremovetrack/index.html
@@ -16,6 +16,7 @@ tags:
 - remove
 - removeTrack
 - track
+browser-compat: api.TextTrackList.onremovetrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.onremovetrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/texttracklist/removetrack_event/index.html
+++ b/files/en-us/web/api/texttracklist/removetrack_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Removing Tracks
   - events
   - removeTrack
+browser-compat: api.TextTrackList.removeTrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -70,7 +71,7 @@ mediaElement.textTracks.onremovetrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TextTrackList.removeTrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/timeranges/end/index.html
+++ b/files/en-us/web/api/timeranges/end/index.html
@@ -9,6 +9,7 @@ tags:
 - NeedsBrowserCompatibility
 - Reference
 - TimeRanges
+browser-compat: api.TimeRanges.end
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -76,4 +77,4 @@ if (buf.length == 1) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TimeRanges.end")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/timeranges/index.html
+++ b/files/en-us/web/api/timeranges/index.html
@@ -8,6 +8,7 @@ tags:
   - Media
   - NeedsExample
   - Reference
+browser-compat: api.TimeRanges
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TimeRanges")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/timeranges/length/index.html
+++ b/files/en-us/web/api/timeranges/length/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - TimeRanges
+browser-compat: api.TimeRanges.length
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -64,4 +65,4 @@ if (buf.length == 1) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TimeRanges.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/timeranges/start/index.html
+++ b/files/en-us/web/api/timeranges/start/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsBrowserCompatibility
   - Reference
   - TimeRanges
+browser-compat: api.TimeRanges.start
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -74,4 +75,4 @@ if (buf.length == 1) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TimeRanges.start")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/clientx/index.html
+++ b/files/en-us/web/api/touch/clientx/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - touch
+browser-compat: api.Touch.clientX
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -89,4 +90,4 @@ src.addEventListener('touchend', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.clientX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/clienty/index.html
+++ b/files/en-us/web/api/touch/clienty/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - touch
+browser-compat: api.Touch.clientY
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -88,4 +89,4 @@ src.addEventListener('touchend', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.clientY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/force/index.html
+++ b/files/en-us/web/api/touch/force/index.html
@@ -7,6 +7,7 @@ tags:
 - Property
 - Read-only
 - touch
+browser-compat: api.Touch.force
 ---
 <p>{{ APIRef("Touch Events") }}{{SeeCompatTable}}</p>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.force")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/identifier/index.html
+++ b/files/en-us/web/api/touch/identifier/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - touch
+browser-compat: api.Touch.identifier
 ---
 <p>{{ APIRef("Touch Events") }}{{SeeCompatTable}}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.identifier")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/index.html
+++ b/files/en-us/web/api/touch/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - TouchEvent
   - touch
+browser-compat: api.Touch
 ---
 <p>{{APIRef("Touch Events")}}</p>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/touch/pagex/index.html
+++ b/files/en-us/web/api/touch/pagex/index.html
@@ -7,6 +7,7 @@ tags:
 - Read-only
 - Reference
 - touch
+browser-compat: api.Touch.pageX
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -75,4 +76,4 @@ src.addEventListener('touchmove', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.pageX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/pagey/index.html
+++ b/files/en-us/web/api/touch/pagey/index.html
@@ -7,6 +7,7 @@ tags:
 - Read-only
 - Reference
 - touch
+browser-compat: api.Touch.pageY
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -74,4 +75,4 @@ src.addEventListener('touchmove', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.pageY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/radiusx/index.html
+++ b/files/en-us/web/api/touch/radiusx/index.html
@@ -8,6 +8,7 @@ tags:
   - Mobile
   - Property
   - touch
+browser-compat: api.Touch.radiusX
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -80,4 +81,4 @@ function rotate (e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.radiusX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/radiusy/index.html
+++ b/files/en-us/web/api/touch/radiusy/index.html
@@ -8,6 +8,7 @@ tags:
   - Mobile
   - Property
   - touch
+browser-compat: api.Touch.radiusY
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.radiusY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/rotationangle/index.html
+++ b/files/en-us/web/api/touch/rotationangle/index.html
@@ -8,6 +8,7 @@ tags:
   - Mobile
   - Property
   - touch
+browser-compat: api.Touch.rotationAngle
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.rotationAngle")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/screenx/index.html
+++ b/files/en-us/web/api/touch/screenx/index.html
@@ -7,6 +7,7 @@ tags:
   - Mobile
   - Property
   - touch
+browser-compat: api.Touch.screenX
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -71,4 +72,4 @@ src.addEventListener('touchstart', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.screenX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/screeny/index.html
+++ b/files/en-us/web/api/touch/screeny/index.html
@@ -7,6 +7,7 @@ tags:
   - Mobile
   - Property
   - touch
+browser-compat: api.Touch.screenY
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.screenY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/target/index.html
+++ b/files/en-us/web/api/touch/target/index.html
@@ -8,6 +8,7 @@ tags:
   - Mobile
   - Property
   - touch
+browser-compat: api.Touch.target
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -70,4 +71,4 @@ src.addEventListener('touchstart', function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.target")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touch/touch/index.html
+++ b/files/en-us/web/api/touch/touch/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Reference
   - touch
+browser-compat: api.Touch.Touch
 ---
 <p>{{APIRef("Touch Events")}}{{SeeCompatTable}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Touch.Touch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/touchevent/altkey/index.html
+++ b/files/en-us/web/api/touchevent/altkey/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent.altKey
 ---
 <p>{{APIRef("Touch Events") }}</p>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.altKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/changedtouches/index.html
+++ b/files/en-us/web/api/touchevent/changedtouches/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent.changedTouches
 ---
 <div>{{ APIRef("Touch Events") }}</div>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.changedTouches")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/ctrlkey/index.html
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent.ctrlKey
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.ctrlKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/index.html
+++ b/files/en-us/web/api/touchevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent
 ---
 <p>{{APIRef("Touch Events")}}</p>
 
@@ -134,7 +135,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/touchevent/metakey/index.html
+++ b/files/en-us/web/api/touchevent/metakey/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent.metaKey
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.metaKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/shiftkey/index.html
+++ b/files/en-us/web/api/touchevent/shiftkey/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent.shiftKey
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.shiftKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/targettouches/index.html
+++ b/files/en-us/web/api/touchevent/targettouches/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - TouchEvent
   - touch
+browser-compat: api.TouchEvent.targetTouches
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.targetTouches")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/touches/index.html
+++ b/files/en-us/web/api/touchevent/touches/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - TouchEvent
 - touch
+browser-compat: api.TouchEvent.touches
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -86,4 +87,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.touches")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchevent/touchevent/index.html
+++ b/files/en-us/web/api/touchevent/touchevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - events
   - touch
+browser-compat: api.TouchEvent.TouchEvent
 ---
 <p id="Summary">{{APIRef("DOM Events")}}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchEvent.TouchEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/touchlist/identifiedtouch/index.html
+++ b/files/en-us/web/api/touchlist/identifiedtouch/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - TouchList
 - touch
+browser-compat: api.TouchList.identifiedTouch
 ---
 <p>{{APIRef("Touch Events")}}{{deprecated_header}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchList.identifiedTouch")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchlist/index.html
+++ b/files/en-us/web/api/touchlist/index.html
@@ -10,6 +10,7 @@ tags:
   - Touch Event
   - TouchList
   - touch
+browser-compat: api.TouchList
 ---
 <p>{{APIRef("Touch Events")}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/touchlist/item/index.html
+++ b/files/en-us/web/api/touchlist/item/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - TouchList
 - touch
+browser-compat: api.TouchList.item
 ---
 <p>{{ APIRef("Touch Events") }}</p>
 
@@ -84,4 +85,4 @@ target.addEventListener('touchstart', function(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchList.item")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/touchlist/length/index.html
+++ b/files/en-us/web/api/touchlist/length/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - TouchList
 - touch
+browser-compat: api.TouchList.length
 ---
 <div>{{ APIRef("Touch Events") }}</div>
 
@@ -74,4 +75,4 @@ target.addEventListener('touchstart', function(ev) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TouchList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trackdefault/bytestreamtrackid/index.html
+++ b/files/en-us/web/api/trackdefault/bytestreamtrackid/index.html
@@ -12,6 +12,7 @@ tags:
   - TrackDefault
   - Video
   - byteStreamTrackID
+browser-compat: api.TrackDefault.byteStreamTrackID
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -37,7 +38,7 @@ tags:
 <div>
 <div>
 
-<p>{{Compat("api.TrackDefault.byteStreamTrackID")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/trackdefault/index.html
+++ b/files/en-us/web/api/trackdefault/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - TrackDefault
   - Video
+browser-compat: api.TrackDefault
 ---
 <p>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefault")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefault/kinds/index.html
+++ b/files/en-us/web/api/trackdefault/kinds/index.html
@@ -12,6 +12,7 @@ tags:
   - TrackDefault
   - Video
   - kinds
+browser-compat: api.TrackDefault.kinds
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefault.kinds")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefault/label/index.html
+++ b/files/en-us/web/api/trackdefault/label/index.html
@@ -12,6 +12,7 @@ tags:
   - TrackDefault
   - Video
   - label
+browser-compat: api.TrackDefault.label
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -35,7 +36,7 @@ tags:
 <div>
 <div>
 
-<p>{{Compat("api.TrackDefault.label")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/trackdefault/language/index.html
+++ b/files/en-us/web/api/trackdefault/language/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - TrackDefault
   - Video
+browser-compat: api.TrackDefault.language
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefault.language")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefault/trackdefault/index.html
+++ b/files/en-us/web/api/trackdefault/trackdefault/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - TrackDefault
   - Video
+browser-compat: api.TrackDefault.TrackDefault
 ---
 <div>{{draft}}{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefault.TrackDefault")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefault/type/index.html
+++ b/files/en-us/web/api/trackdefault/type/index.html
@@ -12,6 +12,7 @@ tags:
   - TrackDefault
   - Type
   - Video
+browser-compat: api.TrackDefault.type
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefault.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefaultlist/index.html
+++ b/files/en-us/web/api/trackdefaultlist/index.html
@@ -13,6 +13,7 @@ tags:
   - TrackDefaultList
   - Video
   - source
+browser-compat: api.TrackDefaultList
 ---
 <p>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</p>
 
@@ -54,7 +55,7 @@ tags:
 <div>
 <div>
 
-<p>{{Compat("api.TrackDefaultList")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/trackdefaultlist/length/index.html
+++ b/files/en-us/web/api/trackdefaultlist/length/index.html
@@ -14,6 +14,7 @@ tags:
   - Video
   - length
   - source
+browser-compat: api.TrackDefaultList.length
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefaultList.length")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefaultlist/trackdefault/index.html
+++ b/files/en-us/web/api/trackdefaultlist/trackdefault/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Video
   - source
+browser-compat: api.TrackDefaultList.TrackDefault
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefaultList.TrackDefault")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackdefaultlist/trackdefaultlist/index.html
+++ b/files/en-us/web/api/trackdefaultlist/trackdefaultlist/index.html
@@ -13,6 +13,7 @@ tags:
   - TrackDefaultList
   - Video
   - source
+browser-compat: api.TrackDefaultList.TrackDefaultList
 ---
 <div>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackDefaultList.TrackDefaultList")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trackevent/index.html
+++ b/files/en-us/web/api/trackevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - TrackEvent
   - Video
+browser-compat: api.TrackEvent
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -106,4 +107,4 @@ function handleTrackEvent(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trackevent/track/index.html
+++ b/files/en-us/web/api/trackevent/track/index.html
@@ -13,6 +13,7 @@ tags:
 - TrackEvent
 - Video
 - track
+browser-compat: api.TrackEvent.track
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackEvent.track")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trackevent/trackevent/index.html
+++ b/files/en-us/web/api/trackevent/trackevent/index.html
@@ -11,6 +11,7 @@ tags:
 - TrackEvent
 - Tracks
 - Video
+browser-compat: api.TrackEvent.TrackEvent
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -81,4 +82,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrackEvent.TrackEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/transferable/index.html
+++ b/files/en-us/web/api/transferable/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Transferable
   - Web Workers
+browser-compat: api.Transferable
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Transferable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transformstream/index.html
+++ b/files/en-us/web/api/transformstream/index.html
@@ -3,6 +3,7 @@ title: TransformStream
 slug: Web/API/TransformStream
 tags:
   - Streams API
+browser-compat: api.TransformStream
 ---
 <p>{{APIRef("Streams")}}</p>
 
@@ -152,7 +153,7 @@ responses.reduce(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransformStream")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transitionevent/elapsedtime/index.html
+++ b/files/en-us/web/api/transitionevent/elapsedtime/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - TransitionEvent
+browser-compat: api.TransitionEvent.elapsedTime
 ---
 <p>{{ apiref("CSSOM") }} {{SeeCompatTable}}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransitionEvent.elapsedTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/index.html
@@ -8,6 +8,7 @@ tags:
   - CSSOM
   - Experimental
   - Reference
+browser-compat: api.TransitionEvent
 ---
 <div>{{APIRef("CSSOM")}} {{SeeCompatTable}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransitionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Method
   - Reference
   - TransitionEvent
+browser-compat: api.TransitionEvent.initTransitionEvent
 ---
 <p>{{ apiref("CSSOM") }} {{deprecated_header}}{{non-standard_header}}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransitionEvent.initTransitionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transitionevent/propertyname/index.html
+++ b/files/en-us/web/api/transitionevent/propertyname/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - TransitionEvent
+browser-compat: api.TransitionEvent.propertyName
 ---
 <p>{{ apiref("CSSOM") }}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransitionEvent.propertyName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transitionevent/pseudoelement/index.html
+++ b/files/en-us/web/api/transitionevent/pseudoelement/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - TransitionEvent
+browser-compat: api.TransitionEvent.pseudoElement
 ---
 <p>{{ apiref("CSSOM") }} {{SeeCompatTable}}</p>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransitionEvent.pseudoElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/transitionevent/transitionevent/index.html
+++ b/files/en-us/web/api/transitionevent/transitionevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Experimental
   - Reference
   - TransitionEvent
+browser-compat: api.TransitionEvent.TransitionEvent
 ---
 <p>{{APIRef("CSSOM")}}{{SeeCompatTable}}</p>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TransitionEvent.TransitionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/currentnode/index.html
+++ b/files/en-us/web/api/treewalker/currentnode/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - Property
   - TreeWalker
+browser-compat: api.TreeWalker.currentNode
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -56,7 +57,7 @@ root = treeWalker.currentNode; // the root element as it is the first element!
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.currentNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.html
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.html
@@ -7,6 +7,7 @@ tags:
 - Deprecated
 - Property
 - TreeWalker
+browser-compat: api.TreeWalker.expandEntityReferences
 ---
 <p>{{ APIRef("DOM") }}{{deprecated_header}}</p>
 
@@ -49,7 +50,7 @@ expand = treeWalker.expandEntityReferences;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.expandEntityReferences")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/filter/index.html
+++ b/files/en-us/web/api/treewalker/filter/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - TreeWalker
+browser-compat: api.TreeWalker.filter
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -58,7 +59,7 @@ nodeFilter = treeWalker.filter; // document.body in this case
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.filter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/firstchild/index.html
+++ b/files/en-us/web/api/treewalker/firstchild/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - TreeWalker
+browser-compat: api.TreeWalker.firstChild
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -58,7 +59,7 @@ var node = treeWalker.firstChild(); // returns the first child of the root eleme
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.firstChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/index.html
+++ b/files/en-us/web/api/treewalker/index.html
@@ -4,6 +4,7 @@ slug: Web/API/TreeWalker
 tags:
   - API
   - DOM
+browser-compat: api.TreeWalker
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -154,7 +155,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/lastchild/index.html
+++ b/files/en-us/web/api/treewalker/lastchild/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - TreeWalker
+browser-compat: api.TreeWalker.lastChild
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -57,7 +58,7 @@ var node = treeWalker.lastChild(); // returns the last visible child of the root
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.lastChild")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/nextnode/index.html
+++ b/files/en-us/web/api/treewalker/nextnode/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - TreeWalker
+browser-compat: api.TreeWalker.nextNode
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -58,7 +59,7 @@ var node = treeWalker.nextNode(); // returns the first child of root, as it is t
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.nextNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/nextsibling/index.html
+++ b/files/en-us/web/api/treewalker/nextsibling/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - TreeWalker
+browser-compat: api.TreeWalker.nextSibling
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -59,7 +60,7 @@ var node = treeWalker.nextSibling(); // returns null if the first child of the r
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.nextSibling")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/parentnode/index.html
+++ b/files/en-us/web/api/treewalker/parentnode/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - TreeWalker
+browser-compat: api.TreeWalker.parentNode
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -59,7 +60,7 @@ var node = treeWalker.parentNode(); // returns null as there is no parent
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.parentNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/previousnode/index.html
+++ b/files/en-us/web/api/treewalker/previousnode/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Method
 - TreeWalker
+browser-compat: api.TreeWalker.previousNode
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -60,7 +61,7 @@ var node = treeWalker.previousNode(); // returns null as there is no parent
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.previousNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/previoussibling/index.html
+++ b/files/en-us/web/api/treewalker/previoussibling/index.html
@@ -9,6 +9,7 @@ tags:
 - TreeWalker
 - createTreeWalker
 - treeWalker.previousSibling
+browser-compat: api.TreeWalker.previousSibling
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -60,7 +61,7 @@ var node = treeWalker.previousSibling(); // returns null as there is no previous
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.previousSibling")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/root/index.html
+++ b/files/en-us/web/api/treewalker/root/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - TreeWalker
+browser-compat: api.TreeWalker.root
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -52,7 +53,7 @@ root = treeWalker.root; // document.body in this case
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.root")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/treewalker/whattoshow/index.html
+++ b/files/en-us/web/api/treewalker/whattoshow/index.html
@@ -6,6 +6,7 @@ tags:
 - DOM
 - Property
 - TreeWalker
+browser-compat: api.TreeWalker.whatToShow
 ---
 <p>{{ APIRef("DOM") }}</p>
 
@@ -146,7 +147,7 @@ if( (treeWalker.whatToShow == NodeFilter.SHOW_ALL) ||
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TreeWalker.whatToShow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trustedhtml/index.html
+++ b/files/en-us/web/api/trustedhtml/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TrustedHTML
+browser-compat: api.TrustedHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -59,7 +60,7 @@ el.innerHTML = escaped;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedHTML")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trustedhtml/tojson/index.html
+++ b/files/en-us/web/api/trustedhtml/tojson/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toJSON
   - TrustedHTML
+browser-compat: api.TrustedHTML.toJSON
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -51,4 +52,4 @@ console.log(escaped.toJSON());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedHTML.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedhtml/tostring/index.html
+++ b/files/en-us/web/api/trustedhtml/tostring/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toString
   - TrustedHTML
+browser-compat: api.TrustedHTML.toString
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -51,4 +52,4 @@ console.log(escaped.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedHTML.toString")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedscript/index.html
+++ b/files/en-us/web/api/trustedscript/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TrustedScript
+browser-compat: api.TrustedScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -49,7 +50,7 @@ console.log(sanitized); /* a TrustedScript object */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedScript")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trustedscript/tojson/index.html
+++ b/files/en-us/web/api/trustedscript/tojson/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toJSON
   - TrustedScript
+browser-compat: api.TrustedScript.toJSON
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedScript.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedscript/tostring/index.html
+++ b/files/en-us/web/api/trustedscript/tostring/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toString
   - TrustedScript
+browser-compat: api.TrustedScript.toString
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -47,4 +48,4 @@ console.log(sanitized.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedScript.toString")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedscripturl/index.html
+++ b/files/en-us/web/api/trustedscripturl/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TrustedScriptURL
+browser-compat: api.TrustedScriptURL
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -49,7 +50,7 @@ console.log(sanitized;) /* a TrustedScriptURL object */
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedScriptURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/trustedscripturl/tojson/index.html
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toJSON
   - TrustedScriptURL
+browser-compat: api.TrustedScriptURL.toJSON
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedScriptURL.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedscripturl/tostring/index.html
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toString
   - TrustedScriptURL
+browser-compat: api.TrustedScriptURL.toString
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -47,4 +48,4 @@ console.log(sanitized.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedScriptURL.toString")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - createHTML
   - TrustedTypePolicy
+browser-compat: api.TrustedTypePolicy.createHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicy.createHTML")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - createScript
   - TrustedTypePolicy
+browser-compat: api.TrustedTypePolicy.createScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicy.createScript")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - createScriptURL
   - TrustedTypePolicy
+browser-compat: api.TrustedTypePolicy.createScriptURL
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicy.createScriptURL")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TrustedTypePolicy
+browser-compat: api.TrustedTypePolicy
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -68,4 +69,4 @@ el.innerHTML = escaped;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicy/name/index.html
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - name
   - TrustedTypePolicy
+browser-compat: api.TrustedTypePolicy.name
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -48,4 +49,4 @@ console.log(escapeHTMLPolicy.name); /* "myEscapePolicy" */</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicy.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - createPolicy
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.createPolicy
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -102,4 +103,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.createPolicy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - defaultPolicy
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.defaultPolicy
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -51,4 +52,4 @@ console.log(trustedTypes.defaultPolicy); // a TrustedTypePolicy object</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.defaultPolicy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - emptyHTML
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.emptyHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.emptyHTML")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - emptyScript
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.emptyScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -49,4 +50,4 @@ eval(supportsTS ? myTrustedScriptObj : myTrustedScriptObj.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.emptyScript")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - getAttributeType
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.getAttributeType
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.getAttributeType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - getPropertyType
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.getPropertyType
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.getPropertyType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -74,4 +75,4 @@ console.log(trustedTypes.isHTML(escaped)) // true;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - isHTML
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.isHTML
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -63,4 +64,4 @@ console.log(trustedTypes.isHTML("&lt;div&gt;plain string&lt;/div&gt;")); // fals
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.isHTML")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - isScript
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.isScript
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -63,4 +64,4 @@ console.log(trustedTypes.isScript("eval('2 + 2')")); // false</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.isScript")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - isScriptURL
   - TrustedTypePolicyFactory
+browser-compat: api.TrustedTypePolicyFactory.isScriptURL
 ---
 <div>{{DefaultAPISidebar("Trusted Types API")}}</div>
 
@@ -63,4 +64,4 @@ console.log(trustedTypes.isScriptURL("https://example.com/myscript.js")); // fal
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.TrustedTypePolicyFactory.isScriptURL")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/t* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

154 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
