### PR TITLE
fix import statement `.models`

### DIFF
--- a/files/en-us/learn/server-side/django/home_page/index.html
+++ b/files/en-us/learn/server-side/django/home_page/index.html
@@ -133,7 +133,7 @@ tags:
 
 <p>Paste the following lines at the bottom of the file:</p>
 
-<pre class="brush: python">from catalog.models import Book, Author, BookInstance, Genre
+<pre class="brush: python">from .models import Book, Author, BookInstance, Genre
 
 def index(request):
     """View function for home page of site."""


### PR DESCRIPTION
changed from `catalog.models` to `.models` consistent with Django official tutorial and https://github.com/mdn/django-locallibrary-tutorial

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

import statement throws `Import "catalog.models" could not be resolved Pylance` when using Visual Studio Code

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Home_page#view_function-based

> Issue number (if there is an associated issue)

fixes #5464 

> Anything else that could help us review it

import statement given by Django:
https://docs.djangoproject.com/en/3.2/intro/tutorial03/#write-views-that-actually-do-something
and https://github.com/mdn/django-locallibrary-tutorial/blob/master/catalog/views.py
using `from .models import ---`

System check however does not identify any issues keeping `catalog.models`
