### PR TITLE
Put browser-compat info in front-runner for http/headers/CSP

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.html
@@ -7,6 +7,7 @@ tags:
   - Document directive
   - HTTP
   - Security
+browser-compat: http.headers.csp.Content-Security-Policy.base-uri
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -94,7 +95,7 @@ Header set Content-Security-Policy "base-uri 'self'";
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.base-uri")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Security
   - block-all-mixed-content
+browser-compat: http.headers.csp.Content-Security-Policy.block-all-mixed-content
 ---
 <div>{{HTTPSidebar}}{{deprecated_header}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.block-all-mixed-content")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - child-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.child-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -91,7 +92,7 @@ Content-Security-Policy: child-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.child-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.html
@@ -10,6 +10,7 @@ tags:
   - Security
   - connect-src
   - source
+browser-compat: http.headers.csp.Content-Security-Policy.connect-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -114,7 +115,7 @@ Content-Security-Policy: connect-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.connect-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.html
@@ -11,6 +11,7 @@ tags:
   - default
   - default-src
   - source
+browser-compat: http.headers.csp.Content-Security-Policy.default-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -163,7 +164,7 @@ Content-Security-Policy: default-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.default-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.html
@@ -10,6 +10,7 @@ tags:
 - Security
 - font
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.font-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -91,7 +92,7 @@ Content-Security-Policy: font-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.font-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.html
@@ -10,6 +10,7 @@ tags:
   - action
   - form
   - form-action
+browser-compat: http.headers.csp.Content-Security-Policy.form-action
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -102,7 +103,7 @@ Header set Content-Security-Policy "form-action 'none';"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.form-action")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.html
@@ -10,6 +10,7 @@ tags:
   - HTTP
   - Security
   - frame-ancestors
+browser-compat: http.headers.csp.Content-Security-Policy.frame-ancestors
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -112,7 +113,7 @@ Content-Security-Policy: frame-ancestors 'self' https://www.example.org;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.frame-ancestors")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - frame-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.frame-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -89,7 +90,7 @@ Content-Security-Policy: frame-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.frame-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - img-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.img-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -87,7 +88,7 @@ Content-Security-Policy: img-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.img-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Security
 - header
+browser-compat: http.headers.csp.Content-Security-Policy
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -357,7 +358,7 @@ Content-Security-Policy: default-src https:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - manifest-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.manifest-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,7 +84,7 @@ Content-Security-Policy: manifest-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.manifest-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - media-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.media-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -91,7 +92,7 @@ Content-Security-Policy: media-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.media-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/navigate-to/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/navigate-to/index.html
@@ -9,6 +9,7 @@ tags:
 - Navigation
 - Reference
 - Security
+browser-compat: http.headers.csp.Content-Security-Policy.navigate-to
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -94,7 +95,7 @@ Content-Security-Policy: navigate-to &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.navigate-to")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - object-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.object-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -101,7 +102,7 @@ Content-Security-Policy: object-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.object-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.html
@@ -11,6 +11,7 @@ tags:
   - Plugin
   - Plugins
   - Security
+browser-compat: http.headers.csp.Content-Security-Policy.plugin-types
 ---
 <div>{{HTTPSidebar}}{{deprecated_header}}</div>
 
@@ -114,7 +115,7 @@ Content-Security-Policy: plugin-types &lt;type&gt;/&lt;subtype&gt; &lt;type&gt;/
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.plugin-types")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.html
@@ -8,6 +8,7 @@ tags:
 - HTTP
 - Reference
 - prefetch-src
+browser-compat: http.headers.csp.Content-Security-Policy.prefetch-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,7 +84,7 @@ Content-Security-Policy: prefetch-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.prefetch-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/referrer/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/referrer/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Security
 - referrer
+browser-compat: http.headers.csp.Content-Security-Policy.referrer
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.referrer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.html
@@ -9,6 +9,7 @@ tags:
 - Reporting
 - Security
 - report-to
+browser-compat: http.headers.csp.Content-Security-Policy.report-to
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.report-to")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.html
@@ -7,6 +7,7 @@ tags:
 - HTTP
 - Reference
 - Security
+browser-compat: http.headers.csp.Content-Security-Policy.report-uri
 ---
 <div>{{HTTPSidebar}}{{deprecated_header}}</div>
 
@@ -132,7 +133,7 @@ if ($json_data = json_decode($json_data)) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.report-uri")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.html
@@ -9,6 +9,7 @@ tags:
 - Security
 - Subresource Integrity
 - require-sri-for
+browser-compat: http.headers.csp.Content-Security-Policy.require-sri-for
 ---
 <div>{{deprecated_header}}</div>
 
@@ -53,7 +54,7 @@ Content-Security-Policy: require-sri-for script style;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.require-sri-for")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.html
@@ -6,6 +6,7 @@ tags:
   - Directive
   - HTTP
   - Security
+browser-compat: http.headers.csp.Content-Security-Policy.trusted-types
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -67,7 +68,7 @@ if (typeof trustedTypes !== 'undefined') {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.trusted-types")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - Sandbox
   - Security
+browser-compat: http.headers.csp.Content-Security-Policy.sandbox
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -114,7 +115,7 @@ Content-Security-Policy: sandbox &lt;value&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.sandbox")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.html
@@ -12,6 +12,7 @@ tags:
 - Security
 - script-src
 - source
+browser-compat: http.headers.csp.Content-Security-Policy.script-src-attr
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -91,7 +92,7 @@ Content-Security-Policy: script-src-attr &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.script-src-attr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.html
@@ -12,6 +12,7 @@ tags:
   - Security
   - script-src
   - source
+browser-compat: http.headers.csp.Content-Security-Policy.script-src-elem
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,7 +84,7 @@ Content-Security-Policy: script-src-elem &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.script-src-elem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.html
@@ -12,6 +12,7 @@ tags:
   - Security
   - script-src
   - source
+browser-compat: http.headers.csp.Content-Security-Policy.script-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -161,7 +162,7 @@ Content-Security-Policy: script-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.script-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.html
@@ -13,6 +13,7 @@ tags:
 - source
 - style-src
 - style-src-attr
+browser-compat: http.headers.csp.Content-Security-Policy.style-src-attr
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -88,7 +89,7 @@ Content-Security-Policy: <code>style</code>-src-attr &lt;source&gt;;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.style-src-attr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.html
@@ -13,6 +13,7 @@ tags:
 - source
 - style-src
 - style-src-elem
+browser-compat: http.headers.csp.Content-Security-Policy.style-src-elem
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -89,7 +90,7 @@ Content-Security-Policy: <code>style</code>-src-elem &lt;source&gt;;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.style-src-elem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.html
@@ -12,6 +12,7 @@ tags:
   - Style
   - source
   - style-src
+browser-compat: http.headers.csp.Content-Security-Policy.style-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -165,7 +166,7 @@ document.querySelector('div').style.cssText = 'display:none;';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.style-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.html
@@ -6,6 +6,7 @@ tags:
   - Directive
   - HTTP
   - Security
+browser-compat: http.headers.csp.Content-Security-Policy.trusted-types
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -66,7 +67,7 @@ if (typeof trustedTypes !== 'undefined') {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.trusted-types")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.html
@@ -11,6 +11,7 @@ tags:
 - Security
 - Upgrade
 - upgrade-insecure-requests
+browser-compat: http.headers.csp.Content-Security-Policy.upgrade-insecure-requests
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -99,7 +100,7 @@ Content-Security-Policy-Report-Only: default-src https:; report-uri /endpoint</p
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.upgrade-insecure-requests")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - Reference
   - Security
+browser-compat: http.headers.csp.Content-Security-Policy.worker-src
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -94,7 +95,7 @@ Content-Security-Policy: worker-src &lt;source&gt; &lt;source&gt;;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.csp.Content-Security-Policy.worker-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers http/headers/Content-Security-Policy for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

32 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
