### PR TITLE
Put browser-compat info in front-runner for html/elements/*

### DIFF
--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -323,7 +323,8 @@ document.querySelector('a').addEventListener('click', event =&gt;
 
 <p><code>&lt;a&gt;</code> elements can have consequences for users’ security and privacy. See <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns"><code>Referer</code> header: privacy and security concerns</a> for information.</p>
 
-<p>Using <code>target="_blank"</code> without <code><a href="/en-US/docs/Web/HTML/Link_types/noreferrer">rel="noreferrer"</a></code> and <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> makes the website vulnerable to {{domxref("window.opener")}} API exploitation attacks (<a href="https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/">vulnerability description</a>), although note that, in newer browser versions setting <code>target="_blank"</code> implicitly provides the same protection as setting <code>rel="noopener"</code>. See <a href="#browser_compatibility">browser compatibility</a> for details.</p>
+<p>Using <code>target="_blank"</code> without <code><a href="/en-US/docs/Web/HTML/Link_types/noreferrer">rel="noreferrer"</a></code> and <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> makes the website vulnerable to {{domxref("window.opener")}} API exploitation attacks (<a href="https://www.jitbit.com/alexblog/256-targetblankbrowser-compat: html.elements.a
+---the-most-underestimated-vulnerability-ever/">vulnerability description</a>), although note that, in newer browser versions setting <code>target="_blank"</code> implicitly provides the same protection as setting <code>rel="noopener"</code>. See <a href="#browser_compatibility">browser compatibility</a> for details.</p>
 
 <h2 id="Accessibility">Accessibility</h2>
 
@@ -491,7 +492,7 @@ document.querySelector('a').addEventListener('click', event =&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.a")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/a/index.html
+++ b/files/en-us/web/html/element/a/index.html
@@ -13,6 +13,7 @@ tags:
   - Inline element
   - Reference
   - Web
+browser-compat: html.elements.a
 ---
 <div>{{HTMLRef}}</div>
 
@@ -323,8 +324,7 @@ document.querySelector('a').addEventListener('click', event =&gt;
 
 <p><code>&lt;a&gt;</code> elements can have consequences for users’ security and privacy. See <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns"><code>Referer</code> header: privacy and security concerns</a> for information.</p>
 
-<p>Using <code>target="_blank"</code> without <code><a href="/en-US/docs/Web/HTML/Link_types/noreferrer">rel="noreferrer"</a></code> and <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> makes the website vulnerable to {{domxref("window.opener")}} API exploitation attacks (<a href="https://www.jitbit.com/alexblog/256-targetblankbrowser-compat: html.elements.a
----the-most-underestimated-vulnerability-ever/">vulnerability description</a>), although note that, in newer browser versions setting <code>target="_blank"</code> implicitly provides the same protection as setting <code>rel="noopener"</code>. See <a href="#browser_compatibility">browser compatibility</a> for details.</p>
+<p>Using <code>target="_blank"</code> without <code><a href="/en-US/docs/Web/HTML/Link_types/noreferrer">rel="noreferrer"</a></code> and <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> makes the website vulnerable to {{domxref("window.opener")}} API exploitation attacks (<a href="https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/">vulnerability description</a>), although note that, in newer browser versions setting <code>target="_blank"</code> implicitly provides the same protection as setting <code>rel="noopener"</code>. See <a href="#browser_compatibility">browser compatibility</a> for details.</p>
 
 <h2 id="Accessibility">Accessibility</h2>
 

--- a/files/en-us/web/html/element/abbr/index.html
+++ b/files/en-us/web/html/element/abbr/index.html
@@ -15,6 +15,7 @@ tags:
   - abbr
   - abbreviation
   - semantics
+browser-compat: html.elements.abbr
 ---
 <div>{{HTMLRef}}</div>
 
@@ -196,7 +197,7 @@ accessed.&lt;/p&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.abbr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/acronym/index.html
+++ b/files/en-us/web/html/element/acronym/index.html
@@ -8,6 +8,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.acronym
 ---
 <div>{{deprecated_header}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.acronym")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/address/index.html
+++ b/files/en-us/web/html/element/address/index.html
@@ -15,6 +15,7 @@ tags:
   - HTML:Palpable Content
   - Reference
   - Web
+browser-compat: html.elements.address
 ---
 <div>{{HTMLRef}}</div>
 
@@ -127,7 +128,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.address")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/applet/index.html
+++ b/files/en-us/web/html/element/applet/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - applet
+browser-compat: html.elements.applet
 ---
 <p>{{HTMLRef}}{{deprecated_header}}</p>
 
@@ -130,7 +131,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.applet")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/html/element/area/index.html
+++ b/files/en-us/web/html/element/area/index.html
@@ -10,6 +10,7 @@ tags:
   - Multimedia
   - Reference
   - Web
+browser-compat: html.elements.area
 ---
 <div>{{HTMLRef}}</div>
 
@@ -178,4 +179,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.area")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/article/index.html
+++ b/files/en-us/web/html/element/article/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML sections
   - Reference
   - Web
+browser-compat: html.elements.article
 ---
 <div>{{HTMLRef}}</div>
 
@@ -138,7 +139,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.article")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/aside/index.html
+++ b/files/en-us/web/html/element/aside/index.html
@@ -11,6 +11,7 @@ tags:
   - HTML:Sectioning content
   - Reference
   - Web
+browser-compat: html.elements.aside
 ---
 <div>{{HTMLRef}}</div>
 
@@ -113,7 +114,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.aside")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/audio/index.html
+++ b/files/en-us/web/html/element/audio/index.html
@@ -15,6 +15,7 @@ tags:
   - Reference
   - Web
   - sound
+browser-compat: html.elements.audio
 ---
 <div>{{HTMLRef}}</div>
 
@@ -392,7 +393,7 @@ Welcome to the Time Keeper's podcast! In this episode we're discussing which Swi
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.audio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/b/index.html
+++ b/files/en-us/web/html/element/b/index.html
@@ -11,6 +11,7 @@ tags:
   - HTML:Phrasing content
   - Reference
   - Web
+browser-compat: html.elements.b
 ---
 <div>{{HTMLRef}}</div>
 
@@ -112,7 +113,7 @@ Keywords are displayed with the default style of the &lt;b&gt;element, likely in
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.b")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/base/index.html
+++ b/files/en-us/web/html/element/base/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML document metadata
   - 'HTML:Metadata content'
   - Reference
+browser-compat: html.elements.base
 ---
 <div>{{HTMLRef}}</div>
 
@@ -130,4 +131,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.base")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/basefont/index.html
+++ b/files/en-us/web/html/element/basefont/index.html
@@ -11,6 +11,7 @@ tags:
   - Style
   - Web
   - basefont
+browser-compat: html.elements.basefont
 ---
 <div>{{deprecated_header}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.basefont")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Notes">Notes</h2>
 

--- a/files/en-us/web/html/element/bdi/index.html
+++ b/files/en-us/web/html/element/bdi/index.html
@@ -21,6 +21,7 @@ tags:
   - i18n
   - ltr
   - rtl
+browser-compat: html.elements.bdi
 ---
 <div>{{HTMLRef}}</div>
 
@@ -196,7 +197,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.bdi")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/bdo/index.html
+++ b/files/en-us/web/html/element/bdo/index.html
@@ -19,6 +19,7 @@ tags:
   - Web
   - ltr
   - rtl
+browser-compat: html.elements.bdo
 ---
 <div>{{HTMLRef}}</div>
 
@@ -122,7 +123,7 @@ to left.&lt;/bdo&gt;&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.bdo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/bgsound/index.html
+++ b/files/en-us/web/html/element/bgsound/index.html
@@ -11,6 +11,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.bgsound
 ---
 <div>{{deprecated_header}}{{non-standard_header}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.bgsound")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/big/index.html
+++ b/files/en-us/web/html/element/big/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.big
 ---
 <div>{{deprecated_header}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.big")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/blink/index.html
+++ b/files/en-us/web/html/element/blink/index.html
@@ -8,6 +8,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.blink
 ---
 <div>{{HTMLRef}}{{Deprecated_header}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.blink")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/blockquote/index.html
+++ b/files/en-us/web/html/element/blockquote/index.html
@@ -12,6 +12,7 @@ tags:
   - Quotations
   - Reference
   - Web
+browser-compat: html.elements.blockquote
 ---
 <div>{{HTMLRef}}</div>
 
@@ -123,7 +124,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.blockquote")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/body/index.html
+++ b/files/en-us/web/html/element/body/index.html
@@ -8,6 +8,7 @@ tags:
   - Sectioning Root Element
   - Sections
   - Web
+browser-compat: html.elements.body
 ---
 <div>{{HTMLRef}}</div>
 
@@ -157,7 +158,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.body")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/br/index.html
+++ b/files/en-us/web/html/element/br/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML text-level semantics
   - Reference
   - Web
+browser-compat: html.elements.br
 ---
 <div>{{HTMLRef}}</div>
 
@@ -128,7 +129,7 @@ USA&lt;br&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.br")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/button/index.html
+++ b/files/en-us/web/html/element/button/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.button
 ---
 <div>{{HTMLRef}}</div>
 
@@ -292,4 +293,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.button")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/canvas/index.html
+++ b/files/en-us/web/html/element/canvas/index.html
@@ -9,6 +9,7 @@ tags:
   - HTML5
   - Reference
   - Web
+browser-compat: html.elements.canvas
 ---
 <div>{{HTMLRef}}</div>
 
@@ -185,7 +186,7 @@ ctx.fillRect(10, 10, 100, 100);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.canvas")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/caption/index.html
+++ b/files/en-us/web/html/element/caption/index.html
@@ -12,6 +12,7 @@ tags:
   - Tables
   - Web
   - caption
+browser-compat: html.elements.caption
 ---
 <div>{{HTMLRef}}</div>
 
@@ -154,7 +155,7 @@ table, th, td {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.caption")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/center/index.html
+++ b/files/en-us/web/html/element/center/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - alignment
   - center
+browser-compat: html.elements.center
 ---
 <div>{{deprecated_header}}</div>
 
@@ -50,7 +51,7 @@ And so will this line.&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.center")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/cite/index.html
+++ b/files/en-us/web/html/element/cite/index.html
@@ -12,6 +12,7 @@ tags:
   - Quotations
   - Reference
   - Web
+browser-compat: html.elements.cite
 ---
 <div>{{HTMLRef}}</div>
 
@@ -140,7 +141,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.cite")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/code/index.html
+++ b/files/en-us/web/html/element/code/index.html
@@ -9,6 +9,7 @@ tags:
   - Inline Code
   - Reference
   - Web
+browser-compat: html.elements.code
 ---
 <div>{{HTMLRef}}</div>
 
@@ -104,7 +105,7 @@ input field so the user can, for example, copy or delete the text.&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.code")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/col/index.html
+++ b/files/en-us/web/html/element/col/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Tables
   - Web
+browser-compat: html.elements.col
 ---
 <div>{{HTMLRef}}</div>
 
@@ -158,7 +159,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.col")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/colgroup/index.html
+++ b/files/en-us/web/html/element/colgroup/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Tables
   - Web
+browser-compat: html.elements.colgroup
 ---
 <div>{{HTMLRef}}</div>
 
@@ -158,7 +159,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.colgroup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/content/index.html
+++ b/files/en-us/web/html/element/content/index.html
@@ -13,6 +13,7 @@ tags:
   - Web
   - Web Components
   - shadow dom
+browser-compat: html.elements.content
 ---
 <div>{{Deprecated_header}}</div>
 
@@ -98,7 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.content")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/data/index.html
+++ b/files/en-us/web/html/element/data/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML text-level semantics
   - Reference
   - Web
+browser-compat: html.elements.data
 ---
 <div>{{HTMLRef}}</div>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/datalist/index.html
+++ b/files/en-us/web/html/element/datalist/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML5
   - Reference
   - Web
+browser-compat: html.elements.datalist
 ---
 <div>{{HTMLRef}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.datalist")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/html/element/dd/index.html
+++ b/files/en-us/web/html/element/dd/index.html
@@ -12,6 +12,7 @@ tags:
   - Web
   - dd
   - details
+browser-compat: html.elements.dd
 ---
 <div>{{HTMLRef}}</div>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.dd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/del/index.html
+++ b/files/en-us/web/html/element/del/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - del
+browser-compat: html.elements.del
 ---
 <div>{{HTMLRef}}</div>
 
@@ -136,7 +137,7 @@ del::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.del")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/details/index.html
+++ b/files/en-us/web/html/element/details/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - details
+browser-compat: html.elements.details
 ---
 <div>{{HTMLRef}}</div>
 
@@ -267,7 +268,7 @@ details &gt; p {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.details")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/dfn/index.html
+++ b/files/en-us/web/html/element/dfn/index.html
@@ -11,6 +11,7 @@ tags:
   - Semantic Markup
   - Web
   - dfn
+browser-compat: html.elements.dfn
 ---
 <div>{{HTMLRef}}</div>
 
@@ -193,7 +194,7 @@ arguably done more to advance science than any device ever built.&lt;/p&gt;</pre
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.dfn")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/dialog/index.html
+++ b/files/en-us/web/html/element/dialog/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - polyfill
+browser-compat: html.elements.dialog
 ---
 <div>{{HTMLRef}}</div>
 
@@ -162,7 +163,7 @@ favDialog.addEventListener('close', function onClose() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.dialog")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Polyfill">Polyfill</h2>
 

--- a/files/en-us/web/html/element/dir/index.html
+++ b/files/en-us/web/html/element/dir/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - dir
   - lists
+browser-compat: html.elements.dir
 ---
 <div>{{HTMLRef}}{{deprecated_header}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.dir")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/div/index.html
+++ b/files/en-us/web/html/element/div/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web
   - div
+browser-compat: html.elements.div
 ---
 <div>{{HTMLRef}}</div>
 
@@ -144,7 +145,7 @@ The <code>&lt;div&gt;</code> element has <a href="https://www.w3.org/TR/wai-aria
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.div")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/dl/index.html
+++ b/files/en-us/web/html/element/dl/index.html
@@ -11,6 +11,7 @@ tags:
   - HTML:Palpable Content
   - Reference
   - Web
+browser-compat: html.elements.dl
 ---
 <div>{{HTMLRef}}</div>
 
@@ -217,7 +218,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.dl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/dt/index.html
+++ b/files/en-us/web/html/element/dt/index.html
@@ -13,6 +13,7 @@ tags:
   - Term
   - Web
   - dt
+browser-compat: html.elements.dt
 ---
 <div>{{HTMLRef}}</div>
 
@@ -97,7 +98,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.dt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/em/index.html
+++ b/files/en-us/web/html/element/em/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML text-level semantics
   - Reference
   - Web
+browser-compat: html.elements.em
 ---
 <div>{{HTMLRef}}</div>
 
@@ -116,7 +117,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.em")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/embed/index.html
+++ b/files/en-us/web/html/element/embed/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Web
   - embed
+browser-compat: html.elements.embed
 ---
 <div>{{HTMLRef}}</div>
 
@@ -119,7 +120,7 @@ tags:
 </div>
 
 
-<p>{{Compat("html.elements.embed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/fieldset/index.html
+++ b/files/en-us/web/html/element/fieldset/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.fieldset
 ---
 <div>{{HTMLRef}}</div>
 
@@ -148,7 +149,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.fieldset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/figcaption/index.html
+++ b/files/en-us/web/html/element/figcaption/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - HTML grouping content
   - Reference
+browser-compat: html.elements.figcaption
 ---
 <div>{{HTMLRef}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.figcaption")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/figure/index.html
+++ b/files/en-us/web/html/element/figure/index.html
@@ -9,6 +9,7 @@ tags:
   - Presentation
   - Reference
   - figure
+browser-compat: html.elements.figure
 ---
 <div>{{HTMLRef}}</div>
 
@@ -164,7 +165,7 @@ Love is a spirit all compact of fire,
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.figure")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/font/index.html
+++ b/files/en-us/web/html/element/font/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.font
 ---
 <div>{{deprecated_header}}</div>
 
@@ -43,6 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.font")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{HTMLRef}}</div>

--- a/files/en-us/web/html/element/footer/index.html
+++ b/files/en-us/web/html/element/footer/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - HTML sections
   - Reference
+browser-compat: html.elements.footer
 ---
 <div>{{HTMLRef}}</div>
 
@@ -101,7 +102,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.footer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/form/index.html
+++ b/files/en-us/web/html/element/form/index.html
@@ -10,6 +10,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.form
 ---
 <div>{{HTMLRef}}</div>
 
@@ -199,7 +200,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.form")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/frame/index.html
+++ b/files/en-us/web/html/element/frame/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML
   - Reference
   - Web
+browser-compat: html.elements.frame
 ---
 <div>{{HTMLRef}}{{Deprecated_header}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.frame")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/frameset/index.html
+++ b/files/en-us/web/html/element/frameset/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML
   - Reference
   - Web
+browser-compat: html.elements.frameset
 ---
 <div>{{HTMLRef}}{{Deprecated_header}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.frameset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/head/index.html
+++ b/files/en-us/web/html/element/head/index.html
@@ -8,6 +8,7 @@ tags:
   - 'HTML:Metadata content'
   - Reference
   - Web
+browser-compat: html.elements.head
 ---
 <div>{{HTMLRef}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.head")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/header/index.html
+++ b/files/en-us/web/html/element/header/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - HTML sections
   - Reference
+browser-compat: html.elements.header
 ---
 <div>{{HTMLRef}}</div>
 
@@ -109,7 +110,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.header")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/hgroup/index.html
+++ b/files/en-us/web/html/element/hgroup/index.html
@@ -9,6 +9,7 @@ tags:
   - HTML5
   - Reference
   - Web
+browser-compat: html.elements.hgroup
 ---
 <div>{{HTMLRef}}</div>
 
@@ -141,7 +142,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.hgroup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/hr/index.html
+++ b/files/en-us/web/html/element/hr/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - HTML grouping content
   - Reference
+browser-compat: html.elements.hr
 ---
 <div>{{HTMLRef}}</div>
 
@@ -120,7 +121,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.hr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/html/index.html
+++ b/files/en-us/web/html/element/html/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML Root Element
   - Reference
   - Web
+browser-compat: html.elements.html
 ---
 <div>{{HTMLRef}}</div>
 
@@ -111,7 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.html")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/html/manifest/index.html
+++ b/files/en-us/web/html/element/html/manifest/index.html
@@ -4,6 +4,7 @@ slug: Web/HTML/Element/html/manifest
 tags:
   - Cache
   - application cache
+browser-compat: html.elements.html.manifest
 ---
 <p>{{Deprecated_Header}}{{Non-standard_Header}}</p>
 
@@ -17,7 +18,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.html.manifest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/i/index.html
+++ b/files/en-us/web/html/element/i/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - em
+browser-compat: html.elements.i
 ---
 <div>{{HTMLRef}}</div>
 
@@ -124,7 +125,7 @@ mentioned in music, art, and literature.&lt;/p&gt;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.i")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/image/index.html
+++ b/files/en-us/web/html/element/image/index.html
@@ -10,6 +10,7 @@ tags:
   - Non-standard
   - Deprecated
   - Reference
+browser-compat: html.elements.image
 ---
 <div>{{deprecated_header}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <p>However, that doesn't mean this is a good idea to use. It's not.</p>
 
-<p>{{Compat("html.elements.image")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/img/index.html
+++ b/files/en-us/web/html/element/img/index.html
@@ -19,6 +19,7 @@ tags:
   - Pictures
   - Reference
   - Web
+browser-compat: html.elements.img
 ---
 <div>{{HTMLRef}}</div>
 
@@ -434,7 +435,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.img")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/ins/index.html
+++ b/files/en-us/web/html/element/ins/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - ins
+browser-compat: html.elements.ins
 ---
 <p>{{HTMLRef}}</p>
 
@@ -133,7 +134,7 @@ ins::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.ins")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/kbd/index.html
+++ b/files/en-us/web/html/element/kbd/index.html
@@ -15,6 +15,7 @@ tags:
   - Web
   - keyboard
   - user input
+browser-compat: html.elements.kbd
 ---
 <div>{{HTMLRef}}</div>
 
@@ -202,7 +203,7 @@ to confirm once you've entered the name of the new file.&lt;/p&gt;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.kbd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/keygen/index.html
+++ b/files/en-us/web/html/element/keygen/index.html
@@ -9,6 +9,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.keygen
 ---
 <p>{{HTMLRef}}{{deprecated_header}}</p>
 
@@ -118,4 +119,4 @@ SignedPublicKeyAndChallenge ::= SEQUENCE {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.keygen")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/label/index.html
+++ b/files/en-us/web/html/element/label/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.label
 ---
 <div>{{HTMLRef}}</div>
 
@@ -192,4 +193,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.label")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/legend/index.html
+++ b/files/en-us/web/html/element/legend/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.legend
 ---
 <div>{{HTMLRef}}</div>
 
@@ -89,7 +90,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.legend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/li/index.html
+++ b/files/en-us/web/html/element/li/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - HTML grouping content
   - Reference
+browser-compat: html.elements.li
 ---
 <div>{{HTMLRef}}</div>
 
@@ -139,7 +140,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.li")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/main/index.html
+++ b/files/en-us/web/html/element/main/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML sections
   - Reference
   - main
+browser-compat: html.elements.main
 ---
 <div>{{HTMLRef}}</div>
 
@@ -156,7 +157,7 @@ tags:
 
 <p>To support Internet Explorer 11 and lower, you can add an {{glossary("ARIA")}} role of <code>"main"</code> to the <code>&lt;main&gt;</code> element. But understand that the ARIA in HTML specification states that <code>role="main"</code> shouldn't actually be used with the <code>&lt;main&gt;</code> element, and the W3C validator will report a warning for it. However, Internet Explorer 11 and lower will otherwise not correctly expose the <code>&lt;main&gt;</code> element to screen readers such JAWS unless the element also has a <code>role="main"</code> attribute.</p>
 
-<p>{{Compat("html.elements.main")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/map/index.html
+++ b/files/en-us/web/html/element/map/index.html
@@ -8,6 +8,7 @@ tags:
   - Multimedia
   - Reference
   - Web
+browser-compat: html.elements.map
 ---
 <div>{{HTMLRef}}</div>
 
@@ -113,7 +114,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.map")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/mark/index.html
+++ b/files/en-us/web/html/element/mark/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Web
   - mark
+browser-compat: html.elements.mark
 ---
 <div>{{HTMLRef}}</div>
 
@@ -166,4 +167,4 @@ mark::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.mark")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/marquee/index.html
+++ b/files/en-us/web/html/element/marquee/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - marquee
+browser-compat: html.elements.marquee
 ---
 <div>{{deprecated_header}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.marquee")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/menu/index.html
+++ b/files/en-us/web/html/element/menu/index.html
@@ -16,6 +16,7 @@ tags:
   - Web
   - menu
   - menus
+browser-compat: html.elements.menu
 ---
 <p>{{HTMLRef}}{{SeeCompatTable}}</p>
 
@@ -210,7 +211,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.menu")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/menuitem/index.html
+++ b/files/en-us/web/html/element/menuitem/index.html
@@ -15,6 +15,7 @@ tags:
   - User experience
   - Web
   - menuitem
+browser-compat: html.elements.menuitem
 ---
 <p>{{HTMLRef}}{{Deprecated_Header}}</p>
 
@@ -143,7 +144,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.menuitem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/meta/index.html
+++ b/files/en-us/web/html/element/meta/index.html
@@ -12,6 +12,7 @@ tags:
   - charset
   - http-equiv
   - metadata
+browser-compat: html.elements.meta
 ---
 <div>{{HTMLRef}}</div>
 
@@ -155,4 +156,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("html.elements.meta")}}</div>
+<div>{{Compat}}</div>

--- a/files/en-us/web/html/element/meta/name/index.html
+++ b/files/en-us/web/html/element/meta/name/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML document metadata
   - Reference
   - metadata
+browser-compat: html.elements.meta.name
 ---
 <div>{{HTMLRef}}</div>
 
@@ -299,4 +300,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.meta.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/meta/name/theme-color/index.html
+++ b/files/en-us/web/html/element/meta/name/theme-color/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML document metadata
   - Reference
   - metadata
+browser-compat: html.elements.meta.name.theme-color
 ---
 <div>{{HTMLRef}}</div>
 
@@ -40,4 +41,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.meta.name.theme-color")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/meter/index.html
+++ b/files/en-us/web/html/element/meter/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML5
   - Reference
   - Web
+browser-compat: html.elements.meter
 ---
 <div>{{HTMLRef}}</div>
 
@@ -133,7 +134,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.meter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/nav/index.html
+++ b/files/en-us/web/html/element/nav/index.html
@@ -11,6 +11,7 @@ tags:
   - Sections
   - Web
   - nav
+browser-compat: html.elements.nav
 ---
 <div>{{HTMLRef}}</div>
 
@@ -121,7 +122,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.nav")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/nobr/index.html
+++ b/files/en-us/web/html/element/nobr/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - nobr
+browser-compat: html.elements.nobr
 ---
 <div>{{HTMLRef}}{{Non-standard_Header}}{{deprecated_header}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("html.elements.nobr")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/noembed/index.html
+++ b/files/en-us/web/html/element/noembed/index.html
@@ -10,6 +10,7 @@ tags:
   - Deprecated
   - Reference
   - noembed
+browser-compat: html.elements.noembed
 ---
 <div>{{HTMLRef}}{{Non-standard_header}}{{deprecated_header}}</div>
 
@@ -33,4 +34,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.noembed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/noframes/index.html
+++ b/files/en-us/web/html/element/noframes/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web
   - noframes
+browser-compat: html.elements.noframes
 ---
 <div>{{deprecated_header}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.noframes")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/noscript/index.html
+++ b/files/en-us/web/html/element/noscript/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML scripting
   - Reference
   - Web
+browser-compat: html.elements.noscript
 ---
 <div>{{HTMLRef}}</div>
 
@@ -102,4 +103,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.noscript")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/object/index.html
+++ b/files/en-us/web/html/element/object/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML embedded content
   - Reference
   - Web
+browser-compat: html.elements.object
 ---
 <p>{{HTMLRef}}</p>
 
@@ -133,7 +134,7 @@ tags:
 
 <p>Note: Google Chrome doesn't support search for text (accessed via <kbd>ctrl + F</kbd> shortcut) inside <code>&lt;object&gt;&lt;/object&gt;</code> tags.</p>
 
-<p>{{Compat("html.elements.object")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/ol/index.html
+++ b/files/en-us/web/html/element/ol/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML grouping content
   - HTML:Flow content
   - Reference
+browser-compat: html.elements.ol
 ---
 <div>{{HTMLRef}}</div>
 
@@ -204,7 +205,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.ol")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/optgroup/index.html
+++ b/files/en-us/web/html/element/optgroup/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.optgroup
 ---
 <div>{{HTMLRef}}</div>
 
@@ -119,7 +120,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.optgroup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/option/index.html
+++ b/files/en-us/web/html/element/option/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Select
+browser-compat: html.elements.option
 ---
 <div>{{HTMLRef}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.option")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/output/index.html
+++ b/files/en-us/web/html/element/output/index.html
@@ -9,6 +9,7 @@ tags:
   - HTML:Flow content
   - Reference
   - Web
+browser-compat: html.elements.output
 ---
 <div>{{HTMLRef}}</div>
 
@@ -106,4 +107,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.output")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/p/index.html
+++ b/files/en-us/web/html/element/p/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML grouping content
   - Reference
   - Web
+browser-compat: html.elements.p
 ---
 <div>{{HTMLRef}}</div>
 
@@ -177,7 +178,7 @@ p.pilcrow + p.pilcrow::before {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.p")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/param/index.html
+++ b/files/en-us/web/html/element/param/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML embedded content
   - Reference
   - Web
+browser-compat: html.elements.param
 ---
 <div>{{HTMLRef}}</div>
 
@@ -106,7 +107,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.param")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/picture/index.html
+++ b/files/en-us/web/html/element/picture/index.html
@@ -11,6 +11,7 @@ tags:
   - Web
   - WebP
   - picture
+browser-compat: html.elements.picture
 ---
 <div>{{HTMLRef}}</div>
 
@@ -155,7 +156,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.picture")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/plaintext/index.html
+++ b/files/en-us/web/html/element/plaintext/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - plaintext
+browser-compat: html.elements.plaintext
 ---
 <div>{{deprecated_header}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.plaintext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/portal/index.html
+++ b/files/en-us/web/html/element/portal/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web
   - Portal
+browser-compat: html.elements.portal
 ---
 <div>{{HTMLRef}}</div>
 
@@ -82,4 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.portal")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/pre/index.html
+++ b/files/en-us/web/html/element/pre/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML:Flow content
   - Reference
   - Web
+browser-compat: html.elements.pre
 ---
 <div>{{HTMLRef}}</div>
 
@@ -97,8 +98,7 @@ body {
          \   ^__^
           \  (oo)\_______
              (__)\       )\/\
-                 ||-browser-compat: html.elements.pre
----w |
+                 ||----w |
                  ||     ||
   &lt;/pre&gt;
   &lt;figcaption id="cow-caption"&gt;

--- a/files/en-us/web/html/element/pre/index.html
+++ b/files/en-us/web/html/element/pre/index.html
@@ -97,7 +97,8 @@ body {
          \   ^__^
           \  (oo)\_______
              (__)\       )\/\
-                 ||----w |
+                 ||-browser-compat: html.elements.pre
+---w |
                  ||     ||
   &lt;/pre&gt;
   &lt;figcaption id="cow-caption"&gt;
@@ -142,7 +143,7 @@ body {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.pre")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/progress/index.html
+++ b/files/en-us/web/html/element/progress/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML5
   - Reference
   - Web
+browser-compat: html.elements.progress
 ---
 <div>{{HTMLRef}}</div>
 
@@ -108,7 +109,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.progress")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/q/index.html
+++ b/files/en-us/web/html/element/q/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Web
   - quote
+browser-compat: html.elements.q
 ---
 <div>{{HTMLRef}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.q")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/rb/index.html
+++ b/files/en-us/web/html/element/rb/index.html
@@ -10,6 +10,7 @@ tags:
   - Ruby
   - Text
   - Web
+browser-compat: html.elements.rb
 ---
 <div>{{HTMLRef}}{{deprecated_header}}</div>
 
@@ -131,7 +132,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.rb")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/rp/index.html
+++ b/files/en-us/web/html/element/rp/index.html
@@ -9,6 +9,7 @@ tags:
   - Ruby
   - Text
   - Web
+browser-compat: html.elements.rp
 ---
 <div>{{HTMLRef}}</div>
 
@@ -125,7 +126,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.rp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/rt/index.html
+++ b/files/en-us/web/html/element/rt/index.html
@@ -9,6 +9,7 @@ tags:
   - Ruby
   - Text
   - Web
+browser-compat: html.elements.rt
 ---
 <div>{{HTMLRef}}</div>
 
@@ -121,7 +122,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.rt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/rtc/index.html
+++ b/files/en-us/web/html/element/rtc/index.html
@@ -12,6 +12,7 @@ tags:
   - Text
   - Web
   - rtc
+browser-compat: html.elements.rtc
 ---
 <div>{{HTMLRef}}{{deprecated_header}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.rtc")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/ruby/index.html
+++ b/files/en-us/web/html/element/ruby/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML text-level semantics
   - Reference
   - Web
+browser-compat: html.elements.ruby
 ---
 <div>{{HTMLRef}}</div>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.ruby")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/s/index.html
+++ b/files/en-us/web/html/element/s/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - text-decoration
+browser-compat: html.elements.s
 ---
 <div>{{HTMLRef}}</div>
 
@@ -121,7 +122,7 @@ s::after {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.s")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/samp/index.html
+++ b/files/en-us/web/html/element/samp/index.html
@@ -10,6 +10,7 @@ tags:
   - Sample Output
   - Sample Text
   - Web
+browser-compat: html.elements.samp
 ---
 <div>{{HTMLRef}}</div>
 
@@ -153,7 +154,7 @@ samp &gt; kbd {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.samp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/section/index.html
+++ b/files/en-us/web/html/element/section/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Section
   - Web
+browser-compat: html.elements.section
 ---
 <div>{{HTMLRef}}</div>
 
@@ -164,7 +165,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.section")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/select/index.html
+++ b/files/en-us/web/html/element/select/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML forms
   - Reference
   - Web
+browser-compat: html.elements.select
 ---
 <div>{{HTMLRef}}</div>
 
@@ -566,7 +567,7 @@ document.forms[0].onsubmit = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.select")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/shadow/index.html
+++ b/files/en-us/web/html/element/shadow/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Components
   - shadow
   - shadow dom
+browser-compat: html.elements.shadow
 ---
 <p>{{deprecated_header}}</p>
 
@@ -101,7 +102,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.shadow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/slot/index.html
+++ b/files/en-us/web/html/element/slot/index.html
@@ -9,6 +9,7 @@ tags:
   - Web Components
   - shadow dom
   - slot
+browser-compat: html.elements.slot
 ---
 <div>{{HTMLRef}}</div>
 
@@ -121,4 +122,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.slot")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/small/index.html
+++ b/files/en-us/web/html/element/small/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web
   - font-size
+browser-compat: html.elements.small
 ---
 <div>{{HTMLRef}}</div>
 
@@ -110,7 +111,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.small")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/source/index.html
+++ b/files/en-us/web/html/element/source/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - Web Performance
+browser-compat: html.elements.source
 ---
 <div>{{HTMLRef}}</div>
 
@@ -148,7 +149,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.source")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/spacer/index.html
+++ b/files/en-us/web/html/element/spacer/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.spacer
 ---
 <div>{{non-standard_header}}{{deprecated_header}}</div>
 
@@ -45,6 +46,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.spacer")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{ HTMLRef }}</p>

--- a/files/en-us/web/html/element/span/index.html
+++ b/files/en-us/web/html/element/span/index.html
@@ -8,6 +8,7 @@ tags:
   - HTML:Flow content
   - Reference
   - Web
+browser-compat: html.elements.span
 ---
 <div>{{HTMLRef}}</div>
 
@@ -118,7 +119,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.span")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/strike/index.html
+++ b/files/en-us/web/html/element/strike/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.strike
 ---
 <p>{{HTMLRef}}{{deprecated_header}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.strike")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/strong/index.html
+++ b/files/en-us/web/html/element/strong/index.html
@@ -13,6 +13,7 @@ tags:
   - Urgency
   - Web
   - strong
+browser-compat: html.elements.strong
 ---
 <div>{{HTMLRef}}</div>
 
@@ -131,7 +132,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.strong")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/style/index.html
+++ b/files/en-us/web/html/element/style/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Style
   - Web
+browser-compat: html.elements.style
 ---
 <div>{{HTMLRef}}</div>
 
@@ -196,7 +197,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.style")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/sub/index.html
+++ b/files/en-us/web/html/element/sub/index.html
@@ -14,6 +14,7 @@ tags:
   - Subscript
   - Web
   - sub
+browser-compat: html.elements.sub
 ---
 <div>{{HTMLRef}}</div>
 
@@ -138,7 +139,7 @@ commonly known as "caffeine."&lt;/p&gt;</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.sub")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/summary/index.html
+++ b/files/en-us/web/html/element/summary/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Summary
   - Web
+browser-compat: html.elements.summary
 ---
 <div>{{HTMLRef}}</div>
 
@@ -152,7 +153,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.summary")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/sup/index.html
+++ b/files/en-us/web/html/element/sup/index.html
@@ -10,6 +10,7 @@ tags:
   - HTML:Phrasing content
   - Reference
   - Web
+browser-compat: html.elements.sup
 ---
 <div>{{HTMLRef}}</div>
 
@@ -133,7 +134,7 @@ languages as follows:&lt;/p&gt;
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.sup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/table/index.html
+++ b/files/en-us/web/html/element/table/index.html
@@ -10,6 +10,7 @@ tags:
   - Sorting
   - Tables
   - Web
+browser-compat: html.elements.table
 ---
 <div>{{HTMLRef}}</div>
 
@@ -697,7 +698,7 @@ tr:last-child td {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.table")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/tbody/index.html
+++ b/files/en-us/web/html/element/tbody/index.html
@@ -11,6 +11,7 @@ tags:
   - Tables
   - Web
   - tbody
+browser-compat: html.elements.tbody
 ---
 <div>{{HTMLRef}}</div>
 
@@ -310,7 +311,7 @@ thead &gt; tr &gt; th {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.tbody")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/td/index.html
+++ b/files/en-us/web/html/element/td/index.html
@@ -15,6 +15,7 @@ tags:
   - cell
   - data
   - td
+browser-compat: html.elements.td
 ---
 <div>{{HTMLRef}}</div>
 
@@ -161,4 +162,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.td")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/template/index.html
+++ b/files/en-us/web/html/element/template/index.html
@@ -13,6 +13,7 @@ tags:
   - Template
   - Web
   - Web Components
+browser-compat: html.elements.template
 ---
 <div>{{HTMLRef}}</div>
 
@@ -194,7 +195,7 @@ container.appendChild(secondClone);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.template")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/textarea/index.html
+++ b/files/en-us/web/html/element/textarea/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - textarea
+browser-compat: html.elements.textarea
 ---
 <div>{{HTMLRef}}</div>
 
@@ -259,7 +260,7 @@ textarea:valid {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.textarea")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/tfoot/index.html
+++ b/files/en-us/web/html/element/tfoot/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Tables
   - Web
+browser-compat: html.elements.tfoot
 ---
 <div>{{HTMLRef}}</div>
 
@@ -133,7 +134,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.tfoot")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/th/index.html
+++ b/files/en-us/web/html/element/th/index.html
@@ -15,6 +15,7 @@ tags:
   - Tables
   - Web
   - cell
+browser-compat: html.elements.th
 ---
 <div>{{HTMLRef}}</div>
 
@@ -226,7 +227,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.th")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/thead/index.html
+++ b/files/en-us/web/html/element/thead/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Tables
   - Web
+browser-compat: html.elements.thead
 ---
 <div>{{HTMLRef}}</div>
 
@@ -185,7 +186,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.thead")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/time/index.html
+++ b/files/en-us/web/html/element/time/index.html
@@ -11,6 +11,7 @@ tags:
   - HTML:Phrasing content
   - Reference
   - Web
+browser-compat: html.elements.time
 ---
 <div>{{HTMLRef}}</div>
 
@@ -164,7 +165,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.time")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/title/index.html
+++ b/files/en-us/web/html/element/title/index.html
@@ -15,6 +15,7 @@ tags:
   - Web
   - Window Name
   - Window Title
+browser-compat: html.elements.title
 ---
 <div>{{HTMLRef}}</div>
 
@@ -137,4 +138,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.title")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/tr/index.html
+++ b/files/en-us/web/html/element/tr/index.html
@@ -11,6 +11,7 @@ tags:
   - tag
   - tr
   - tr tag
+browser-compat: html.elements.tr
 ---
 <div>{{HTMLRef}}</div>
 
@@ -563,7 +564,7 @@ thead &gt; tr:last-of-type &gt; th:nth-of-type(2) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.tr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/track/index.html
+++ b/files/en-us/web/html/element/track/index.html
@@ -14,6 +14,7 @@ tags:
   - Web
   - a11y
   - track
+browser-compat: html.elements.track
 ---
 <div>{{HTMLRef}}</div>
 
@@ -170,7 +171,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.track")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/tt/index.html
+++ b/files/en-us/web/html/element/tt/index.html
@@ -14,6 +14,7 @@ tags:
   - Web
   - font-family
   - tt
+browser-compat: html.elements.tt
 ---
 <div>{{HTMLRef}}{{deprecated_header}}</div>
 
@@ -130,7 +131,7 @@ The telnet client should display: &lt;tt&gt;Local Echo is on&lt;/tt&gt;&lt;/p&gt
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.tt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/u/index.html
+++ b/files/en-us/web/html/element/u/index.html
@@ -13,6 +13,7 @@ tags:
   - Unarticulated Annotation
   - Underline
   - Web
+browser-compat: html.elements.u
 ---
 <div>{{HTMLRef}}</div>
 
@@ -202,7 +203,7 @@ Chicken Noodle Soup With Carrots</pre>
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.u")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/ul/index.html
+++ b/files/en-us/web/html/element/ul/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - HTML grouping content
   - Reference
+browser-compat: html.elements.ul
 ---
 <div>{{HTMLRef}}</div>
 
@@ -172,7 +173,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.ul")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/var/index.html
+++ b/files/en-us/web/html/element/var/index.html
@@ -12,6 +12,7 @@ tags:
   - Web
   - var
   - variable
+browser-compat: html.elements.var
 ---
 <div>{{HTMLRef}}</div>
 
@@ -147,4 +148,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.var")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/html/element/wbr/index.html
+++ b/files/en-us/web/html/element/wbr/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML text-level semantics
   - Reference
   - Web
+browser-compat: html.elements.wbr
 ---
 <div>{{HTMLRef}}</div>
 
@@ -97,7 +98,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.wbr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/xmp/index.html
+++ b/files/en-us/web/html/element/xmp/index.html
@@ -7,6 +7,7 @@ tags:
   - Deprecated
   - Reference
   - Web
+browser-compat: html.elements.xmp
 ---
 <div>{{deprecated_header}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.xmp")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers html/elements/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

132 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
