### PR TITLE
fix http:// links in Web/API/Geolocation_API

### DIFF
--- a/files/en-us/web/api/geolocation_api/index.html
+++ b/files/en-us/web/api/geolocation_api/index.html
@@ -85,7 +85,7 @@ tags:
 
 <h3 id="Availability">Availability</h3>
 
-<p>As WiFi-based locationing is often provided by Google, the vanilla Geolocation API may be unavailable in China. You may use local third-party providers such as <a href="http://lbsyun.baidu.com/index.php?title=jspopular/guide/geolocation">Baidu</a>, <a href="https://lbs.amap.com/api/javascript-api/guide/services/geolocation#geolocation">Autonavi</a>, or <a href="http://lbs.qq.com/tool/component-geolocation.html">Tencent</a>. These services use the user's IP address and/or a local app to provide enhanced positioning.</p>
+<p>As WiFi-based locationing is often provided by Google, the vanilla Geolocation API may be unavailable in China. You may use local third-party providers such as <a href="https://lbsyun.baidu.com/index.php?title=jspopular/guide/geolocation">Baidu</a>, <a href="https://lbs.amap.com/api/javascript-api/guide/services/geolocation#geolocation">Autonavi</a>, or <a href="https://lbs.qq.com/tool/component-geolocation.html">Tencent</a>. These services use the user's IP address and/or a local app to provide enhanced positioning.</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There was two uses of `http://` links that can confidently be converted to `https://`

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it

It was a fixable flaw. 