### PR TITLE
Put browser-compat info in front-runner for http/headers/*

### DIFF
--- a/files/en-us/web/http/headers/accept-ch-lifetime/index.html
+++ b/files/en-us/web/http/headers/accept-ch-lifetime/index.html
@@ -5,6 +5,7 @@ tags:
 - Client hints
 - HTTP
 - header
+browser-compat: http.headers.Accept-CH-Lifetime
 ---
 <div>{{HTTPSidebar}}{{securecontext_header}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -45,7 +46,7 @@ Accept-CH-Lifetime: 86400
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Accept-CH-Lifetime")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/accept-ch/index.html
+++ b/files/en-us/web/http/headers/accept-ch/index.html
@@ -5,6 +5,7 @@ tags:
   - Client hints
   - HTTP
   - HTTP Header
+browser-compat: http.headers.Accept-CH
 ---
 <div>{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}</div>
 
@@ -52,7 +53,7 @@ Vary: Viewport-Width, Width
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Accept-CH")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/accept-encoding/index.html
+++ b/files/en-us/web/http/headers/accept-encoding/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
+browser-compat: http.headers.Accept-Encoding
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -103,7 +104,7 @@ Accept-Encoding: br;q=1.0, gzip;q=0.8, *;q=0.1
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Accept-Encoding")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/accept-language/index.html
+++ b/files/en-us/web/http/headers/accept-language/index.html
@@ -8,6 +8,7 @@ tags:
 - HTTP Header
 - Reference
 - Request header
+browser-compat: http.headers.Accept-Language
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -110,7 +111,7 @@ Accept-Language: en-US,en;q=0.5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Accept-Language")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/accept-ranges/index.html
+++ b/files/en-us/web/http/headers/accept-ranges/index.html
@@ -7,6 +7,7 @@ tags:
 - Range Requests
 - Reference
 - Response Header
+browser-compat: http.headers.Accept-Ranges
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -75,7 +76,7 @@ Accept-Ranges: none</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Accept-Ranges")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/accept/index.html
+++ b/files/en-us/web/http/headers/accept/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
+browser-compat: http.headers.Accept
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,7 +84,7 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Accept")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-credentials/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-credentials/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - credentials
 - header
+browser-compat: http.headers.Access-Control-Allow-Credentials
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -105,7 +106,7 @@ xhr.send(null);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Allow-Credentials")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.Access-Control-Allow-Headers
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -116,7 +117,7 @@ Access-Control-Max-Age: 86400</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Allow-Headers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.Access-Control-Allow-Methods
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -73,7 +74,7 @@ Access-Control-Allow-Methods: *
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Allow-Methods")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-allow-origin/index.html
+++ b/files/en-us/web/http/headers/access-control-allow-origin/index.html
@@ -14,6 +14,7 @@ tags:
   - cross-origin issue
   - header
   - origin
+browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -92,7 +93,7 @@ Vary: Origin</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Allow-Origin")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-expose-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - header
+browser-compat: http.headers.Access-Control-Expose-Headers
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -81,7 +82,7 @@ Access-Control-Expose-Headers: *
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Expose-Headers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-max-age/index.html
+++ b/files/en-us/web/http/headers/access-control-max-age/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - header
+browser-compat: http.headers.Access-Control-Max-Age
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Max-Age")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-request-headers/index.html
+++ b/files/en-us/web/http/headers/access-control-request-headers/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - header
+browser-compat: http.headers.Access-Control-Request-Headers
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Request-Headers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/access-control-request-method/index.html
+++ b/files/en-us/web/http/headers/access-control-request-method/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.Access-Control-Request-Method
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Access-Control-Request-Method")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/age/index.html
+++ b/files/en-us/web/http/headers/age/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Response
 - header
+browser-compat: http.headers.Age
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Age")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/alt-svc/index.html
+++ b/files/en-us/web/http/headers/alt-svc/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Header
 - NeedsCompatTable
 - Reference
+browser-compat: http.headers.Alt-Svc
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -71,7 +72,7 @@ Alt-Svc: h3-25=":443"; ma=3600, h2=":443"; ma=3600</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Alt-Svc")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/cache-control/index.html
+++ b/files/en-us/web/http/headers/cache-control/index.html
@@ -8,6 +8,7 @@ tags:
   - Request header
   - Response header
   - Reference
+browser-compat: http.headers.Cache-Control
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -206,7 +207,7 @@ Cache-Control: stale-if-error=&lt;seconds&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Cache-Control")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/clear-site-data/index.html
+++ b/files/en-us/web/http/headers/clear-site-data/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.Clear-Site-Data
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -101,7 +102,7 @@ Clear-Site-Data: "*"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Clear-Site-Data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/connection/index.html
+++ b/files/en-us/web/http/headers/connection/index.html
@@ -8,6 +8,7 @@ tags:
 - Response header
 - Reference
 - Web
+browser-compat: http.headers.Connection
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -68,4 +69,4 @@ Connection: close
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Connection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/http/headers/content-disposition/index.html
+++ b/files/en-us/web/http/headers/content-disposition/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Reference
+browser-compat: http.headers.Content-Disposition
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -125,7 +126,7 @@ value2
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Content-Disposition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>
 

--- a/files/en-us/web/http/headers/content-language/index.html
+++ b/files/en-us/web/http/headers/content-language/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Headers
   - Reference
+browser-compat: http.headers.Content-Language
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -91,7 +92,7 @@ Content-Language: de-DE, en-CA
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Content-Language")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-location/index.html
+++ b/files/en-us/web/http/headers/content-location/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - header
+browser-compat: http.headers.Content-Location
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -181,7 +182,7 @@ Content-Location: /my-receipts/38
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Content-Location")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-range/index.html
+++ b/files/en-us/web/http/headers/content-range/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - Response Header
 - header
+browser-compat: http.headers.Content-Range
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -72,7 +73,7 @@ Content-Range: &lt;unit&gt; */&lt;size&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Content-Range")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.html
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Security
   - header
