### PR TITLE
Put browser-compat info in front-runner for api/[xyz]*

### DIFF
--- a/files/en-us/web/api/xdomainrequest/abort/index.html
+++ b/files/en-us/web/api/xdomainrequest/abort/index.html
@@ -9,6 +9,7 @@ tags:
 - Microsoft
 - Deprecated
 - Reference
+browser-compat: api.XDomainRequest.abort
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -31,4 +32,4 @@ xdr.abort();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.abort")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/index.html
+++ b/files/en-us/web/api/xdomainrequest/index.html
@@ -9,6 +9,7 @@ tags:
 - Microsoft
 - Deprecated
 - Web
+browser-compat: api.XDomainRequest
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -123,4 +124,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/onerror/index.html
+++ b/files/en-us/web/api/xdomainrequest/onerror/index.html
@@ -10,6 +10,7 @@ tags:
 - Deprecated
 - Property
 - Reference
+browser-compat: api.XDomainRequest.onerror
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -53,4 +54,4 @@ xdr.send("param1=value1&amp;param2=value2");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.onerror")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/onload/index.html
+++ b/files/en-us/web/api/xdomainrequest/onload/index.html
@@ -10,6 +10,7 @@ tags:
 - Deprecated
 - Property
 - Reference
+browser-compat: api.XDomainRequest.onload
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -40,4 +41,4 @@ xdr.send("param1=value1&amp;param2=value2");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.onload")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/onprogress/index.html
+++ b/files/en-us/web/api/xdomainrequest/onprogress/index.html
@@ -11,6 +11,7 @@ tags:
 - Deprecated
 - Property
 - Reference
+browser-compat: api.XDomainRequest.onprogress
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -58,4 +59,4 @@ xdr.send("param1=value1&amp;param2=value2");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.onprogress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/ontimeout/index.html
+++ b/files/en-us/web/api/xdomainrequest/ontimeout/index.html
@@ -10,6 +10,7 @@ tags:
 - Deprecated
 - Property
 - Reference
+browser-compat: api.XDomainRequest.ontimeout
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -48,4 +49,4 @@ xdr.send("param1=value1&amp;param2=value2");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.ontimeout")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/open/index.html
+++ b/files/en-us/web/api/xdomainrequest/open/index.html
@@ -9,6 +9,7 @@ tags:
 - Microsoft
 - Deprecated
 - Reference
+browser-compat: api.XDomainRequest.open
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -39,4 +40,4 @@ xdr.open("get", "http://example.com/api/method");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.open")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/responsetext/index.html
+++ b/files/en-us/web/api/xdomainrequest/responsetext/index.html
@@ -8,6 +8,7 @@ tags:
 - Deprecated
 - Property
 - Reference
+browser-compat: api.XDomainRequest.responseText
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -36,4 +37,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.responseText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/send/index.html
+++ b/files/en-us/web/api/xdomainrequest/send/index.html
@@ -9,6 +9,7 @@ tags:
 - Microsoft
 - Deprecated
 - Reference
