### PR TITLE
Put browser-compat info in front-runner for api/u*

### DIFF
--- a/files/en-us/web/api/uievent/detail/index.html
+++ b/files/en-us/web/api/uievent/detail/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Read-only
   - Reference
+browser-compat: api.UIEvent.detail
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.detail")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/uievent/index.html
+++ b/files/en-us/web/api/uievent/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - UIEvent
   - events
+browser-compat: api.UIEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/uievent/inituievent/index.html
+++ b/files/en-us/web/api/uievent/inituievent/index.html
@@ -8,6 +8,7 @@ tags:
 - Event
 - Method
 - UIEvent
+browser-compat: api.UIEvent.initUIEvent
 ---
 <p>{{APIRef("DOM Events")}} {{deprecated_header}}</p>
 
@@ -85,7 +86,7 @@ e.initUIEvent("click", true, true, window, 1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.initUIEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/uievent/ischar/index.html
+++ b/files/en-us/web/api/uievent/ischar/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - UIEvent
 - isChar
+browser-compat: api.UIEvent.isChar
 ---
 <div>{{APIRef("DOM Events")}} {{deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.isChar")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/uievent/layerx/index.html
+++ b/files/en-us/web/api/uievent/layerx/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - UIEvent
+browser-compat: api.UIEvent.layerX
 ---
 <p>{{APIRef("DOM Events")}} {{Non-standard_header}}</p>
 
@@ -119,4 +120,4 @@ scrolling.&lt;/span&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.layerX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/uievent/layery/index.html
+++ b/files/en-us/web/api/uievent/layery/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - UIEvent
+browser-compat: api.UIEvent.layerY
 ---
 <p>{{APIRef("DOM Events")}}{{Non-standard_header}}</p>
 
@@ -120,4 +121,4 @@ scrolling.&lt;/span&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.layerY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/uievent/pagex/index.html
+++ b/files/en-us/web/api/uievent/pagex/index.html
@@ -13,6 +13,7 @@ tags:
 - UIEvent
 - events
 - pageX
+browser-compat: api.UIEvent.pageX
 ---
 <div>{{APIRef("DOM Events")}} {{deprecated_header}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.pageX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/uievent/pagey/index.html
+++ b/files/en-us/web/api/uievent/pagey/index.html
@@ -8,6 +8,7 @@ tags:
 - Read-only
 - Reference
 - UIEvent
+browser-compat: api.UIEvent.pageY
 ---
 <p>{{APIRef("DOM Events")}} {{Deprecated_Header}} {{Non-standard_header}}</p>
 
@@ -114,7 +115,7 @@ scrolling.&lt;/span&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.pageY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/uievent/sourcecapabilities/index.html
+++ b/files/en-us/web/api/uievent/sourcecapabilities/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - UIEvent
+browser-compat: api.UIEvent.sourceCapabilities
 ---
 <p>{{SeeCompatTable}}{{APIRef()}}</p>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.sourceCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/uievent/uievent/index.html
+++ b/files/en-us/web/api/uievent/uievent/index.html
@@ -6,6 +6,7 @@ tags:
 - Constructor
 - Reference
 - UIEvent
+browser-compat: api.UIEvent.UIEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.UIEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/uievent/view/index.html
+++ b/files/en-us/web/api/uievent/view/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - UIEvent
+browser-compat: api.UIEvent.view
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UIEvent.view")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ulongrange/index.html
+++ b/files/en-us/web/api/ulongrange/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - ULongRange
   - WebRTC
+browser-compat: api.ULongRange
 ---
 <div>{{APIRef("Media Capture and Streams")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ULongRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/createobjecturl/index.html
+++ b/files/en-us/web/api/url/createobjecturl/index.html
@@ -11,6 +11,7 @@ tags:
   - URL
   - URL API
   - createObjectURL
+browser-compat: api.URL.createObjectURL
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -110,7 +111,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.createObjectURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/hash/index.html
+++ b/files/en-us/web/api/url/hash/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.hash
 ---
 <div>{{ APIRef("URL API") }}</div>
 
@@ -55,7 +56,7 @@ console.log(url.hash); // Logs: '#Examples'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.hash")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/host/index.html
+++ b/files/en-us/web/api/url/host/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.host
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -59,7 +60,7 @@ console.log(url.host); // "developer.mozilla.org:4097"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.host")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/hostname/index.html
+++ b/files/en-us/web/api/url/hostname/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.hostname
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -49,7 +50,7 @@ console.log(url.hostname); // Logs: 'developer.mozilla.org'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.hostname")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/href/index.html
+++ b/files/en-us/web/api/url/href/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.href
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -50,7 +51,7 @@ console.log(url.href); // Logs: 'https://developer.mozilla.org/en-US/docs/Web/AP
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.href")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/index.html
+++ b/files/en-us/web/api/url/index.html
@@ -17,6 +17,7 @@ tags:
   - href
   - origin
   - Polyfill
+browser-compat: api.URL
 ---
 <p>{{APIRef("URL API")}}</p>
 
@@ -140,7 +141,7 @@ console.log(parsedUrl.searchParams.get("id")); // "123"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/origin/index.html
+++ b/files/en-us/web/api/url/origin/index.html
@@ -9,6 +9,7 @@ tags:
 - URL
 - URL API
 - origin
+browser-compat: api.URL.origin
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -64,7 +65,7 @@ console.log(url.origin); // Logs 'https://mozilla.org'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.origin")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/password/index.html
+++ b/files/en-us/web/api/url/password/index.html
@@ -8,6 +8,7 @@ tags:
 - URL
 - URL API
 - password
+browser-compat: api.URL.password
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -55,7 +56,7 @@ console.log(url.password) // Logs "flabada"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.password")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/pathname/index.html
+++ b/files/en-us/web/api/url/pathname/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.pathname
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -52,7 +53,7 @@ console.log(url.pathname); // Logs "/en-US/docs/Web/API/URL/pathname"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.pathname")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/port/index.html
+++ b/files/en-us/web/api/url/port/index.html
@@ -8,6 +8,7 @@ tags:
 - URL
 - URL API
 - port
+browser-compat: api.URL.port
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -52,7 +53,7 @@ console.log(url.port); // Logs '80'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.port")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/protocol/index.html
+++ b/files/en-us/web/api/url/protocol/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.protocol
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -51,7 +52,7 @@ console.log(url.protocol); // Logs "https:"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.protocol")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/revokeobjecturl/index.html
+++ b/files/en-us/web/api/url/revokeobjecturl/index.html
@@ -7,6 +7,7 @@ tags:
   - URL
   - URL API
   - revokeObjectURL
+browser-compat: api.URL.revokeObjectURL
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.revokeObjectURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/search/index.html
+++ b/files/en-us/web/api/url/search/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL
 - URL API
+browser-compat: api.URL.search
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -55,7 +56,7 @@ console.log(url.search); // Logs "?q=123"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.search")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/searchparams/index.html
+++ b/files/en-us/web/api/url/searchparams/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - URL
 - URLSearchParams
+browser-compat: api.URL.searchParams
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -55,4 +56,4 @@ let age = parseInt(params.get('age')); // is the number 18</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.searchParams")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/url/tojson/index.html
+++ b/files/en-us/web/api/url/tojson/index.html
@@ -8,6 +8,7 @@ tags:
 - URL
 - URL API
 - Polyfill
+browser-compat: api.URL.toJSON
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -51,7 +52,7 @@ url.toJSON(); // should return the URL as a string</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.toJSON")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/tostring/index.html
+++ b/files/en-us/web/api/url/tostring/index.html
@@ -8,6 +8,7 @@ tags:
 - Stringifier
 - URL
 - URL API
+browser-compat: api.URL.toString
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -51,7 +52,7 @@ url.toString(); // should return the URL as a string
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.toString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/url/index.html
+++ b/files/en-us/web/api/url/url/index.html
@@ -8,6 +8,7 @@ tags:
 - URL
 - URL API
 - Polyfill
+browser-compat: api.URL.URL
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -109,7 +110,7 @@ let d = new URL('/en-US/docs', b);                     // =
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.URL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/url/username/index.html
+++ b/files/en-us/web/api/url/username/index.html
@@ -8,6 +8,7 @@ tags:
 - URL
 - URL API
 - username
+browser-compat: api.URL.username
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -52,7 +53,7 @@ console.log(url.username) // Logs "anonymous"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URL.username")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/append/index.html
+++ b/files/en-us/web/api/urlsearchparams/append/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - URL API
 - URLSearchParams
+browser-compat: api.URLSearchParams.append
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -66,7 +67,7 @@ params.append('foo', 4);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.append")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/delete/index.html
+++ b/files/en-us/web/api/urlsearchparams/delete/index.html
@@ -7,6 +7,7 @@ tags:
 - URL API
 - URLSearchParams
 - delete
+browser-compat: api.URLSearchParams.delete
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -60,4 +61,4 @@ params.delete('foo'); //Query string is now: 'bar=2'</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.delete")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/urlsearchparams/entries/index.html
+++ b/files/en-us/web/api/urlsearchparams/entries/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL API
 - URLSearchParams
+browser-compat: api.URLSearchParams.entries
 ---
 <p>{{APIRef("URL API")}}</p>
 
@@ -68,7 +69,7 @@ key2, value2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.entries")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/foreach/index.html
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URLSearchParams
 - forEach
+browser-compat: api.URLSearchParams.forEach
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -69,7 +70,7 @@ value2 key2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.forEach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/get/index.html
+++ b/files/en-us/web/api/urlsearchparams/get/index.html
@@ -7,6 +7,7 @@ tags:
   - URL API
   - URLSearchParams
   - get
+browser-compat: api.URLSearchParams.get
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -67,4 +68,4 @@ let age = parseInt(params.get(&quot;age&quot;), 10); // is the number 18
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.get")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/urlsearchparams/getall/index.html
+++ b/files/en-us/web/api/urlsearchparams/getall/index.html
@@ -7,6 +7,7 @@ tags:
 - URL API
 - URLSearchParams
 - getAll
+browser-compat: api.URLSearchParams.getAll
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -63,4 +64,4 @@ console.log(params.getAll('foo')) //Prints ["1","4"].
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.getAll")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/urlsearchparams/has/index.html
+++ b/files/en-us/web/api/urlsearchparams/has/index.html
@@ -7,6 +7,7 @@ tags:
 - URL API
 - URLSearchParams
 - has
+browser-compat: api.URLSearchParams.has
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -61,4 +62,4 @@ params.has('bar') === true; //true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.has")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/urlsearchparams/index.html
+++ b/files/en-us/web/api/urlsearchparams/index.html
@@ -9,6 +9,7 @@ tags:
   - URL API
   - URLSearchParams
   - Polyfill
+browser-compat: api.URLSearchParams
 ---
 <div>{{ApiRef("URL API")}}</div>
 
@@ -133,7 +134,7 @@ searchParams.get("bin2"); // "E+AXQB+A"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/keys/index.html
+++ b/files/en-us/web/api/urlsearchparams/keys/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL API
 - URLSearchParams
+browser-compat: api.URLSearchParams.keys
 ---
 <p>{{APIRef("URL API")}}</p>
 
@@ -70,7 +71,7 @@ key2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/set/index.html
+++ b/files/en-us/web/api/urlsearchparams/set/index.html
@@ -7,6 +7,7 @@ tags:
 - URL API
 - URLSearchParams
 - set
+browser-compat: api.URLSearchParams.set
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -133,5 +134,5 @@ console.info( url, url.toString() )
 
 <div>
 
-	<p>{{Compat("api.URLSearchParams.set")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/urlsearchparams/sort/index.html
+++ b/files/en-us/web/api/urlsearchparams/sort/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URLSearchParams
 - sort
+browser-compat: api.URLSearchParams.sort
 ---
 <p>{{APIRef("URL API")}}</p>
 
@@ -65,4 +66,4 @@ console.log(searchParams.toString());
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.sort")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/urlsearchparams/tostring/index.html
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.html
@@ -7,6 +7,7 @@ tags:
   - URL API
   - URLSearchParams
   - toString
+browser-compat: api.URLSearchParams.toString
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -76,7 +77,7 @@ let params = new URLSearchParams('foo=1&amp;bar=2');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.toString")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.html
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - URL API
 - URLSearchParams
+browser-compat: api.URLSearchParams.URLSearchParams
 ---
 <p>{{ApiRef("URL API")}}</p>
 
@@ -80,4 +81,4 @@ var params4 = new URLSearchParams({"foo": "1", "bar": "2"});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.URLSearchParams")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/urlsearchparams/values/index.html
+++ b/files/en-us/web/api/urlsearchparams/values/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - URL API
 - URLSearchParams
+browser-compat: api.URLSearchParams.values
 ---
 <div>{{APIRef("URL API")}}</div>
 
@@ -67,7 +68,7 @@ value2</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.URLSearchParams.values")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/usb/getdevices/index.html
+++ b/files/en-us/web/api/usb/getdevices/index.html
@@ -9,6 +9,7 @@ tags:
 - WebUSB
 - WebUSB API
 - getDevices()
+browser-compat: api.USB.getDevices
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USB.getDevices")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usb/index.html
+++ b/files/en-us/web/api/usb/index.html
@@ -8,6 +8,7 @@ tags:
   - USB
   - WebUSB
   - WebUSB API
+browser-compat: api.USB
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USB")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usb/onconnect/index.html
+++ b/files/en-us/web/api/usb/onconnect/index.html
@@ -9,6 +9,7 @@ tags:
 - WebUSB
 - WebUSB API
 - onconnect
+browser-compat: api.USB.onconnect
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}</p>
 
@@ -39,4 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USB.onconnect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usb/ondisconnect/index.html
+++ b/files/en-us/web/api/usb/ondisconnect/index.html
@@ -9,6 +9,7 @@ tags:
 - WebUSB
 - WebUSB API
 - ondisconnect
+browser-compat: api.USB.ondisconnect
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}</p>
 
@@ -39,4 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USB.ondisconnect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usb/requestdevice/index.html
+++ b/files/en-us/web/api/usb/requestdevice/index.html
@@ -9,6 +9,7 @@ tags:
 - WebUSB
 - WebUSB API
 - getDevices()
+browser-compat: api.USB.requestDevice
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}</p>
 
@@ -89,4 +90,4 @@ navigator.usb.requestDevice({filters: filters})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USB.requestDevice")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbalternateinterface/index.html
+++ b/files/en-us/web/api/usbalternateinterface/index.html
@@ -10,6 +10,7 @@ tags:
   - USBAlternateInterface
   - WebUSB
   - WebUSB API
+browser-compat: api.USBAlternateInterface
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBAlternateInterface")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.html
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - configurationName
+browser-compat: api.USBConfiguration.configurationName
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConfiguration.configurationName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.html
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - configurationValue
+browser-compat: api.USBConfiguration.configurationValue
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConfiguration.configurationValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconfiguration/index.html
+++ b/files/en-us/web/api/usbconfiguration/index.html
@@ -9,6 +9,7 @@ tags:
   - USBConfiguration
   - WebUSB
   - WebUSB API
+browser-compat: api.USBConfiguration
 ---
 <p>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</p>
 
@@ -51,4 +52,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConfiguration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.html
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.html
@@ -10,6 +10,7 @@ tags:
 - USBConfiguration
 - WebUSB
 - WebUSB API
+browser-compat: api.USBConfiguration.interfaces
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConfiguration.interfaces")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.html
@@ -11,6 +11,7 @@ tags:
 - USBConfiguration
 - WebUSB
 - WebUSB API
+browser-compat: api.USBConfiguration.USBConfiguration
 ---
 <div>{{draft}}{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConfiguration.USBConfiguration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconnectionevent/device/index.html
+++ b/files/en-us/web/api/usbconnectionevent/device/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - device
   - USBConnectionEvent
+browser-compat: api.USBConnectionEvent.device
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConnectionEvent.device")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - USBConnectionEvent
+browser-compat: api.USBConnectionEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
@@ -56,4 +57,4 @@ navigator.usb.addEventListener('disconnect', event => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConnectionEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/claiminterface/index.html
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - claimInterface
+browser-compat: api.USBDevice.claimInterface
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.claimInterface")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/clearhalt/index.html
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - clearHalt
+browser-compat: api.USBDevice.clearHalt
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.clearHalt")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/close/index.html
+++ b/files/en-us/web/api/usbdevice/close/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - close
+browser-compat: api.USBDevice.close
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.close")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/configuration/index.html
+++ b/files/en-us/web/api/usbdevice/configuration/index.html
@@ -10,6 +10,7 @@ tags:
 - USBDevice
 - WebUSB
 - WebUSB API
+browser-compat: api.USBDevice.configuration
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.configuration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/configurations/index.html
+++ b/files/en-us/web/api/usbdevice/configurations/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - configurations
+browser-compat: api.USBDevice.configurations
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.configurations")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/controltransferin/index.html
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - controlTransferIn
+browser-compat: api.USBDevice.controlTransferIn
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.controlTransferIn")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/controltransferout/index.html
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - controlTransferOut
+browser-compat: api.USBDevice.controlTransferOut
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.controlTransferOut")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/deviceclass/index.html
+++ b/files/en-us/web/api/usbdevice/deviceclass/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - deviceClass
+browser-compat: api.USBDevice.deviceClass
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.deviceClass")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/deviceprotocol/index.html
+++ b/files/en-us/web/api/usbdevice/deviceprotocol/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - deviceProtocol
+browser-compat: api.USBDevice.deviceProtocol
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.deviceProtocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/devicesubclass/index.html
+++ b/files/en-us/web/api/usbdevice/devicesubclass/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - deviceSubclass
+browser-compat: api.USBDevice.deviceSubclass
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.deviceSubclass")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/deviceversionmajor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionmajor/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - deviceVersionMajor
+browser-compat: api.USBDevice.deviceVersionMajor
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.deviceVersionMajor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/deviceversionminor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionminor/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - deviceVersionMinor
+browser-compat: api.USBDevice.deviceVersionMinor
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.deviceVersionMinor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/deviceversionsubminor/index.html
+++ b/files/en-us/web/api/usbdevice/deviceversionsubminor/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - deviceVersionSubminor
+browser-compat: api.USBDevice.deviceVersionSubminor
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.deviceVersionSubminor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/index.html
+++ b/files/en-us/web/api/usbdevice/index.html
@@ -8,6 +8,7 @@ tags:
   - USBDevice
   - WebUSB
   - WebUSB API
+browser-compat: api.USBDevice
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -104,4 +105,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/isochronoustransferin/index.html
+++ b/files/en-us/web/api/usbdevice/isochronoustransferin/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - isochronousTransferIn
+browser-compat: api.USBDevice.isochronousTransferIn
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.isochronousTransferIn")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.html
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - isochronousTransferOut
+browser-compat: api.USBDevice.isochronousTransferOut
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.isochronousTransferOut")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/manufacturername/index.html
+++ b/files/en-us/web/api/usbdevice/manufacturername/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - manufacturerName
+browser-compat: api.USBDevice.manufacturerName
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.manufacturerName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/open/index.html
+++ b/files/en-us/web/api/usbdevice/open/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - open
+browser-compat: api.USBDevice.open
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.open")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/opened/index.html
+++ b/files/en-us/web/api/usbdevice/opened/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - opened
+browser-compat: api.USBDevice.opened
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.opened")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/productid/index.html
+++ b/files/en-us/web/api/usbdevice/productid/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - productID
+browser-compat: api.USBDevice.productId
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.productId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/productname/index.html
+++ b/files/en-us/web/api/usbdevice/productname/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - productName
+browser-compat: api.USBDevice.productName
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.productName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/releaseinterface/index.html
+++ b/files/en-us/web/api/usbdevice/releaseinterface/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - releaseInterface
+browser-compat: api.USBDevice.releaseInterface
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.releaseInterface")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/reset/index.html
+++ b/files/en-us/web/api/usbdevice/reset/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - reset
+browser-compat: api.USBDevice.reset
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.reset")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.html
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - selectAlternateInterface
+browser-compat: api.USBDevice.selectAlternateInterface
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.selectAlternateInterface")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.html
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - selectConfiguration
+browser-compat: api.USBDevice.selectConfiguration
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.selectConfiguration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/serialnumber/index.html
+++ b/files/en-us/web/api/usbdevice/serialnumber/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - serialNumber
+browser-compat: api.USBDevice.serialNumber
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.serialNumber")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/transferin/index.html
+++ b/files/en-us/web/api/usbdevice/transferin/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - transferIn
+browser-compat: api.USBDevice.transferIn
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.transferIn")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/transferout/index.html
+++ b/files/en-us/web/api/usbdevice/transferout/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - transferOut
+browser-compat: api.USBDevice.transferOut
 ---
 <p>{{APIRef("WebUSB API")}}{{SeeCompatTable}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.transferOut")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/usbversionmajor/index.html
+++ b/files/en-us/web/api/usbdevice/usbversionmajor/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - usbVersionMajor
+browser-compat: api.USBDevice.usbVersionMajor
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.usbVersionMajor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/usbversionminor/index.html
+++ b/files/en-us/web/api/usbdevice/usbversionminor/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - usbVersionMinor
+browser-compat: api.USBDevice.usbVersionMinor
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.usbVersionMinor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/usbversionsubminor/index.html
+++ b/files/en-us/web/api/usbdevice/usbversionsubminor/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - usbVersionSubminor
+browser-compat: api.USBDevice.usbVersionSubminor
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.usbVersionSubminor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbdevice/vendorid/index.html
+++ b/files/en-us/web/api/usbdevice/vendorid/index.html
@@ -10,6 +10,7 @@ tags:
 - WebUSB
 - WebUSB API
 - vendorID
+browser-compat: api.USBDevice.vendorId
 ---
 <p>{{SeeCompatTable}}{{APIRef("WebUSB API")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBDevice.vendorId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbendpoint/index.html
+++ b/files/en-us/web/api/usbendpoint/index.html
@@ -8,6 +8,7 @@ tags:
   - USB
   - USBEndpoint
   - Web USB API
+browser-compat: api.USBEndpoint
 ---
 {{securecontext_header}}
 <p>The <code>USBEndpoint</code> interface of the <a href="/en-US/docs/Web/API/WebUSB_API">WebUSB API</a> provides information about an endpoint provided by the USB device. An endpoint represents a unidirectional data stream into or out of a device.</p>
@@ -108,4 +109,4 @@ for (const interface of device.configuration.interfaces) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBEndpoint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbinterface/index.html
+++ b/files/en-us/web/api/usbinterface/index.html
@@ -10,6 +10,7 @@ tags:
   - USBInterface
   - WebUSB
   - WebUSB API
+browser-compat: api.USBInterface
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBInterface")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbintransferresult/index.html
+++ b/files/en-us/web/api/usbintransferresult/index.html
@@ -10,6 +10,7 @@ tags:
   - USBInTransferResult
   - WebUSB
   - WebUSB API
+browser-compat: api.USBInTransferResult
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBInTransferResult")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbisochronousintransferpacket/index.html
+++ b/files/en-us/web/api/usbisochronousintransferpacket/index.html
@@ -10,6 +10,7 @@ tags:
   - USBIsochronousInTransferPacket
   - WebUSB
   - WebUSB API
+browser-compat: api.USBIsochronousInTransferPacket
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBIsochronousInTransferPacket")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbisochronousintransferresult/index.html
+++ b/files/en-us/web/api/usbisochronousintransferresult/index.html
@@ -10,6 +10,7 @@ tags:
   - USBIsochronousInTransferResult
   - WebUSB
   - WebUSB API
+browser-compat: api.USBIsochronousInTransferResult
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBIsochronousInTransferResult")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbisochronousouttransferpacket/index.html
+++ b/files/en-us/web/api/usbisochronousouttransferpacket/index.html
@@ -10,6 +10,7 @@ tags:
   - USBIsochronousOutTransferPacket
   - WebUSB
   - WebUSB API
+browser-compat: api.USBIsochronousOutTransferPacket
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBIsochronousOutTransferPacket")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbisochronousouttransferresult/index.html
+++ b/files/en-us/web/api/usbisochronousouttransferresult/index.html
@@ -10,6 +10,7 @@ tags:
   - USBIsochronousOutTransferResult
   - WebUSB
   - WebUSB API
+browser-compat: api.USBIsochronousOutTransferResult
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBIsochronousOutTransferResult")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/usbouttransferresult/index.html
+++ b/files/en-us/web/api/usbouttransferresult/index.html
@@ -11,6 +11,7 @@ tags:
   - USBOutTransferResult
   - WebUSB
   - WebUSB API
+browser-compat: api.USBOutTransferResult
 ---
 <p>{{draft}}{{securecontext_header}}{{APIRef("WebUSB API")}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBOutTransferResult")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/userdatahandler/index.html
+++ b/files/en-us/web/api/userdatahandler/index.html
@@ -6,6 +6,7 @@ tags:
   - DOM
   - NeedsMarkupWork
   - Deprecated
+browser-compat: api.UserDataHandler
 ---
 <p>{{APIRef("DOM")}}{{deprecated_header}}</p>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UserDataHandler")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/userproximityevent/index.html
+++ b/files/en-us/web/api/userproximityevent/index.html
@@ -8,6 +8,7 @@ tags:
   - Proximity Events
   - Reference
   - Deprecated
+browser-compat: api.UserProximityEvent
 ---
 <p>{{APIRef("Proximity Events")}}{{deprecated_header}}</p>
 <div class="notecard warning">
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.UserProximityEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/u* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

99 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