+browser-compat: http.headers.Content-Security-Policy-Report-Only
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -137,7 +138,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Content-Security-Policy-Report-Only")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-type/index.html
+++ b/files/en-us/web/http/headers/content-type/index.html
@@ -83,7 +83,8 @@ Content-Disposition: form-data; name="myFile"; filename="foo.txt"
 Content-Type: text/plain
 
 (content of the uploaded file foo.txt)
------------------------------974767299852498929531610575--
+--------------------------browser-compat: http.headers.Content-Type
+---974767299852498929531610575--
 </pre>
 
 <h2 id="Specifications">Specifications</h2>
@@ -109,7 +110,7 @@ Content-Type: text/plain
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Content-Type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/content-type/index.html
+++ b/files/en-us/web/http/headers/content-type/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP header
   - Representation header
   - Reference
+browser-compat: http.headers.Content-Type
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,8 +84,7 @@ Content-Disposition: form-data; name="myFile"; filename="foo.txt"
 Content-Type: text/plain
 
 (content of the uploaded file foo.txt)
---------------------------browser-compat: http.headers.Content-Type
----974767299852498929531610575--
+-----------------------------974767299852498929531610575--
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/http/headers/cookie/index.html
+++ b/files/en-us/web/http/headers/cookie/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - header
   - request
+browser-compat: http.headers.Cookie
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -61,7 +62,7 @@ Cookie: name=value; name2=value2; name3=value3</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Cookie")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/cookie2/index.html
+++ b/files/en-us/web/http/headers/cookie2/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - header
   - request
+browser-compat: http.headers.Cookie2
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Cookie2")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/cross-origin-embedder-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-embedder-policy/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.Cross-Origin-Embedder-Policy
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,7 +84,7 @@ Cross-Origin-Opener-Policy: same-origin
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Cross-Origin-Embedder-Policy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.Cross-Origin-Opener-Policy
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -82,7 +83,7 @@ Cross-Origin-Embedder-Policy: require-corp
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Cross-Origin-Opener-Policy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/cross-origin-resource-policy/index.html
+++ b/files/en-us/web/http/headers/cross-origin-resource-policy/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - Response Header
 - header
+browser-compat: http.headers.Cross-Origin-Resource-Policy
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Cross-Origin-Resource-Policy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/date/index.html
+++ b/files/en-us/web/http/headers/date/index.html
@@ -7,6 +7,7 @@ tags:
 - Request header
 - Response header
 - Reference
+browser-compat: http.headers.Date
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Date")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/device-memory/index.html
+++ b/files/en-us/web/http/headers/device-memory/index.html
@@ -6,6 +6,7 @@ tags:
   - Device Memory API
   - HTTP
   - HTTP Header
+browser-compat: http.headers.Device-Memory
 ---
 <div>{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}</div>
 
@@ -69,7 +70,7 @@ Accept-CH-Lifetime: 86400
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Device-Memory")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/digest/index.html
+++ b/files/en-us/web/http/headers/digest/index.html
@@ -4,6 +4,7 @@ slug: Web/HTTP/Headers/Digest
 tags:
 - HTTP
 - HTTP Header
