### PR TITLE
Put browser-compat info in front-runner for http/status/*

### DIFF
--- a/files/en-us/web/http/status/100/index.html
+++ b/files/en-us/web/http/status/100/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Informational
 - Status code
+browser-compat: http.status.100
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.100")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/103/index.html
+++ b/files/en-us/web/http/status/103/index.html
@@ -8,6 +8,7 @@ tags:
 - NeedsCompatTable
 - NeedsContent
 - Status code
+browser-compat: http.status.103
 ---
 <p>{{HTTPSidebar}}{{Draft}}</p>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.103")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/200/index.html
+++ b/files/en-us/web/http/status/200/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Status code
   - Success
+browser-compat: http.status.200
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.200")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/201/index.html
+++ b/files/en-us/web/http/status/201/index.html
@@ -6,6 +6,7 @@ tags:
 - Reference
 - Status code
 - Success
+browser-compat: http.status.201
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.201")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/204/index.html
+++ b/files/en-us/web/http/status/204/index.html
@@ -6,6 +6,7 @@ tags:
 - Reference
 - Status code
 - Success
+browser-compat: http.status.204
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.204")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>
 

--- a/files/en-us/web/http/status/206/index.html
+++ b/files/en-us/web/http/status/206/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Status
 - Range Requests
 - Success
+browser-compat: http.status.206
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -76,7 +77,7 @@ Content-Range: bytes 4590-7999/8000
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.206")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/301/index.html
+++ b/files/en-us/web/http/status/301/index.html
@@ -6,6 +6,7 @@ tags:
   - Redirect
   - Reference
   - Status code
+browser-compat: http.status.301
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -48,7 +49,7 @@ Location: http://www.example.org/index.asp</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.301")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/302/index.html
+++ b/files/en-us/web/http/status/302/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Status Code
 - Reference
 - redirects
+browser-compat: http.status.302
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.302")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/303/index.html
+++ b/files/en-us/web/http/status/303/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Status Code
 - Reference
 - redirects
+browser-compat: http.status.303
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.303")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/304/index.html
+++ b/files/en-us/web/http/status/304/index.html
@@ -6,6 +6,7 @@ tags:
 - Redirection
 - Reference
 - Status code
+browser-compat: http.status.304
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.304")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Compatibility_Notes">Compatibility Notes</h2>
 

--- a/files/en-us/web/http/status/307/index.html
+++ b/files/en-us/web/http/status/307/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Status Code
 - Reference
 - redirects
+browser-compat: http.status.307
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.307")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/308/index.html
+++ b/files/en-us/web/http/status/308/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP Status Code
 - Reference
 - redirects
+browser-compat: http.status.308
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.308")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/401/index.html
+++ b/files/en-us/web/http/status/401/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Reference
 - Status code
+browser-compat: http.status.401
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -46,7 +47,7 @@ WWW-Authenticate: Basic realm="Access to staging site"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.401")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/402/index.html
+++ b/files/en-us/web/http/status/402/index.html
@@ -6,6 +6,7 @@ tags:
   - Client error
   - HTTP
   - Status code
+browser-compat: http.status.402
 ---
 <p>{{HTTPSidebar}}{{SeeCompatTable}}</p>
 
@@ -42,7 +43,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.402")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/403/index.html
+++ b/files/en-us/web/http/status/403/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - Status code
+browser-compat: http.status.403
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -42,7 +43,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.403")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/404/index.html
+++ b/files/en-us/web/http/status/404/index.html
@@ -6,6 +6,7 @@ tags:
   - Client error
   - HTTP
   - Status code
+browser-compat: http.status.404
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.404")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/406/index.html
+++ b/files/en-us/web/http/status/406/index.html
@@ -5,6 +5,7 @@ tags:
 - HTTP
 - Reference
 - Status code
+browser-compat: http.status.406
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -56,7 +57,7 @@ tags:
     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).
 </p>
 
-<p>{{Compat("http.status.406")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/407/index.html
+++ b/files/en-us/web/http/status/407/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Reference
 - Status code
+browser-compat: http.status.407
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -44,7 +45,7 @@ Proxy-Authenticate: Basic realm="Access to internal site"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.407")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/409/index.html
+++ b/files/en-us/web/http/status/409/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - HTTP Status Code
   - Reference
+browser-compat: http.status.409
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.409")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/410/index.html
+++ b/files/en-us/web/http/status/410/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - Status code
+browser-compat: http.status.410
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.410")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/412/index.html
+++ b/files/en-us/web/http/status/412/index.html
@@ -6,6 +6,7 @@ tags:
 - HTTP
 - Reference
 - Status code
+browser-compat: http.status.412
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -69,7 +70,7 @@ ETag: W/"0815"</code></pre>
     href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).
 </p>
 
-<p>{{Compat("http.status.412")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/416/index.html
+++ b/files/en-us/web/http/status/416/index.html
@@ -5,6 +5,7 @@ tags:
   - Client error
   - HTTP
   - Status code
+browser-compat: http.status.416
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>). </p>
 
-<p>{{Compat("http.status.416")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/418/index.html
+++ b/files/en-us/web/http/status/418/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - HTTP Status Code
   - Reference
+browser-compat: http.status.418
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.418")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/425/index.html
+++ b/files/en-us/web/http/status/425/index.html
@@ -6,6 +6,7 @@ tags:
 - Client error
 - HTTP
 - Status code
+browser-compat: http.status.425
 ---
 <div>{{SeeCompatTable}}{{HTTPSidebar}}</div>
 
@@ -36,4 +37,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.status.425")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/http/status/451/index.html
+++ b/files/en-us/web/http/status/451/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - Status code
+browser-compat: http.status.451
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -59,7 +60,7 @@ Content-Type: text/html</pre>
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.451")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/500/index.html
+++ b/files/en-us/web/http/status/500/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Server error
   - Status code
+browser-compat: http.status.500
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.500")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/501/index.html
+++ b/files/en-us/web/http/status/501/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Server error
   - Status code
+browser-compat: http.status.501
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.501")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/http/status/502/index.html
+++ b/files/en-us/web/http/status/502/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Server error
   - Status code
+browser-compat: http.status.502
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.502")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/503/index.html
+++ b/files/en-us/web/http/status/503/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Server error
   - Status code
+browser-compat: http.status.503
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.503")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/status/504/index.html
+++ b/files/en-us/web/http/status/504/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Server error
   - Status code
+browser-compat: http.status.504
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <p>The information shown below has been pulled from MDN's GitHub (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p>{{Compat("http.status.504")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers http/status/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

30 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
