### PR TITLE
Update Headers.get() example to show multivalued header handling

### DIFF
--- a/files/en-us/web/api/headers/get/index.html
+++ b/files/en-us/web/api/headers/get/index.html
@@ -61,6 +61,7 @@ myHeaders.get('Content-Type'); // Returns "image/jpeg"
 <pre class="brush: js">myHeaders.append('Accept-Encoding', 'deflate');
 myHeaders.append('Accept-Encoding', 'gzip');
 myHeaders.get('Accept-Encoding'); // Returns "deflate,gzip"
+myHeaders.get('Accept-Encoding').split(',').map(v => v.trimStart()); // Returns [ "deflate", "gzip" ]
 </pre>
 
 <div class="note">


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The `Headers.getAll( )` method was deprecated. The documentation of `Headers.get( )` explains how to get raw multivalued header but does not explain how to fully parse the value. Further explanation is needed if `get` is to be used instead of the deprecated `getAll` method. This PR adds example code that shows how multivalued headers can be safely parsed. This spares the programmer from reading RFCs about encoding used for multivalued headers.

> MDN URL of main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Headers/get

> Anything else that could help us review it

I also created a PR about adding a polyfill for `getAll`. However, documenting the intended way of parsing multivalued header fields seems more important than adding polyfills for obsolete features. Anyway, the other PR and related discussion can be found at https://github.com/mdn/content/pull/3934