+browser-compat: http.headers.Digest
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -99,7 +100,7 @@ Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,unixsum=30637</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Digest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/dnt/index.html
+++ b/files/en-us/web/http/headers/dnt/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.DNT
 ---
 <div>{{HTTPSidebar}}{{Deprecated_header}}</div>
 
@@ -74,7 +75,7 @@ DNT: null
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.DNT")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/dpr/index.html
+++ b/files/en-us/web/http/headers/dpr/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP Header
   - Deprecated
   - Non-standard
+browser-compat: http.headers.DPR
 ---
 <div>{{deprecated_header}}{{Non-standard_header}}</div>
 
@@ -51,7 +52,7 @@ Accept-CH-Lifetime: 86400
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.DPR")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/early-data/index.html
+++ b/files/en-us/web/http/headers/early-data/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - header
   - request
+browser-compat: http.headers.Early-Data
 ---
 <div>{{SeeCompatTable}}{{HTTPSidebar}}</div>
 
@@ -61,4 +62,4 @@ Early-Data: 1</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Early-Data")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/http/headers/etag/index.html
+++ b/files/en-us/web/http/headers/etag/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - Response
   - header
+browser-compat: http.headers.ETag
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -120,7 +121,7 @@ ETag: W/"0815"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.ETag")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/expect-ct/index.html
+++ b/files/en-us/web/http/headers/expect-ct/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - header
+browser-compat: http.headers.Expect-CT
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -103,4 +104,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Expect-CT")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/http/headers/expect/index.html
+++ b/files/en-us/web/http/headers/expect/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Header
 - Reference
 - Request header
+browser-compat: http.headers.Expect
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -95,7 +96,7 @@ Expect: 100-continue
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Expect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/expires/index.html
+++ b/files/en-us/web/http/headers/expires/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Response
 - header
+browser-compat: http.headers.Expires
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Expires")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/accelerometer/index.html
+++ b/files/en-us/web/http/headers/feature-policy/accelerometer/index.html
@@ -7,6 +7,7 @@ tags:
   - Feature Policy
   - HTTP
   - Reference
+browser-compat: http.headers.Feature-Policy.accelerometer
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('http.headers.Feature-Policy.accelerometer')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/ambient-light-sensor/index.html
+++ b/files/en-us/web/http/headers/feature-policy/ambient-light-sensor/index.html
@@ -5,6 +5,7 @@ tags:
   - Ambient Light Sensor
   - Feature Policy
   - HTTP
+browser-compat: http.headers.Feature-Policy.ambient-light-sensor
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('http.headers.Feature-Policy.ambient-light-sensor')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/autoplay/index.html
+++ b/files/en-us/web/http/headers/feature-policy/autoplay/index.html
@@ -8,6 +8,7 @@ tags:
 - HTTP
 - Reference
 - autoplay
+browser-compat: http.headers.Feature-Policy.autoplay
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.autoplay")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/battery/index.html
+++ b/files/en-us/web/http/headers/feature-policy/battery/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'Feature-Policy: battery'
 slug: Web/HTTP/Headers/Feature-Policy/battery
+browser-compat: http.headers.Feature-Policy.battery
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
@@ -45,7 +46,7 @@ slug: Web/HTTP/Headers/Feature-Policy/battery
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.battery")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/camera/index.html
+++ b/files/en-us/web/http/headers/feature-policy/camera/index.html
@@ -8,6 +8,7 @@ tags:
 - HTTP
 - Reference
 - camera
+browser-compat: http.headers.Feature-Policy.camera
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('http.headers.Feature-Policy.camera')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/display-capture/index.html
+++ b/files/en-us/web/http/headers/feature-policy/display-capture/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'Feature-Policy: display-capture'
 slug: Web/HTTP/Headers/Feature-Policy/display-capture
+browser-compat: http.headers.Feature-Policy.display-capture
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -41,7 +42,7 @@ slug: Web/HTTP/Headers/Feature-Policy/display-capture
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.display-capture")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/document-domain/index.html
+++ b/files/en-us/web/http/headers/feature-policy/document-domain/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - document-domain
 - header
+browser-compat: http.headers.Feature-Policy.document-domain
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.document-domain")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/encrypted-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/encrypted-media/index.html
@@ -8,6 +8,7 @@ tags:
   - Feature-Policy
   - HTTP
   - Reference
+browser-compat: http.headers.Feature-Policy.encrypted-media
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.encrypted-media")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
+++ b/files/en-us/web/http/headers/feature-policy/fullscreen/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - fullscreen
   - header
