### PR TITLE
Put browser-compat info in front-runner for webextensions/manifest.json/*

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.author
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -38,4 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.author")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -6,6 +6,7 @@ tags:
   - WebExtensions
   - browser_specific_settings
   - manifest.json
+browser-compat: webextensions.manifest.browser_specific_settings
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -130,4 +131,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.browser_specific_settings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.chrome_url_overrides
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -91,4 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.chrome_url_overrides")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.html
@@ -6,6 +6,7 @@ tags:
   - Extensions
   - Keyboard Shortcuts
   - WebExtensions
+browser-compat: webextensions.manifest.commands
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -194,4 +195,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.commands")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.content_scripts
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -246,4 +247,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.content_scripts")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.content_security_policy
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -111,4 +112,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.content_security_policy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.default_locale
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -38,4 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.default_locale")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.description
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -38,4 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.description")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.developer
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.developer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools_page
+browser-compat: webextensions.manifest.devtools_page
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.devtools_page")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.html
@@ -6,6 +6,7 @@ tags:
   - Extensions
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest.dictionaries
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.dictionaries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest.externally_connectable
 ---
 <p>{{AddonSidebar}}{{SeeCompatTable}}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.externally_connectable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.homepage_url
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.homepage_url")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.icons
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.icons")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
@@ -6,6 +6,7 @@ tags:
   - WebExtensions
   - incognito
   - manifest.json
+browser-compat: webextensions.manifest.incognito
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.incognito")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.html
@@ -7,6 +7,7 @@ tags:
   - Overview
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -128,7 +129,7 @@ tags:
 
 <p>For a full overview of all manifest keys and their sub-keys, see the<a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json"> full <code>manifest.json</code> browser compatibility table</a>.</p>
 
-<p>{{Compat("webextensions.manifest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.manifest_version
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -39,4 +40,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.manifest_version")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/name/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.name
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.html
@@ -9,6 +9,7 @@ tags:
   - Offline
   - WebExtensions
   - google chrome
+browser-compat: webextensions.manifest.offline_enabled
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.offline_enabled")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.omnibox
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.omnibox")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
@@ -6,6 +6,7 @@ tags:
   - WebExtensions
   - manifest.json
   - optional_permissions
+browser-compat: webextensions.manifest.optional_permissions
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -101,4 +102,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.optional_permissions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.html
@@ -9,6 +9,7 @@ tags:
   - Options
   - WebExtensions
   - options_page
+browser-compat: webextensions.manifest.options_page
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.options_page")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
@@ -10,6 +10,7 @@ tags:
   - Web
   - WebExtensions
   - options_ui
+browser-compat: webextensions.manifest.options_ui
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -105,7 +106,7 @@ The latter (or {{WebExtAPIRef("runtime.Port")}} equivalents) can also be used 
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.options_ui")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.page_action
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -189,7 +190,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.page_action")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest.permissions
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -210,4 +211,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.permissions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -6,6 +6,7 @@ tags:
   - Extensions
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest.protocol_handlers
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -91,4 +92,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.protocol_handlers")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.short_name
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -38,4 +39,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.short_name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.html
@@ -3,6 +3,7 @@ title: sidebar_action
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
 tags:
   - WebExtensions
+browser-compat: webextensions.manifest.sidebar_action
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -141,7 +142,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.sidebar_action")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.html
@@ -11,6 +11,7 @@ tags:
   - Themes
   - colors
   - theme manifest
+browser-compat: webextensions.manifest.theme_experiment
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -187,4 +188,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.theme_experiment")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.html
@@ -7,6 +7,7 @@ tags:
   - WebExtensions
   - manifest.json
   - user_scripts key
+browser-compat: webextensions.manifest.user_scripts
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.user_scripts")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.version
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.version")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.version_name
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -34,4 +35,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.version_name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.web_accessible_resources
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -94,4 +95,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.web_accessible_resources")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.html
@@ -3,6 +3,7 @@ title: Match patterns in extension manifests
 slug: Mozilla/Add-ons/WebExtensions/Match_patterns
 tags:
   - WebExtensions
+browser-compat: webextensions.match_patterns.scheme
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -426,4 +427,4 @@ tags:
 
 <h3 id="scheme_2">scheme</h3>
 
-<p>{{Compat("webextensions.match_patterns.scheme",10)}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers webextensions/manifest.json/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

33 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
