### PR TITLE
Update OpenGL ES Shading Language spec link to latest version

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.html
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.html
@@ -29,7 +29,7 @@ tags:
 
 <h3 id="The_shaders">The shaders</h3>
 
-<p>A <strong>shader</strong> is a program, written using the <a href="https://www.khronos.org/files/opengles_shading_language.pdf">OpenGL ES Shading Language</a> (<strong>GLSL</strong>), that takes information about the vertices that make up a shape and generates the data needed to render the pixels onto the screen: namely, the positions of the pixels and their colors.</p>
+<p>A <strong>shader</strong> is a program, written using the <a href="https://www.khronos.org/registry/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.pdf">OpenGL ES Shading Language</a> (<strong>GLSL</strong>), that takes information about the vertices that make up a shape and generates the data needed to render the pixels onto the screen: namely, the positions of the pixels and their colors.</p>
 
 <p>There are two shader functions run when drawing WebGL content: the <strong>vertex shader</strong> and the <strong>fragment shader</strong>. You write these in GLSL and pass the text of the code into WebGL to be compiled for execution on the GPU. Together, a set of vertex and fragment shaders is called a <strong>shader program</strong>.</p>
 


### PR DESCRIPTION
The current link points to version 1.0 of the specification. This new link points to version 3.2 (currently the latest).