+browser-compat: http.headers.Feature-Policy.fullscreen
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.fullscreen")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/geolocation/index.html
+++ b/files/en-us/web/http/headers/feature-policy/geolocation/index.html
@@ -7,6 +7,7 @@ tags:
   - Geolocation
   - HTTP
   - header
+browser-compat: http.headers.Feature-Policy.geolocation
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.geolocation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/gyroscope/index.html
+++ b/files/en-us/web/http/headers/feature-policy/gyroscope/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'Feature-Policy: gyroscope'
 slug: Web/HTTP/Headers/Feature-Policy/gyroscope
+browser-compat: http.headers.Feature-Policy.gyroscope
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -36,7 +37,7 @@ slug: Web/HTTP/Headers/Feature-Policy/gyroscope
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.gyroscope")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/index.html
+++ b/files/en-us/web/http/headers/feature-policy/index.html
@@ -12,6 +12,7 @@ tags:
   - Security
   - Web
   - header
+browser-compat: http.headers.Feature-Policy
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -138,7 +139,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
+++ b/files/en-us/web/http/headers/feature-policy/layout-animations/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Reference
   - layout-animations
+browser-compat: http.headers.Feature-Policy.layout-animations
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
 
@@ -23,7 +24,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.layout-animations")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
+++ b/files/en-us/web/http/headers/feature-policy/legacy-image-formats/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Reference
   - legacy-image-formats
+browser-compat: http.headers.Feature-Policy.legacy-image-formats
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}{{Non-standard_header}}</p>
 
@@ -23,7 +24,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.legacy-image-formats")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/magnetometer/index.html
+++ b/files/en-us/web/http/headers/feature-policy/magnetometer/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Magnetometer
   - Reference
+browser-compat: http.headers.Feature-Policy.magnetometer
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.magnetometer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/microphone/index.html
+++ b/files/en-us/web/http/headers/feature-policy/microphone/index.html
@@ -7,6 +7,7 @@ tags:
 - HTTP
 - header
 - microphone
+browser-compat: http.headers.Feature-Policy.microphone
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.microphone")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/midi/index.html
+++ b/files/en-us/web/http/headers/feature-policy/midi/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - MIDI
   - Reference
+browser-compat: http.headers.Feature-Policy.midi
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.midi")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/oversized-images/index.html
@@ -6,6 +6,7 @@ tags:
   - Feature-Policy
   - HTTP
   - Reference
+browser-compat: http.headers.Feature-Policy.oversized-images
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
 
@@ -26,7 +27,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.oversized-images")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/payment/index.html
+++ b/files/en-us/web/http/headers/feature-policy/payment/index.html
@@ -9,6 +9,7 @@ tags:
   - Payment Request API
   - Payments API
   - Reference
+browser-compat: http.headers.Feature-Policy.payment
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.payment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/picture-in-picture/index.html
+++ b/files/en-us/web/http/headers/feature-policy/picture-in-picture/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Picture in picture
   - Reference
+browser-compat: http.headers.Feature-Policy.picture-in-picture
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.picture-in-picture")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
+++ b/files/en-us/web/http/headers/feature-policy/publickey-credentials-get/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'Feature-Policy: publickey-credentials-get'
 slug: Web/HTTP/Headers/Feature-Policy/publickey-credentials-get
+browser-compat: http.headers.Feature-Policy.publickey-credentials-get
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -47,7 +48,7 @@ slug: Web/HTTP/Headers/Feature-Policy/publickey-credentials-get
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.publickey-credentials-get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/screen-wake-lock/index.html
+++ b/files/en-us/web/http/headers/feature-policy/screen-wake-lock/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'Feature-Policy: screen-wake-lock'
 slug: Web/HTTP/Headers/Feature-Policy/screen-wake-lock
+browser-compat: http.headers.Feature-Policy.screen-wake-lock
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -53,7 +54,7 @@ slug: Web/HTTP/Headers/Feature-Policy/screen-wake-lock
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.screen-wake-lock")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/sync-xhr/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - Reference
   - XMLHttpRequest
+browser-compat: http.headers.Feature-Policy.sync-xhr
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.sync-xhr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unoptimized-images/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Image
   - Reference
+browser-compat: http.headers.Feature-Policy.unoptimized-images
 ---
 <p>{{HTTPSidebar}}{{Non-standard_header}}</p>
 
@@ -23,7 +24,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.unoptimized-images")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
+++ b/files/en-us/web/http/headers/feature-policy/unsized-media/index.html
@@ -6,6 +6,7 @@ tags:
   - Feature-Policy
   - HTTP
   - Reference
