### PR TITLE
Remove unnecessary div wrapping

### DIFF
--- a/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
+++ b/files/en-us/web/javascript/guide/details_of_the_object_model/index.html
@@ -222,7 +222,6 @@ public class Engineer extends WorkerBee {
 
 <h3 id="Creating_objects_with_simple_definitions">Creating objects with simple definitions</h3>
 
-<div class="twocolumns">
 <h4 id="Object_hierarchy">Object hierarchy</h4>
 
 <p>The following hierarchy is created using the code on the right side.</p>
@@ -260,7 +259,6 @@ var jane = new Engineer;
 // jane.projects is []
 // jane.machine is ''
 </pre>
-</div>
 
 <h2 id="Object_properties">Object properties</h2>
 


### PR DESCRIPTION
Hey @wbamberg,

unfortunately [that markup throws prettier](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBlCBbOACATnAQwBsiBPbI6Ac23gA8ZaALAxgdwgFciATbAIxxV8rWhGxtcBAA7YAzuICS2GdPxgAlqxxsWjAAr4YMDXFzYNc7DwgaoNJmbgAdKK4A8PDQDcAfO7U4X1ciOEYobABebAAmAGYAblcQsOwAKyjsABYspKhQxjBMgFZivPcAekD-Lz9XEAAaEAhpE2g5ZFACXFwINn1uhA6UYjYCUg6m-ikwAGsw1GkCTXtkGFxOOCa4DEEeHjgeABkCe04CKjgAMQhcDFYTVZHOGAhGkCYYDCIAdSYNeByJZgOCoIYAnwA0jIcBySYgOxyMwwQwXe7IABmxCRTTScjoACEZvMYKgCFgjnY4JjsVsQHi6Kg7FRQgBFTgQeA0og4kBLXBI3Aw+64WY2NhQd5qOwwH4aHgwJjIAAcAAYmmoIEiflJpDDRuN4QBHDnwQwtYYgAhyAC0UDgh0O73wJo0+FRVHRSCxPLpSIwGjWGz9zLZpup3tpTRgBH4coVSqQMWjUg0RGZAGFMF6QHA5MV3pwkQAVWPDH287ybRRQA6wVBgXAaVoAQVrqBgpFC3KRAF9e0A), which [I have created an issue for](https://github.com/prettier/prettier/issues/10963) but the easiest fix on our side seems to be to just drop the div, so that the inside of it are converted to markdown proper.