### PR TITLE
Put browser-compat info in front-runner for webextensions/api/*

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - alarm
   - alarms
+browser-compat: webextensions.api.alarms.Alarm
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.Alarm")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - alarms
   - clear
+browser-compat: webextensions.api.alarms.clear
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ clearAlarm.then(onCleared);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.clear")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - alarms
   - clearAll
+browser-compat: webextensions.api.alarms.clearAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ clearAlarms.then(onClearedAll);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.clearAll")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - alarms
+browser-compat: webextensions.api.alarms.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -83,7 +84,7 @@ browser.alarms.create("my-periodic-alarm", {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.create")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - alarms
   - get
+browser-compat: webextensions.api.alarms.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ getAlarm.then(gotAlarm);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.get")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - alarms
   - getAll
+browser-compat: webextensions.api.alarms.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ getAlarms.then(gotAll);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - alarms
+browser-compat: webextensions.api.alarms
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - alarms
   - onAlarm
+browser-compat: webextensions.api.alarms.onAlarm
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -64,7 +65,7 @@ browser.alarms.onAlarm.addListener(handleAlarm);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.alarms.onAlarm")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.html
@@ -11,6 +11,7 @@ tags:
   - Non-standard
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ createBookmark.then(onCreated);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.create")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/export/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/export/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - export
+browser-compat: webextensions.api.bookmarks.export
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.export")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - get
+browser-compat: webextensions.api.bookmarks.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -55,7 +56,7 @@ gettingBookmarks.then(onFulfilled, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.get")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getChildren
+browser-compat: webextensions.api.bookmarks.getChildren
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ gettingChildren.then(onFulfilled, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.getChildren")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getRecent
+browser-compat: webextensions.api.bookmarks.getRecent
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -57,7 +58,7 @@ gettingRecent.then(onFulfilled, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.getRecent")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getSubTree
+browser-compat: webextensions.api.bookmarks.getSubTree
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -79,7 +80,7 @@ gettingSubTree.then(logSubTree, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.getSubTree")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getTree
+browser-compat: webextensions.api.bookmarks.getTree
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -72,7 +73,7 @@ gettingTree.then(logTree, onRejected);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.getTree")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.html
@@ -10,6 +10,7 @@ tags:
   - Non-standard
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.bookmarks
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden note">
 <p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - move
+browser-compat: webextensions.api.bookmarks.move
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -74,7 +75,7 @@ movingBookmark.then(onMoved, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.move")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onChanged
+browser-compat: webextensions.api.bookmarks.onChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -83,7 +84,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onChanged")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onChildrenReordered
+browser-compat: webextensions.api.bookmarks.onChildrenReordered
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -66,7 +67,7 @@ browser.bookmarks.onChildrenReordered.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onChildrenReordered")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onCreated
+browser-compat: webextensions.api.bookmarks.onCreated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ browser.bookmarks.onCreated.addListener(handleCreated);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onCreated")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onImportBegan
+browser-compat: webextensions.api.bookmarks.onImportBegan
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ browser.bookmarks.onImportBegan.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onImportBegan")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onImportEnded
+browser-compat: webextensions.api.bookmarks.onImportEnded
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ browser.bookmarks.onImportEnded.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onImportEnded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onMoved
+browser-compat: webextensions.api.bookmarks.onMoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -72,7 +73,7 @@ browser.bookmarks.onMoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onMoved")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onRemoved
+browser-compat: webextensions.api.bookmarks.onRemoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -86,7 +87,7 @@ browser.browserAction.onClicked.addListener(handleClick);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.onRemoved")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - remove
+browser-compat: webextensions.api.bookmarks.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -61,7 +62,7 @@ removingBookmark.then(onRemoved, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.remove")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - removeTree
+browser-compat: webextensions.api.bookmarks.removeTree
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ searchingBookmarks.then(removeMDN, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.removeTree")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Search
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.search
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -105,7 +106,7 @@ browser.browserAction.onClicked.addListener(checkActiveTab);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.search")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Update
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ searching.then(updateFolders, onRejected);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.update")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - browserAction
+browser-compat: webextensions.api.browserAction.ColorArray
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.ColorArray")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - disable
+browser-compat: webextensions.api.browserAction.disable
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.disable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - browserAction
+browser-compat: webextensions.api.browserAction.enable
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.enable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - browserAction
+browser-compat: webextensions.api.browserAction.ImageDataType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.ImageDataType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - browserAction
+browser-compat: webextensions.api.browserAction
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden note">
 <p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - onClicked
+browser-compat: webextensions.api.browserAction.onClicked
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -61,7 +62,7 @@ browser.browserAction.onClicked.hasListener(listener)
 
  <h2 id="Browser_compatibility">Browser compatibility</h2>
 
- <p>{{Compat("webextensions.api.browserAction.onClicked")}}</p>
+ <p>{{Compat}}</p>
 
  <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - allowPopupsForUserEvents
   - browserSettings
+browser-compat: webextensions.api.browserSettings.allowPopupsForUserEvents
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.allowPopupsForUserEvents")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - cacheEnabled
+browser-compat: webextensions.api.browserSettings.cacheEnabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -19,7 +20,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.cacheEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - closeTabsByDoubleClick
+browser-compat: webextensions.api.browserSettings.closeTabsByDoubleClick
 ---
 
 <div>{{AddonSidebar()}}</div>
@@ -22,4 +23,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.closeTabsByDoubleClick")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - contextMenuShowEvent
+browser-compat: webextensions.api.browserSettings.contextMenuShowEvent
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -21,7 +22,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.contextMenuShowEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.html
@@ -11,6 +11,7 @@ tags:
   - browserSettings
   - contextMenuShowEvent
   - ftpProtocolEnabled
+browser-compat: webextensions.api.browserSettings.ftpProtocolEnabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -25,7 +26,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.ftpProtocolEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - browserSettings
+browser-compat: webextensions.api.browserSettings
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -59,6 +60,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - openBookmarksInNewTabs
+browser-compat: webextensions.api.browserSettings.openBookmarksInNewTabs
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -19,7 +20,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.openBookmarksInNewTabs")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - openSearchResultsInNewTabs
+browser-compat: webextensions.api.browserSettings.openSearchResultsInNewTabs
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -21,7 +22,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.openSearchResultsInNewTabs")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - openUrlbarResultsInNewTabs
+browser-compat: webextensions.api.browserSettings.openUrlbarResultsInNewTabs
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -21,7 +22,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.openUrlbarResultsInNewTabs")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - overrideDocumentColors
+browser-compat: webextensions.api.browserSettings.overrideDocumentColors
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -27,7 +28,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.overrideDocumentColors")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - useDocumentFonts
+browser-compat: webextensions.api.browserSettings.useDocumentFonts
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -26,7 +27,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.useDocumentFonts")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - webNotificationsDisabled
+browser-compat: webextensions.api.browserSettings.webNotificationsDisabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -27,7 +28,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.webNotificationsDisabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - zoomFullPage
+browser-compat: webextensions.api.browserSettings.zoomFullPage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -26,7 +27,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.zoomFullPage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - browserSettings
   - zoomSiteSpecific
+browser-compat: webextensions.api.browserSettings.zoomSiteSpecific
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.zoomSiteSpecific")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - browsingData
+browser-compat: webextensions.api.browsingData.DataTypeSet
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.DataTypeSet")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - remove
+browser-compat: webextensions.api.browsingData.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removeCache
+browser-compat: webextensions.api.browsingData.removeCache
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removeCache")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removeCookies
+browser-compat: webextensions.api.browsingData.removeCookies
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removeCookies")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removeDownloads
+browser-compat: webextensions.api.browsingData.removeDownloads
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removeDownloads")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removeDownloads
+browser-compat: webextensions.api.browsingData.removeFormData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removeFormData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removePasswords
+browser-compat: webextensions.api.browsingData.removePasswords
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removePasswords")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removePluginData
+browser-compat: webextensions.api.browsingData.removePluginData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removePluginData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.html
@@ -10,6 +10,7 @@ tags:
   - Settings
   - WebExtensions
   - browsingData
+browser-compat: webextensions.api.browsingData.settings
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.settings")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.html
@@ -8,6 +8,7 @@ tags:
   - WebExtensions
   - canonicalURL
   - captivePortal
+browser-compat: webextensions.api.captivePortal.canonicalURL
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -15,7 +16,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.captivePortal.canonicalURL")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - captivePortal
+browser-compat: webextensions.api.captivePortal.getLastChecked
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.captivePortal.getLastChecked")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden">
 <pre>// Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - captivePortal
+browser-compat: webextensions.api.captivePortal.getState
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -27,7 +28,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.captivePortal.getState")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden">
 <pre>// Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - captivePortal
+browser-compat: webextensions.api.captivePortal
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.captivePortal")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden note">
 <p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - captivePortal
+browser-compat: webextensions.api.captivePortal.onConnectivityAvailable
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -63,7 +64,7 @@ browser.captivePortal.onConnectivityAvailable.addListener(handleConnectivity);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.captivePortal.onConnectivityAvailable")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden">
 <pre>// Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - captivePortal
+browser-compat: webextensions.api.captivePortal.onStateChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -65,7 +66,7 @@ browser.captivePortal.onStateChanged.addListener(handlePortalStatus)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.captivePortal.onStateChanged")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden">
 <pre>// Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - commands
+browser-compat: webextensions.api.commands.Command
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.commands.Command")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - commands
   - getAll
+browser-compat: webextensions.api.commands.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.commands.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - commands
   - onCommand
+browser-compat: webextensions.api.commands.onCommand
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ browser.commands.onCommand.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.commands.onCommand")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/reset/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - commands
   - reset
+browser-compat: webextensions.api.commands.reset
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.commands.reset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - contextualIdentities
+browser-compat: webextensions.api.contextualIdentities.ContextualIdentity
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.ContextualIdentity")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/create/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - contextualIdentities
+browser-compat: webextensions.api.contextualIdentities.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.create")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/get/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - contextualIdentities
   - get
+browser-compat: webextensions.api.contextualIdentities.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.html
@@ -3,6 +3,7 @@ title: contextualIdentities
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities
 tags:
   - WebExtensions
+browser-compat: webextensions.api.contextualIdentities
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -59,6 +60,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - contextualIdentities
   - onCreated
+browser-compat: webextensions.api.contextualIdentities.onCreated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ browser.contextualIdentities.onCreated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.onCreated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - contextualIdentities
   - onRemoved
+browser-compat: webextensions.api.contextualIdentities.onRemoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ browser.contextualIdentities.onRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.onRemoved")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - contextualIdentities
   - onUpdated
+browser-compat: webextensions.api.contextualIdentities.onUpdated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ browser.contextualIdentities.onUpdated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.onUpdated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/query/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - contextualIdentities
   - query
+browser-compat: webextensions.api.contextualIdentities.query
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.query")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - contextualIdentities
   - remove
+browser-compat: webextensions.api.contextualIdentities.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/update/index.html
@@ -10,6 +10,7 @@ tags:
   - Update
   - WebExtensions
   - contextualIdentities
+browser-compat: webextensions.api.contextualIdentities.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contextualIdentities.update")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - cookie
+browser-compat: webextensions.api.cookies.Cookie
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.Cookie")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.cookies.CookieStore
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.CookieStore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - get
+browser-compat: webextensions.api.cookies.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getAll
+browser-compat: webextensions.api.cookies.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getAllCookieStores
+browser-compat: webextensions.api.cookies.getAllCookieStores
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.getAllCookieStores")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.html
@@ -10,6 +10,7 @@ tags:
   - Non-standard
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.cookies
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -122,7 +123,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onChanged
+browser-compat: webextensions.api.cookies.onChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -71,7 +72,7 @@ browser.cookies.onChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.onChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.cookies.OnChangedCause
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.OnChangedCause")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - remove
+browser-compat: webextensions.api.cookies.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - set
+browser-compat: webextensions.api.cookies.set
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.cookies.set")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/index.html
@@ -10,6 +10,7 @@ tags:
   - devtools.inspectedWindow
   - devtools.network
   - devtools.panels
+browser-compat: webextensions.api.devtools
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -30,7 +31,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - devtools.inspectedWindow
   - eval
+browser-compat: webextensions.api.devtools.inspectedWindow.eval
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.inspectedWindow.eval")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools.inspectedWindow
+browser-compat: webextensions.api.devtools.inspectedWindow
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.inspectedWindow")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - devtools.inspectedWindow
   - reload
+browser-compat: webextensions.api.devtools.inspectedWindow.reload
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.inspectedWindow.reload")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - devtools.inspectedWindow
   - tabId
+browser-compat: webextensions.api.devtools.inspectedWindow.tabId
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.inspectedWindow.tabId")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.html
@@ -8,6 +8,7 @@ tags:
   - WebExtensions
   - devtools.network
   - getHAR
+browser-compat: webextensions.api.devtools.network.getHAR
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -30,7 +31,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.network.getHAR")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools.network
+browser-compat: webextensions.api.devtools.network
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.network")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.html
@@ -9,6 +9,7 @@ tags:
   - Event
   - WebExtensions
   - devtools.network
+browser-compat: webextensions.api.devtools.network.onNavigated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ browser.devtools.network.onNavigated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.network.onNavigated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - devtools.network
   - onRequestFinished
+browser-compat: webextensions.api.devtools.network.onRequestFinished
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -55,7 +56,7 @@ browser.devtools.network.onRequestFinished.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.network.onRequestFinished")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools.panels
+browser-compat: webextensions.api.devtools.panels.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.create")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools.panels
+browser-compat: webextensions.api.devtools.panels.ExtensionPanel
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -25,7 +26,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionPanel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - onThemeChanged
+browser-compat: webextensions.api.devtools.panels.onThemeChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ browser.devtools.panels.onThemeChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.onThemeChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - themeName
+browser-compat: webextensions.api.devtools.panels.themeName
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -25,7 +26,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.themeName")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/index.html
@@ -7,6 +7,7 @@ tags:
   - DNS
   - Extensions
   - WebExtensions
+browser-compat: webextensions.api.dns
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -27,6 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.dns")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dns/resolve/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - resolve
+browser-compat: webextensions.api.dns.resolve
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.dns.resolve")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - acceptDanger
   - downloads
+browser-compat: webextensions.api.downloads.acceptDanger
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.acceptDanger")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.BooleanDelta
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.BooleanDelta")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - cancel
   - downloads
+browser-compat: webextensions.api.downloads.cancel
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.cancel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.DangerType
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.DangerType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.DoubleDelta
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.DoubleDelta")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - download
   - downloads
+browser-compat: webextensions.api.downloads.download
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.download")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.DownloadItem
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.DownloadItem")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.DownloadQuery
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.DownloadQuery")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.DownloadTime
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.DownloadTime")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/drag/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.drag
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.drag")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - erase
+browser-compat: webextensions.api.downloads.erase
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.erase")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.FilenameConflictAction
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.FilenameConflictAction")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - getFileIcon
+browser-compat: webextensions.api.downloads.getFileIcon
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.getFileIcon")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.InterruptReason
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.InterruptReason")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - onChanged
+browser-compat: webextensions.api.downloads.onChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -91,7 +92,7 @@ browser.downloads.onChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.onChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - onCreated
+browser-compat: webextensions.api.downloads.onCreated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ browser.downloads.onCreated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.onCreated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - onErased
+browser-compat: webextensions.api.downloads.onErased
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ browser.downloads.onErased.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.onErased")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - open
+browser-compat: webextensions.api.downloads.open
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.open")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - pause
+browser-compat: webextensions.api.downloads.pause
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.pause")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - removeFile
+browser-compat: webextensions.api.downloads.removeFile
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.removeFile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - resume
+browser-compat: webextensions.api.downloads.resume
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.resume")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.html
@@ -11,6 +11,7 @@ tags:
   - Search
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.search
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.search")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - setShelfEnabled
+browser-compat: webextensions.api.downloads.setShelfEnabled
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.setShelfEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - show
+browser-compat: webextensions.api.downloads.show
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.show")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - showDefaultFolder
+browser-compat: webextensions.api.downloads.showDefaultFolder
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -27,7 +28,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.showDefaultFolder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - downloads
   - state
+browser-compat: webextensions.api.downloads.State
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.State")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - downloads
+browser-compat: webextensions.api.downloads.StringDelta
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.downloads.StringDelta")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - events
+browser-compat: webextensions.api.events.Event
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.events.Event")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - events
+browser-compat: webextensions.api.events
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.events")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - events
+browser-compat: webextensions.api.events.Rule
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.events.Rule")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.html
@@ -11,6 +11,7 @@ tags:
   - UrlFilter
   - WebExtensions
   - events
+browser-compat: webextensions.api.events.UrlFilter
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.events.UrlFilter")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getBackgroundPage
+browser-compat: webextensions.api.extension.getBackgroundPage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ page.foo(); // -&gt; "I'm defined in background.js"</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.getBackgroundPage")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getExtensionTabs
+browser-compat: webextensions.api.extension.getExtensionTabs
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.getExtensionTabs")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - WebExtensions
   - getURL
+browser-compat: webextensions.api.extension.getURL
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.getURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getViews
+browser-compat: webextensions.api.extension.getViews
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.getViews")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.html
@@ -9,6 +9,7 @@ tags:
   - Interface
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.extension
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - inIncognitoContext
+browser-compat: webextensions.api.extension.inIncognitoContext
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -26,7 +27,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.inIncognitoContext")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - isAllowedFileSchemeAccess
+browser-compat: webextensions.api.extension.isAllowedFileSchemeAccess
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.isAllowedFileSchemeAccess")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - isAllowedIncognitoAccess
+browser-compat: webextensions.api.extension.isAllowedIncognitoAccess
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ isAllowed.then(logIsAllowed);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.isAllowedIncognitoAccess")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - lastError
+browser-compat: webextensions.api.extension.lastError
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -18,7 +19,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.lastError")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onRequest
+browser-compat: webextensions.api.extension.onRequest
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -70,7 +71,7 @@ chrome.extension.onRequest.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.onRequest")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onRequestExternal
+browser-compat: webextensions.api.extension.onRequestExternal
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -70,7 +71,7 @@ chrome.extension.onRequestExternal.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.onRequestExternal")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - WebExtensions
   - sendRequest
+browser-compat: webextensions.api.extension.sendRequest
 ---
 <div>{{AddonSidebar}}{{Deprecated_Header}}
 <div class="notecard warning">
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.sendRequest")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - setUpdateUrlData
+browser-compat: webextensions.api.extension.setUpdateUrlData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.setUpdateUrlData")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - ViewType
   - WebExtensions
+browser-compat: webextensions.api.extension.ViewType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extension.ViewType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - extensionTypes
+browser-compat: webextensions.api.extensionTypes.ImageDetails
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extensionTypes.ImageDetails")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - extensionTypes
+browser-compat: webextensions.api.extensionTypes.ImageFormat
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extensionTypes.ImageFormat")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - extensionTypes
+browser-compat: webextensions.api.extensionTypes
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extensionTypes")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - extensionTypes
+browser-compat: webextensions.api.extensionTypes.RunAt
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -30,7 +31,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.extensionTypes.RunAt")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - addUrl
+browser-compat: webextensions.api.history.addUrl
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.addUrl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - deleteAll
+browser-compat: webextensions.api.history.deleteAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.deleteAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - deleteRange
+browser-compat: webextensions.api.history.deleteRange
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.deleteRange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - deleteUrl
+browser-compat: webextensions.api.history.deleteUrl
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.deleteUrl")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getVisits
+browser-compat: webextensions.api.history.getVisits
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.getVisits")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.history.HistoryItem
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.HistoryItem")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.html
@@ -10,6 +10,7 @@ tags:
   - Non-standard
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.history
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - onTitleChanged
+browser-compat: webextensions.api.history.onTitleChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -58,7 +59,7 @@ browser.history.onTitleChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.onTitleChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onVisited
+browser-compat: webextensions.api.history.onVisited
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -56,7 +57,7 @@ browser.history.onVisited.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.onVisited")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onVisitRemoved
+browser-compat: webextensions.api.history.onVisitRemoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -64,7 +65,7 @@ browser.history.onVisitRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.onVisitRemoved")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Search
   - WebExtensions
+browser-compat: webextensions.api.history.search
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -111,7 +112,7 @@ searching.then(onGot);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.search")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.html
@@ -11,6 +11,7 @@ tags:
   - TransitionType
   - Type
   - WebExtensions
+browser-compat: webextensions.api.history.TransitionType
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.TransitionType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - VisitItem
   - WebExtensions
+browser-compat: webextensions.api.history.VisitItem
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.history.VisitItem")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - detectLanguage
   - i18n
+browser-compat: webextensions.api.i18n.detectLanguage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.i18n.detectLanguage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getAcceptLanguages
   - i18n
+browser-compat: webextensions.api.i18n.getAcceptLanguages
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.i18n.getAcceptLanguages")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getMessage
   - i18n
+browser-compat: webextensions.api.i18n.getMessage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.i18n.getMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getUILanguage
   - i18n
+browser-compat: webextensions.api.i18n.getUILanguage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.i18n.getUILanguage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - i18n
+browser-compat: webextensions.api.i18n
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.i18n")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - i18n
+browser-compat: webextensions.api.i18n.LanguageCode
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.i18n.LanguageCode")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - getRedirectURL
+browser-compat: webextensions.api.identity.getRedirectURL
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.identity.getRedirectURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.html
@@ -8,6 +8,7 @@ tags:
   - Identity
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.identity
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -69,7 +70,7 @@ Loopback addresses are an accepted alternative that do not require domain valida
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.identity")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - launchWebAuthFlow
+browser-compat: webextensions.api.identity.launchWebAuthFlow
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.identity.launchWebAuthFlow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.idle.IdleState
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.idle.IdleState")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/index.html
@@ -10,6 +10,7 @@ tags:
   - Non-standard
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.idle
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.idle")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onStateChanged
+browser-compat: webextensions.api.idle.onStateChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -58,7 +59,7 @@ browser.idle.onStateChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.idle.onStateChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - queryState
+browser-compat: webextensions.api.idle.queryState
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.idle.queryState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - setDetectionInterval
+browser-compat: webextensions.api.idle.setDetectionInterval
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.idle.setDetectionInterval")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - management
+browser-compat: webextensions.api.management.ExtensionInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.ExtensionInfo")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - get
   - management
+browser-compat: webextensions.api.management.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - getAll
   - management
+browser-compat: webextensions.api.management.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - getPermissionWarningsById
   - management
+browser-compat: webextensions.api.management.getPermissionWarningsById
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.getPermissionWarningsById")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - getPermissionWarningsByManifest
   - management
+browser-compat: webextensions.api.management.getPermissionWarningsByManifest
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.getPermissionWarningsByManifest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - getSelf
   - management
+browser-compat: webextensions.api.management.getSelf
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.getSelf")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - management
+browser-compat: webextensions.api.management
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/install/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - install
   - management
+browser-compat: webextensions.api.management.install
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.install")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - onDisabled
+browser-compat: webextensions.api.management.onDisabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.management.onDisabled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.onDisabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - onEnabled
+browser-compat: webextensions.api.management.onEnabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.management.onEnabled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.onEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - onInstalled
+browser-compat: webextensions.api.management.onInstalled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.management.onInstalled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.onInstalled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - onUninstalled
+browser-compat: webextensions.api.management.onUninstalled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.management.onUninstalled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.onUninstalled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - setEnabled
+browser-compat: webextensions.api.management.setEnabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.setEnabled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - uninstall
+browser-compat: webextensions.api.management.uninstall
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.management.uninstall")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - management
   - uninstallSelf
+browser-compat: webextensions.api.management.uninstallSelf
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
  <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-{{Compat("webextensions.api.management.uninstallSelf")}}
+{{Compat}}
 
  <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.html
@@ -8,6 +8,7 @@ tags:
   - WebExtensions
   - getTargetElement
   - menus
+browser-compat: webextensions.api.menus.getTargetElement
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.getTargetElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - clear
+browser-compat: webextensions.api.notifications.clear
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.clear")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.html
@@ -11,6 +11,7 @@ tags:
   - Notifications
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.notifications.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.create")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - getAll
+browser-compat: webextensions.api.notifications.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.html
@@ -7,6 +7,7 @@ tags:
   - Extensions
   - Notifications
   - WebExtensions
+browser-compat: webextensions.api.notifications
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.notifications.NotificationOptions
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -77,7 +78,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.NotificationOptions")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onButtonClicked
+browser-compat: webextensions.api.notifications.onButtonClicked
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ browser.notifications.onButtonClicked.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.onButtonClicked")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onClicked
+browser-compat: webextensions.api.notifications.onClicked
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.notifications.onClicked.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.onClicked")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onClosed
+browser-compat: webextensions.api.notifications.onClosed
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ browser.notifications.onClosed.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.onClosed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - events
   - onShown
+browser-compat: webextensions.api.notifications.onShown
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.notifications.onShown.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.onShown")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.html
@@ -11,6 +11,7 @@ tags:
   - TemplateType
   - Type
   - WebExtensions
+browser-compat: webextensions.api.notifications.TemplateType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.TemplateType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Update
   - WebExtensions
+browser-compat: webextensions.api.notifications.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.notifications.update")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - omnibox
+browser-compat: webextensions.api.omnibox
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - omnibox
   - onInputCancelled
+browser-compat: webextensions.api.omnibox.onInputCancelled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ browser.omnibox.onInputCancelled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.onInputCancelled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - omnibox
   - onInputChanged
+browser-compat: webextensions.api.omnibox.onInputChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ browser.omnibox.onInputChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.onInputChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - omnibox
   - onInputEntered
+browser-compat: webextensions.api.omnibox.onInputEntered
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ browser.omnibox.onInputEntered.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.onInputEntered")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - omnibox
+browser-compat: webextensions.api.omnibox.OnInputEnteredDisposition
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.OnInputEnteredDisposition")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - omnibox
   - onInputStarted
+browser-compat: webextensions.api.omnibox.onInputStarted
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ browser.omnibox.onInputStarted.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.onInputStarted")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - omnibox
   - setDefaultSuggestion
+browser-compat: webextensions.api.omnibox.setDefaultSuggestion
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.setDefaultSuggestion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - omnibox
+browser-compat: webextensions.api.omnibox.SuggestResult
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -30,7 +31,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.omnibox.SuggestResult")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getPopup
   - pageAction
+browser-compat: webextensions.api.pageAction.getPopup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.getPopup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getTitle
   - pageAction
+browser-compat: webextensions.api.pageAction.getTitle
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.getTitle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - hide
   - pageAction
+browser-compat: webextensions.api.pageAction.hide
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.hide")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - pageAction
+browser-compat: webextensions.api.pageAction.ImageDataType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.ImageDataType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - pageAction
+browser-compat: webextensions.api.pageAction
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/isshown/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - isShown
   - pageAction
+browser-compat: webextensions.api.pageAction.isShown
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.isShown")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onClicked
   - pageAction
+browser-compat: webextensions.api.pageAction.onClicked
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -61,7 +62,7 @@ browser.pageAction.onClicked.hasListener(listener)
 
 	<h2 id="Browser_compatibility">Browser compatibility</h2>
 
-	<p>{{Compat("webextensions.api.pageAction.onClicked")}}</p>
+	<p>{{Compat}}</p>
 
 	<h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - pageAction
   - setIcon
+browser-compat: webextensions.api.pageAction.setIcon
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("webextensions.api.pageAction.setIcon")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - pageAction
   - setPopup
+browser-compat: webextensions.api.pageAction.setPopup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.setPopup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - pageAction
   - setTitle
+browser-compat: webextensions.api.pageAction.setTitle
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.setTitle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - pageAction
   - show
+browser-compat: webextensions.api.pageAction.show
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.show")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.html
@@ -9,6 +9,7 @@ tags:
   - Permissions
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.permissions.contains
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.contains")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - getAll
+browser-compat: webextensions.api.permissions.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.html
@@ -8,6 +8,7 @@ tags:
   - Permissions
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.permissions
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - onAdded
+browser-compat: webextensions.api.permissions.onAdded
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ browser.permissions.onAdded.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.onAdded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - onRemoved
+browser-compat: webextensions.api.permissions.onRemoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ browser.permissions.onRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.onRemoved")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.permissions.Permissions
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -26,7 +27,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.Permissions")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - remove
+browser-compat: webextensions.api.permissions.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - request
+browser-compat: webextensions.api.permissions.request
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.permissions.request")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getModuleSlots
   - pkcs11
+browser-compat: webextensions.api.pkcs11.getModuleSlots
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pkcs11.getModuleSlots")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.privacy.network
 ---
 <div>{{AddonSidebar}}
 <p>The {{WebExtAPIRef("privacy.network")}} property contains privacy-related network settings. Each property is a {{WebExtAPIRef("types.BrowserSetting")}} object.</p>
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.privacy.network")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden note">
 <p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - websites
+browser-compat: webextensions.api.privacy.websites
 ---
 <div>{{AddonSidebar}}
 <p>The {{WebExtAPIRef("privacy.websites")}} property contains privacy-related settings controlling the way to browser interacts with websites. Each property is a {{WebExtAPIRef("types.BrowserSetting")}} object.</p>
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.privacy.websites")}}</p>
+<p>{{Compat}}</p>
 
 <div class="hidden note">
 <p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.html
@@ -6,6 +6,7 @@ tags:
   - Add-ons
   - Proxy
   - WebExtensions
+browser-compat: webextensions.api.proxy
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onerror/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - onProxyError
+browser-compat: webextensions.api.proxy.onError
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,4 +55,4 @@ browser.proxy.onError.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.onError")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.html
@@ -8,6 +8,7 @@ tags:
   - ProxyInfo
   - Type
   - WebExtensions
+browser-compat: webextensions.api.proxy.ProxyInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,6 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.ProxyInfo")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/register/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - register
   - registerProxyScript
+browser-compat: webextensions.api.proxy.register
 ---
 <p>{{AddonSidebar()}} {{deprecated_header}}</p>
 
@@ -154,7 +155,7 @@ browser.proxy.register(proxyScriptURL);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.register")}}</p>
+<p>{{Compat}}</p>
 
 <div class="notecard note">
   <h4>Acknowledgements</h4>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.html
@@ -8,6 +8,7 @@ tags:
   - RequestDetails
   - Type
   - WebExtensions
+browser-compat: webextensions.api.proxy.RequestDetails
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,6 +53,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.RequestDetails")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/unregister/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - unregister
+browser-compat: webextensions.api.proxy.unregister
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.unregister")}}</p>
+<p>{{Compat}}</p>
 
 <div class="notecard note">
   <h4>Acknowledgements</h4>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - connect
   - runtime
+browser-compat: webextensions.api.runtime.connect
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.connect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - connectNative
   - runtime
+browser-compat: webextensions.api.runtime.connectNative
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.connectNative")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getBackgroundPage
   - runtime
+browser-compat: webextensions.api.runtime.getBackgroundPage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.getBackgroundPage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getBrowserInfo
   - runtime
+browser-compat: webextensions.api.runtime.getBrowserInfo
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.getBrowserInfo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getManifest
   - runtime
+browser-compat: webextensions.api.runtime.getManifest
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.getManifest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getPackageDirectoryEntry
   - runtime
+browser-compat: webextensions.api.runtime.getPackageDirectoryEntry
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.getPackageDirectoryEntry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getPlatformInfo
   - runtime
+browser-compat: webextensions.api.runtime.getPlatformInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.getPlatformInfo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getURL
   - runtime
+browser-compat: webextensions.api.runtime.getURL
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.getURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - id
   - runtime
+browser-compat: webextensions.api.runtime.id
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -26,7 +27,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.id")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -120,7 +121,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime")}}</p>
+<p>{{Compat}}</p>
 
 <div>{{WebExtExamples("h2")}}</div>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - lastError
   - runtime
+browser-compat: webextensions.api.runtime.lastError
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -72,7 +73,7 @@ setCookie.then(logCookie, logError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.lastError")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.MessageSender
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.MessageSender")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - onBrowserUpdateAvailable
   - runtime
+browser-compat: webextensions.api.runtime.onBrowserUpdateAvailable
 ---
 <p>{{AddonSidebar}}{{Deprecated_header}}</p>
 
@@ -48,7 +49,7 @@ browser.runtime.onBrowserUpdateAvailable.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onBrowserUpdateAvailable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onconnect
   - runtime
+browser-compat: webextensions.api.runtime.onConnect
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.runtime.onConnect.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onConnect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onConnectExternal
   - runtime
+browser-compat: webextensions.api.runtime.onConnectExternal
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -56,7 +57,7 @@ browser.runtime.onConnectExternal.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onConnectExternal")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.OnInstalledReason
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.OnInstalledReason")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onmessage
   - runtime
+browser-compat: webextensions.api.runtime.onMessage
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -138,7 +139,7 @@ browser.runtime.onMessage.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onMessageExternal
   - runtime
+browser-compat: webextensions.api.runtime.onMessageExternal
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -84,7 +85,7 @@ browser.runtime.onMessageExternal.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onMessageExternal")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onRestartRequired
   - runtime
+browser-compat: webextensions.api.runtime.onRestartRequired
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.runtime.onRestartRequired.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onRestartRequired")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.OnRestartRequiredReason
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.OnRestartRequiredReason")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onStartup
   - runtime
+browser-compat: webextensions.api.runtime.onStartup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ browser.runtime.onStartup.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onStartup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onSuspend
   - runtime
+browser-compat: webextensions.api.runtime.onSuspend
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ browser.runtime.onSuspend.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onSuspend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onSuspendCanceled
   - runtime
+browser-compat: webextensions.api.runtime.onSuspendCanceled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -47,7 +48,7 @@ browser.runtime.onSuspendCanceled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onSuspendCanceled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onUpdateAvailable
   - runtime
+browser-compat: webextensions.api.runtime.onUpdateAvailable
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -60,7 +61,7 @@ browser.runtime.onUpdateAvailable.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onUpdateAvailable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - openOptionsPage
   - runtime
+browser-compat: webextensions.api.runtime.openOptionsPage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.openOptionsPage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.PlatformArch
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.PlatformArch")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.PlatformInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.PlatformInfo")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.PlatformNaclArch
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.PlatformNaclArch")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.PlatformOs
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.PlatformOs")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - port
   - runtime
+browser-compat: webextensions.api.runtime.Port
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.Port")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - reload
   - runtime
+browser-compat: webextensions.api.runtime.reload
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.reload")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - requestUpdateCheck
   - runtime
+browser-compat: webextensions.api.runtime.requestUpdateCheck
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.requestUpdateCheck")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - runtime
+browser-compat: webextensions.api.runtime.RequestUpdateCheckStatus
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.RequestUpdateCheckStatus")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - runtime
   - sendMessage
+browser-compat: webextensions.api.runtime.sendMessage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.sendMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - runtime
   - sendNativeMessage
+browser-compat: webextensions.api.runtime.sendNativeMessage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.sendNativeMessage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - runtime
   - setUninstallURL
+browser-compat: webextensions.api.runtime.setUninstallURL
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.setUninstallURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - filter
   - sessions
+browser-compat: webextensions.api.sessions.Filter
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -27,7 +28,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.Filter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - forgetClosedTab
   - sessions
+browser-compat: webextensions.api.sessions.forgetClosedTab
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.forgetClosedTab")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - forgetClosedWindow
   - sessions
+browser-compat: webextensions.api.sessions.forgetClosedWindow
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.forgetClosedWindow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getRecentlyClosed
   - sessions
+browser-compat: webextensions.api.sessions.getRecentlyClosed
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.getRecentlyClosed")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - sessions
+browser-compat: webextensions.api.sessions
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - sessions
+browser-compat: webextensions.api.sessions.MAX_SESSION_RESULTS
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -18,7 +19,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.MAX_SESSION_RESULTS")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onChanged
   - sessions
+browser-compat: webextensions.api.sessions.onChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -47,7 +48,7 @@ browser.sessions.onChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.onChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - restore
   - sessions
+browser-compat: webextensions.api.sessions.restore
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.restore")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - sessions
+browser-compat: webextensions.api.sessions.Session
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.Session")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.ImageDataType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -21,7 +22,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.ImageDataType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.html
@@ -9,6 +9,7 @@ tags:
   - Sidebar
   - WebExtensions
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Example_add-ons">Example add-ons</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Storage
   - WebExtensions
+browser-compat: webextensions.api.storage
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.html
@@ -11,6 +11,7 @@ tags:
   - Storage
   - WebExtensions
   - local
+browser-compat: webextensions.api.storage.local
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.local")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.html
@@ -11,6 +11,7 @@ tags:
   - Storage
   - WebExtensions
   - managed
+browser-compat: webextensions.api.storage.managed
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ storageItem.then((res) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.managed")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.html
@@ -11,6 +11,7 @@ tags:
   - Storage
   - WebExtensions
   - onChanged
+browser-compat: webextensions.api.storage.onChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ browser.storage.onChanged.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.onChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.html
@@ -12,6 +12,7 @@ tags:
   - StorageArea
   - WebExtensions
   - remove
+browser-compat: webextensions.api.storage.StorageArea.clear
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.clear")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
@@ -14,6 +14,7 @@ tags:
   - Web
   - WebExtensions
   - get
+browser-compat: webextensions.api.storage.StorageArea.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.html
@@ -12,6 +12,7 @@ tags:
   - StorageArea
   - WebExtensions
   - getBytesInUse
+browser-compat: webextensions.api.storage.StorageArea.getBytesInUse
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.getBytesInUse")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.html
@@ -11,6 +11,7 @@ tags:
   - StorageArea
   - Type
   - WebExtensions
+browser-compat: webextensions.api.storage.StorageArea
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.html
@@ -12,6 +12,7 @@ tags:
   - StorageArea
   - WebExtensions
   - remove
+browser-compat: webextensions.api.storage.StorageArea.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
@@ -12,6 +12,7 @@ tags:
   - StorageArea
   - WebExtensions
   - set
+browser-compat: webextensions.api.storage.StorageArea.set
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.set")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
@@ -11,6 +11,7 @@ tags:
   - StorageChange
   - Type
   - WebExtensions
+browser-compat: webextensions.api.storage.StorageChange
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageChange")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.html
@@ -11,6 +11,7 @@ tags:
   - Storage
   - Sync
   - WebExtensions
+browser-compat: webextensions.api.storage.sync
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.storage.sync")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - captureTab
   - tabs
+browser-compat: webextensions.api.tabs.captureTab
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -60,7 +61,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.captureTab")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - captureVisibleTab
   - tabs
+browser-compat: webextensions.api.tabs.captureVisibleTab
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -61,7 +62,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.captureVisibleTab")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - connect
   - tabs
+browser-compat: webextensions.api.tabs.connect
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -78,7 +79,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.connect")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - detectLanguage
   - tabs
+browser-compat: webextensions.api.tabs.detectLanguage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -83,7 +84,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.detectLanguage")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.duplicate
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ querying.then(duplicateFirstTab, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.duplicate")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - executeScript
   - tabs
+browser-compat: webextensions.api.tabs.executeScript
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -183,7 +184,7 @@ executing.then(onExecuted, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.executeScript")}}</p>
+<p>{{Compat}}</p>
 
 <div class="notecard note">
 	<h4>Acknowledgements</h4>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - get
   - tabs
+browser-compat: webextensions.api.tabs.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -55,7 +56,7 @@ browser.tabs.onActivated.addListener(logListener);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.get")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - getAllInWindow
   - tabs
+browser-compat: webextensions.api.tabs.getAllInWindow
 ---
 <div>{{AddonSidebar}}
 <div class="blockIndicator deprecated">
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.getAllInWindow")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getCurrent
   - tabs
+browser-compat: webextensions.api.tabs.getCurrent
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -56,7 +57,7 @@ gettingCurrent.then(onGot, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.getCurrent")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - getSelected
   - tabs
+browser-compat: webextensions.api.tabs.getSelected
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.getSelected")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getZoom
   - tabs
+browser-compat: webextensions.api.tabs.getZoom
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ gettingZoom.then(onGot, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.getZoom")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getZoomSettings
   - tabs
+browser-compat: webextensions.api.tabs.getZoomSettings
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -55,7 +56,7 @@ gettingZoomSettings.then(onGot, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.getZoomSettings")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - goBack
+browser-compat: webextensions.api.tabs.goBack
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.goBack")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - goForward
+browser-compat: webextensions.api.tabs.goForward
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.goForward")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/hide/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/hide/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - hide
   - tabs
+browser-compat: webextensions.api.tabs.hide
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,4 +83,4 @@ browser.tabs.hide([15, 14, 1]).then(onHidden, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.hide")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -177,7 +178,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - insertCSS
   - tabs
+browser-compat: webextensions.api.tabs.insertCSS
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -105,7 +106,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.insertCSS")}}</p>
+<p>{{Compat}}</p>
 
 <div class="notecard note">
   <h4>Acknowledgements</h4>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - move
   - tabs
+browser-compat: webextensions.api.tabs.move
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -123,7 +124,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.move")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.MutedInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.MutedInfo")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.MutedInfoReason
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.MutedInfoReason")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onActivated
   - tabs
+browser-compat: webextensions.api.tabs.onActivated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -78,7 +79,7 @@ browser.tabs.onActivated.addListener(handleActivated);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onActivated")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - onActiveChanged
   - tabs
+browser-compat: webextensions.api.tabs.onActiveChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -71,7 +72,7 @@ browser.tabs.onActiveChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onActiveChanged")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onAttached
   - tabs
+browser-compat: webextensions.api.tabs.onAttached
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ browser.tabs.onAttached.addListener(handleAttached);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onAttached")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onCreated
   - tabs
+browser-compat: webextensions.api.tabs.onCreated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -66,7 +67,7 @@ browser.tabs.onCreated.addListener(handleCreated);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onCreated")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onDetached
   - tabs
+browser-compat: webextensions.api.tabs.onDetached
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ browser.tabs.onDetached.addListener(handleDetached);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onDetached")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - onHighlightChanged
   - tabs
+browser-compat: webextensions.api.tabs.onHighlightChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -66,7 +67,7 @@ browser.tabs.onHighlightChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onHighlightChanged")}}</p>
+<p>{{Compat}}</p>
 
 <p><strong>Acknowledgements</strong></p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onHighlighted
   - tabs
+browser-compat: webextensions.api.tabs.onHighlighted
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -77,7 +78,7 @@ browser.tabs.onHighlighted.addListener(handleHighlighted);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onHighlighted")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onMoved
   - tabs
+browser-compat: webextensions.api.tabs.onMoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -86,7 +87,7 @@ browser.tabs.onMoved.addListener(handleMoved);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onMoved")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onRemoved
   - tabs
+browser-compat: webextensions.api.tabs.onRemoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ browser.tabs.onRemoved.addListener(handleRemoved);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onRemoved")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onReplaced
   - tabs
+browser-compat: webextensions.api.tabs.onReplaced
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -73,7 +74,7 @@ browser.tabs.onReplaced.addListener(handleReplaced);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onReplaced")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - onSelectionChanged
   - tabs
+browser-compat: webextensions.api.tabs.onSelectionChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -69,7 +70,7 @@ browser.tabs.onSelectionChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onSelectionChanged")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onZoomChange
   - tabs
+browser-compat: webextensions.api.tabs.onZoomChange
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -81,7 +82,7 @@ browser.tabs.onZoomChange.addListener(handleZoomed);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onZoomChange")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.PageSettings
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -82,6 +83,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.PageSettings")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/print/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/print/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - print
   - tabs
+browser-compat: webextensions.api.tabs.print
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.print")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/printpreview/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - printPreview
   - tabs
+browser-compat: webextensions.api.tabs.printPreview
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.printPreview")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - query
   - tabs
+browser-compat: webextensions.api.tabs.query
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -145,7 +146,7 @@ querying.then(logTabs, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.query")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - reload
   - tabs
+browser-compat: webextensions.api.tabs.reload
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -71,7 +72,7 @@ reloading.then(onReloaded, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.reload")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - remove
   - tabs
+browser-compat: webextensions.api.tabs.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ removing.then(onRemoved, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.remove")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - removeCSS
   - tabs
+browser-compat: webextensions.api.tabs.removeCSS
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -76,7 +77,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.removeCSS")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - saveAsPDF
   - tabs
+browser-compat: webextensions.api.tabs.saveAsPDF
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.saveAsPDF")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - sendMessage
   - tabs
+browser-compat: webextensions.api.tabs.sendMessage
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -103,7 +104,7 @@ browser.runtime.onMessage.addListener(request =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.sendMessage")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - sendRequest
   - tabs
+browser-compat: webextensions.api.tabs.sendRequest
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.sendRequest")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - setZoom
   - tabs
+browser-compat: webextensions.api.tabs.setZoom
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -63,7 +64,7 @@ setting.then(null, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.setZoom")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - setZoomSettings
   - tabs
+browser-compat: webextensions.api.tabs.setZoomSettings
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -58,7 +59,7 @@ setting.then(onSet, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.setZoomSettings")}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/show/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/show/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - show
   - tabs
+browser-compat: webextensions.api.tabs.show
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -65,4 +66,4 @@ browser.tabs.show([15, 14, 1]).then(onShown, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.show")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.html
@@ -11,6 +11,7 @@ tags:
   - TAB_ID_NONE
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.TAB_ID_NONE
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -18,7 +19,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.TAB_ID_NONE")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.TabStatus
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.TabStatus")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - tabs
   - toggleReaderMode
+browser-compat: webextensions.api.tabs.toggleReaderMode
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -72,4 +73,4 @@ browser.tabs.onUpdated.addListener(switchToReaderMode);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.toggleReaderMode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/warmup/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - tabs
   - warmup
+browser-compat: webextensions.api.tabs.warmup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -75,4 +76,4 @@ browser.browserAction.onClicked.addListener(warmupMDN);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.warmup")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - WindowType
   - tabs
+browser-compat: webextensions.api.tabs.WindowType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.WindowType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - ZoomSettings
   - tabs
+browser-compat: webextensions.api.tabs.ZoomSettings
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.ZoomSettings")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - ZoomSettingsMode
   - tabs
+browser-compat: webextensions.api.tabs.ZoomSettingsMode
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.ZoomSettingsMode")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - ZoomSettingsScope
   - tabs
+browser-compat: webextensions.api.tabs.ZoomSettingsScope
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.ZoomSettingsScope")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/index.html
@@ -6,6 +6,7 @@ tags:
   - Themes
   - WebExtensions
   - add-on
+browser-compat: webextensions.api.theme
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -44,6 +45,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.theme")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.html
@@ -10,6 +10,7 @@ tags:
   - Theme
   - WebExtensions
   - reset
+browser-compat: webextensions.api.theme.reset
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.theme.reset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/theme/index.html
@@ -7,6 +7,7 @@ tags:
   - Type
   - WebExtensions
   - add-on
+browser-compat: webextensions.api.theme.Theme
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -18,6 +19,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.theme.Theme")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - get
   - topSites
+browser-compat: webextensions.api.topSites.get
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.topSites.get")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - topSites
+browser-compat: webextensions.api.topSites
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.topSites")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - topSites
+browser-compat: webextensions.api.topSites.MostVisitedURL
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.topSites.MostVisitedURL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - Types
   - WebExtensions
+browser-compat: webextensions.api.types.BrowserSetting
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.types.BrowserSetting")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - onchange
+browser-compat: webextensions.api.types.BrowserSetting.onChange
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ BrowserSetting.onChange.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.types.BrowserSetting.onChange")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.html
@@ -13,6 +13,7 @@ tags:
   - User Scripts API
   - WebExtensions
   - userScripts
+browser-compat: webextensions.api.userScripts.onBeforeScript
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -114,7 +115,7 @@ browser.userScripts.onBeforeScript.hasListener(listener)
 
 <div>
 
-<p>{{Compat("webextensions.api.userScripts.onBeforeScript")}}</p>
+<p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - unregister
   - userScripts
+browser-compat: webextensions.api.userScripts.RegisteredUserScript.unregister
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -36,7 +37,7 @@ await registeredUserScript.unregister()</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.userScripts.RegisteredUserScript.unregister")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getAllFrames
   - webNavigation
+browser-compat: webextensions.api.webNavigation.getAllFrames
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.getAllFrames")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - getFrame
   - webNavigation
+browser-compat: webextensions.api.webNavigation.getFrame
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.getFrame")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - webNavigation
+browser-compat: webextensions.api.webNavigation
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onBeforeNavigate
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onBeforeNavigate
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -78,7 +79,7 @@ browser.webNavigation.onBeforeNavigate.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onBeforeNavigate")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onCommitted
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onCommitted
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -82,7 +83,7 @@ browser.webNavigation.onCommitted.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onCommitted")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onCompleted
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onCompleted
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -76,7 +77,7 @@ browser.webNavigation.onCompleted.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onCompleted")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onCreatedNavigationTarget
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onCreatedNavigationTarget
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -89,7 +90,7 @@ browser.webNavigation.onCreatedNavigationTarget.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onCreatedNavigationTarget")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onDOMContentLoaded
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onDOMContentLoaded
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -76,7 +77,7 @@ browser.webNavigation.onDOMContentLoaded.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onDOMContentLoaded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onErrorOccurred
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onErrorOccurred
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -89,7 +90,7 @@ browser.webNavigation.onErrorOccurred.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onErrorOccurred")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onHistoryStateUpdated
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onHistoryStateUpdated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -80,7 +81,7 @@ browser.webNavigation.onHistoryStateUpdated.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onHistoryStateUpdated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onReferenceFragmentUpdated
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onReferenceFragmentUpdated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -80,7 +81,7 @@ browser.webNavigation.onReferenceFragmentUpdated.hasListener(<var>listener</var>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onReferenceFragmentUpdated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onTabReplaced
   - webNavigation
+browser-compat: webextensions.api.webNavigation.onTabReplaced
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ browser.webNavigation.onTabReplaced.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.onTabReplaced")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - webNavigation
+browser-compat: webextensions.api.webNavigation.TransitionQualifier
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.TransitionQualifier")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - webNavigation
+browser-compat: webextensions.api.webNavigation.TransitionType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webNavigation.TransitionType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.BlockingResponse
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.BlockingResponse")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - handlerBehaviorChanged
   - webRequest
+browser-compat: webextensions.api.webRequest.handlerBehaviorChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.handlerBehaviorChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.HttpHeaders
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.HttpHeaders")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -152,7 +153,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest")}}</p>
+<p>{{Compat}}</p>
 
 <p><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#webrequest_incompatibilities">Extra notes on Chrome incompatibilities</a>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -21,7 +22,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.RequestFilter
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.RequestFilter")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.ResourceType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.ResourceType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.html
@@ -11,6 +11,7 @@ tags:
   - UploadData
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.UploadData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.UploadData")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - Windows
+browser-compat: webextensions.api.windows.CreateType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.CreateType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - getAll
+browser-compat: webextensions.api.windows.getAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.getAll")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - Windows
+browser-compat: webextensions.api.windows
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - onCreated
+browser-compat: webextensions.api.windows.onCreated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.windows.onCreated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.onCreated")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - onFocusChanged
+browser-compat: webextensions.api.windows.onFocusChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -56,7 +57,7 @@ browser.windows.onFocusChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.onFocusChanged")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - onRemoved
+browser-compat: webextensions.api.windows.onRemoved
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.windows.onRemoved.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.onRemoved")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.html
@@ -12,6 +12,7 @@ tags:
   - Windows
   - close
   - remove
+browser-compat: webextensions.api.windows.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.remove")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.html
@@ -11,6 +11,7 @@ tags:
   - Update
   - WebExtensions
   - Windows
+browser-compat: webextensions.api.windows.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.update")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Window
   - Windows
+browser-compat: webextensions.api.windows.Window
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.Window")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.html
@@ -11,6 +11,7 @@ tags:
   - WINDOW_ID_CURRENT
   - WebExtensions
   - Windows
+browser-compat: webextensions.api.windows.WINDOW_ID_CURRENT
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -18,7 +19,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.WINDOW_ID_CURRENT")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.html
@@ -11,6 +11,7 @@ tags:
   - WINDOW_ID_NONE
   - WebExtensions
   - Windows
+browser-compat: webextensions.api.windows.WINDOW_ID_NONE
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -18,7 +19,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.WINDOW_ID_NONE")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - WindowState
   - Windows
+browser-compat: webextensions.api.windows.WindowState
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.WindowState")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - WindowType
   - Windows
+browser-compat: webextensions.api.windows.WindowType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -29,7 +30,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.WindowType")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers webextensions/api/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

400 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