+browser-compat: http.headers.Feature-Policy.unsized-media
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}{{Non-standard_header}}</p>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('http.headers.Feature-Policy.unsized-media')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/usb/index.html
+++ b/files/en-us/web/http/headers/feature-policy/usb/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Vibration API
   - Web USB
+browser-compat: http.headers.Feature-Policy.usb
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('http.headers.Feature-Policy.usb')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/vibrate/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vibrate/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Reference
   - Vibration API
+browser-compat: http.headers.Feature-Policy.vibrate
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.vibrate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/vr/index.html
+++ b/files/en-us/web/http/headers/feature-policy/vr/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP
   - Reference
   - WebVR
+browser-compat: http.headers.Feature-Policy.vr
 ---
 <div>{{HTTPSidebar}} {{SeeCompatTable}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.vr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/feature-policy/web-share/index.html
+++ b/files/en-us/web/http/headers/feature-policy/web-share/index.html
@@ -5,6 +5,7 @@ tags:
   - Feature-Policy
   - HTTP
   - Web Share
+browser-compat: http.headers.Feature-Policy.web-share
 ---
 <p>{{HTTPSidebar}} {{SeeCompatTable}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('http.headers.Feature-Policy.web-share')}}</p>
+<p>{{Compat}}</p>
 
 <p>Browser implementation is being discussed in <a href="https://github.com/w3c/web-share/issues/169">https://github.com/w3c/web-share/issues/169</a>.</p>
 

--- a/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.html
+++ b/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.html
@@ -1,6 +1,7 @@
 ---
 title: 'Feature-Policy: xr-spatial-tracking'
 slug: Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking
+browser-compat: http.headers.Feature-Policy.xr-spatial-tracking
 ---
 <div>{{HTTPSidebar}}{{Draft}}{{SeeCompatTable}}</div>
 
@@ -40,7 +41,7 @@ slug: Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Feature-Policy.xr-spatial-tracking")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/forwarded/index.html
+++ b/files/en-us/web/http/headers/forwarded/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Request header
   - header
+browser-compat: http.headers.Forwarded
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -103,7 +104,7 @@ Forwarded: for=192.0.2.43, for="[2001:db8:cafe::17]"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Forwarded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/from/index.html
+++ b/files/en-us/web/http/headers/from/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.From
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.From")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/host/index.html
+++ b/files/en-us/web/http/headers/host/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.Host
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Host")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/if-match/index.html
+++ b/files/en-us/web/http/headers/if-match/index.html
@@ -7,6 +7,7 @@ tags:
 - HTTP Header
 - Reference
 - Request header
+browser-compat: http.headers.If-Match
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -97,7 +98,7 @@ If-Match: *
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.If-Match")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/if-modified-since/index.html
+++ b/files/en-us/web/http/headers/if-modified-since/index.html
@@ -7,6 +7,7 @@ tags:
 - HTTP Header
 - Reference
 - Request header
+browser-compat: http.headers.If-Modified-Since
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.If-Modified-Since")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/if-none-match/index.html
+++ b/files/en-us/web/http/headers/if-none-match/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP Header
   - Reference
   - Request header
+browser-compat: http.headers.If-None-Match
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -81,7 +82,7 @@ If-None-Match: *
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.If-None-Match")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/if-range/index.html
+++ b/files/en-us/web/http/headers/if-range/index.html
@@ -8,6 +8,7 @@ tags:
 - Range Requests
 - Reference
 - Request header
+browser-compat: http.headers.If-Range
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -93,7 +94,7 @@ If-Range: &lt;etag&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.If-Range")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/if-unmodified-since/index.html
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Header
 - Reference
 - Request header
+browser-compat: http.headers.If-Unmodified-Since
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.If-Unmodified-Since")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/keep-alive/index.html
+++ b/files/en-us/web/http/headers/keep-alive/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Reference
+browser-compat: http.headers.Keep-Alive
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -87,7 +88,7 @@ Server: Apache
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Keep-Alive")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/large-allocation/index.html
+++ b/files/en-us/web/http/headers/large-allocation/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Response Header
 - header
+browser-compat: http.headers.Large-Allocation
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -132,7 +133,7 @@ Large-Allocation: 500
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Large-Allocation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/last-modified/index.html
+++ b/files/en-us/web/http/headers/last-modified/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Header
 - Reference
 - Response Header
+browser-compat: http.headers.Last-Modified
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Last-Modified")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/link/index.html
+++ b/files/en-us/web/http/headers/link/index.html
@@ -10,6 +10,7 @@ tags:
   - NeedsContent
   - NeedsSyntax
   - Reference
+browser-compat: http.headers.Link
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Link")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/location/index.html
+++ b/files/en-us/web/http/headers/location/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Header
 - Reference
 - Response Header
