### PR TITLE
Streamline /en-US/docs/Tools/Validators

### DIFF
--- a/files/en-us/tools/validators/index.html
+++ b/files/en-us/tools/validators/index.html
@@ -7,65 +7,16 @@ tags:
   - html5 validator
   - validator
 ---
-<div>{{ToolsSidebar}}</div><p class="summary"><span class="seoSummary">This document lists different resources for developers to validate web pages.</span></p>
+<div>{{ToolsSidebar}}</div>
 
-<pre class="eval">Sidebar tabs are not available at this time.
-Tune-up wizard links back to devedge
-</pre>
-
-<p>If you're writing new code that isn't validating immediately, see the available standards-compliant <a href="/en-US/Standards-Compliant_Authoring_Tools">authoring</a> and <a href="/en-US/docs/Tools">development</a> tools.</p>
-
-<h3 id="Firefox_Extensions_for_Validation">Firefox Extensions for Validation</h3>
-
-<h4 id="Quick_Reference_Sidebar_Tabs">Quick Reference Sidebar Tabs</h4>
-
-<p>Install DevEdge Toolbox Sidebars for quick access to web development references.</p>
-
-<h4 id="Checky">Checky</h4>
-
-<p><a class="external" href="http://checky.sourceforge.net/">Checky</a> adds a submenu to your Netscape or Mozilla context menu that allows you to run whatever page you're on through one of (currently) 18 different online validation and analysis services.</p>
-
-<h3 id="Applications_and_Services">Applications and Services</h3>
-
-<h4 id="DevEdge_Web_Tune-Up_Wizard">DevEdge Web Tune-Up Wizard</h4>
-
-<p><a class="external" href="http://devedge-temp.mozilla.org/toolbox/tools/2001/tune-up/">This interface to W3C services</a> guides beginning-to-intermediate web authors through the process of updating content to support Netscape 7.x, Mozilla and other browsers that support W3C Standards.</p>
-
-<h4 id="W3C_HTML_Validator">W3C HTML Validator</h4>
-
-<p>The <a class="external" href="https://validator.w3.org/">W3C HTML Validator</a> will validate any Web page according to the W3C HTML standards. It is very useful for detecting the use of proprietary HTML as well as invalid HTML.</p>
-
-<h4 id="W3C_CSS_Validator">W3C CSS Validator</h4>
-
-<p>The <a class="external" href="https://jigsaw.w3.org/css-validator/">W3C CSS Validator</a> will validate the CSS within any web page or external CSS files according to the W3C CSS standards.</p>
-
-<h4 id="W3C_RDF_Validator">W3C RDF Validator</h4>
-
-<p>The <a class="external" href="https://www.w3.org/RDF/Validator/">RDF Validator</a> service will validate the RDF/XML contained on a given URI.</p>
-
-<h4 id="Link_Checker">Link Checker</h4>
-
-<p><a class="external" href="https://validator.w3.org/checklink">This tool</a> will check links on a given web page.</p>
-
-<h4 id="HTML_Tidy">HTML Tidy</h4>
-
-<p><a class="external" href="http://tidy.sourceforge.net/">HTML Tidy</a> is a tool that can be used to report errors in an HTML page and to format web pages for better reading. (Some authoring software, such as <a class="external" href="https://www.chami.com/html-kit/">HTML-Kit</a>, builds in HTML Tidy which makes validation quick and easy.)</p>
-
-<h4 id="HTML_Validator_Pro">HTML Validator Pro</h4>
-
-<p>This is an <a href="http://html.validator.pro/">automated HTML5 checker</a> using the same validator as the W3C. Provide a starting URL and the tool will find and validate all pages in a website.</p>
-
-<h3 id="Accessibility_Services">Accessibility Services</h3>
-
-<h4 id="Lynx_Viewer">Lynx Viewer</h4>
-
-<p><a class="external" href="http://www.delorie.com/web/lynxview.html">Checks a web page</a> using Lynx visualization and allows validation of accessibility features</p>
-
-<div class="originaldocinfo">
-<h3 id="Original_Document_Information">Original Document Information</h3>
+<p class="summary"><span class="seoSummary">This article lists different resources for developers to check web documents.</span></p>
 
 <ul>
- <li>Last Updated Date: August 16th, 2002</li>
- <li>Copyright © 2001-2003 Netscape.</li>
+<li>The <a class="external" href="https://validator.w3.org/">W3C HTML Validator</a> validates HTML documents.</li>
+
+<li>The <a class="external" href="https://jigsaw.w3.org/css-validator/">W3C CSS Validator</a> validates CSS stylesheets.</li>
+
+<li>The <a class="external" href="https://validator.w3.org/checklink">W3C Link Checker</a> checks for broken links in HTML documents.</li>
+
+<li>The <a class="external" href="https://www.html-tidy.org/">HTML Tidy</a> tool finds errors in HTML documents, and can automatically fix some errors.</li>
 </ul>
-</div>


### PR DESCRIPTION
The /en-US/docs/Tools/Validators page had a number of outdated links, and made unnecessary use of headings for each tool it linked to. This change pares it down to a bulleted list of currently relevant resources. The page can subsequently be built back up with further links other current resources. Fixes https://github.com/mdn/content/issues/4659.