### PR TITLE
Put browser-compat info in front-runner for api/v*

### DIFF
--- a/files/en-us/web/api/validitystate/badinput/index.html
+++ b/files/en-us/web/api/validitystate/badinput/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Read-only
   - ValidityState
+browser-compat: api.ValidityState.badInput
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -54,7 +55,7 @@ if (input.validity.badInput) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.badInput")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/index.html
+++ b/files/en-us/web/api/validitystate/index.html
@@ -7,6 +7,7 @@ tags:
   - Forms
   - HTML DOM
   - Interface
+browser-compat: api.ValidityState
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/patternmismatch/index.html
+++ b/files/en-us/web/api/validitystate/patternmismatch/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.ValidityState.patternMismatch
 ---
 <p>{{draft}}The read-only <strong><code>patternMismatch</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code><a href="/en-US/docs/Web/HTML/Attributes/pattern">pattern</a></code> attribute.</p>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.patternMismatch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/rangeoverflow/index.html
+++ b/files/en-us/web/api/validitystate/rangeoverflow/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.ValidityState.rangeOverflow
 ---
 <p>The read-only <strong><code>rangeOverflow</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code><a href="/en-US/docs/Web/HTML/Attributes/max">max</a></code> attribute.</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.rangeOverflow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/rangeunderflow/index.html
+++ b/files/en-us/web/api/validitystate/rangeunderflow/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.ValidityState.rangeUnderflow
 ---
 <p>The read-only <strong><code>rangeUnderflow</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code><a href="/en-US/docs/Web/HTML/Attributes/min">min</a></code> attribute.</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.rangeUnderflow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/stepmismatch/index.html
+++ b/files/en-us/web/api/validitystate/stepmismatch/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.ValidityState.stepMismatch
 ---
 <p>The read-only <strong><code>stepMismatch</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code>step</code> attribute.</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.stepMismatch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/toolong/index.html
+++ b/files/en-us/web/api/validitystate/toolong/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsExample
   - Property
   - Reference
