### PR TITLE
Put browser-compat info in front-runner for mathml

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.html
+++ b/files/en-us/web/mathml/element/maction/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Enlivening Expressions
+browser-compat: mathml.elements.maction
 ---
 <div>{{MathMLRef}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.maction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/math/index.html
+++ b/files/en-us/web/mathml/element/math/index.html
@@ -5,6 +5,7 @@ tags:
   - MathML
   - MathML Reference
   - MathML:Element
+browser-compat: mathml.elements.math
 ---
 <div>{{MathMLRef}}</div>
 
@@ -140,7 +141,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("mathml.elements.math")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="Firefox-specific_notes">Firefox-specific notes</h2>

--- a/files/en-us/web/mathml/element/menclose/index.html
+++ b/files/en-us/web/mathml/element/menclose/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.menclose
 ---
 <div>{{MathMLRef}}</div>
 
@@ -180,7 +181,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.menclose")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/merror/index.html
+++ b/files/en-us/web/mathml/element/merror/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.merror
 ---
 <div>{{MathMLRef}}</div>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.merror")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/mathml/element/mfenced/index.html
+++ b/files/en-us/web/mathml/element/mfenced/index.html
@@ -7,6 +7,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mfenced
 ---
 <div>{{MathMLRef}}</div>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mfenced")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/mathml/element/mfrac/index.html
+++ b/files/en-us/web/mathml/element/mfrac/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mfrac
 ---
 <div>{{MathMLRef}}</div>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mfrac")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/mathml/element/mi/index.html
+++ b/files/en-us/web/mathml/element/mi/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Token Elements
+browser-compat: mathml.elements.mi
 ---
 <div>{{MathMLRef}}</div>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mi")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/mmultiscripts/index.html
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.mmultiscripts
 ---
 <div>{{MathMLRef}}</div>
 
@@ -135,7 +136,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mmultiscripts")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mn/index.html
+++ b/files/en-us/web/mathml/element/mn/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Token Elements
+browser-compat: mathml.elements.mn
 ---
 <div>{{MathMLRef}}</div>
 
@@ -111,7 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mn")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/mo/index.html
+++ b/files/en-us/web/mathml/element/mo/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Token Elements
+browser-compat: mathml.elements.mo
 ---
 <div>{{MathMLRef}}</div>
 
@@ -153,7 +154,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mo")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/mover/index.html
+++ b/files/en-us/web/mathml/element/mover/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.mover
 ---
 <div>{{MathMLRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mover")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mpadded/index.html
+++ b/files/en-us/web/mathml/element/mpadded/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mpadded
 ---
 <div>{{MathMLRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mpadded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mphantom/index.html
+++ b/files/en-us/web/mathml/element/mphantom/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mphantom
 ---
 <div>{{MathMLRef}}</div>
 
@@ -74,7 +75,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mphantom")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mroot/index.html
+++ b/files/en-us/web/mathml/element/mroot/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mroot
 ---
 <div>{{MathMLRef}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mroot")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mrow/index.html
+++ b/files/en-us/web/mathml/element/mrow/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mrow
 ---
 <div>{{MathMLRef}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mrow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/ms/index.html
+++ b/files/en-us/web/mathml/element/ms/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Token Elements
+browser-compat: mathml.elements.ms
 ---
 <div>{{MathMLRef}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.ms")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/mspace/index.html
+++ b/files/en-us/web/mathml/element/mspace/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Token Elements
+browser-compat: mathml.elements.mspace
 ---
 <div>{{MathMLRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mspace")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/msqrt/index.html
+++ b/files/en-us/web/mathml/element/msqrt/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.msqrt
 ---
 <div>{{MathMLRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.msqrt")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mstyle/index.html
+++ b/files/en-us/web/mathml/element/mstyle/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:General Layout Schemata
+browser-compat: mathml.elements.mstyle
 ---
 <div>{{MathMLRef}}</div>
 
@@ -102,7 +103,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mstyle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/msub/index.html
+++ b/files/en-us/web/mathml/element/msub/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.msub
 ---
 <div>{{MathMLRef}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.msub")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/msubsup/index.html
+++ b/files/en-us/web/mathml/element/msubsup/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.msubsup
 ---
 <div>{{MathMLRef}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.msubsup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/msup/index.html
+++ b/files/en-us/web/mathml/element/msup/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.msup
 ---
 <div>{{MathMLRef}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.msup")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mtable/index.html
+++ b/files/en-us/web/mathml/element/mtable/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Tabular Math
+browser-compat: mathml.elements.mtable
 ---
 <div>{{MathMLRef}}</div>
 
@@ -118,7 +119,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mtable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mtd/index.html
+++ b/files/en-us/web/mathml/element/mtd/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Tabular Math
+browser-compat: mathml.elements.mtd
 ---
 <div>{{MathMLRef}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mtd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/mtext/index.html
+++ b/files/en-us/web/mathml/element/mtext/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Token Elements
+browser-compat: mathml.elements.mtext
 ---
 <div>{{MathMLRef}}</div>
 
@@ -108,7 +109,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mtext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 

--- a/files/en-us/web/mathml/element/mtr/index.html
+++ b/files/en-us/web/mathml/element/mtr/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Tabular Math
+browser-compat: mathml.elements.mtr
 ---
 <div>{{MathMLRef}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.mtr")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/munder/index.html
+++ b/files/en-us/web/mathml/element/munder/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.munder
 ---
 <div>{{MathMLRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.munder")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/munderover/index.html
+++ b/files/en-us/web/mathml/element/munderover/index.html
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Script and Limit Schemata
+browser-compat: mathml.elements.munderover
 ---
 <div>{{MathMLRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.munderover")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/mathml/element/semantics/index.html
+++ b/files/en-us/web/mathml/element/semantics/index.html
@@ -5,6 +5,7 @@ tags:
   - MathML
   - MathML Reference
   - 'MathML:Element'
+browser-compat: mathml.elements.semantics
 ---
 <div>{{MathMLRef}}</div>
 
@@ -119,7 +120,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("mathml.elements.semantics")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Gecko-specific_notes">Gecko-specific notes</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers mathml/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

29 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
