### PR TITLE
Update prefers-contrast example

### DIFF
--- a/files/en-us/web/css/@media/prefers-contrast/index.html
+++ b/files/en-us/web/css/@media/prefers-contrast/index.html
@@ -43,7 +43,7 @@ browser-compat: css.at-rules.media.prefers-contrast
   outline: 2px dashed black;
 }
 
-@media (prefers-contrast: high) {
+@media (prefers-contrast: more) {
   .contrast {
     outline: 2px solid black;
   }


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

In https://github.com/w3c/csswg-drafts/issues/2943 and associated discussion, `prefers-contrast`’s `high` value was replaced with `more`.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast

> Anything else that could help us review it

In Safari 14.1.1 on macOS 11.4, after enabling System Preferences → Accessibility → Display → Increase contrast,

using `prefers-contrast: high` (incorrect)
<img width="161" alt="image" src="https://user-images.githubusercontent.com/33663/120031861-3b988c80-bfae-11eb-9853-e344d075defd.png">

using `prefers-contrast: more` (correct)
<img width="156" alt="image" src="https://user-images.githubusercontent.com/33663/120032055-80242800-bfae-11eb-9def-06e17935e6c5.png">