+browser-compat: api.ValidityState.tooLong
 ---
 <div>{{draft}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.tooLong")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/tooshort/index.html
+++ b/files/en-us/web/api/validitystate/tooshort/index.html
@@ -1,6 +1,7 @@
 ---
 title: validityState.tooShort
 slug: Web/API/ValidityState/tooShort
+browser-compat: api.ValidityState.tooShort
 ---
 <p>The read-only <strong><code>tooShort</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, {{HTMLElement("button")}}, {{HTMLElement("select")}}, {{HTMLElement("output")}}, {{HTMLElement("fieldset")}} or {{HTMLElement("textarea")}}, after having been edited by the user, is less than the minimum code-unit length established by the element's <code>minlength</code> attribute.</p>
 
@@ -33,7 +34,7 @@ slug: Web/API/ValidityState/tooShort
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.tooShort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/validitystate/typemismatch/index.html
+++ b/files/en-us/web/api/validitystate/typemismatch/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM
   - Property
   - Reference
+browser-compat: api.ValidityState.typeMismatch
 ---
 <p>{{draft}}The read-only <strong><code>typeMismatch</code></strong> property of a <strong><code><a href="/en-US/docs/Web/API/ValidityState">ValidityState</a></code></strong> object indicates if the value of an {{HTMLElement("input")}}, after having been edited by the user, does not conform to the constraints set by the element's <code><a href="/en-US/docs/Web/HTML/Element/input#input_types">type</a></code> attribute.</p>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ValidityState.typeMismatch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoconfiguration/index.html
+++ b/files/en-us/web/api/videoconfiguration/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Video
   - VideoConfiguration
+browser-compat: api.VideoConfiguration
 ---
 <div>{{APIRef("Media Capabilities API")}}</div>
 
@@ -63,7 +64,7 @@ const mediaConfig = {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoConfiguration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.html
+++ b/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.html
@@ -17,6 +17,7 @@ tags:
 - Video
 - VideoPlaybackQuality
 - corruptedVideoFrames
+browser-compat: api.VideoPlaybackQuality.corruptedVideoFrames
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
@@ -76,7 +77,7 @@ if (quality.corruptedVideoFrames/quality.totalVideoFrames &gt; 0.05) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoPlaybackQuality.corruptedVideoFrames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/creationtime/index.html
+++ b/files/en-us/web/api/videoplaybackquality/creationtime/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - VideoPlaybackQuality
 - creationTime
+browser-compat: api.VideoPlaybackQuality.creationTime
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -69,7 +70,7 @@ if ((quality.corruptedVideoFrames + quality.droppedVideoFrames)/quality.totalVid
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoPlaybackQuality.creationTime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.html
+++ b/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.html
@@ -16,6 +16,7 @@ tags:
 - Video
 - VideoPlaybackQuality
 - droppedVideoFrames
+browser-compat: api.VideoPlaybackQuality.droppedVideoFrames
 ---
 <p>{{APIRef("HTML DOM")}}<br>
   <span class="seoSummary">The read-only <code><strong>droppedVideoFrames</strong></code>
@@ -75,7 +76,7 @@ percentElem.innerText = Math.trunc(dropPercent).toString(10);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoPlaybackQuality.droppedVideoFrames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/index.html
+++ b/files/en-us/web/api/videoplaybackquality/index.html
@@ -15,6 +15,7 @@ tags:
   - Reference
   - Video
   - VideoPlaybackQuality
+browser-compat: api.VideoPlaybackQuality
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoPlaybackQuality")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/totalframedelay/index.html
+++ b/files/en-us/web/api/videoplaybackquality/totalframedelay/index.html
@@ -11,6 +11,7 @@ tags:
 - Video
 - VideoPlaybackQuality
 - totalFrameDelay
+browser-compat: api.VideoPlaybackQuality.totalFrameDelay
 ---
 <p>{{APIRef("Media Source Extensions")}}{{deprecated_header}}</p>
 
@@ -35,7 +36,7 @@ alert(quality.totalFrameDelay);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoPlaybackQuality.totalFrameDelay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.html
+++ b/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.html
@@ -16,6 +16,7 @@ tags:
 - Video
 - VideoPlaybackQuality
 - totalVideoFrames
+browser-compat: api.VideoPlaybackQuality.totalVideoFrames
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -76,7 +77,7 @@ if ((quality.corruptedVideoFrames + quality.droppedVideoFrames)/quality.totalVid
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoPlaybackQuality.totalVideoFrames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videotrack/id/index.html
+++ b/files/en-us/web/api/videotrack/id/index.html
@@ -14,6 +14,7 @@ tags:
 - VideoTrack
 - id
 - track
+browser-compat: api.VideoTrack.id
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotrack/index.html
+++ b/files/en-us/web/api/videotrack/index.html
@@ -10,6 +10,7 @@ tags:
   - Video
   - VideoTrack
   - track
+browser-compat: api.VideoTrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -79,4 +80,4 @@ var tracks = el.videoTracks;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotrack/kind/index.html
+++ b/files/en-us/web/api/videotrack/kind/index.html
@@ -13,6 +13,7 @@ tags:
 - VideoTrack
 - id
 - track
+browser-compat: api.VideoTrack.kind
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack.kind")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotrack/label/index.html
+++ b/files/en-us/web/api/videotrack/label/index.html
@@ -14,6 +14,7 @@ tags:
 - label
 - metadata
 - track
+browser-compat: api.VideoTrack.label
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack.label")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotrack/language/index.html
+++ b/files/en-us/web/api/videotrack/language/index.html
@@ -13,6 +13,7 @@ tags:
 - Video
 - VideoTrack
 - track
+browser-compat: api.VideoTrack.language
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack.language")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotrack/selected/index.html
+++ b/files/en-us/web/api/videotrack/selected/index.html
@@ -12,6 +12,7 @@ tags:
 - VideoTrack
 - selected
 - track
+browser-compat: api.VideoTrack.selected
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack.selected")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotrack/sourcebuffer/index.html
+++ b/files/en-us/web/api/videotrack/sourcebuffer/index.html
@@ -14,6 +14,7 @@ tags:
 - Video
 - VideoTrack
 - track
+browser-compat: api.VideoTrack.sourceBuffer
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrack.sourceBuffer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/addtrack_event/index.html
+++ b/files/en-us/web/api/videotracklist/addtrack_event/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Reference
   - events
+browser-compat: api.VideoTrackList.addtrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -66,7 +67,7 @@ videoElement.videoTracks.onaddtrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.addtrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videotracklist/change_event/index.html
+++ b/files/en-us/web/api/videotracklist/change_event/index.html
@@ -3,6 +3,7 @@ title: 'VideoTrackList: change event'
 slug: Web/API/VideoTrackList/change_event
 tags:
   - Event
+browser-compat: api.VideoTrackList.change_event
 ---
 <div>{{APIRef}}</div>
 
@@ -77,7 +78,7 @@ toggleTrackButton.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.change_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videotracklist/gettrackbyid/index.html
+++ b/files/en-us/web/api/videotracklist/gettrackbyid/index.html
@@ -15,6 +15,7 @@ tags:
 - getTrackById
 - id
 - track
+browser-compat: api.VideoTrackList.getTrackById
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.getTrackById")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/index.html
+++ b/files/en-us/web/api/videotracklist/index.html
@@ -12,6 +12,7 @@ tags:
   - Video
   - VideoTrackList
   - list
+browser-compat: api.VideoTrackList
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -110,4 +111,4 @@ function updateTrackCount(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/length/index.html
+++ b/files/en-us/web/api/videotracklist/length/index.html
@@ -13,6 +13,7 @@ tags:
 - length
 - list
 - track
+browser-compat: api.VideoTrackList.length
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -72,4 +73,4 @@ if (videoElem.videoTracks) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/onaddtrack/index.html
+++ b/files/en-us/web/api/videotracklist/onaddtrack/index.html
@@ -15,6 +15,7 @@ tags:
 - addTrack
 - onaddtrack
 - track
+browser-compat: api.VideoTrackList.onaddtrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.onaddtrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/onchange/index.html
+++ b/files/en-us/web/api/videotracklist/onchange/index.html
@@ -15,6 +15,7 @@ tags:
 - addTrack
 - onchange
 - track
+browser-compat: api.VideoTrackList.onchange
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -85,4 +86,4 @@ trackList.onchange = function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/onremovetrack/index.html
+++ b/files/en-us/web/api/videotracklist/onremovetrack/index.html
@@ -16,6 +16,7 @@ tags:
 - remove
 - removeTrack
 - track
+browser-compat: api.VideoTrackList.onremovetrack
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.onremovetrack")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/videotracklist/removetrack_event/index.html
+++ b/files/en-us/web/api/videotracklist/removetrack_event/index.html
@@ -10,6 +10,7 @@ tags:
   - Removing Tracks
   - events
   - removeTrack
+browser-compat: api.VideoTrackList.removetrack_event
 ---
 <div>{{APIRef}}</div>
 
@@ -71,7 +72,7 @@ videoElement.videoTracks.onremovetrack = (event) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.removetrack_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/videotracklist/selectedindex/index.html
+++ b/files/en-us/web/api/videotracklist/selectedindex/index.html
@@ -11,6 +11,7 @@ tags:
 - Video
 - VideoTrackList
 - track
+browser-compat: api.VideoTrackList.selectedIndex
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VideoTrackList.selectedIndex")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/height/index.html
+++ b/files/en-us/web/api/visualviewport/height/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - height
 - viewport
+browser-compat: api.VisualViewport.height
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.height")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/index.html
+++ b/files/en-us/web/api/visualviewport/index.html
@@ -9,6 +9,7 @@ tags:
   - Visual Viewport API
   - VisualViewport
   - viewport
+browser-compat: api.VisualViewport
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -121,7 +122,7 @@ window.visualViewport.addEventListener('resize', viewportHandler);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/visualviewport/offsetleft/index.html
+++ b/files/en-us/web/api/visualviewport/offsetleft/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - offsetleft
 - viewport
+browser-compat: api.VisualViewport.offsetLeft
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.offsetLeft")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/offsettop/index.html
+++ b/files/en-us/web/api/visualviewport/offsettop/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - offsetTop
 - viewport
+browser-compat: api.VisualViewport.offsetTop
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.offsetTop")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/onresize/index.html
+++ b/files/en-us/web/api/visualviewport/onresize/index.html
@@ -11,6 +11,7 @@ tags:
 - onresize
 - resize
 - viewport
+browser-compat: api.VisualViewport.onresize
 ---
 <p>{{APIRef("Visual Viewport")}}{{ SeeCompatTable() }}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.onresize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/onscroll/index.html
+++ b/files/en-us/web/api/visualviewport/onscroll/index.html
@@ -11,6 +11,7 @@ tags:
 - VisualViewport
 - onscroll
 - viewport
+browser-compat: api.VisualViewport.onscroll
 ---
 <p>{{APIRef("Visual Viewport")}}{{ SeeCompatTable() }}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.onscroll")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/pageleft/index.html
+++ b/files/en-us/web/api/visualviewport/pageleft/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - pageLeft
 - viewport
+browser-compat: api.VisualViewport.pageLeft
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.pageLeft")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/pagetop/index.html
+++ b/files/en-us/web/api/visualviewport/pagetop/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - pageLeft
 - viewport
+browser-compat: api.VisualViewport.pageTop
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.pageTop")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/resize_event/index.html
+++ b/files/en-us/web/api/visualviewport/resize_event/index.html
@@ -8,6 +8,7 @@ tags:
   - VisualViewport
   - events
   - resize
+browser-compat: api.VisualViewport.resize_event
 ---
 <div>{{APIRef("Window")}}{{SeeCompatTable}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.resize_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/visualviewport/scale/index.html
+++ b/files/en-us/web/api/visualviewport/scale/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - size
 - viewport
+browser-compat: api.VisualViewport.scale
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.scale")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/visualviewport/scroll_event/index.html
+++ b/files/en-us/web/api/visualviewport/scroll_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Scroll
   - VisualViewport
   - events
+browser-compat: api.VisualViewport.scroll_event
 ---
 <div>{{APIRef("Window")}}{{SeeCompatTable}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.scroll_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/visualviewport/width/index.html
+++ b/files/en-us/web/api/visualviewport/width/index.html
@@ -9,6 +9,7 @@ tags:
 - VisualViewport
 - viewport
 - width
+browser-compat: api.VisualViewport.width
 ---
 <p>{{SeeCompatTable}}{{APIRef("Visual Viewport")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VisualViewport.width")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - cancelAnimationFrame()
+browser-compat: api.VRDisplay.cancelAnimationFrame
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -115,7 +116,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.cancelAnimationFrame")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/capabilities/index.html
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - capabilities
+browser-compat: api.VRDisplay.capabilities
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.capabilities")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/depthfar/index.html
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - depthFar
+browser-compat: api.VRDisplay.depthFar
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -58,7 +59,7 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.depthFar")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/depthnear/index.html
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - depthNear
+browser-compat: api.VRDisplay.depthNear
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -58,7 +59,7 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.depthNear")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayid/index.html
+++ b/files/en-us/web/api/vrdisplay/displayid/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - displayId
+browser-compat: api.VRDisplay.displayId
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.displayId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/displayname/index.html
+++ b/files/en-us/web/api/vrdisplay/displayname/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - displayName
+browser-compat: api.VRDisplay.displayName
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.displayName")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - exitPresent()
+browser-compat: api.VRDisplay.exitPresent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.exitPresent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - getEyeParameters()
+browser-compat: api.VRDisplay.getEyeParameters
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.getEyeParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/getframedata/index.html
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - getFrameData
+browser-compat: api.VRDisplay.getFrameData
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -119,7 +120,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.getFrameData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
+++ b/files/en-us/web/api/vrdisplay/getimmediatepose/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - getImmediatePose()
+browser-compat: api.VRDisplay.getImmediatePose
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.getImmediatePose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/getlayers/index.html
+++ b/files/en-us/web/api/vrdisplay/getlayers/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - getLayers()
+browser-compat: api.VRDisplay.getLayers
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.getLayers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/getpose/index.html
+++ b/files/en-us/web/api/vrdisplay/getpose/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - getPose()
+browser-compat: api.VRDisplay.getPose
 ---
 <div>{{APIRef("WebVR API")}}{{deprecated_header}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.getPose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
+++ b/files/en-us/web/api/vrdisplay/hardwareunitid/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hardwareUnitId
+browser-compat: api.VRDisplay.hardwareUnitId
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -53,7 +54,7 @@ function reportDevices(devices) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.hardwareUnitId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/index.html
+++ b/files/en-us/web/api/vrdisplay/index.html
@@ -12,6 +12,7 @@ tags:
   - VRDisplay
   - Virtual Reality
   - WebVR
+browser-compat: api.VRDisplay
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/isconnected/index.html
+++ b/files/en-us/web/api/vrdisplay/isconnected/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - isConnected
+browser-compat: api.VRDisplay.isConnected
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.isConnected")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/ispresenting/index.html
+++ b/files/en-us/web/api/vrdisplay/ispresenting/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - isPresenting
+browser-compat: api.VRDisplay.isPresenting
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.isPresenting")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - requestAnimationFrame()
+browser-compat: api.VRDisplay.requestAnimationFrame
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -121,7 +122,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.requestAnimationFrame")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.html
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Display
   - WebVR
   - requestPresent()
+browser-compat: api.VRDisplay.requestPresent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.requestPresent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/resetpose/index.html
+++ b/files/en-us/web/api/vrdisplay/resetpose/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - resetPose()
+browser-compat: api.VRDisplay.resetPose
 ---
 <div>{{APIRef("WebVR API")}}{{deprecated_header}}</div>
 
@@ -63,7 +64,7 @@ btn.addEventListener('click', function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.resetPose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/stageparameters/index.html
+++ b/files/en-us/web/api/vrdisplay/stageparameters/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - stageParameters
+browser-compat: api.VRDisplay.stageParameters
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.stageParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplay/submitframe/index.html
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - submitFrame()
+browser-compat: api.VRDisplay.submitFrame
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -115,7 +116,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplay.submitFrame")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/canpresent/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - canPresent
+browser-compat: api.VRDisplayCapabilities.canPresent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayCapabilities.canPresent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasexternaldisplay/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasExternalDisplay
+browser-compat: api.VRDisplayCapabilities.hasExternalDisplay
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayCapabilities.hasExternalDisplay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasorientation/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasOrientation
+browser-compat: api.VRDisplayCapabilities.hasOrientation
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_header}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayCapabilities.hasOrientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/hasposition/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasPosition
+browser-compat: api.VRDisplayCapabilities.hasPosition
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayCapabilities.hasPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.html
@@ -10,6 +10,7 @@ tags:
   - VRDisplayCapabilities
   - Virtual Reality
   - WebVR
+browser-compat: api.VRDisplayCapabilities
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayCapabilities")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - maxLayers
+browser-compat: api.VRDisplayCapabilities.maxLayers
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayCapabilities.maxLayers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/display/index.html
+++ b/files/en-us/web/api/vrdisplayevent/display/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - display
+browser-compat: api.VRDisplayEvent.display
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayEvent.display")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/index.html
@@ -10,6 +10,7 @@ tags:
   - VRDisplayEvent
   - Virtual Reality
   - WebVR
+browser-compat: api.VRDisplayEvent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/reason/index.html
+++ b/files/en-us/web/api/vrdisplayevent/reason/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - reason
+browser-compat: api.VRDisplayEvent.reason
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRDisplayEvent.reason")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.html
@@ -10,6 +10,7 @@ tags:
   - VRDisplayEvent
   - Virtual Reality
   - WebVR
+browser-compat: api.VRDisplayEvent.VRDisplayEvent
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -60,7 +61,7 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.VRDisplayEvent.VRDisplayEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/fieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/fieldofview/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - fieldOfView
+browser-compat: api.VREyeParameters.fieldOfView
 ---
 <p>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</p>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.fieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/index.html
+++ b/files/en-us/web/api/vreyeparameters/index.html
@@ -10,6 +10,7 @@ tags:
   - VREyeParameters
   - Virtual Reality
   - WebVR
+browser-compat: api.VREyeParameters
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/maximumfieldofview/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - maximumFieldOfView
+browser-compat: api.VREyeParameters.maximumFieldOfView
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.maximumFieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/minimumfieldofview/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - minimumFieldOfView
+browser-compat: api.VREyeParameters.minimumFieldOfView
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.minimumFieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/offset/index.html
+++ b/files/en-us/web/api/vreyeparameters/offset/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - offset
+browser-compat: api.VREyeParameters.offset
 ---
 <p>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.offset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
+++ b/files/en-us/web/api/vreyeparameters/recommendedfieldofview/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - recommendedFieldOfView
+browser-compat: api.VREyeParameters.recommendedFieldOfView
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.recommendedFieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderheight/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderheight/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - renderHeight
+browser-compat: api.VREyeParameters.renderHeight
 ---
 <p>{{APIRef("WebVR API")}}{{Deprecated_Header}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.renderHeight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderrect/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderrect/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - renderRect
+browser-compat: api.VREyeParameters.renderRect
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.renderRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vreyeparameters/renderwidth/index.html
+++ b/files/en-us/web/api/vreyeparameters/renderwidth/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - renderWidth
+browser-compat: api.VREyeParameters.renderWidth
 ---
 <p>{{APIRef("WebVR API")}}{{Deprecated_Header}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VREyeParameters.renderWidth")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - downDegrees
+browser-compat: api.VRFieldOfView.downDegrees
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFieldOfView.downDegrees")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/index.html
@@ -10,6 +10,7 @@ tags:
   - VRFieldOfView
   - Virtual Reality
   - WebVR
+browser-compat: api.VRFieldOfView
 ---
 <p>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</p>
 
@@ -96,7 +97,7 @@ function reportFieldOfView() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - leftDegrees
+browser-compat: api.VRFieldOfView.leftDegrees
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFieldOfView.leftDegrees")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - rightDegrees
+browser-compat: api.VRFieldOfView.rightDegrees
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFieldOfView.rightDegrees")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.html
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - upDegrees
+browser-compat: api.VRFieldOfView.upDegrees
 ---
 <div>{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFieldOfView.upDegrees")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
+++ b/files/en-us/web/api/vrfieldofview/vrfieldofview/index.html
@@ -10,6 +10,7 @@ tags:
   - VRFieldOfView
   - Virtual Reality
   - WebVR
+browser-compat: api.VRFieldOfView.VRFieldOfView
 ---
 <p>{{deprecated_header}}</p>
 
@@ -76,7 +77,7 @@ var myFOV = new VRFieldOfView(init);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFieldOfView.VRFieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/index.html
@@ -10,6 +10,7 @@ tags:
   - VRFrameData
   - Virtual Reality
   - WebVR
+browser-compat: api.VRFrameData
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftprojectionmatrix/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - leftProjectionMatrix
+browser-compat: api.VRFrameData.leftProjectionMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.leftProjectionMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/leftviewmatrix/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - leftViewMatrix
+browser-compat: api.VRFrameData.leftViewMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.leftViewMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/pose/index.html
+++ b/files/en-us/web/api/vrframedata/pose/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - pose
+browser-compat: api.VRFrameData.pose
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.pose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightprojectionmatrix/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - rightProjectionMatrix
+browser-compat: api.VRFrameData.rightProjectionMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.rightProjectionMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
+++ b/files/en-us/web/api/vrframedata/rightviewmatrix/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - rightViewMatrix
+browser-compat: api.VRFrameData.rightViewMatrix
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.rightViewMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/timestamp/index.html
+++ b/files/en-us/web/api/vrframedata/timestamp/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - timeStamp
+browser-compat: api.VRFrameData.timestamp
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -81,7 +82,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.timestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrframedata/vrframedata/index.html
+++ b/files/en-us/web/api/vrframedata/vrframedata/index.html
@@ -10,6 +10,7 @@ tags:
   - VRFrameData
   - Virtual Reality
   - WebVR
+browser-compat: api.VRFrameData.VRFrameData
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRFrameData.VRFrameData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrlayerinit/index.html
+++ b/files/en-us/web/api/vrlayerinit/index.html
@@ -11,6 +11,7 @@ tags:
   - VRLayerInit
   - Virtual Reality
   - WebVR
+browser-compat: api.VRLayerInit
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -88,7 +89,7 @@ if(navigator.getVRDisplays) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRLayerInit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrlayerinit/leftbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/leftbounds/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - leftBounds
+browser-compat: api.VRLayerInit.leftBounds
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ myVRLayerInit.leftBounds = [0.0, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRLayerInit.leftBounds")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrlayerinit/rightbounds/index.html
+++ b/files/en-us/web/api/vrlayerinit/rightbounds/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - rightBounds
+browser-compat: api.VRLayerInit.rightBounds
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ myVRLayerInit.rightBounds = [0.5, 0.0, 0.5, 1.0];</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRLayerInit.rightBounds")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrlayerinit/source/index.html
+++ b/files/en-us/web/api/vrlayerinit/source/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - source
+browser-compat: api.VRLayerInit.source
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -48,7 +49,7 @@ myVRLayerInit.source = myCanvas;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRLayerInit.source")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/angularacceleration/index.html
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - angularAcceleration
+browser-compat: api.VRPose.angularAcceleration
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -70,7 +71,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.angularAcceleration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/angularvelocity/index.html
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - angularVelocity
+browser-compat: api.VRPose.angularVelocity
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -70,7 +71,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.angularVelocity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/hasorientation/index.html
+++ b/files/en-us/web/api/vrpose/hasorientation/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasOrientation
+browser-compat: api.VRPose.hasOrientation
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.hasOrientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/hasposition/index.html
+++ b/files/en-us/web/api/vrpose/hasposition/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - hasPosition
+browser-compat: api.VRPose.hasPosition
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.hasPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/index.html
+++ b/files/en-us/web/api/vrpose/index.html
@@ -10,6 +10,7 @@ tags:
   - VRPose
   - Virtual Reality
   - WebVR
+browser-compat: api.VRPose
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/linearacceleration/index.html
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - linearAcceleration
+browser-compat: api.VRPose.linearAcceleration
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -70,7 +71,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.linearAcceleration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/linearvelocity/index.html
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - linearVelocity
+browser-compat: api.VRPose.linearVelocity
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -70,7 +71,7 @@ function drawVRScene() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.linearVelocity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/orientation/index.html
+++ b/files/en-us/web/api/vrpose/orientation/index.html
@@ -11,6 +11,7 @@ tags:
   - VRPose
   - Virtual Reality
   - WebVR
+browser-compat: api.VRPose.orientation
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.orientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/position/index.html
+++ b/files/en-us/web/api/vrpose/position/index.html
@@ -11,6 +11,7 @@ tags:
   - VRPose
   - Virtual Reality
   - WebVR
+browser-compat: api.VRPose.position
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.position")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrpose/timestamp/index.html
+++ b/files/en-us/web/api/vrpose/timestamp/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - timeStamp
+browser-compat: api.VRPose.timestamp
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRPose.timestamp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrstageparameters/index.html
+++ b/files/en-us/web/api/vrstageparameters/index.html
@@ -10,6 +10,7 @@ tags:
   - VRStageParameters
   - Virtual Reality
   - WebVR
+browser-compat: api.VRStageParameters
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -67,7 +68,7 @@ navigator.getVRDisplays().then(function(displays) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRStageParameters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
+++ b/files/en-us/web/api/vrstageparameters/sittingtostandingtransform/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - sittingToStandingTransform
+browser-compat: api.VRStageParameters.sittingToStandingTransform
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRStageParameters.sittingToStandingTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizex/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizex/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - sizeX
+browser-compat: api.VRStageParameters.sizeX
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRStageParameters.sizeX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vrstageparameters/sizey/index.html
+++ b/files/en-us/web/api/vrstageparameters/sizey/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebVR
   - sizeY
+browser-compat: api.VRStageParameters.sizeY
 ---
 <div>{{APIRef("WebVR API")}}{{Deprecated_Header}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VRStageParameters.sizeY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/vttcue/index.html
+++ b/files/en-us/web/api/vttcue/index.html
@@ -5,6 +5,7 @@ tags:
   - VTTCue
   - text track
   - vtt
+browser-compat: api.VTTCue
 ---
 <p>{{APIRef("WebVTT")}}<br>
  The <code>VTTCue</code> interface—part of the API for handling WebVTT (text tracks on media presentations)—describes and controls the text track associated with a particular {{HTMLElement("track")}} element.</p>
@@ -116,4 +117,4 @@ video.addEventListener('loadedmetadata', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VTTCue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/vttcue/vttcue/index.html
+++ b/files/en-us/web/api/vttcue/vttcue/index.html
@@ -12,6 +12,7 @@ tags:
 - a11y
 - captions
 - vtt
+browser-compat: api.VTTCue.VTTCue
 ---
 <p>{{APIRef("WebVTT")}}</p>
 
@@ -71,4 +72,4 @@ var cue = new VTTCue(2, 3, 'Cool text to be displayed');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VTTCue.VTTCue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/vttregion/index.html
+++ b/files/en-us/web/api/vttregion/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - VTTRegion
   - WebVTT
+browser-compat: api.VTTRegion
 ---
 <p>{{APIRef("WebVTT")}}</p>
 
@@ -66,4 +67,4 @@ cue.region = region;  // This cue will be drawn only within this region.</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.VTTRegion")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/v* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

120 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
