### PR TITLE
Removed a stray class=hidden instruction

### DIFF
--- a/files/en-us/web/html/element/dd/index.html
+++ b/files/en-us/web/html/element/dd/index.html
@@ -19,8 +19,6 @@ tags:
 
 <div>{{EmbedInteractiveExample("pages/tabbed/dd.html", "tabbed-standard")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples </a> and send us a pull request.</div>
-
 <table class="properties">
  <tbody>
   <tr>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The hidden instruction has been remained.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
