### PR TITLE
Put browser-compat info in front-runner for http/methods/*

### DIFF
--- a/files/en-us/web/http/basics_of_http/data_uris/index.html
+++ b/files/en-us/web/http/basics_of_http/data_uris/index.html
@@ -7,6 +7,7 @@ tags:
   - HTTP
   - Intermediate
   - URL
+browser-compat: http.data-url
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -125,7 +126,7 @@ base64 a.txt&gt;b.txt
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{compat("http.data-url")}}</p>
+<p>{{compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/connect/index.html
+++ b/files/en-us/web/http/methods/connect/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.CONNECT
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -86,7 +87,7 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.CONNECT")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/delete/index.html
+++ b/files/en-us/web/http/methods/delete/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.DELETE
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -96,7 +97,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.DELETE")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/get/index.html
+++ b/files/en-us/web/http/methods/get/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.GET
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.GET")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/head/index.html
+++ b/files/en-us/web/http/methods/head/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.HEAD
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.HEAD")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/index.html
+++ b/files/en-us/web/http/methods/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Methods
   - Reference
+browser-compat: http.methods
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -57,9 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request against this file: <a href="https://github.com/mdn/browser-compat-data/blob/master/http/methods.json">https://github.com/mdn/browser-compat-data/blob/master/http/methods.json</a>.</p>
-
-<p>{{Compat("http/methods")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/options/index.html
+++ b/files/en-us/web/http/methods/options/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.OPTIONS
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -124,7 +125,7 @@ Connection: Keep-Alive</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.OPTIONS")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/post/index.html
+++ b/files/en-us/web/http/methods/post/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.POST
 ---
 <p>{{HTTPSidebar}}</p>
 
@@ -115,7 +116,7 @@ value2
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.POST")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/put/index.html
+++ b/files/en-us/web/http/methods/put/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.PUT
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -89,7 +90,7 @@ Content-Location: /existing.html
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.PUT")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/http/methods/trace/index.html
+++ b/files/en-us/web/http/methods/trace/index.html
@@ -5,6 +5,7 @@ tags:
   - HTTP
   - Reference
   - Request method
+browser-compat: http.methods.TRACE
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.methods.TRACE")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers http/methods (and data_url) for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

10 files in http/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
