### PR TITLE
Drop outdated info on Params tab in devtools Network pane

### DIFF
--- a/files/en-us/tools/network_monitor/request_details/index.html
+++ b/files/en-us/tools/network_monitor/request_details/index.html
@@ -29,7 +29,6 @@ tags:
 <ul>
  <li><strong><a href="#headers_tab">Headers</a></strong></li>
  <li><strong>Messages</strong> (only for WebSocket items)</li>
- <li><strong><a href="#params_tab">Params</a></strong></li>
  <li><strong><a href="#request_tab">Request</a></strong></li>
  <li><strong><a href="#response_tab">Response</a></strong></li>
  <li><strong><a href="#cache_tab">Cache</a></strong></li>
@@ -287,12 +286,6 @@ tags:
 <p><img alt="cookies panel in firefox devtools network monitor, showing a number of cookie attributes including samesite" src="highlight-samesite-attribute.png" style="display: block; margin: 0px auto;"></p>
 
 <p>The <code>samesite</code> attribute has been shown since Firefox 62 ({{bug("1452715")}}).</p>
-
-<h3 id="Params_tab">Params tab</h3>
-
-<p>This tab displays the GET parameters and POST data of a request:</p>
-
-<p><img alt="" src="params.png" style="display: block; margin-left: auto; margin-right: auto;"></p>
 
 <h3 id="Request_tab">Request tab</h3>
 


### PR DESCRIPTION
There is no longer any Params tab in the Network pane in Firefox devtools.

Fixes https://github.com/mdn/content/issues/5480.