+browser-compat: api.XDomainRequest.send
 ---
 <div>{{APIRef("XDomain")}}{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -42,4 +43,4 @@ xdr.send("param1=value1&amp;param2=value2");</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.send")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xdomainrequest/timeout/index.html
+++ b/files/en-us/web/api/xdomainrequest/timeout/index.html
@@ -8,6 +8,7 @@ tags:
   - Deprecated
   - Property
   - Reference
+browser-compat: api.XDomainRequest.timeout
 ---
 <p>{{APIRef("XDomain")}}{{deprecated_header}}</p>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XDomainRequest.timeout")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmldocument/async/index.html
+++ b/files/en-us/web/api/xmldocument/async/index.html
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - async
+browser-compat: api.XMLDocument.async
 ---
 <p>{{APIRef("DOM")}}{{Non-standard_header}}{{Deprecated_header}}</p>
 
@@ -32,7 +33,7 @@ xmlDoc.load('querydata.xml');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLDocument.async")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmldocument/index.html
+++ b/files/en-us/web/api/xmldocument/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Reference
   - XMLDocument
+browser-compat: api.XMLDocument
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLDocument")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmldocument/load/index.html
+++ b/files/en-us/web/api/xmldocument/load/index.html
@@ -9,6 +9,7 @@ tags:
   - Non-standard
   - Reference
   - load
+browser-compat: api.XMLDocument.load
 ---
 <p>{{APIRef("DOM")}}{{Non-standard_Header}}{{Deprecated_Header}}</p>
 
@@ -37,7 +38,7 @@ xmlDoc.load('querydata.xml');</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLDocument.load")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/abort/index.html
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.html
@@ -16,6 +16,7 @@ tags:
 - abort
 - cancel
 - stop
+browser-compat: api.XMLHttpRequest.abort
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -73,7 +74,7 @@ if (OH_NOES_WE_NEED_TO_CANCEL_RIGHT_NOW_OR_ELSE) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.abort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/abort_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/abort_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Web
   - XMLHttpRequest
   - abort
+browser-compat: api.XMLHttpRequest.abort_event
 ---
 <div>{{APIRef}}</div>
 
@@ -133,7 +134,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.abort_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/error_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/error_event/index.html
@@ -8,6 +8,7 @@ tags:
   - ProgressEvent
   - Web
   - XMLHttpRequest
+browser-compat: api.XMLHttpRequest.error_event
 ---
 <div>{{APIRef}}</div>
 
@@ -133,7 +134,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.error_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.html
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.html
@@ -13,6 +13,7 @@ tags:
 - XHR
 - XMLHttpRequest
 - getAllResponseHeaders
+browser-compat: api.XMLHttpRequest.getAllResponseHeaders
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -128,7 +129,7 @@ request.onreadystatechange = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XMLHttpRequest.getAllResponseHeaders")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.html
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.html
@@ -14,6 +14,7 @@ tags:
 - XHR Header
 - XMLHttpRequest
 - getResponseHeader
+browser-compat: api.XMLHttpRequest.getResponseHeader
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -95,7 +96,7 @@ client.onreadystatechange = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XMLHttpRequest.getResponseHeader")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - XHR
   - XMLHttpRequest
+browser-compat: api.XMLHttpRequest
 ---
 <div>{{DefaultAPISidebar("XMLHttpRequest")}}</div>
 
@@ -160,7 +161,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XMLHttpRequest")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/load_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/load_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Web
   - XMLHttpRequest
   - load
+browser-compat: api.XMLHttpRequest.load_event
 ---
 <div>{{APIRef}}</div>
 
@@ -133,7 +134,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.load_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/loadend_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/loadend_event/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - events
   - loadend
+browser-compat: api.XMLHttpRequest.loadend_event
 ---
 <div>{{APIRef}}</div>
 
@@ -136,7 +137,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.loadend_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/loadstart_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/loadstart_event/index.html
@@ -11,6 +11,7 @@ tags:
   - XMLHttpRequest
   - events
   - loadstart
+browser-compat: api.XMLHttpRequest.loadstart_event
 ---
 <div>{{APIRef}}</div>
 
@@ -136,7 +137,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.loadstart_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.html
+++ b/files/en-us/web/api/xmlhttprequest/onreadystatechange/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - XHR
 - XMLHttpRequest
+browser-compat: api.XMLHttpRequest.onreadystatechange
 ---
 <div>{{APIRef}}</div>
 
@@ -79,4 +80,4 @@ xhr.send();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.onreadystatechange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequest/open/index.html
+++ b/files/en-us/web/api/xmlhttprequest/open/index.html
@@ -10,6 +10,7 @@ tags:
 - XHR
 - XMLHttpRequest
 - open
+browser-compat: api.XMLHttpRequest.open
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.open")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.html
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.html
@@ -11,6 +11,7 @@ tags:
 - XHR MIME Type
 - XMLHttpRequest
 - overrideMimeType
+browser-compat: api.XMLHttpRequest.overrideMimeType
 ---
 <div>{{draft}}{{APIRef('XMLHttpRequest')}}</div>
 
@@ -83,7 +84,7 @@ req.send();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.overrideMimeType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/progress_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/progress_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Web
   - XMLHttpRequest
   - progress
+browser-compat: api.XMLHttpRequest.progress_event
 ---
 <div>{{APIRef}}</div>
 
@@ -134,7 +135,7 @@ xhrButtonAbort.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.progress_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/readystate/index.html
+++ b/files/en-us/web/api/xmlhttprequest/readystate/index.html
@@ -6,6 +6,7 @@ tags:
   - Property
   - Reference
   - XMLHttpRequest
+browser-compat: api.XMLHttpRequest.readyState
 ---
 <p>{{APIRef('XMLHttpRequest')}}</p>
 
@@ -101,4 +102,4 @@ xhr.send(null);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.readyState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequest/response/index.html
+++ b/files/en-us/web/api/xmlhttprequest/response/index.html
@@ -14,6 +14,7 @@ tags:
 - Response
 - Server
 - XMLHttpRequest
+browser-compat: api.XMLHttpRequest.response
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -95,7 +96,7 @@ function load(url, callback) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.response")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - XMLHttpRequest
 - responseText
+browser-compat: api.XMLHttpRequest.responseText
 ---
 <div>{{draft}}</div>
 
@@ -89,4 +90,4 @@ xhr.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.responseText")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.html
@@ -13,6 +13,7 @@ tags:
 - XHR
 - XMLHttpRequest
 - responseType
+browser-compat: api.XMLHttpRequest.responseType
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.responseType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/responseurl/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responseurl/index.html
@@ -9,6 +9,7 @@ tags:
   - URL
   - XMLHttpRequest
   - responseURL
+browser-compat: api.XMLHttpRequest.responseURL
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -44,4 +45,4 @@ xhr.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.responseURL")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.html
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.html
@@ -16,6 +16,7 @@ tags:
 - download
 - responseXML
 - upload
+browser-compat: api.XMLHttpRequest.responseXML
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -101,7 +102,7 @@ xhr.send();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.responseXML")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/send/index.html
+++ b/files/en-us/web/api/xmlhttprequest/send/index.html
@@ -13,6 +13,7 @@ tags:
 - XHR Request
 - XMLHttpRequest
 - send
+browser-compat: api.XMLHttpRequest.send
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -141,7 +142,7 @@ xhr.send("foo=bar&amp;lorem=ipsum");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XMLHttpRequest.send")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.html
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.html
@@ -15,6 +15,7 @@ tags:
 - header
 - request
 - setRequestHeader
+browser-compat: api.XMLHttpRequest.setRequestHeader
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.setRequestHeader")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/status/index.html
+++ b/files/en-us/web/api/xmlhttprequest/status/index.html
@@ -10,6 +10,7 @@ tags:
   - XMLHttpRequest Status
   - result
   - status
+browser-compat: api.XMLHttpRequest.status
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -66,7 +67,7 @@ xhr.send();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.status")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.html
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - XMLHttpRequest
   - XMLHttpRequest Status
+browser-compat: api.XMLHttpRequest.statusText
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -67,7 +68,7 @@ xhr.send(null);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.statusText")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/timeout/index.html
+++ b/files/en-us/web/api/xmlhttprequest/timeout/index.html
@@ -10,6 +10,7 @@ tags:
   - XHR
   - XMLHttpRequest
   - timeout
+browser-compat: api.XMLHttpRequest.timeout
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -57,4 +58,4 @@ xhr.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.timeout")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequest/timeout_event/index.html
+++ b/files/en-us/web/api/xmlhttprequest/timeout_event/index.html
@@ -9,6 +9,7 @@ tags:
   - XMLHttpRequest
   - events
   - timeout
+browser-compat: api.XMLHttpRequest.timeout_event
 ---
 <div>{{APIRef}}</div>
 
@@ -72,7 +73,7 @@ client.send();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.timeout_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/upload/index.html
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.html
@@ -16,6 +16,7 @@ tags:
   - XMLHttpRequest Uploads
   - XMLHttpRequestUpload
   - upload
+browser-compat: api.XMLHttpRequest.upload
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -93,7 +94,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.upload")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.html
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.html
@@ -11,6 +11,7 @@ tags:
   - XMLHttpRequest
   - credentials
   - withCredentials
+browser-compat: api.XMLHttpRequest.withCredentials
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
@@ -52,4 +53,4 @@ xhr.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequest.withCredentials")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequesteventtarget/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsContent
   - Reference
   - XMLHttpRequest
+browser-compat: api.XMLHttpRequestEventTarget
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequestEventTarget")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onabort/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onabort/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web
 - XHMLHttpRequestEventTarget
+browser-compat: api.XMLHttpRequestEventTarget.onabort
 ---
 <div>{{APIRef("XMLHttpRequest")}}</div>
 
@@ -61,4 +62,4 @@ xmlhttp.abort(); // This will invoke our onabort handler above
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequestEventTarget.onabort")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onerror/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web
 - XMLHttpRequestEventTarget
+browser-compat: api.XMLHttpRequestEventTarget.onerror
 ---
 <div>{{APIRef("XMLHttpRequest")}}</div>
 
@@ -62,4 +63,4 @@ xmlhttp.send();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequestEventTarget.onerror")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onload/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onload/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web
 - XMLHttpRequestEventTarget
+browser-compat: api.XMLHttpRequestEventTarget.onload
 ---
 <div>{{APIRef("XMLHttpRequest")}}</div>
 
@@ -60,4 +61,4 @@ xmlhttp.send();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequestEventTarget.onload")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onloadstart/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onloadstart/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web
 - XMLHttpRequestEventTarget
+browser-compat: api.XMLHttpRequestEventTarget.onloadstart
 ---
 <div>{{APIRef("XMLHttpRequest")}}</div>
 
@@ -58,4 +59,4 @@ xmlhttp.send();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequestEventTarget.onloadstart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlhttprequesteventtarget/onprogress/index.html
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/onprogress/index.html
@@ -8,6 +8,7 @@ tags:
   - Web
   - XHR
   - XMLHttpRequestEventTarget
+browser-compat: api.XMLHttpRequestEventTarget.onprogress
 ---
 <p>{{APIRef("XMLHttpRequest")}}</p>
 
@@ -67,4 +68,4 @@ xmlhttp.send();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLHttpRequestEventTarget.onprogress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xmlserializer/index.html
+++ b/files/en-us/web/api/xmlserializer/index.html
@@ -12,6 +12,7 @@ tags:
   - XML
   - XMLSerializer
   - conversion
+browser-compat: api.XMLSerializer
 ---
 <div>{{APIRef("XMLSerializer")}}</div>
 
@@ -85,7 +86,7 @@ document.body.insertAdjacentHTML('afterbegin', inp_xmls);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XMLSerializer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathevaluator/createexpression/index.html
+++ b/files/en-us/web/api/xpathevaluator/createexpression/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - XPath
 - XPathEvaluator
+browser-compat: api.XPathEvaluator.createExpression
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -92,7 +93,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathEvaluator.createExpression")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathevaluator/creatensresolver/index.html
+++ b/files/en-us/web/api/xpathevaluator/creatensresolver/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - XPath
 - XPathEvaluator
+browser-compat: api.XPathEvaluator.createNSResolver
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathEvaluator.createNSResolver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathevaluator/index.html
+++ b/files/en-us/web/api/xpathevaluator/index.html
@@ -11,6 +11,7 @@ tags:
   - XML
   - XPath
   - XPathEvaluator
+browser-compat: api.XPathEvaluator
 ---
 <p>{{APIRef("DOM XPath")}}</p>
 
@@ -71,7 +72,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathEvaluator")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathexception/code/index.html
+++ b/files/en-us/web/api/xpathexception/code/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - XPath
 - XPathException
+browser-compat: api.XPathException.code
 ---
 <div>{{APIRef("DOM XPath")}}{{Deprecated_Header}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathException.code")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathexception/index.html
+++ b/files/en-us/web/api/xpathexception/index.html
@@ -8,6 +8,7 @@ tags:
   - Exception
   - Reference
   - XPath
+browser-compat: api.XPathException
 ---
 <p>{{APIRef("DOM XPath")}}{{Deprecated_Header}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathException")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathexpression/index.html
+++ b/files/en-us/web/api/xpathexpression/index.html
@@ -11,6 +11,7 @@ tags:
   - XML
   - XPath
   - XPathExpression
+browser-compat: api.XPathExpression
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -67,7 +68,7 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathExpression")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathnsresolver/index.html
+++ b/files/en-us/web/api/xpathnsresolver/index.html
@@ -10,6 +10,7 @@ tags:
   - XML
   - XPath
   - XPathNSResolver
+browser-compat: api.XPathNSResolver
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathNSResolver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.html
+++ b/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - XPath
 - XPathNSResolver
+browser-compat: api.XPathNSResolver.lookupNamespaceURI
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathNSResolver.lookupNamespaceURI")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathresult/booleanvalue/index.html
+++ b/files/en-us/web/api/xpathresult/booleanvalue/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.booleanValue
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -75,4 +76,4 @@ document.querySelector("output").textContent = result.booleanValue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.booleanValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/index.html
+++ b/files/en-us/web/api/xpathresult/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - XPath
   - XPathResult
+browser-compat: api.XPathResult
 ---
 <div>{{APIRef}}</div>
 
@@ -124,7 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathresult/invaliditeratorstate/index.html
+++ b/files/en-us/web/api/xpathresult/invaliditeratorstate/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.invalidIteratorState
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -72,4 +73,4 @@ document.querySelector("output").textContent = result.invalidIteratorState ? "in
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.invalidIteratorState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/numbervalue/index.html
+++ b/files/en-us/web/api/xpathresult/numbervalue/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.numberValue
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -75,4 +76,4 @@ document.querySelector("output").textContent = result.numberValue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.numberValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/resulttype/index.html
+++ b/files/en-us/web/api/xpathresult/resulttype/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.resultType
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -147,4 +148,4 @@ document.querySelector("output").textContent =
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.resultType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/singlenodevalue/index.html
+++ b/files/en-us/web/api/xpathresult/singlenodevalue/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.singleNodeValue
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -78,4 +79,4 @@ document.querySelector("output").textContent = result.singleNodeValue.localName;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.singleNodeValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/snapshotlength/index.html
+++ b/files/en-us/web/api/xpathresult/snapshotlength/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.snapshotLength
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -75,4 +76,4 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.snapshotLength")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/stringvalue/index.html
+++ b/files/en-us/web/api/xpathresult/stringvalue/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.stringValue
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -75,4 +76,4 @@ document.querySelector("output").textContent = result.stringValue;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.stringValue")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.html
@@ -21,6 +21,7 @@ tags:
 - augmented
 - boundsGeometry
 - space
+browser-compat: api.XRBoundedReferenceSpace.boundsGeometry
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}{{draft}}</p>
 
@@ -122,4 +123,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRBoundedReferenceSpace.boundsGeometry")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrboundedreferencespace/index.html
+++ b/files/en-us/web/api/xrboundedreferencespace/index.html
@@ -15,6 +15,7 @@ tags:
   - XR
   - XRBoundedReferenceSpace
   - augmented
+browser-compat: api.XRBoundedReferenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRBoundedReferenceSpace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrenvironmentblendmode/index.html
+++ b/files/en-us/web/api/xrenvironmentblendmode/index.html
@@ -17,6 +17,7 @@ tags:
   - WebXR Device API
   - XR
   - augmented
+browser-compat: api.XREnvironmentBlendMode
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XREnvironmentBlendMode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xreye/index.html
+++ b/files/en-us/web/api/xreye/index.html
@@ -17,6 +17,7 @@ tags:
   - XR
   - XREye
   - augmented
+browser-compat: api.XREye
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XREye")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrframe/getpose/index.html
+++ b/files/en-us/web/api/xrframe/getpose/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRFrame
 - getPose
+browser-compat: api.XRFrame.getPose
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRFrame.getPose")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrframe/getviewerpose/index.html
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.html
@@ -15,6 +15,7 @@ tags:
 - XRFrame
 - getViewerPose
 - pose
+browser-compat: api.XRFrame.getViewerPose
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -93,4 +94,4 @@ if (viewerPose) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRFrame.getViewerPose")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrframe/index.html
+++ b/files/en-us/web/api/xrframe/index.html
@@ -16,6 +16,7 @@ tags:
   - WebXR Device API
   - XR
   - XRFrame
+browser-compat: api.XRFrame
 ---
 <div>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRFrame")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrframe/session/index.html
+++ b/files/en-us/web/api/xrframe/session/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XR
 - XRFrame
+browser-compat: api.XRFrame.session
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRFrame.session")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrframerequestcallback/index.html
+++ b/files/en-us/web/api/xrframerequestcallback/index.html
@@ -3,6 +3,7 @@ title: XRFrameRequestCallback
 slug: Web/API/XRFrameRequestCallback
 tags:
 - Fixup spec table
+browser-compat: api.XRFrameRequestCallback
 ---
 <div>{{APIRef}}{{SeeCompatTable}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRFrameRequestCallback")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrhandedness/index.html
+++ b/files/en-us/web/api/xrhandedness/index.html
@@ -16,6 +16,7 @@ tags:
   - hand
   - left
   - right
+browser-compat: api.XRHandedness
 ---
 <p>{{APIRef("WebXR")}}</p>
 
@@ -71,7 +72,7 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRHandedness")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsource/gripspace/index.html
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.html
@@ -14,6 +14,7 @@ tags:
   - WebXR Device API
   - XRInputSession
   - gripSpace
+browser-compat: api.XRInputSource.gripSpace
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -125,4 +126,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSource.gripSpace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrinputsource/handedness/index.html
+++ b/files/en-us/web/api/xrinputsource/handedness/index.html
@@ -19,6 +19,7 @@ tags:
 - hand
 - left
 - right
+browser-compat: api.XRInputSource.handedness
 ---
 <p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSource.handedness")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsource/index.html
+++ b/files/en-us/web/api/xrinputsource/index.html
@@ -15,6 +15,7 @@ tags:
   - WebXR Device API
   - XRInputSource
   - control
+browser-compat: api.XRInputSource
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSource")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsource/profiles/index.html
+++ b/files/en-us/web/api/xrinputsource/profiles/index.html
@@ -18,6 +18,7 @@ tags:
 - XRInputSource
 - augmented
 - profile
+browser-compat: api.XRInputSource.profiles
 ---
 <p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSource.profiles")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.html
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.html
@@ -19,6 +19,7 @@ tags:
 - pointer
 - target
 - targetRayMode
+browser-compat: api.XRInputSource.targetRayMode
 ---
 <p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSource.targetRayMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.html
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.html
@@ -38,7 +38,8 @@ tags:
   used both to fully interpret the device as an input source.</p>
 
 <p><strong>&lt;&lt;&lt;--- needs diagram showing targetRaySpace relative to gripSpace and
-    world space ---&gt;&gt;&gt;</strong></p>
+    world space browser-compat: api.XRInputSource.targetRaySpace
+---&gt;&gt;&gt;</strong></p>
 
 <p>To obtain an <code>XRSpace</code> representing the input controller's position and
   orientation in virtual space, use the {{domxref("XRInputSource.gripSpace",
@@ -108,7 +109,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSource.targetRaySpace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.html
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.html
@@ -25,6 +25,7 @@ tags:
 - source
 - space
 - target
+browser-compat: browser-compat: api.XRInputSource.targetRaySpace
 ---
 <p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
 
@@ -38,8 +39,7 @@ tags:
   used both to fully interpret the device as an input source.</p>
 
 <p><strong>&lt;&lt;&lt;--- needs diagram showing targetRaySpace relative to gripSpace and
-    world space browser-compat: api.XRInputSource.targetRaySpace
----&gt;&gt;&gt;</strong></p>
+    world space ---&gt;&gt;&gt;</strong></p>
 
 <p>To obtain an <code>XRSpace</code> representing the input controller's position and
   orientation in virtual space, use the {{domxref("XRInputSource.gripSpace",

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.html
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.html
@@ -25,7 +25,7 @@ tags:
 - source
 - space
 - target
-browser-compat: browser-compat: api.XRInputSource.targetRaySpace
+browser-compat: api.XRInputSource.targetRaySpace
 ---
 <p>{{APIRef("WebXR")}}{{securecontext_header}}</p>
 

--- a/files/en-us/web/api/xrinputsourcearray/entries/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/entries/index.html
@@ -16,6 +16,7 @@ tags:
 - WebXR Device API
 - XR
 - XRInputSourceArray
+browser-compat: api.XRInputSourceArray.entries
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -107,4 +108,4 @@ for (let input of sources.entries()) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSourceArray.entries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrinputsourcearray/foreach/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/foreach/index.html
@@ -19,6 +19,7 @@ tags:
 - XRInputSourceArray
 - augmented
 - forEach
+browser-compat: api.XRInputSourceArray.forEach
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -126,7 +127,7 @@ inputSources.forEach((input) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSourceArray.forEach")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsourcearray/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/index.html
@@ -20,6 +20,7 @@ tags:
   - XRInputSourceArray
   - augmented
   - list
+browser-compat: api.XRInputSourceArray
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -82,4 +83,4 @@ if (sources.length &gt; 0) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSourceArray")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.html
@@ -22,6 +22,7 @@ tags:
 - XRInputSourceArray
 - augmented
 - keys
+browser-compat: api.XRInputSourceArray.keys
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -93,7 +94,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSourceArray.keys")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsourcearray/length/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/length/index.html
@@ -20,6 +20,7 @@ tags:
 - augmented
 - controllers
 - count
+browser-compat: api.XRInputSourceArray.length
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -83,4 +84,4 @@ if (sources.length === 0) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSourceArray.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrinputsourcearray/values/index.html
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.html
@@ -21,6 +21,7 @@ tags:
 - XRInputSourceArrray
 - augmented
 - values
+browser-compat: api.XRInputSourceArray.values
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRInputSourceArray.values")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.html
@@ -20,6 +20,7 @@ tags:
 - XRInputSourceEvent
 - augmented
 - events
+browser-compat: api.XRInputSourceEvent.frame
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -98,4 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEvent.frame")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceevent/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/index.html
@@ -22,6 +22,7 @@ tags:
   - augmented
   - controllers
   - events
+browser-compat: api.XRInputSourceEvent
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -103,4 +104,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEvent")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.html
@@ -21,6 +21,7 @@ tags:
 - augmented
 - inputSource
 - source
+browser-compat: api.XRInputSourceEvent.inputSource
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -81,4 +82,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEvent.inputSource")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.html
+++ b/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.html
@@ -20,6 +20,7 @@ tags:
 - augmented
 - controllers
 - events
+browser-compat: api.XRInputSourceEvent.XRInputSourceEvent
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -81,4 +82,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEvent.XRInputSourceEvent")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceeventinit/frame/index.html
+++ b/files/en-us/web/api/xrinputsourceeventinit/frame/index.html
@@ -23,6 +23,7 @@ tags:
 - XR
 - XRInputSourceEventInit
 - source
+browser-compat: api.XRInputSourceEventInit.frame
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -99,4 +100,4 @@ if (event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEventInit.frame")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceeventinit/index.html
+++ b/files/en-us/web/api/xrinputsourceeventinit/index.html
@@ -17,6 +17,7 @@ tags:
   - XRInputSourceEventInit
   - augmented
   - events
+browser-compat: api.XRInputSourceEventInit
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEventInit")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceeventinit/inputsource/index.html
+++ b/files/en-us/web/api/xrinputsourceeventinit/inputsource/index.html
@@ -17,6 +17,7 @@ tags:
 - controllers
 - inputSource
 - value
+browser-compat: api.XRInputSourceEventInit.inputSource
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -83,4 +84,4 @@ if (event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourceEventInit.inputSource")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeevent/added/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/added/index.html
@@ -17,6 +17,7 @@ tags:
 - XRInputSource
 - XRInputSourcesChangeEvent
 - augmented
+browser-compat: api.XRInputSourcesChangeEvent.added
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEvent.added")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeevent/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/index.html
@@ -20,6 +20,7 @@ tags:
   - augmented
   - events
   - inputsourceschange
+browser-compat: api.XRInputSourcesChangeEvent
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -94,4 +95,4 @@ function onInputSourcesChange(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEvent")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/removed/index.html
@@ -21,6 +21,7 @@ tags:
 - augmented
 - controllers
 - removed
+browser-compat: api.XRInputSourcesChangeEvent.removed
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEvent.removed")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeevent/session/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/session/index.html
@@ -20,6 +20,7 @@ tags:
 - XR
 - XRInputSourcesChangeEvent
 - augmented
+browser-compat: api.XRInputSourcesChangeEvent.session
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEvent.session")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.html
@@ -19,6 +19,7 @@ tags:
 - XR
 - XRInputSourcesChangeEvent
 - augmented
+browser-compat: api.XRInputSourcesChangeEvent.XRInputSourcesChangeEvent
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEvent.XRInputSourcesChangeEvent")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/added/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/added/index.html
@@ -20,6 +20,7 @@ tags:
 - XRInputSource
 - XRInputSourcesChangeEventInit
 - augmented
+browser-compat: api.XRInputSourcesChangeEventInit.added
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEventInit.added")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/index.html
@@ -19,6 +19,7 @@ tags:
   - XRInputSource
   - XRInputSourcesChangeEventInit
   - augmented
+browser-compat: api.XRInputSourcesChangeEventInit
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEventInit")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/removed/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/removed/index.html
@@ -19,6 +19,7 @@ tags:
 - XRInputSourcesChangeEventInit
 - augmented
 - removed
+browser-compat: api.XRInputSourcesChangeEventInit.removed
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEventInit.removed")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrinputsourceschangeeventinit/session/index.html
+++ b/files/en-us/web/api/xrinputsourceschangeeventinit/session/index.html
@@ -17,6 +17,7 @@ tags:
 - XR
 - XRInputSourcesChangeEventInit
 - augmented
+browser-compat: api.XRInputSourcesChangeEventInit.session
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRInputSourcesChangeEventInit.session")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrpermissiondescriptor/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/index.html
@@ -18,6 +18,7 @@ tags:
   - XRPermissionDescriptor
   - augmented
   - descriptor
+browser-compat: api.XRPermissionDescriptor
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -98,7 +99,7 @@ if (navigator.permissions) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRPermissionDescriptor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/mode/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/mode/index.html
@@ -20,6 +20,7 @@ tags:
 - XRSessionMode
 - augmented
 - mode
+browser-compat: api.XRPermissionDescriptor.mode
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -108,7 +109,7 @@ if (navigator.permissions) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRPermissionDescriptor.mode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/optionalfeatures/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/optionalfeatures/index.html
@@ -19,6 +19,7 @@ tags:
 - XRPermissionDescriptor
 - augmented
 - descriptor
+browser-compat: api.XRPermissionDescriptor.optionalFeatures
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -103,7 +104,7 @@ if (navigator.permissions) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRPermissionDescriptor.optionalFeatures")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpermissiondescriptor/requiredfeatures/index.html
+++ b/files/en-us/web/api/xrpermissiondescriptor/requiredfeatures/index.html
@@ -20,6 +20,7 @@ tags:
 - augmented
 - features
 - requiredFeatures
+browser-compat: api.XRPermissionDescriptor.requiredFeatures
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -116,7 +117,7 @@ if (navigator.permissions) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRPermissionDescriptor.requiredFeatures")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpermissionstatus/granted/index.html
+++ b/files/en-us/web/api/xrpermissionstatus/granted/index.html
@@ -18,6 +18,7 @@ tags:
 - XRPermissionStatus
 - augmented
 - granted
+browser-compat: api.XRPermissionStatus.granted
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}{{draft}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRPermissionStatus.granted")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpermissionstatus/index.html
+++ b/files/en-us/web/api/xrpermissionstatus/index.html
@@ -17,6 +17,7 @@ tags:
   - XR
   - XRPermissionStatus
   - augmented
+browser-compat: api.XRPermissionStatus
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRPermissionStatus")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpose/emulatedposition/index.html
+++ b/files/en-us/web/api/xrpose/emulatedposition/index.html
@@ -23,6 +23,7 @@ tags:
 - offset
 - pose
 - tracking
+browser-compat: api.XRPose.emulatedPosition
 ---
 <div>{{APIRef}}{{draft}}</div>
 
@@ -90,4 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRPose.emulatedPosition")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrpose/index.html
+++ b/files/en-us/web/api/xrpose/index.html
@@ -23,6 +23,7 @@ tags:
   - pose
   - space
   - transform
+browser-compat: api.XRPose
 ---
 <p>{{APIRef("WebXR Device API")}}{{securecontext_header}}{{draft}}</p>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRPose")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrpose/transform/index.html
+++ b/files/en-us/web/api/xrpose/transform/index.html
@@ -16,6 +16,7 @@ tags:
 - XR
 - XRPose
 - transform
+browser-compat: api.XRPose.transform
 ---
 <div>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRPose.transform")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.html
@@ -21,6 +21,7 @@ tags:
 - getOffsetReferenceSpace
 - move
 - movement
+browser-compat: api.XRReferenceSpace.getOffsetReferenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -206,4 +207,4 @@ function rotateViewBy(dx, dy) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpace.getOffsetReferenceSpace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespace/index.html
+++ b/files/en-us/web/api/xrreferencespace/index.html
@@ -20,6 +20,7 @@ tags:
   - XRReferenceSpace
   - matrix
   - transform
+browser-compat: api.XRReferenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -100,7 +101,7 @@ xrReferenceSpace = xrReferenceSpace.getOffsetReferenceSpace(offsetTransform);</p
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRReferenceSpace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrreferencespace/onreset/index.html
+++ b/files/en-us/web/api/xrreferencespace/onreset/index.html
@@ -20,6 +20,7 @@ tags:
 - onreset
 - reset
 - tracking
+browser-compat: api.XRReferenceSpace.onreset
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}{{draft}}</p>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpace.onreset")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.html
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.html
@@ -17,6 +17,7 @@ tags:
   - XRReferenceSpace
   - augmented
   - reset
+browser-compat: api.XRReferenceSpace.reset_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -113,4 +114,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRReferenceSpace.reset_event")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/index.html
@@ -18,6 +18,7 @@ tags:
   - XR
   - XRReferenceSpaceEvent
   - augmented
+browser-compat: api.XRReferenceSpaceEvent
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -70,4 +71,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRReferenceSpaceEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.html
@@ -19,6 +19,7 @@ tags:
 - events
 - referenceSpace
 - source
+browser-compat: api.XRReferenceSpaceEvent.referenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpaceEvent.referenceSpace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.html
@@ -24,6 +24,7 @@ tags:
 - augmented
 - reset
 - transform
+browser-compat: api.XRReferenceSpaceEvent.transform
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -91,4 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpaceEvent.transform")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
+++ b/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.html
@@ -19,6 +19,7 @@ tags:
 - XRReferenceSpaceEvent
 - augmented
 - events
+browser-compat: api.XRReferenceSpaceEvent.XRReferenceSpaceEvent
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -77,4 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpaceEvent.XRReferenceSpaceEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/index.html
@@ -19,6 +19,7 @@ tags:
   - XR
   - XRReferenceSpaceEventInit
   - augmented
+browser-compat: api.XRReferenceSpaceEventInit
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -67,4 +68,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRReferenceSpaceEventInit")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/referencespace/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/referencespace/index.html
@@ -17,6 +17,7 @@ tags:
 - XRReferenceSpaceEventInit
 - augmented
 - referenceSpace
+browser-compat: api.XRReferenceSpaceEventInit.referenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpaceEventInit.referenceSpace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespaceeventinit/transform/index.html
+++ b/files/en-us/web/api/xrreferencespaceeventinit/transform/index.html
@@ -17,6 +17,7 @@ tags:
 - XRReferenceSpaceEventInit
 - augmented
 - transform
+browser-compat: api.XRReferenceSpaceEventInit.transform
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpaceEventInit.transform")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrreferencespacetype/index.html
+++ b/files/en-us/web/api/xrreferencespacetype/index.html
@@ -20,6 +20,7 @@ tags:
   - augmented
   - space
   - tracking
+browser-compat: api.XRReferenceSpaceType
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -97,4 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRReferenceSpaceType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.html
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRRenderState
 - baseLayer
+browser-compat: api.XRRenderState.baseLayer
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -86,4 +87,4 @@ function setNewWebGLLayer(gl) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRRenderState.baseLayer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRRenderState
 - depthNear
+browser-compat: api.XRRenderState.depthNear
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRRenderState.depthNear")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrrenderstate/index.html
+++ b/files/en-us/web/api/xrrenderstate/index.html
@@ -13,6 +13,7 @@ tags:
   - WebXR
   - WebXR Device API
   - XRRenderState
+browser-compat: api.XRRenderState
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRRenderState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.html
+++ b/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.html
@@ -7,6 +7,7 @@ tags:
 - Vertical Field of View
 - WebXR
 - WebXR Device API
+browser-compat: api.XRRenderState.inlineVerticalFieldOfView
 ---
 <p>{{Draft}}{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRRenderState.inlineVerticalFieldOfView")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrrenderstateinit/index.html
+++ b/files/en-us/web/api/xrrenderstateinit/index.html
@@ -17,6 +17,7 @@ tags:
   - augmented
   - render
   - state
+browser-compat: api.XRRenderStateInit
 ---
 <p>{{APIRef("WebXR Device API")}}{{draft}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRRenderStateInit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/index.html
+++ b/files/en-us/web/api/xrrigidtransform/index.html
@@ -19,6 +19,7 @@ tags:
   - augmented
   - space
   - transform
+browser-compat: api.XRRigidTransform
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -91,4 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRRigidTransform")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrrigidtransform/inverse/index.html
+++ b/files/en-us/web/api/xrrigidtransform/inverse/index.html
@@ -18,6 +18,7 @@ tags:
 - augmented
 - inverse
 - transform
+browser-compat: api.XRRigidTransform.inverse
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -92,4 +93,4 @@ for (let view of pose.view) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRRigidTransform.inverse")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrrigidtransform/matrix/index.html
+++ b/files/en-us/web/api/xrrigidtransform/matrix/index.html
@@ -18,6 +18,7 @@ tags:
 - augmented
 - matrix
 - transform
+browser-compat: api.XRRigidTransform.matrix
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -873,4 +874,4 @@ drawGLObject("magic-lamp", transform.matrix);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRRigidTransform.matrix")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrrigidtransform/orientation/index.html
+++ b/files/en-us/web/api/xrrigidtransform/orientation/index.html
@@ -18,6 +18,7 @@ tags:
 - XRRigidTransform
 - augmented
 - rotation
+browser-compat: api.XRRigidTransform.orientation
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRRigidTransform.orientation")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrrigidtransform/position/index.html
+++ b/files/en-us/web/api/xrrigidtransform/position/index.html
@@ -17,6 +17,7 @@ tags:
 - XR
 - XRRigidTransform
 - transform
+browser-compat: api.XRRigidTransform.position
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -116,4 +117,4 @@ function refSpaceCreated(refSpace) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRRigidTransform.position")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.html
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.html
@@ -17,6 +17,7 @@ tags:
 - XRRigidTransform
 - augmented
 - transform
+browser-compat: api.XRRigidTransform.XRRigidTransform
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -118,4 +119,4 @@ xrSession.requestReferenceSpace("local-floor")
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRRigidTransform.XRRigidTransform")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.html
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - cancelAnimationFrame()
+browser-compat: api.XRSession.cancelAnimationFrame
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -117,7 +118,7 @@ function pauseXR() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.cancelAnimationFrame")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/end/index.html
+++ b/files/en-us/web/api/xrsession/end/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - end()
+browser-compat: api.XRSession.end
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.end")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/end_event/index.html
+++ b/files/en-us/web/api/xrsession/end_event/index.html
@@ -20,6 +20,7 @@ tags:
   - events
   - stop
   - terminate
+browser-compat: api.XRSession.end_event
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -82,4 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.end_event")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrsession/environmentblendmode/index.html
+++ b/files/en-us/web/api/xrsession/environmentblendmode/index.html
@@ -15,6 +15,7 @@ tags:
 - XRSession
 - augmented
 - environmentBlendMode
+browser-compat: api.XRSession.environmentBlendMode
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.environmentBlendMode")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/index.html
+++ b/files/en-us/web/api/xrsession/index.html
@@ -11,6 +11,7 @@ tags:
   - Virtual Reality
   - WebXR Device API
   - XRSession
+browser-compat: api.XRSession
 ---
 <div>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{Draft}}</div>
 
@@ -164,4 +165,4 @@ if (XR) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/inputsources/index.html
+++ b/files/en-us/web/api/xrsession/inputsources/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - inputSources
+browser-compat: api.XRSession.inputSources
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.inputSources")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.html
@@ -20,6 +20,7 @@ tags:
   - augmented
   - events
   - inputsourceschange
+browser-compat: api.XRSession.inputsourceschange_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.inputsourceschange_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/onend/index.html
+++ b/files/en-us/web/api/xrsession/onend/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XR
 - onend
+browser-compat: api.XRSession.onend
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onend")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrsession/oninputsourceschange/index.html
+++ b/files/en-us/web/api/xrsession/oninputsourceschange/index.html
@@ -14,6 +14,7 @@ tags:
   - WebXR Device API
   - XR
   - oninputsourceschange
+browser-compat: api.XRSession.oninputsourceschange
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.oninputsourceschange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onselect/index.html
+++ b/files/en-us/web/api/xrsession/onselect/index.html
@@ -15,6 +15,7 @@ tags:
 - XR
 - XRSession
 - onselect
+browser-compat: api.XRSession.onselect
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onselect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onselectend/index.html
+++ b/files/en-us/web/api/xrsession/onselectend/index.html
@@ -12,6 +12,7 @@ tags:
 - WebXR Device API
 - XRSession
 - onselectend
+browser-compat: api.XRSession.onselectend
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onselectend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onselectstart/index.html
+++ b/files/en-us/web/api/xrsession/onselectstart/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - onselectstart
+browser-compat: api.XRSession.onselectstart
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onselectstart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onsqueeze/index.html
+++ b/files/en-us/web/api/xrsession/onsqueeze/index.html
@@ -19,6 +19,7 @@ tags:
 - augmented
 - onsqueeze
 - squeeze
+browser-compat: api.XRSession.onsqueeze
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -111,7 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onsqueeze")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onsqueezeend/index.html
+++ b/files/en-us/web/api/xrsession/onsqueezeend/index.html
@@ -19,6 +19,7 @@ tags:
 - augmented
 - onsqueezeend
 - squeeze
+browser-compat: api.XRSession.onsqueezeend
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onsqueezeend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onsqueezestart/index.html
+++ b/files/en-us/web/api/xrsession/onsqueezestart/index.html
@@ -20,6 +20,7 @@ tags:
 - actions
 - augmented
 - onsqueezestart
+browser-compat: api.XRSession.onsqueezestart
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onsqueezestart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/onvisibilitychange/index.html
+++ b/files/en-us/web/api/xrsession/onvisibilitychange/index.html
@@ -12,6 +12,7 @@ tags:
 - WebXR Device API
 - XRSession
 - onvisibilitychange
+browser-compat: api.XRSession.onvisibilitychange
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.onvisibilitychange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/renderstate/index.html
+++ b/files/en-us/web/api/xrsession/renderstate/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - renderState
+browser-compat: api.XRSession.renderState
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.renderState")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.html
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - requestAnimationFrame()
+browser-compat: api.XRSession.requestAnimationFrame
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -171,7 +172,7 @@ function onXRSessionEnded() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.requestAnimationFrame")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.html
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.html
@@ -17,6 +17,7 @@ tags:
 - requestReferenceSpace
 - space
 - tracking
+browser-compat: api.XRSession.requestReferenceSpace
 ---
 <p>{{APIRef("WebXR")}}{{Draft}}{{SecureContext_Header}}</p>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSession.requestReferenceSpace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrsession/select_event/index.html
+++ b/files/en-us/web/api/xrsession/select_event/index.html
@@ -21,6 +21,7 @@ tags:
   - controllers
   - events
   - target
+browser-compat: api.XRSession.select_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -97,4 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.select_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/selectend_event/index.html
+++ b/files/en-us/web/api/xrsession/selectend_event/index.html
@@ -20,6 +20,7 @@ tags:
   - augmented
   - controllers
   - selectend
+browser-compat: api.XRSession.selectend_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.selectend_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/selectstart_event/index.html
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.html
@@ -20,6 +20,7 @@ tags:
   - augmented
   - controllers
   - selectstart
+browser-compat: api.XRSession.selectstart_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -122,4 +123,4 @@ xrSession.onselectend = onSelectionEvent;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.selectstart_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/squeeze_event/index.html
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.html
@@ -22,6 +22,7 @@ tags:
   - augmented
   - controllers
   - squeeze
+browser-compat: api.XRSession.squeeze_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -100,4 +101,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.squeeze_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.html
@@ -21,6 +21,7 @@ tags:
   - actions
   - augmented
   - squeezeend
+browser-compat: api.XRSession.squeezeend_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.squeezeend_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.html
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.html
@@ -22,6 +22,7 @@ tags:
   - augmented
   - controllers
   - squeezestart
+browser-compat: api.XRSession.squeezestart_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -124,4 +125,4 @@ xrSession.onsqueezeend = onSqueezeEvent;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.squeezestart_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.html
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.html
@@ -18,6 +18,7 @@ tags:
 - render
 - state
 - updateRenderState()
+browser-compat: api.XRSession.updateRenderState
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -111,7 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.updateRenderState")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.html
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.html
@@ -23,6 +23,7 @@ tags:
   - focused
   - hidden
   - visibilitychange
+browser-compat: api.XRSession.visibilitychange_event
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -99,4 +100,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.visibilitychange_event")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsession/visibilitystate/index.html
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRSession
 - visibilityState
+browser-compat: api.XRSession.visibilityState
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSession.visibilityState")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsessionevent/index.html
+++ b/files/en-us/web/api/xrsessionevent/index.html
@@ -19,6 +19,7 @@ tags:
   - XRSession
   - XRSessionEvent
   - augmented
+browser-compat: api.XRSessionEvent
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSessionEvent")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsessionevent/session/index.html
+++ b/files/en-us/web/api/xrsessionevent/session/index.html
@@ -20,6 +20,7 @@ tags:
 - augmented
 - events
 - sessions
+browser-compat: api.XRSessionEvent.session
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSessionEvent.session")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
+++ b/files/en-us/web/api/xrsessionevent/xrsessionevent/index.html
@@ -16,6 +16,7 @@ tags:
 - XRSessionEvent
 - augmented
 - events
+browser-compat: api.XRSessionEvent.XRSessionEvent
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSessionEvent.XRSessionEvent")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsessioneventinit/index.html
+++ b/files/en-us/web/api/xrsessioneventinit/index.html
@@ -20,6 +20,7 @@ tags:
   - augmented
   - events
   - sessions
+browser-compat: api.XRSessionEventInit
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSessionEventInit")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsessioneventinit/session/index.html
+++ b/files/en-us/web/api/xrsessioneventinit/session/index.html
@@ -19,6 +19,7 @@ tags:
 - XR
 - XRSessionEventInit
 - augmented
+browser-compat: api.XRSessionEventInit.session
 ---
 <p>{{APIRef("WebXR Device API")}} {{SecureContext_Header}}</p>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSessionEventInit.session")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsessionmode/index.html
+++ b/files/en-us/web/api/xrsessionmode/index.html
@@ -16,6 +16,7 @@ tags:
   - XR
   - XRSession
   - XRSessionMode
+browser-compat: api.XRSessionMode
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSessionMode")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrspace/index.html
+++ b/files/en-us/web/api/xrspace/index.html
@@ -13,6 +13,7 @@ tags:
   - WebXR
   - WebXR Device API
   - XRSpace
+browser-compat: api.XRSpace
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSpace")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.html
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.html
@@ -12,6 +12,7 @@ tags:
   - XR
   - XRSystem
   - devicechange
+browser-compat: api.XRSystem.devicechange_event
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -98,7 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRSystem.devicechange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsystem/index.html
+++ b/files/en-us/web/api/xrsystem/index.html
@@ -14,6 +14,7 @@ tags:
   - WebXR Device API
   - XR
   - XRSystem
+browser-compat: api.XRSystem
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -108,4 +109,4 @@ function onButtonClicked() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSystem")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.html
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XR
 - isSessionSupported
+browser-compat: api.XRSystem.isSessionSupported
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -119,4 +120,4 @@ function onButtonClicked() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSystem.isSessionSupported")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrsystem/ondevicechange/index.html
+++ b/files/en-us/web/api/xrsystem/ondevicechange/index.html
@@ -13,6 +13,7 @@ tags:
 - XR
 - XRSystem
 - ondevicechange
+browser-compat: api.XRSystem.ondevicechange
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSystem.ondevicechange")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrsystem/requestsession/index.html
+++ b/files/en-us/web/api/xrsystem/requestsession/index.html
@@ -15,6 +15,7 @@ tags:
 - XR
 - XRSystem
 - requestSession
+browser-compat: api.XRSystem.requestSession
 ---
 <div>{{APIRef("WebXR Device API")}}</div>
 
@@ -156,4 +157,4 @@ function onButtonClicked() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRSystem.requestSession")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrtargetraymode/index.html
+++ b/files/en-us/web/api/xrtargetraymode/index.html
@@ -21,6 +21,7 @@ tags:
   - augmented
   - source
   - target
+browser-compat: api.XRTargetRayMode
 ---
 <p>{{APIRef("WebXR")}}</p>
 
@@ -90,7 +91,7 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRTargetRayMode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrview/eye/index.html
+++ b/files/en-us/web/api/xrview/eye/index.html
@@ -17,6 +17,7 @@ tags:
 - XR
 - XRView
 - augmented
+browser-compat: api.XRView.eye
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -107,4 +108,4 @@ for (let view of xrPose.views) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRView.eye")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrview/index.html
+++ b/files/en-us/web/api/xrview/index.html
@@ -17,6 +17,7 @@ tags:
   - XR
   - XRView
   - camera
+browser-compat: api.XRView
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -158,4 +159,4 @@ mat4.transpose(normalMatrix, normalMatrix);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRView")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrview/projectionmatrix/index.html
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.html
@@ -18,6 +18,7 @@ tags:
 - augmented
 - perspective
 - projectionMatrix
+browser-compat: api.XRView.projectionMatrix
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft}}</p>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRView.projectionMatrix")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrview/transform/index.html
+++ b/files/en-us/web/api/xrview/transform/index.html
@@ -110,7 +110,8 @@ for (let view of pose.views) {
 
 <div class="notecard note">
   <p><strong>Note:</strong> This example is derived from a larger example...
-    <strong>&lt;&lt;&lt;--- finish and add link ---&gt;&gt;&gt;</strong></p>
+    <strong>&lt;&lt;&lt;--- finish and add link browser-compat: api.XRView.transform
+---&gt;&gt;&gt;</strong></p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>
@@ -134,4 +135,4 @@ for (let view of pose.views) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRView.transform")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrview/transform/index.html
+++ b/files/en-us/web/api/xrview/transform/index.html
@@ -22,6 +22,7 @@ tags:
 - augmented
 - camera
 - transform
+browser-compat: api.XRView.transform
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft}}</p>
 
@@ -110,8 +111,7 @@ for (let view of pose.views) {
 
 <div class="notecard note">
   <p><strong>Note:</strong> This example is derived from a larger example...
-    <strong>&lt;&lt;&lt;--- finish and add link browser-compat: api.XRView.transform
----&gt;&gt;&gt;</strong></p>
+    <strong>&lt;&lt;&lt;--- finish and add link ---&gt;&gt;&gt;</strong></p>
 </div>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/api/xrviewerpose/index.html
+++ b/files/en-us/web/api/xrviewerpose/index.html
@@ -17,6 +17,7 @@ tags:
   - WebXR Device API
   - XR
   - augmented
+browser-compat: api.XRViewerPose
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -65,7 +66,7 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.XRViewerPose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrviewerpose/views/index.html
+++ b/files/en-us/web/api/xrviewerpose/views/index.html
@@ -17,6 +17,7 @@ tags:
 - augmented
 - pose
 - views
+browser-compat: api.XRViewerPose.views
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -102,7 +103,7 @@ if (pose) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRViewerPose.views")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrviewport/height/index.html
+++ b/files/en-us/web/api/xrviewport/height/index.html
@@ -19,6 +19,7 @@ tags:
 - height
 - size
 - viewport
+browser-compat: api.XRViewport.height
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRViewport.height")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrviewport/index.html
+++ b/files/en-us/web/api/xrviewport/index.html
@@ -19,6 +19,7 @@ tags:
   - augmented
   - render
   - viewport
+browser-compat: api.XRViewport
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -86,4 +87,4 @@ gl.viewport(xrViewport.x, xrViewport.y, xrViewport.width, xrViewport.height);</p
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRViewport")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrviewport/width/index.html
+++ b/files/en-us/web/api/xrviewport/width/index.html
@@ -19,6 +19,7 @@ tags:
 - size
 - viewport
 - width
+browser-compat: api.XRViewport.width
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRViewport.width")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrviewport/x/index.html
+++ b/files/en-us/web/api/xrviewport/x/index.html
@@ -22,6 +22,7 @@ tags:
 - origin
 - viewport
 - x
+browser-compat: api.XRViewport.x
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRViewport.x")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrviewport/y/index.html
+++ b/files/en-us/web/api/xrviewport/y/index.html
@@ -21,6 +21,7 @@ tags:
 - origin
 - viewport
 - 'y'
+browser-compat: api.XRViewport.y
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_Header}}</p>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.XRViewport.y")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/api/xrvisibilitystate/index.html
+++ b/files/en-us/web/api/xrvisibilitystate/index.html
@@ -18,6 +18,7 @@ tags:
   - augmented
   - blur
   - hidden
+browser-compat: api.XRVisibilityState
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRVisibilityState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/antialias/index.html
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.html
@@ -21,6 +21,7 @@ tags:
 - appearance
 - augmented
 - rendering
+browser-compat: api.XRWebGLLayer.antialias
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -93,7 +94,7 @@ if (!glLayer.antialias) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.antialias")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.html
@@ -18,6 +18,7 @@ tags:
 - XRWebGLLayer
 - augmented
 - framebuffer
+browser-compat: api.XRWebGLLayer.framebuffer
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -135,7 +136,7 @@ gl.bindFramebuffer(gl.FRAMEBUFFER, glLayer.framebuffer);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.framebuffer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.html
@@ -21,6 +21,7 @@ tags:
 - framebufferHeight
 - height
 - size
+browser-compat: api.XRWebGLLayer.framebufferHeight
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -74,7 +75,7 @@ frameHeight = glLayer.framebufferHeight;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.framebufferHeight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.html
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.html
@@ -20,6 +20,7 @@ tags:
 - augmented
 - framebufferWidth
 - width
+browser-compat: api.XRWebGLLayer.framebufferWidth
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -73,7 +74,7 @@ frameHeight = glLayer.framebufferHeight;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.framebufferWidth")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.html
@@ -23,6 +23,7 @@ tags:
   - getNativeFramebufferScaleFactor
   - native
   - resolution
+browser-compat: api.XRWebGLLayer.getNativeFramebufferScaleFactor
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -176,7 +177,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.getNativeFramebufferScaleFactor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.html
@@ -73,7 +73,8 @@ tags:
   into the correct half of the framebuffer.</p>
 
 <p><strong>&lt;&lt;&lt;--- add link to appropriate section in the Cameras and views
-    article ---&gt;&gt;&gt;</strong></p>
+    article browser-compat: api.XRWebGLLayer.getViewport
+---&gt;&gt;&gt;</strong></p>
 
 <pre class="brush: js">function drawFrame(time, frame) {
   let session = frame.session;
@@ -118,7 +119,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.getViewport")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.html
@@ -19,7 +19,7 @@ tags:
 - augmented
 - getViewport
 - viewport
-browser-compat: browser-compat: api.XRWebGLLayer.getViewport
+browser-compat: api.XRWebGLLayer.getViewport
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.html
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.html
@@ -19,6 +19,7 @@ tags:
 - augmented
 - getViewport
 - viewport
+browser-compat: browser-compat: api.XRWebGLLayer.getViewport
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -73,8 +74,7 @@ tags:
   into the correct half of the framebuffer.</p>
 
 <p><strong>&lt;&lt;&lt;--- add link to appropriate section in the Cameras and views
-    article browser-compat: api.XRWebGLLayer.getViewport
----&gt;&gt;&gt;</strong></p>
+    article ---&gt;&gt;&gt;</strong></p>
 
 <pre class="brush: js">function drawFrame(time, frame) {
   let session = frame.session;

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.html
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.html
@@ -19,6 +19,7 @@ tags:
 - XRWebGLLayer
 - augmented
 - ignoreDepthValues
+browser-compat: api.XRWebGLLayer.ignoreDepthValues
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -105,7 +106,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, glLayerOptions);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.ignoreDepthValues")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/index.html
@@ -14,6 +14,7 @@ tags:
   - WebXR Device API
   - XR
   - XRWebGLLayer
+browser-compat: api.XRWebGLLayer
 ---
 <div>{{securecontext_header}}{{APIRef("WebXR Device API")}}</div>
 
@@ -107,7 +108,7 @@ if (pose) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.html
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.html
@@ -20,6 +20,7 @@ tags:
 - XRWebGLLayer
 - augmented
 - new
+browser-compat: api.XRWebGLLayer.XRWebGLLayer
 ---
 <p>{{APIRef("WebXR Device API")}}{{secureContext_header}}</p>
 
@@ -101,7 +102,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayer.XRWebGLLayer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/alpha/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/alpha/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XRWebGLLayerInit
 - color
+browser-compat: api.XRWebGLLayerInit.alpha
 ---
 <p>{{APIRef("WebXR Device API")}}{{securecontext_header}}</p>
 
@@ -72,7 +73,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { alpha: <em>boolValue</em> });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit.alpha")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/antialias/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/antialias/index.html
@@ -22,6 +22,7 @@ tags:
 - augmented
 - detail
 - rendering
+browser-compat: api.XRWebGLLayerInit.antialias
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -99,7 +100,7 @@ if (glLayer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit.antialias")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/depth/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/depth/index.html
@@ -21,6 +21,7 @@ tags:
   - XRWebGLLayerInit
   - augmented
   - rendering
+browser-compat: api.XRWebGLLayerInit.depth
 ---
 <p>{{APIRef("WebXR Device API")}}{{securecontext_header}}</p>
 
@@ -81,7 +82,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { depth: false });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit.depth")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/framebufferscalefactor/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/framebufferscalefactor/index.html
@@ -24,6 +24,7 @@ tags:
   - framebufferScaleFactor
   - resolution
   - size
+browser-compat: api.XRWebGLLayerInit.framebufferScaleFactor
 ---
 <p>{{APIRef("WebXR Device API")}}{{securecontext_header}}</p>
 
@@ -79,7 +80,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { framebufferScaleFactor: <em>scal
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit.framebufferScaleFactor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/ignoredepthvalues/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/ignoredepthvalues/index.html
@@ -19,6 +19,7 @@ tags:
 - XRWebGLLayerInit
 - augmented
 - ignoreDepthValues
+browser-compat: api.XRWebGLLayerInit.ignoreDepthValues
 ---
 <p>{{securecontext_header}}{{APIRef("WebXR Device API")}}</p>
 
@@ -109,7 +110,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { ignoreDepthValues: <em>boolValue
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit.ignoreDepthValues")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/index.html
@@ -18,6 +18,7 @@ tags:
   - XR
   - XRWebGLLayerInit
   - augmented
+browser-compat: api.XRWebGLLayerInit
 ---
 <p>{{APIRef("WebXR Device API")}}</p>
 
@@ -72,7 +73,7 @@ xrSession.updateRenderState({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xrwebgllayerinit/stencil/index.html
+++ b/files/en-us/web/api/xrwebgllayerinit/stencil/index.html
@@ -16,6 +16,7 @@ tags:
   - XRWebGLLayerInit
   - augmented
   - stencil
+browser-compat: api.XRWebGLLayerInit.stencil
 ---
 <p>{{APIRef("WebXR Device API")}}{{securecontext_header}}</p>
 
@@ -66,7 +67,7 @@ let glLayer = new XRWebGLLayer(xrSession, gl, { stencil: false });
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRWebGLLayerInit.stencil")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xsltprocessor/index.html
+++ b/files/en-us/web/api/xsltprocessor/index.html
@@ -7,6 +7,7 @@ tags:
 - DOM Reference
 - Reference
 - XSLT
+browser-compat: api.XSLTProcessor
 ---
 <div>{{Non-standard_header}}{{SeeCompatTable}}{{APIRef("XSLT")}}</div>
 
@@ -172,7 +173,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XSLTProcessor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/[xyz]* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

203 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