+browser-compat: http.headers.Location
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Location")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/nel/index.html
+++ b/files/en-us/web/http/headers/nel/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.NEL
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.NEL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/origin/index.html
+++ b/files/en-us/web/http/headers/origin/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - header
   - origin
+browser-compat: http.headers.Origin
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -79,7 +80,7 @@ Origin: &lt;scheme&gt; "://" &lt;hostname&gt; [ ":" &lt;port&gt; ]
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("http.headers.Origin")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/pragma/index.html
+++ b/files/en-us/web/http/headers/pragma/index.html
@@ -8,6 +8,7 @@ tags:
   - HTTP Header
   - Request header
   - Response header
+browser-compat: http.headers.Pragma
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Pragma")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/proxy-authenticate/index.html
+++ b/files/en-us/web/http/headers/proxy-authenticate/index.html
@@ -7,6 +7,7 @@ tags:
   - Proxy
   - Reference
   - Response Header
+browser-compat: http.headers.Proxy-Authenticate
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -79,7 +80,7 @@ Proxy-Authenticate: Basic realm="Access to the internal site"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Proxy-Authenticate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/public-key-pins-report-only/index.html
+++ b/files/en-us/web/http/headers/public-key-pins-report-only/index.html
@@ -8,6 +8,7 @@ tags:
 - Deprecated
 - Security
 - header
+browser-compat: http.headers.Public-Key-Pins-Report-Only
 ---
 <p>{{HTTPSidebar}}{{deprecated_header}}</p>
 
@@ -101,7 +102,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Public-Key-Pins-Report-Only")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/public-key-pins/index.html
+++ b/files/en-us/web/http/headers/public-key-pins/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Security
 - header
