### PR TITLE
Fix a few broken links in HTML elements

### DIFF
--- a/files/en-us/glossary/localization/index.html
+++ b/files/en-us/glossary/localization/index.html
@@ -35,6 +35,5 @@ tags:
 <h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
- <li>{{Link("/en-US/docs/Mozilla/Localization")}} on MDN</li>
  <li>{{interwiki("wikipedia", "Language localisation", "Localization")}} on Wikipedia</li>
 </ul>

--- a/files/en-us/web/html/element/audio/index.html
+++ b/files/en-us/web/html/element/audio/index.html
@@ -117,7 +117,7 @@ tags:
   </tr>
   <tr>
    <td>{{domxref("HTMLMediaElement.emptied_event", 'emptied')}}</td>
-   <td>The media has become empty; for example, this event is sent if the media has already been loaded (or partially loaded), and the <a href="/en-US/docs/XPCOM_Interface_Reference/NsIDOMHTMLMediaElement" rel="internal"><code>load()</code></a> method is called to reload it.</td>
+   <td>The media has become empty; for example, this event is sent if the media has already been loaded (or partially loaded), and the {{domxref("HTMLMediaElement.load")}} method is called to reload it.</td>
   </tr>
   <tr>
    <td>{{domxref("HTMLMediaElement.ended_event", 'ended')}}</td>

--- a/files/en-us/web/html/element/bdi/index.html
+++ b/files/en-us/web/html/element/bdi/index.html
@@ -203,7 +203,7 @@ tags:
 <ul>
  <li><a href="https://www.w3.org/International/articles/inline-bidi-markup/">Inline markup and bidirectional text in HTML</a></li>
  <li><a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a></li>
- <li><a href="/en-US/docs/Web/Localization">Localization and Internationalization</a></li>
+ <li>{{Glossary("Localization")}}
  <li>Related HTML element: {{HTMLElement("bdo")}}</li>
  <li>Related CSS properties: {{cssxref("direction")}}, {{cssxref("unicode-bidi")}}</li>
 </ul>

--- a/files/en-us/web/html/element/big/index.html
+++ b/files/en-us/web/html/element/big/index.html
@@ -13,7 +13,7 @@ tags:
 <p><span class="seoSummary">The obsolete <strong>HTML Big Element</strong> (<strong><code>&lt;big&gt;</code></strong>) renders the enclosed text at a font size one level larger than the surrounding text (<code>medium</code> becomes <code>large</code>, for example).</span> The size is capped at the browser's maximum permitted font size.</p>
 
 <div class="note">
-<p><strong>Usage note:</strong> As it was purely presentational, this element has been removed in <a href="/en-US/docs/Web/Guide/HTML/HTML5">HTML5</a> and shouldn't be used anymore. Instead web developers should use the CSS {{cssxref("font-size")}} property to adjust the font size.</p>
+<p><strong>Usage note:</strong> As it was purely presentational, this element has been removed in {{Glossary("HTML5")}} and shouldn't be used anymore. Instead web developers should use the CSS {{cssxref("font-size")}} property to adjust the font size.</p>
 </div>
 
 <h2 id="Attributes">Attributes</h2>

--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -164,7 +164,7 @@ tags:
 
 <ul>
  <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size.html">Understanding Success Criterion 2.5.5: Target Size | W3C Understanding WCAG 2.1</a></li>
- <li><a href="http://adrianroselli.com/2019/06/target-size-and-2-5-5.html">Target Size and 2.5.5 | Adrian Roselli</a></li>
+ <li><a href="https://adrianroselli.com/2019/06/target-size-and-2-5-5.html">Target Size and 2.5.5 | Adrian Roselli</a></li>
  <li><a href="https://a11yproject.com/posts/large-touch-targets/">Quick test: Large touch targets - The A11Y Project</a></li>
 </ul>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There were a few broken or incorrect links in HTML element pages

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
https://developer.mozilla.org/en-US/docs/Glossary/Localization
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/big
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it
