### PR TITLE
Mark webglcontextlost|restored as Bubbles: No

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.html
@@ -14,7 +14,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Bubbles</th>
-   <td>Yes</td>
+   <td>No</td>
   </tr>
   <tr>
    <th scope="row">Cancelable</th>

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.html
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.html
@@ -14,7 +14,7 @@ tags:
  <tbody>
   <tr>
    <th scope="row">Bubbles</th>
-   <td>Yes</td>
+   <td>No</td>
   </tr>
   <tr>
    <th scope="row">Cancelable</th>


### PR DESCRIPTION
By default, unless the relevant normative spec says otherwise, events don’t bubble; see https://dom.spec.whatwg.org/#ref-for-dom-event-initevent.

https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2 and https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.3 and https://www.khronos.org/registry/webgl/specs/latest/1.0/#fire-a-webgl-context-event are the relevant normative spec requirements for the `webglcontextlost` and `webglcontextrestored` events, and the specific relevent part there is:

> To fire a WebGL context event named `e` means that an event using the WebGLContextEvent interface, with its type attribute [DOM4] initialized to e, its cancelable attribute initialized to true, and its isTrusted attribute [DOM4] initialized to true, is to be dispatched at the given object.

Notice that text specifically requires initializing the “cancelable” attribute to true but doesn’t state any requirements about the “bubbles” attribute. Therefore, “bubbles” is initialized to false. (And incidentally, if that text didn’t explicitly require “cancelable to be initialized to true, it also would instead be initialized to false.)

Fixes https://github.com/mdn/content/issues/5451