+browser-compat: http.headers.Public-Key-Pins
 ---
 <div>{{HTTPSidebar}}{{deprecated_header}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Public-Key-Pins")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/range/index.html
+++ b/files/en-us/web/http/headers/range/index.html
@@ -7,6 +7,7 @@ tags:
   - Range Requests
   - Reference
   - Request header
+browser-compat: http.headers.Range
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -77,7 +78,7 @@ Range: &lt;unit&gt;=-&lt;suffix-length&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Range")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/referer/index.html
+++ b/files/en-us/web/http/headers/referer/index.html
@@ -7,6 +7,7 @@ tags:
   - header
   - referer
   - referrer
+browser-compat: http.headers.Referer
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -75,7 +76,7 @@ Referer: https://example.com/
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Referer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/referrer-policy/index.html
+++ b/files/en-us/web/http/headers/referrer-policy/index.html
@@ -10,6 +10,7 @@ tags:
   - Response
   - Response Header
   - referrer
+browser-compat: http.headers.Referrer-Policy
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -247,7 +248,7 @@ Referrer-Policy: unsafe-url
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Referrer-Policy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/retry-after/index.html
+++ b/files/en-us/web/http/headers/retry-after/index.html
@@ -7,6 +7,7 @@ tags:
 - Response
 - Response Header
 - header
+browser-compat: http.headers.Retry-After
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -85,7 +86,7 @@ Retry-After: 120
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Retry-After")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/save-data/index.html
+++ b/files/en-us/web/http/headers/save-data/index.html
@@ -8,6 +8,7 @@ tags:
 - Request header
 - Save-Data
 - header
+browser-compat: http.headers.Save-Data
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -102,7 +103,7 @@ Content-Type: image/jpeg
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Save-Data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/sec-fetch-dest/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.html
@@ -5,6 +5,7 @@ tags:
   - Fetch Metadata Request Headers
   - HTTP
   - HTTP Headers
+browser-compat: http.headers.Sec-Fetch-Dest
 ---
 <p>{{HTTPSidebar}}{{Draft}}</p>
 
@@ -123,7 +124,7 @@ Sec-Fetch-Dest: audioworklet
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Sec-Fetch-Dest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/sec-fetch-mode/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-mode/index.html
@@ -5,6 +5,7 @@ tags:
   - Fetch Metadata Request Headers
   - HTTP
   - HTTP Header
+browser-compat: http.headers.Sec-Fetch-Mode
 ---
 <div>{{HTTPSidebar}}{{Draft}}</div>
 
@@ -79,7 +80,7 @@ Sec-Fetch-Mode: websocket
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Sec-Fetch-Mode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/sec-fetch-site/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-site/index.html
@@ -5,6 +5,7 @@ tags:
   - Fetch Metadata Request Headers
   - HTTP
   - HTTP Header
+browser-compat: http.headers.Sec-Fetch-Site
 ---
 <p>{{HTTPSidebar}}{{Draft}}</p>
 
@@ -77,7 +78,7 @@ Sec-Fetch-Site: none
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Sec-Fetch-Site")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/sec-fetch-user/index.html
+++ b/files/en-us/web/http/headers/sec-fetch-user/index.html
@@ -5,6 +5,7 @@ tags:
   - Fetch metadate request headers
   - HTTP
   - HTTP Headers
+browser-compat: http.headers.Sec-Fetch-User
 ---
 <p>{{HTTPSidebar}}{{Draft}}</p>
 
@@ -62,7 +63,7 @@ Sec-Fetch-User: ?1
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Sec-Fetch-User")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/sec-websocket-accept/index.html
+++ b/files/en-us/web/http/headers/sec-websocket-accept/index.html
@@ -10,6 +10,7 @@ tags:
   - Sec-WebSocket-Accept
   - WebSockets
   - header
+browser-compat: http.headers.Sec-WebSocket-Accept
 ---
 <div>{{HTTPSidebar}}{{Draft}}</div>
 
@@ -77,4 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Sec-WebSocket-Accept")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/http/headers/server-timing/index.html
+++ b/files/en-us/web/http/headers/server-timing/index.html
@@ -44,7 +44,8 @@ Server-Timing: db;dur=53, app;dur=47.2
 
 // Server-Timing as trailer
 Trailer: Server-Timing
---- response body ---
+--- response body browser-compat: http.headers.Server-Timing
+---
 Server-Timing: total;dur=123.4
 </pre>
 
@@ -75,7 +76,7 @@ Server-Timing: total;dur=123.4
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Server-Timing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/server-timing/index.html
+++ b/files/en-us/web/http/headers/server-timing/index.html
@@ -6,6 +6,7 @@ tags:
   - Performance
   - Reference
   - header
+browser-compat: http.headers.Server-Timing
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -44,8 +45,7 @@ Server-Timing: db;dur=53, app;dur=47.2
 
 // Server-Timing as trailer
 Trailer: Server-Timing
---- response body browser-compat: http.headers.Server-Timing
----
+--- response body ---
 Server-Timing: total;dur=123.4
 </pre>
 

--- a/files/en-us/web/http/headers/server/index.html
+++ b/files/en-us/web/http/headers/server/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.Server
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Server")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/set-cookie2/index.html
+++ b/files/en-us/web/http/headers/set-cookie2/index.html
@@ -7,6 +7,7 @@ tags:
 - Deprecated
 - Reference
 - header
+browser-compat: http.headers.Set-Cookie2
 ---
 <div>{{HTTPSidebar}} {{deprecated_header}}</div>
 
@@ -65,7 +66,7 @@ Set-Cookie2: &lt;cookie-name&gt;=&lt;cookie-value&gt;, &lt;cookie-name&gt;=&lt;c
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Set-Cookie2")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/sourcemap/index.html
+++ b/files/en-us/web/http/headers/sourcemap/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.SourceMap
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -59,7 +60,7 @@ X-SourceMap: &lt;url&gt; (deprecated)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.SourceMap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.html
+++ b/files/en-us/web/http/headers/strict-transport-security/index.html
@@ -7,6 +7,7 @@ tags:
 - HTTPS
 - Security
 - header
+browser-compat: http.headers.Strict-Transport-Security
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -153,7 +154,7 @@ Strict-Transport-Security: max-age=&lt;expire-time&gt;; preload
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Strict-Transport-Security")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/te/index.html
+++ b/files/en-us/web/http/headers/te/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Reference
 - header
+browser-compat: http.headers.TE
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -86,7 +87,7 @@ TE: trailers, deflate;q=0.5
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.TE")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/timing-allow-origin/index.html
+++ b/files/en-us/web/http/headers/timing-allow-origin/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Timing-Allow-Origin
   - header
+browser-compat: http.headers.Timing-Allow-Origin
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -71,7 +72,7 @@ Timing-Allow-Origin: &lt;origin&gt;[, &lt;origin&gt;]*
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Timing-Allow-Origin")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/tk/index.html
+++ b/files/en-us/web/http/headers/tk/index.html
@@ -8,6 +8,7 @@ tags:
 - Response
 - header
 - tracking
+browser-compat: http.headers.Tk
 ---
 <div>{{HTTPSidebar}}{{Deprecated_header}}</div>
 
@@ -98,7 +99,7 @@ Tk: U  (updated)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Tk")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/trailer/index.html
+++ b/files/en-us/web/http/headers/trailer/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP Header
   - Request header
   - Response header
+browser-compat: http.headers.Trailer
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -103,7 +104,7 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT\r\n
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Trailer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/transfer-encoding/index.html
+++ b/files/en-us/web/http/headers/transfer-encoding/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Reference
+browser-compat: http.headers.Transfer-Encoding
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -130,7 +131,7 @@ Network\r\n
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Transfer-Encoding")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/upgrade-insecure-requests/index.html
+++ b/files/en-us/web/http/headers/upgrade-insecure-requests/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTPS
   - Security
   - header
+browser-compat: http.headers.Upgrade-Insecure-Requests
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -62,7 +63,7 @@ Vary: Upgrade-Insecure-Requests</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Upgrade-Insecure-Requests")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/upgrade/index.html
+++ b/files/en-us/web/http/headers/upgrade/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Upgrade
+browser-compat: http.headers.Upgrade
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -127,7 +128,7 @@ Upgrade: websocket
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Upgrade")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/user-agent/index.html
+++ b/files/en-us/web/http/headers/user-agent/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - User-agent
+browser-compat: http.headers.User-Agent
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -141,7 +142,7 @@ Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.User-Agent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/vary/index.html
+++ b/files/en-us/web/http/headers/vary/index.html
@@ -7,6 +7,7 @@ tags:
   - Response
   - Response Header
   - header
+browser-compat: http.headers.Vary
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -83,7 +84,7 @@ Vary: &lt;header-name&gt;, &lt;header-name&gt;, ...
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Vary")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>
 

--- a/files/en-us/web/http/headers/via/index.html
+++ b/files/en-us/web/http/headers/via/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Reference
+browser-compat: http.headers.Via
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -72,7 +73,7 @@ Via: 1.0 fred, 1.1 p.example.net
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Via")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/want-digest/index.html
+++ b/files/en-us/web/http/headers/want-digest/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP Header
   - Request header
   - Response header
+browser-compat: http.headers.Want-Digest
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -148,7 +149,7 @@ Response:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Want-Digest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/warning/index.html
+++ b/files/en-us/web/http/headers/warning/index.html
@@ -7,6 +7,7 @@ tags:
   - Request header
   - Response header
   - Reference
+browser-compat: http.headers.Warning
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -155,7 +156,7 @@ Warning: 112 - "cache down" "Wed, 21 Oct 2015 07:28:00 GMT"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Warning")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/www-authenticate/index.html
+++ b/files/en-us/web/http/headers/www-authenticate/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Response Header
   - header
+browser-compat: http.headers.WWW-Authenticate
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.WWW-Authenticate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/x-content-type-options/index.html
+++ b/files/en-us/web/http/headers/x-content-type-options/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP Header
   - Reference
   - Response Header
+browser-compat: http.headers.X-Content-Type-Options
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -102,7 +103,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-Content-Type-Options")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Browser_specific_notes">Browser specific notes</h3>
 

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.html
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - X-DNS-Prefetch-Control
 - header
+browser-compat: http.headers.X-DNS-Prefetch-Control
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -118,7 +119,7 @@ X-DNS-Prefetch-Control: off
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-DNS-Prefetch-Control")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/x-forwarded-for/index.html
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Request header
 - header
+browser-compat: http.headers.X-Forwarded-For
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -80,7 +81,7 @@ X-ProxyUser-Ip: 203.0.113.19</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-Forwarded-For")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/x-forwarded-host/index.html
+++ b/files/en-us/web/http/headers/x-forwarded-host/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Request header
 - header
+browser-compat: http.headers.X-Forwarded-Host
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-Forwarded-Host")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/x-forwarded-proto/index.html
+++ b/files/en-us/web/http/headers/x-forwarded-proto/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Request header
 - header
+browser-compat: http.headers.X-Forwarded-Proto
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -67,7 +68,7 @@ X-Url-Scheme: https
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-Forwarded-Proto")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/x-frame-options/index.html
+++ b/files/en-us/web/http/headers/x-frame-options/index.html
@@ -8,6 +8,7 @@ tags:
   - Response Header
   - Security
   - nginx
+browser-compat: http.headers.X-Frame-Options
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -143,7 +144,7 @@ app.use(frameguard({ action: 'SAMEORIGIN' }))
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-Frame-Options")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/headers/x-xss-protection/index.html
+++ b/files/en-us/web/http/headers/x-xss-protection/index.html
@@ -7,6 +7,7 @@ tags:
   - Security
   - XSS
   - header
+browser-compat: http.headers.X-XSS-Protection
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -80,7 +81,7 @@ X-XSS-Protection: 1; report=&lt;reporting-uri&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.X-XSS-Protection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/headers/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

124 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
