### PR TITLE
Fix link (http->https)

### DIFF
--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -441,7 +441,7 @@ document.querySelector('a').addEventListener('click', event =&gt;
 
 <ul>
  <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size.html">Understanding Success Criterion 2.5.5: Target Size</a></li>
- <li><a href="http://adrianroselli.com/2019/06/target-size-and-2-5-5.html">Target Size and 2.5.5</a></li>
+ <li><a href="https://adrianroselli.com/2019/06/target-size-and-2-5-5.html">Target Size and 2.5.5</a></li>
  <li><a href="https://a11yproject.com/posts/large-touch-targets/">Quick test: Large touch targets</a></li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A link was http, and it works in https.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
> Issue number (if there is an associated issue)

N/A
> Anything else that could help us review it

I tested the new link, it works.