### PR TITLE
Put browser-compat info in front-runner for svg

### DIFF
--- a/files/en-us/web/svg/attribute/accent-height/index.html
+++ b/files/en-us/web/svg/attribute/accent-height/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.accent-height
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.accent-height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/alignment-baseline/index.html
+++ b/files/en-us/web/svg/attribute/alignment-baseline/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/alignment-baseline
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.alignment-baseline
 ---
 <div>{{SVGRef}}</div>
 
@@ -155,7 +156,7 @@ text{
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.alignment-baseline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/alphabetic/index.html
+++ b/files/en-us/web/svg/attribute/alphabetic/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.alphabetic
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.alphabetic")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/arabic-form/index.html
+++ b/files/en-us/web/svg/attribute/arabic-form/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.glyph.arabic-form
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.glyph.arabic-form")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/ascent/index.html
+++ b/files/en-us/web/svg/attribute/ascent/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.ascent
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.ascent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/azimuth/index.html
+++ b/files/en-us/web/svg/attribute/azimuth/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feDistantLight.azimuth
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDistantLight.azimuth")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/basefrequency/index.html
+++ b/files/en-us/web/svg/attribute/basefrequency/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feTurbulence.baseFrequency
 ---
 <div>{{SVGRef}}</div>
 
@@ -105,4 +106,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feTurbulence.baseFrequency")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/baseline-shift/index.html
+++ b/files/en-us/web/svg/attribute/baseline-shift/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.baseline-shift
 ---
 <div>{{SVGRef}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.baseline-shift")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/bbox/index.html
+++ b/files/en-us/web/svg/attribute/bbox/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.bbox
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.bbox")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/bias/index.html
+++ b/files/en-us/web/svg/attribute/bias/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.bias
 ---
 <div>{{SVGRef}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.bias")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/by/index.html
+++ b/files/en-us/web/svg/attribute/by/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/by
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.by
 ---
 <div>{{SVGRef}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.by")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/cap-height/index.html
+++ b/files/en-us/web/svg/attribute/cap-height/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.cap-height
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.cap-height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/class/index.html
+++ b/files/en-us/web/svg/attribute/class/index.html
@@ -5,6 +5,7 @@ tags:
   - Reference
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.style.class
 ---
 <p>« <a href="/en-US/docs/Web/SVG/Attribute">SVG Attribute reference home</a></p>
 
@@ -132,4 +133,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.style.class")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/clip-path/index.html
+++ b/files/en-us/web/svg/attribute/clip-path/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/clip-path
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.clip-path
 ---
 <div>{{SVGRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.clip-path")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/clip-rule/index.html
+++ b/files/en-us/web/svg/attribute/clip-rule/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/clip-rule
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.clip-rule
 ---
 <p>« <a href="/en-US/docs/SVG/Attribute">SVG Attribute reference home</a></p>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.clip-rule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/clip/index.html
+++ b/files/en-us/web/svg/attribute/clip/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/clip
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.clip
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.clip")}}s</p>
+<p>{{Compat}}s</p>

--- a/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation-filters/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.color-interpolation-filters
 ---
 <div>{{SVGRef}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.color-interpolation-filters")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/color-interpolation/index.html
+++ b/files/en-us/web/svg/attribute/color-interpolation/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.color-interpolation
 ---
 <div>{{SVGRef}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.color-interpolation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/color-profile/index.html
+++ b/files/en-us/web/svg/attribute/color-profile/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.color-profile
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.color-profile")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/color-rendering/index.html
+++ b/files/en-us/web/svg/attribute/color-rendering/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/color-rendering
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.color-rendering
 ---
 <div>{{deprecated_header}}</div>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.color-rendering")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/color/index.html
+++ b/files/en-us/web/svg/attribute/color/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/color
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.color
 ---
 <div>{{SVGRef}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.color")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/conditional_processing/index.html
+++ b/files/en-us/web/svg/attribute/conditional_processing/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - SVG
+browser-compat: svg.attributes.conditional_processing
 ---
 <p>The SVG conditional processing attributes are all the attributes that can be specified on some SVG elements to control whether or not the element on which it appears should be rendered.</p>
 
@@ -34,4 +35,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.conditional_processing")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/contentscripttype/index.html
+++ b/files/en-us/web/svg/attribute/contentscripttype/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.svg.contentScriptType
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.svg.contentScriptType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/contentstyletype/index.html
+++ b/files/en-us/web/svg/attribute/contentstyletype/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.svg.contentStyleType
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.svg.contentStyleType")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/core/index.html
+++ b/files/en-us/web/svg/attribute/core/index.html
@@ -6,6 +6,7 @@ tags:
   - Intermediate
   - Reference
   - SVG
+browser-compat: svg.attributes.core
 ---
 <p>The SVG core attributes are all the common attributes that can be specified on any SVG element.</p>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.core")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/crossorigin/index.html
+++ b/files/en-us/web/svg/attribute/crossorigin/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsContent
   - Reference
   - Security
+browser-compat: api.SVGImageElement.crossOrigin
 ---
 <p>{{SVGRef}}{{draft}}</p>
 
@@ -62,7 +63,7 @@ tags:
 
 <h3 id="&lt;link_crossorigin&gt;">&lt;link crossorigin&gt;</h3>
 
-<p>{{Compat("api.SVGImageElement.crossOrigin")}}</p>
+<p>{{Compat}}</p>
 <!-- TODO: This should link to an attribute of the element instead
 https://github.com/mdn/browser-compat-data/blob/178137547bc29a79b712cec221af099329b1f4a0/svg/elements/image.json
 -->

--- a/files/en-us/web/svg/attribute/cursor/index.html
+++ b/files/en-us/web/svg/attribute/cursor/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/cursor
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.cursor
 ---
 <p>« <a href="/en-US/docs/Web/SVG/Attribute">SVG Attribute reference home</a></p>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.cursor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/data-_star_/index.html
+++ b/files/en-us/web/svg/attribute/data-_star_/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/data-*
 tags:
   - Attribute
   - SVG
+browser-compat: svg.attributes.data
 ---
 <p>{{APIRef("SVG")}}</p>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.data")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/descent/index.html
+++ b/files/en-us/web/svg/attribute/descent/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.descent
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.descent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/diffuseconstant/index.html
+++ b/files/en-us/web/svg/attribute/diffuseconstant/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feDiffuseLighting.diffuseConstant
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDiffuseLighting.diffuseConstant")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/direction/index.html
+++ b/files/en-us/web/svg/attribute/direction/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/direction
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.direction
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.direction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/display/index.html
+++ b/files/en-us/web/svg/attribute/display/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/display
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.display
 ---
 <div>{{SVGRef}}</div>
 
@@ -96,7 +97,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.display")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/divisor/index.html
+++ b/files/en-us/web/svg/attribute/divisor/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.divisor
 ---
 <div>{{SVGRef}}</div>
 
@@ -86,4 +87,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.divisor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/dominant-baseline/index.html
+++ b/files/en-us/web/svg/attribute/dominant-baseline/index.html
@@ -5,6 +5,7 @@ tags:
   - Reference
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.dominant-baseline
 ---
 <div>{{SVGRef}}</div>
 
@@ -179,7 +180,7 @@ text {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.dominant-baseline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/dur/index.html
+++ b/files/en-us/web/svg/attribute/dur/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/dur
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.dur
 ---
 <div>{{SVGRef}}</div>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.dur")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/elevation/index.html
+++ b/files/en-us/web/svg/attribute/elevation/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feDistantLight.elevation
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDistantLight.elevation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/enable-background/index.html
+++ b/files/en-us/web/svg/attribute/enable-background/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.enable-background
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.enable-background")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/events/index.html
+++ b/files/en-us/web/svg/attribute/events/index.html
@@ -8,6 +8,7 @@ tags:
   - Landing
   - NeedsUpdate
   - SVG
+browser-compat: svg.attributes.events
 ---
 <p>Event attributes always have their name starting with "on" followed by the name of the event for which they are intended. They specifies some script to run when the event of the given type is dispatched to the element on which the attributes are specified.</p>
 
@@ -41,4 +42,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.events")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/fill-opacity/index.html
+++ b/files/en-us/web/svg/attribute/fill-opacity/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/fill-opacity
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.fill-opacity
 ---
 <div>{{SVGRef}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.fill-opacity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/fill-rule/index.html
+++ b/files/en-us/web/svg/attribute/fill-rule/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/fill-rule
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.fill-rule
 ---
 <div>{{SVGRef}}</div>
 
@@ -131,7 +132,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.fill-rule")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/fill/index.html
+++ b/files/en-us/web/svg/attribute/fill/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/fill
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.fill
 ---
 <div>{{SVGRef}}</div>
 
@@ -449,6 +450,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.fill")}}</p>
+<p>{{Compat}}</p>
 
 <p class="note"><strong>Note:</strong> For information on using the <code style="white-space: nowrap;">context-fill</code> (and <code style="white-space: nowrap;">context-stroke</code>) values from HTML documents, see the documentation for the non-standard <span style="white-space: nowrap;">{{cssxref("-moz-context-properties")}}</span> property.</p>

--- a/files/en-us/web/svg/attribute/filter/index.html
+++ b/files/en-us/web/svg/attribute/filter/index.html
@@ -5,6 +5,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.attributes.presentation.filter
 ---
 <div>{{SVGRef}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.filter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/filterres/index.html
+++ b/files/en-us/web/svg/attribute/filterres/index.html
@@ -6,6 +6,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.elements.filter.filterRes
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.filter.filterRes")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/filterunits/index.html
+++ b/files/en-us/web/svg/attribute/filterunits/index.html
@@ -6,6 +6,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.elements.filter.filterUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.filter.filterUnits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/flood-color/index.html
+++ b/files/en-us/web/svg/attribute/flood-color/index.html
@@ -5,6 +5,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.attributes.presentation.flood-color
 ---
 <div>{{SVGRef}}</div>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.flood-color")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/flood-opacity/index.html
+++ b/files/en-us/web/svg/attribute/flood-opacity/index.html
@@ -5,6 +5,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.attributes.presentation.flood-opacity
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.flood-opacity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-family/index.html
+++ b/files/en-us/web/svg/attribute/font-family/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/font-family
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.font-family
 ---
 <div>{{SVGRef}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-family")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-size-adjust/index.html
+++ b/files/en-us/web/svg/attribute/font-size-adjust/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/font-size-adjust
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.font-size-adjust
 ---
 <p>The <code>font-size-adjust</code> attribute allows authors to specify an aspect value for an element that will preserve the x-height of the first choice font in a substitute font.</p>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-size-adjust")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-size/index.html
+++ b/files/en-us/web/svg/attribute/font-size/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/font-size
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.font-size
 ---
 <div>{{SVGRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-size")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-stretch/index.html
+++ b/files/en-us/web/svg/attribute/font-stretch/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.font-stretch
 ---
 <div>{{SVGRef}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-stretch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-style/index.html
+++ b/files/en-us/web/svg/attribute/font-style/index.html
@@ -11,6 +11,7 @@ tags:
   - Text
   - Type
   - font
+browser-compat: svg.attributes.presentation.font-style
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-style")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-variant/index.html
+++ b/files/en-us/web/svg/attribute/font-variant/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/font-variant
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.font-variant
 ---
 <div>{{SVGRef}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-variant")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/font-weight/index.html
+++ b/files/en-us/web/svg/attribute/font-weight/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/font-weight
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.font-weight
 ---
 <div>{{SVGRef}}</div>
 
@@ -80,7 +81,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.font-weight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/format/index.html
+++ b/files/en-us/web/svg/attribute/format/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.altGlyph.format
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -107,7 +108,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.altGlyph.format")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/fr/index.html
+++ b/files/en-us/web/svg/attribute/fr/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/fr
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.radialGradient.fr
 ---
 <div>{{SVGRef}}</div>
 
@@ -102,4 +103,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.radialGradient.fr")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/from/index.html
+++ b/files/en-us/web/svg/attribute/from/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/From
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.from
 ---
 <div>{{SVGRef}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.from")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/fx/index.html
+++ b/files/en-us/web/svg/attribute/fx/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/fx
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.radialGradient.fx
 ---
 <div>{{SVGRef}}</div>
 
@@ -107,4 +108,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.radialGradient.fx")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/fy/index.html
+++ b/files/en-us/web/svg/attribute/fy/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/fy
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.radialGradient.fy
 ---
 <div>{{SVGRef}}</div>
 
@@ -107,4 +108,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.radialGradient.fy")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/g1/index.html
+++ b/files/en-us/web/svg/attribute/g1/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.hkern.g1
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hkern.g1")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/g2/index.html
+++ b/files/en-us/web/svg/attribute/g2/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.hkern.g2
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hkern.g2")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/glyph-name/index.html
+++ b/files/en-us/web/svg/attribute/glyph-name/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.glyph.glyph-name
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.glyph.glyph-name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/glyph-orientation-horizontal/index.html
+++ b/files/en-us/web/svg/attribute/glyph-orientation-horizontal/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.glyph-orientation-horizontal
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.glyph-orientation-horizontal")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/glyph-orientation-vertical/index.html
+++ b/files/en-us/web/svg/attribute/glyph-orientation-vertical/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.glyph-orientation-vertical
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.glyph-orientation-vertical")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/glyphref/index.html
+++ b/files/en-us/web/svg/attribute/glyphref/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.altGlyph.glyphRef
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.altGlyph.glyphRef")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/gradienttransform/index.html
+++ b/files/en-us/web/svg/attribute/gradienttransform/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/gradientTransform
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.linearGradient.gradientTransform
 ---
 <div>{{SVGRef}}</div>
 
@@ -105,7 +106,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.linearGradient.gradientTransform")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/hanging/index.html
+++ b/files/en-us/web/svg/attribute/hanging/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.hanging
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.hanging")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/horiz-adv-x/index.html
+++ b/files/en-us/web/svg/attribute/horiz-adv-x/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font.horiz-adv-x
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font.horiz-adv-x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/horiz-origin-x/index.html
+++ b/files/en-us/web/svg/attribute/horiz-origin-x/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font.horiz-origin-x
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font.horiz-origin-x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/horiz-origin-y/index.html
+++ b/files/en-us/web/svg/attribute/horiz-origin-y/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font.horiz-origin-y
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font.horiz-origin-y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/href/index.html
+++ b/files/en-us/web/svg/attribute/href/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/href
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.href
 ---
 <div>{{SVGRef}}</div>
 
@@ -393,7 +394,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.href")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/id/index.html
+++ b/files/en-us/web/svg/attribute/id/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/id
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.core.id
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.style.class")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/ideographic/index.html
+++ b/files/en-us/web/svg/attribute/ideographic/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.ideographic
 ---
 <div>dep{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.ideographic")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/image-rendering/index.html
+++ b/files/en-us/web/svg/attribute/image-rendering/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.image-rendering
 ---
 <div>{{SVGRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.image-rendering")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/k/index.html
+++ b/files/en-us/web/svg/attribute/k/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.hkern.k
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hkern.k")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/k1/index.html
+++ b/files/en-us/web/svg/attribute/k1/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feComposite.k1
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feComposite.k1")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/k2/index.html
+++ b/files/en-us/web/svg/attribute/k2/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feComposite.k2
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feComposite.k2")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/k3/index.html
+++ b/files/en-us/web/svg/attribute/k3/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feComposite.k3
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feComposite.k3")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/k4/index.html
+++ b/files/en-us/web/svg/attribute/k4/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feComposite.k4
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feComposite.k4")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/kernelmatrix/index.html
+++ b/files/en-us/web/svg/attribute/kernelmatrix/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.kernelMatrix
 ---
 <div>{{SVGRef}}</div>
 
@@ -92,4 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.kernelMatrix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/kerning/index.html
+++ b/files/en-us/web/svg/attribute/kerning/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.kerning
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.kerning")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/keypoints/index.html
+++ b/files/en-us/web/svg/attribute/keypoints/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/keyPoints
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animateMotion.keyPoints
 ---
 <div>{{SVGRef}}</div>
 
@@ -92,4 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animateMotion.keyPoints")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/keysplines/index.html
+++ b/files/en-us/web/svg/attribute/keysplines/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/keySplines
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.keySplines
 ---
 <div>{{SVGRef}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.keySplines")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/keytimes/index.html
+++ b/files/en-us/web/svg/attribute/keytimes/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/keyTimes
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.keyTimes
 ---
 <div>{{SVGRef}}</div>
 
@@ -92,4 +93,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.keyTimes")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/lang/index.html
+++ b/files/en-us/web/svg/attribute/lang/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/lang
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.core.lang
 ---
 <div>{{SVGRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.core.lang")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/lengthadjust/index.html
+++ b/files/en-us/web/svg/attribute/lengthadjust/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/lengthAdjust
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.text.lengthAdjust
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.text.lengthAdjust")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/letter-spacing/index.html
+++ b/files/en-us/web/svg/attribute/letter-spacing/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/letter-spacing
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.letter-spacing
 ---
 <div>{{SVGRef}}</div>
 
@@ -81,7 +82,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.letter-spacing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/lighting-color/index.html
+++ b/files/en-us/web/svg/attribute/lighting-color/index.html
@@ -5,6 +5,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.attributes.presentation.lighting-color
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.lighting-color")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/limitingconeangle/index.html
+++ b/files/en-us/web/svg/attribute/limitingconeangle/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feSpotLight.limitingConeAngle
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,4 +84,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpotLight.limitingConeAngle")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/marker-end/index.html
+++ b/files/en-us/web/svg/attribute/marker-end/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/marker-end
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.marker-end
 ---
 <div>{{SVGRef}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.marker-end")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/marker-mid/index.html
+++ b/files/en-us/web/svg/attribute/marker-mid/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/marker-mid
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.marker-mid
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.marker-mid")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/marker-start/index.html
+++ b/files/en-us/web/svg/attribute/marker-start/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/marker-start
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.marker-start
 ---
 <div>{{SVGRef}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.marker-start")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/markerheight/index.html
+++ b/files/en-us/web/svg/attribute/markerheight/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.marker.markerHeight
 ---
 <div>{{SVGRef}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.marker.markerHeight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/markerunits/index.html
+++ b/files/en-us/web/svg/attribute/markerunits/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.marker.markerUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.marker.markerUnits")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/markerwidth/index.html
+++ b/files/en-us/web/svg/attribute/markerwidth/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.marker.markerWidth
 ---
 <div>{{SVGRef}}</div>
 
@@ -67,7 +68,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.marker.markerWidth")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/mask/index.html
+++ b/files/en-us/web/svg/attribute/mask/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/mask
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.mask
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.mask")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/maskcontentunits/index.html
+++ b/files/en-us/web/svg/attribute/maskcontentunits/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/maskContentUnits
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.mask.maskContentUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -99,4 +100,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.mask.maskContentUnits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/maskunits/index.html
+++ b/files/en-us/web/svg/attribute/maskunits/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/maskUnits
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.mask.maskUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -101,4 +102,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.mask.maskUnits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/mathematical/index.html
+++ b/files/en-us/web/svg/attribute/mathematical/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.mathematical
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.mathematical")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/max/index.html
+++ b/files/en-us/web/svg/attribute/max/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/max
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.max
 ---
 <div>{{SVGRef}}</div>
 
@@ -82,7 +83,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.max")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/media/index.html
+++ b/files/en-us/web/svg/attribute/media/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/media
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.style.media
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.style.media")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/method/index.html
+++ b/files/en-us/web/svg/attribute/method/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.textPath.method
 ---
 <div>{{SVGRef}}{{SeeCompatTable}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.textPath.method")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/min/index.html
+++ b/files/en-us/web/svg/attribute/min/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/min
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.min
 ---
 <div>{{SVGRef}}</div>
 
@@ -82,4 +83,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.min")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/mode/index.html
+++ b/files/en-us/web/svg/attribute/mode/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feBlend.mode
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,4 +88,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feBlend.mode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/numoctaves/index.html
+++ b/files/en-us/web/svg/attribute/numoctaves/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feTurbulence.numOctaves
 ---
 <div>{{SVGRef}}</div>
 
@@ -104,7 +105,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feTurbulence.numOctaves")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/onclick/index.html
+++ b/files/en-us/web/svg/attribute/onclick/index.html
@@ -5,6 +5,7 @@ tags:
   - SVG
   - SVG Attribute
   - events
+browser-compat: svg.attributes.events.global.onclick
 ---
 <div>{{SVGRef}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.events.global.onclick")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/opacity/index.html
+++ b/files/en-us/web/svg/attribute/opacity/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/opacity
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.opacity
 ---
 <div>{{SVGRef}}</div>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.opacity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/order/index.html
+++ b/files/en-us/web/svg/attribute/order/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.order
 ---
 <div>{{SVGRef}}</div>
 
@@ -90,4 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.order")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/orient/index.html
+++ b/files/en-us/web/svg/attribute/orient/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/orient
 tags:
   - SVG
   - SVG Attr
+browser-compat: svg.elements.marker.orient
 ---
 <div>{{SVGRef}}</div>
 
@@ -108,4 +109,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.marker.orient")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/orientation/index.html
+++ b/files/en-us/web/svg/attribute/orientation/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.glyph.orientation
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.glyph.orientation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/overflow/index.html
+++ b/files/en-us/web/svg/attribute/overflow/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/overflow
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.overflow
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.overflow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/paint-order/index.html
+++ b/files/en-us/web/svg/attribute/paint-order/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/paint-order
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.paint-order
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.paint-order")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/panose-1/index.html
+++ b/files/en-us/web/svg/attribute/panose-1/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.panose-1
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.panose-1")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/patterncontentunits/index.html
+++ b/files/en-us/web/svg/attribute/patterncontentunits/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/patternContentUnits
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.pattern.patternContentUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -107,4 +108,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.pattern.patternContentUnits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/patterntransform/index.html
+++ b/files/en-us/web/svg/attribute/patterntransform/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/patternTransform
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.pattern.patternTransform
 ---
 <div>{{SVGRef}}</div>
 
@@ -86,4 +87,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.pattern.patternTransform")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/patternunits/index.html
+++ b/files/en-us/web/svg/attribute/patternunits/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/patternUnits
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.pattern.patternUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -95,4 +96,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.pattern.patternUnits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/pointer-events/index.html
+++ b/files/en-us/web/svg/attribute/pointer-events/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/pointer-events
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.pointer-events
 ---
 <div>{{SVGRef}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.pointer-events")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/pointsatx/index.html
+++ b/files/en-us/web/svg/attribute/pointsatx/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feSpotLight.pointsAtX
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpotLight.pointsAtX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/pointsaty/index.html
+++ b/files/en-us/web/svg/attribute/pointsaty/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feSpotLight.pointsAtY
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpotLight.pointsAtY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/pointsatz/index.html
+++ b/files/en-us/web/svg/attribute/pointsatz/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feSpotLight.pointsAtZ
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpotLight.pointsAtZ")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/presentation/index.html
+++ b/files/en-us/web/svg/attribute/presentation/index.html
@@ -7,6 +7,7 @@ tags:
   - Draft
   - Reference
   - SVG
+browser-compat: svg.attributes.presentation
 ---
 <p>{{draft}}</p>
 
@@ -276,4 +277,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/preservealpha/index.html
+++ b/files/en-us/web/svg/attribute/preservealpha/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.preserveAlpha
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.preserveAlpha")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/primitiveunits/index.html
+++ b/files/en-us/web/svg/attribute/primitiveunits/index.html
@@ -6,6 +6,7 @@ tags:
   - SVG
   - SVG Attribute
   - SVG Filter
+browser-compat: svg.elements.filter.primitiveUnits
 ---
 <div>{{SVGRef}}</div>
 
@@ -67,4 +68,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.filter.primitiveUnits")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/radius/index.html
+++ b/files/en-us/web/svg/attribute/radius/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feMorphology.radius
 ---
 <div>{{SVGRef}}</div>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feMorphology.radius")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/repeatcount/index.html
+++ b/files/en-us/web/svg/attribute/repeatcount/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/repeatCount
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.repeatCount
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.repeatCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/repeatdur/index.html
+++ b/files/en-us/web/svg/attribute/repeatdur/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/repeatDur
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.repeatDur
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.repeatDur")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/requiredfeatures/index.html
+++ b/files/en-us/web/svg/attribute/requiredfeatures/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/requiredFeatures
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.conditional_processing.requiredFeatures
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -624,7 +625,7 @@ text{
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.conditional_processing.requiredFeatures")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/restart/index.html
+++ b/files/en-us/web/svg/attribute/restart/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/restart
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.animate.restart
 ---
 <div>{{SVGRef}}</div>
 
@@ -99,4 +100,4 @@ a {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate.restart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/scale/index.html
+++ b/files/en-us/web/svg/attribute/scale/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feDisplacementMap.scale
 ---
 <div>{{SVGRef}}</div>
 
@@ -90,4 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDisplacementMap.scale")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/seed/index.html
+++ b/files/en-us/web/svg/attribute/seed/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feTurbulence.seed
 ---
 <div>{{SVGRef}}</div>
 
@@ -96,4 +97,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feTurbulence.seed")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/shape-rendering/index.html
+++ b/files/en-us/web/svg/attribute/shape-rendering/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/shape-rendering
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.shape-rendering
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.shape-rendering")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/side/index.html
+++ b/files/en-us/web/svg/attribute/side/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/side
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.textPath.side
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,4 +85,4 @@ text {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.textPath.side")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/slope/index.html
+++ b/files/en-us/web/svg/attribute/slope/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVGAttribute
+browser-compat: svg.elements.font-face.slope
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.slope")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/spacing/index.html
+++ b/files/en-us/web/svg/attribute/spacing/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.textPath.spacing
 ---
 <div>{{SVGRef}}</div>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.textPath.spacing")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/specularconstant/index.html
+++ b/files/en-us/web/svg/attribute/specularconstant/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feSpecularLighting.specularConstant
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpecularLighting.specularConstant")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/spreadmethod/index.html
+++ b/files/en-us/web/svg/attribute/spreadmethod/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/spreadMethod
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.spreadMethod
 ---
 <div>{{SVGRef}}</div>
 
@@ -158,4 +159,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.spreadMethod")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/startoffset/index.html
+++ b/files/en-us/web/svg/attribute/startoffset/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/startOffset
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.textPath.startOffset
 ---
 <div>{{SVGRef}}</div>
 
@@ -98,4 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.textPath.startOffset")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/stddeviation/index.html
+++ b/files/en-us/web/svg/attribute/stddeviation/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feGaussianBlur.stdDeviation
 ---
 <div>{{SVGRef}}</div>
 
@@ -90,4 +91,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feGaussianBlur.stdDeviation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/stemh/index.html
+++ b/files/en-us/web/svg/attribute/stemh/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.stemh
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.stemh")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/stemv/index.html
+++ b/files/en-us/web/svg/attribute/stemv/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.stemv
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.stemv")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/stitchtiles/index.html
+++ b/files/en-us/web/svg/attribute/stitchtiles/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feTurbulence.stitchTiles
 ---
 <div>{{SVGRef}}</div>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feTurbulence.stitchTiles")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/stop-color/index.html
+++ b/files/en-us/web/svg/attribute/stop-color/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stop-color
 ---
 <div>{{SVGRef}}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stop-color")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/stop-opacity/index.html
+++ b/files/en-us/web/svg/attribute/stop-opacity/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.stop.stop-opacity
 ---
 <div>{{SVGRef}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.stop.stop-opacity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/string/index.html
+++ b/files/en-us/web/svg/attribute/string/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face-format.string
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face-format.string")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/stroke-dasharray/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dasharray/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke-dasharray
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke-dasharray
 ---
 <div>{{SVGRef}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-dasharray")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
+++ b/files/en-us/web/svg/attribute/stroke-dashoffset/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke-dashoffset
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke-dashoffset
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-dashoffset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-linecap/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linecap/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke-linecap
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke-linecap
 ---
 <div>{{SVGRef}}</div>
 
@@ -163,7 +164,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-linecap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-linejoin/index.html
+++ b/files/en-us/web/svg/attribute/stroke-linejoin/index.html
@@ -6,6 +6,7 @@ tags:
   - SVG
   - SVG Attribute
   - stroke-linejoin
+browser-compat: svg.attributes.presentation.stroke-linejoin
 ---
 <div>{{SVGRef}}</div>
 
@@ -301,4 +302,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-linejoin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
+++ b/files/en-us/web/svg/attribute/stroke-miterlimit/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke-miterlimit
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke-miterlimit
 ---
 <div>{{SVGRef}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-miterlimit")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-opacity/index.html
+++ b/files/en-us/web/svg/attribute/stroke-opacity/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke-opacity
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke-opacity
 ---
 <div>{{SVGRef}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-opacity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/stroke-width/index.html
+++ b/files/en-us/web/svg/attribute/stroke-width/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke-width
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke-width
 ---
 <div>{{SVGRef}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke-width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/svg/attribute/stroke/index.html
+++ b/files/en-us/web/svg/attribute/stroke/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/stroke
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.stroke
 ---
 <div>{{SVGRef}}</div>
 
@@ -85,6 +86,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.stroke")}}</p>
+<p>{{Compat}}</p>
 
 <p class="note"><strong>Note:</strong> For information on using the <code style="white-space: nowrap;">context-stroke</code> (and <code style="white-space: nowrap;">context-fill</code>) values from HTML documents, see the documentation for the non-standard <span style="white-space: nowrap;">{{cssxref("-moz-context-properties")}}</span> property.</p>

--- a/files/en-us/web/svg/attribute/style/index.html
+++ b/files/en-us/web/svg/attribute/style/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/style
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.style.style
 ---
 <div>{{SVGRef}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.style.style")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/styling/index.html
+++ b/files/en-us/web/svg/attribute/styling/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsExample
   - Reference
   - SVG
+browser-compat: svg.attributes.style
 ---
 <p>The SVG styling attributes are all the attributes that can be specified on any SVG element to apply CSS styling effects.</p>
 
@@ -32,4 +33,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.style")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/systemlanguage/index.html
+++ b/files/en-us/web/svg/attribute/systemlanguage/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/systemLanguage
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.conditional_processing.systemLanguage
 ---
 <div>{{SVGRef}}</div>
 
@@ -79,4 +80,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.conditional_processing.systemLanguage")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/tabindex/index.html
+++ b/files/en-us/web/svg/attribute/tabindex/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/tabindex
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.core.tabindex
 ---
 <div>{{SVGRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.core.tabindex")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/target/index.html
+++ b/files/en-us/web/svg/attribute/target/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/target
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.a.target
 ---
 <div>{{SVGRef}}</div>
 
@@ -105,4 +106,4 @@ text {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.a.target")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/targetx/index.html
+++ b/files/en-us/web/svg/attribute/targetx/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.targetX
 ---
 <div>{{SVGRef}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.targetX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/targety/index.html
+++ b/files/en-us/web/svg/attribute/targety/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feConvolveMatrix.targetY
 ---
 <div>{{SVGRef}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix.targetY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/text-anchor/index.html
+++ b/files/en-us/web/svg/attribute/text-anchor/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/text-anchor
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.text-anchor
 ---
 <div>{{SVGRef}}</div>
 
@@ -100,4 +101,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.text-anchor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/text-decoration/index.html
+++ b/files/en-us/web/svg/attribute/text-decoration/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/text-decoration
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.text-decoration
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.text-decoration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/text-rendering/index.html
+++ b/files/en-us/web/svg/attribute/text-rendering/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/text-rendering
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.text-rendering
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.text-rendering")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/textlength/index.html
+++ b/files/en-us/web/svg/attribute/textlength/index.html
@@ -12,6 +12,7 @@ tags:
   - length
   - size
   - width
+browser-compat: svg.attributes.textLength
 ---
 <div>{{SVGRef}}</div>
 
@@ -162,7 +163,7 @@ widthSlider.dispatchEvent(new Event("input"));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.textLength")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/transform-origin/index.html
+++ b/files/en-us/web/svg/attribute/transform-origin/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/transform-origin
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.transform-origin
 ---
 <p>{{SVGRef()}}</p>
 
@@ -86,4 +87,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.transform-origin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/u1/index.html
+++ b/files/en-us/web/svg/attribute/u1/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.hkern.u1
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hkern.u1")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/u2/index.html
+++ b/files/en-us/web/svg/attribute/u2/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.hkern.u2
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hkern.u2")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/unicode-bidi/index.html
+++ b/files/en-us/web/svg/attribute/unicode-bidi/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/unicode-bidi
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.unicode-bidi
 ---
 <div>{{SVGRef}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.unicode-bidi")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/unicode-range/index.html
+++ b/files/en-us/web/svg/attribute/unicode-range/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.unicode-range
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.unicode-range")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/unicode/index.html
+++ b/files/en-us/web/svg/attribute/unicode/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.glyph.unicode
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -65,4 +66,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.glyph.unicode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/units-per-em/index.html
+++ b/files/en-us/web/svg/attribute/units-per-em/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.units-per-em
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.units-per-em")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/v-alphabetic/index.html
+++ b/files/en-us/web/svg/attribute/v-alphabetic/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.v-alphabetic
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.v-alphabetic")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/v-hanging/index.html
+++ b/files/en-us/web/svg/attribute/v-hanging/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.v-hanging
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.v-hanging")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/v-ideographic/index.html
+++ b/files/en-us/web/svg/attribute/v-ideographic/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.v-ideographic
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.v-ideographic")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/v-mathematical/index.html
+++ b/files/en-us/web/svg/attribute/v-mathematical/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.v-mathematical
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.v-mathematical")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/vector-effect/index.html
+++ b/files/en-us/web/svg/attribute/vector-effect/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/vector-effect
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.vector-effect
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.vector-effect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/version/index.html
+++ b/files/en-us/web/svg/attribute/version/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.svg.version
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.svg.version")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/vert-adv-y/index.html
+++ b/files/en-us/web/svg/attribute/vert-adv-y/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font.vert-adv-y
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font.vert-adv-y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/vert-origin-x/index.html
+++ b/files/en-us/web/svg/attribute/vert-origin-x/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font.vert-origin-x
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font.vert-origin-x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/vert-origin-y/index.html
+++ b/files/en-us/web/svg/attribute/vert-origin-y/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font.vert-origin-y
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font.vert-origin-y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/viewtarget/index.html
+++ b/files/en-us/web/svg/attribute/viewtarget/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/viewTarget
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.view.viewTarget
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.view.viewTarget")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/visibility/index.html
+++ b/files/en-us/web/svg/attribute/visibility/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/visibility
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.visibility
 ---
 <div>{{SVGRef}}</div>
 
@@ -136,7 +137,7 @@ button {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.visibility")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/widths/index.html
+++ b/files/en-us/web/svg/attribute/widths/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.widths
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.widths")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/word-spacing/index.html
+++ b/files/en-us/web/svg/attribute/word-spacing/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Attribute/word-spacing
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.word-spacing
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.word-spacing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/writing-mode/index.html
+++ b/files/en-us/web/svg/attribute/writing-mode/index.html
@@ -5,6 +5,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.presentation.writing-mode
 ---
 <div>{{SVGRef}}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.presentation.writing-mode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/x-height/index.html
+++ b/files/en-us/web/svg/attribute/x-height/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.font-face.x-height
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face.x-height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/xchannelselector/index.html
+++ b/files/en-us/web/svg/attribute/xchannelselector/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feDisplacementMap.xChannelSelector
 ---
 <div>{{SVGRef}}</div>
 
@@ -99,4 +100,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDisplacementMap.xChannelSelector")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/xlink_colon_arcrole/index.html
+++ b/files/en-us/web/svg/attribute/xlink_colon_arcrole/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.xlink.xlink_arcrole
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.xlink.xlink_arcrole")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/xlink_colon_show/index.html
+++ b/files/en-us/web/svg/attribute/xlink_colon_show/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.xlink.xlink_show
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.xlink.xlink_show")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/xlink_colon_title/index.html
+++ b/files/en-us/web/svg/attribute/xlink_colon_title/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.xlink.xlink_title
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.xlink.xlink_title")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/xlink_colon_type/index.html
+++ b/files/en-us/web/svg/attribute/xlink_colon_type/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.xlink.xlink_type
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.xlink.xlink_type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/xml_colon_base/index.html
+++ b/files/en-us/web/svg/attribute/xml_colon_base/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.core.xml_base
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.core.xml_base")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.html
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.html
@@ -4,6 +4,7 @@ slug: 'Web/SVG/Attribute/xml:lang'
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.core.xml_lang
 ---
 <div>{{SVGRef}}</div>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.core.xml_lang")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/attribute/xml_colon_space/index.html
+++ b/files/en-us/web/svg/attribute/xml_colon_space/index.html
@@ -4,6 +4,7 @@ slug: 'Web/SVG/Attribute/xml:space'
 tags:
   - SVG
   - SVG Attribute
+browser-compat: svg.attributes.core.xml_space
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -96,4 +97,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.attributes.core.xml_space")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/ychannelselector/index.html
+++ b/files/en-us/web/svg/attribute/ychannelselector/index.html
@@ -5,6 +5,7 @@ tags:
   - Filters
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.feDisplacementMap.yChannelSelector
 ---
 <div>{{SVGRef}}</div>
 
@@ -98,4 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDisplacementMap.yChannelSelector")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/attribute/zoomandpan/index.html
+++ b/files/en-us/web/svg/attribute/zoomandpan/index.html
@@ -5,6 +5,7 @@ tags:
   - Deprecated
   - SVG
   - SVG Attribute
+browser-compat: svg.elements.svg.zoomAndPan
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.svg.zoomAndPan")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/a/index.html
+++ b/files/en-us/web/svg/element/a/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Container
+browser-compat: svg.elements.a
 ---
 <div>{{SVGRef}}</div>
 
@@ -142,4 +143,4 @@ svg|a:hover, svg|a:active {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.a")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/altglyph/index.html
+++ b/files/en-us/web/svg/element/altglyph/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.altGlyph
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.altGlyph")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/altglyphdef/index.html
+++ b/files/en-us/web/svg/element/altglyphdef/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.altGlyphDef
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.altGlyphDef")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/altglyphitem/index.html
+++ b/files/en-us/web/svg/element/altglyphitem/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.altGlyphItem
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.altGlyphItem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/animate/index.html
+++ b/files/en-us/web/svg/element/animate/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Animation
+browser-compat: svg.elements.animate
 ---
 <div>{{SVGRef}}</div>
 
@@ -94,4 +95,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/animatecolor/index.html
+++ b/files/en-us/web/svg/element/animatecolor/index.html
@@ -6,6 +6,7 @@ tags:
   - Element
   - SVG
   - SVG Animation
+browser-compat: svg.elements.animateColor
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animateColor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/animatemotion/index.html
+++ b/files/en-us/web/svg/element/animatemotion/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Animation
+browser-compat: svg.elements.animateMotion
 ---
 <div>{{SVGRef}}</div>
 
@@ -108,7 +109,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animateMotion")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/animatetransform/index.html
+++ b/files/en-us/web/svg/element/animatetransform/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Animation
+browser-compat: svg.elements.animateTransform
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.animateTransform")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/circle/index.html
+++ b/files/en-us/web/svg/element/circle/index.html
@@ -7,6 +7,7 @@ tags:
   - Graphics
   - Reference
   - SVG
+browser-compat: svg.elements.circle
 ---
 <div>{{SVGRef}}</div>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.circle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/clippath/index.html
+++ b/files/en-us/web/svg/element/clippath/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - Reference
   - SVG
+browser-compat: svg.elements.clipPath
 ---
 <div>{{SVGRef}}</div>
 
@@ -103,7 +104,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.clipPath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Related">Related</h2>
 

--- a/files/en-us/web/svg/element/cursor/index.html
+++ b/files/en-us/web/svg/element/cursor/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsExample
   - Reference
   - SVG
+browser-compat: svg.elements.cursor
 ---
 <div>{{SVGRef}}{{Deprecated_Header}}
 <div class="notecard note">
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.cursor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/defs/index.html
+++ b/files/en-us/web/svg/element/defs/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Element/defs
 tags:
   - SVG
   - SVG Container
+browser-compat: svg.elements.defs
 ---
 <div>{{SVGRef}}</div>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.defs")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/desc/index.html
+++ b/files/en-us/web/svg/element/desc/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Descriptive
+browser-compat: svg.elements.desc
 ---
 <div>{{SVGRef}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.desc")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/discard/index.html
+++ b/files/en-us/web/svg/element/discard/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Animation
+browser-compat: svg.elements.discard
 ---
 <div>{{SVGRef}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.discard")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/ellipse/index.html
+++ b/files/en-us/web/svg/element/ellipse/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.ellipse
 ---
 <div>{{SVGRef}}</div>
 
@@ -98,7 +99,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.ellipse")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/feblend/index.html
+++ b/files/en-us/web/svg/element/feblend/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feBlend
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feBlend")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fecolormatrix/index.html
+++ b/files/en-us/web/svg/element/fecolormatrix/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feColorMatrix
 ---
 <div>{{SVGRef}}</div>
 
@@ -187,7 +188,7 @@ A' | 0 0 0 1 0 |
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feColorMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fecomponenttransfer/index.html
+++ b/files/en-us/web/svg/element/fecomponenttransfer/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feComponentTransfer
 ---
 <div>{{SVGRef}}</div>
 
@@ -141,7 +142,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feComponentTransfer")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fecomposite/index.html
+++ b/files/en-us/web/svg/element/fecomposite/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feComposite
 ---
 <div>{{SVGRef}}</div>
 
@@ -262,7 +263,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feComposite")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/feconvolvematrix/index.html
+++ b/files/en-us/web/svg/element/feconvolvematrix/index.html
@@ -6,6 +6,7 @@ tags:
   - Filters
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feConvolveMatrix
 ---
 <div>{{SVGRef}}</div>
 
@@ -131,7 +132,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feConvolveMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fediffuselighting/index.html
+++ b/files/en-us/web/svg/element/fediffuselighting/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feDiffuseLighting
 ---
 <div>{{SVGRef}}</div>
 
@@ -132,7 +133,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDiffuseLighting")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fedisplacementmap/index.html
+++ b/files/en-us/web/svg/element/fedisplacementmap/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feDisplacementMap
 ---
 <div>{{SVGRef}}</div>
 
@@ -89,7 +90,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDisplacementMap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fedistantlight/index.html
+++ b/files/en-us/web/svg/element/fedistantlight/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Light Source
+browser-compat: svg.elements.feDistantLight
 ---
 <div>{{SVGRef}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDistantLight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fedropshadow/index.html
+++ b/files/en-us/web/svg/element/fedropshadow/index.html
@@ -6,6 +6,7 @@ tags:
   - Filters
   - Reference
   - SVG
+browser-compat: svg.elements.feDropShadow
 ---
 <div>{{SVGRef}}</div>
 
@@ -98,4 +99,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feDropShadow")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/feflood/index.html
+++ b/files/en-us/web/svg/element/feflood/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feFlood
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,7 +84,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("svg.elements.feFlood")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/svg/element/fefunca/index.html
+++ b/files/en-us/web/svg/element/fefunca/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feFuncA
 ---
 <div>{{SVGRef}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feFuncA")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fefuncb/index.html
+++ b/files/en-us/web/svg/element/fefuncb/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feFuncB
 ---
 <div>{{SVGRef}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feFuncB")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fefuncg/index.html
+++ b/files/en-us/web/svg/element/fefuncg/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feFuncG
 ---
 <div>{{SVGRef}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feFuncG")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fefuncr/index.html
+++ b/files/en-us/web/svg/element/fefuncr/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feFuncR
 ---
 <div>{{SVGRef}}</div>
 
@@ -59,7 +60,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feFuncR")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fegaussianblur/index.html
+++ b/files/en-us/web/svg/element/fegaussianblur/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feGaussianBlur
 ---
 <div>{{SVGRef}}</div>
 
@@ -113,7 +114,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feGaussianBlur")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/feimage/index.html
+++ b/files/en-us/web/svg/element/feimage/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feImage
 ---
 <div>{{SVGRef}}</div>
 
@@ -84,7 +85,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feImage")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/femerge/index.html
+++ b/files/en-us/web/svg/element/femerge/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feMerge
 ---
 <div>{{SVGRef}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feMerge")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/femergenode/index.html
+++ b/files/en-us/web/svg/element/femergenode/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feMergeNode
 ---
 <p>The <code>feMergeNode</code> takes the result of another filter to be processed by its parent {{ SVGElement("feMerge") }}.</p>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feMergeNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/femorphology/index.html
+++ b/files/en-us/web/svg/element/femorphology/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsMobileBrowserCompatibility
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feMorphology
 ---
 <div>{{SVGRef}}</div>
 
@@ -138,7 +139,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feMorphology")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/feoffset/index.html
+++ b/files/en-us/web/svg/element/feoffset/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feOffset
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feOffset")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fepointlight/index.html
+++ b/files/en-us/web/svg/element/fepointlight/index.html
@@ -7,6 +7,7 @@ tags:
   - SVG
   - SVG Filter
   - SVG Light Source
+browser-compat: svg.elements.fePointLight
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.fePointLight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fespecularlighting/index.html
+++ b/files/en-us/web/svg/element/fespecularlighting/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsMobileBrowserCompatibility
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feSpecularLighting
 ---
 <div>{{SVGRef}}</div>
 
@@ -89,7 +90,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpecularLighting")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fespotlight/index.html
+++ b/files/en-us/web/svg/element/fespotlight/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feSpotLight
 ---
 <div>{{SVGRef}}</div>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feSpotLight")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/fetile/index.html
+++ b/files/en-us/web/svg/element/fetile/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsMobileBrowserCompatibility
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feTile
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feTile")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/feturbulence/index.html
+++ b/files/en-us/web/svg/element/feturbulence/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Filter
+browser-compat: svg.elements.feTurbulence
 ---
 <div>{{SVGRef}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.feTurbulence")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/filter/index.html
+++ b/files/en-us/web/svg/element/filter/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - Reference
   - SVG
+browser-compat: svg.elements.filter
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.filter")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/font-face-format/index.html
+++ b/files/en-us/web/svg/element/font-face-format/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.font-face-format
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face-format")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/font-face-name/index.html
+++ b/files/en-us/web/svg/element/font-face-name/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.font-face-name
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face-name")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/font-face-src/index.html
+++ b/files/en-us/web/svg/element/font-face-src/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.font-face-src
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face-src")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/font-face-uri/index.html
+++ b/files/en-us/web/svg/element/font-face-uri/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.font-face-uri
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face-uri")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/font-face/index.html
+++ b/files/en-us/web/svg/element/font-face/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.font-face
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font-face")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/font/index.html
+++ b/files/en-us/web/svg/element/font/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.font
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.font")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/foreignobject/index.html
+++ b/files/en-us/web/svg/element/foreignobject/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - Reference
   - SVG
+browser-compat: svg.elements.foreignObject
 ---
 <div>{{SVGRef}}</div>
 
@@ -114,4 +115,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.foreignObject")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/g/index.html
+++ b/files/en-us/web/svg/element/g/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Container
+browser-compat: svg.elements.g
 ---
 <div>{{SVGRef}}</div>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.g")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/glyph/index.html
+++ b/files/en-us/web/svg/element/glyph/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.glyph
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -101,7 +102,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.glyph")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/glyphref/index.html
+++ b/files/en-us/web/svg/element/glyphref/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.glyphRef
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.glyphRef")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/hatch/index.html
+++ b/files/en-us/web/svg/element/hatch/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsMobileBrowserCompatibility
   - Reference
   - SVG
+browser-compat: svg.elements.hatch
 ---
 <div>{{SVGRef}}{{SeeCompatTable}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hatch")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/hatchpath/index.html
+++ b/files/en-us/web/svg/element/hatchpath/index.html
@@ -7,6 +7,7 @@ tags:
   - Filters
   - Reference
   - SVG
+browser-compat: svg.elements.hatchpath
 ---
 <div>{{SVGRef}}{{SeeCompatTable}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hatchpath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/hkern/index.html
+++ b/files/en-us/web/svg/element/hkern/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.hkern
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.hkern")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/image/index.html
+++ b/files/en-us/web/svg/element/image/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.image
 ---
 <div>{{SVGRef}}</div>
 
@@ -97,4 +98,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.image")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/line/index.html
+++ b/files/en-us/web/svg/element/line/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.line
 ---
 <div>{{SVGRef}}</div>
 
@@ -93,7 +94,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.line")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/lineargradient/index.html
+++ b/files/en-us/web/svg/element/lineargradient/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Gradient
+browser-compat: svg.elements.linearGradient
 ---
 <div>{{SVGRef}}</div>
 
@@ -112,4 +113,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.linearGradient")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/marker/index.html
+++ b/files/en-us/web/svg/element/marker/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Container
+browser-compat: svg.elements.marker
 ---
 <div>{{SVGRef}}</div>
 
@@ -124,7 +125,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.marker")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/mask/index.html
+++ b/files/en-us/web/svg/element/mask/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Container
+browser-compat: svg.elements.mask
 ---
 <div>{{SVGRef}}</div>
 
@@ -99,7 +100,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.mask")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/metadata/index.html
+++ b/files/en-us/web/svg/element/metadata/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Descriptive
+browser-compat: svg.elements.metadata
 ---
 <div>{{SVGRef}}</div>
 
@@ -215,4 +216,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.metadata")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/missing-glyph/index.html
+++ b/files/en-us/web/svg/element/missing-glyph/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Container
+browser-compat: svg.elements.missing-glyph
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.missing-glyph")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/mpath/index.html
+++ b/files/en-us/web/svg/element/mpath/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - SVG
   - SVG Animation
+browser-compat: svg.elements.mpath
 ---
 <div>{{SVGRef}}</div>
 
@@ -97,7 +98,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.mpath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/path/index.html
+++ b/files/en-us/web/svg/element/path/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.path
 ---
 <div>{{SVGRef}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.path")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/pattern/index.html
+++ b/files/en-us/web/svg/element/pattern/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Container
+browser-compat: svg.elements.pattern
 ---
 <div>{{SVGRef}}</div>
 
@@ -118,4 +119,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.pattern")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/polygon/index.html
+++ b/files/en-us/web/svg/element/polygon/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.polygon
 ---
 <div>{{SVGRef}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.polygon")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/polyline/index.html
+++ b/files/en-us/web/svg/element/polyline/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.polyline
 ---
 <div>{{SVGRef}}</div>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.polyline")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/radialgradient/index.html
+++ b/files/en-us/web/svg/element/radialgradient/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Gradient
+browser-compat: svg.elements.radialGradient
 ---
 <div>{{SVGRef}}</div>
 
@@ -118,4 +119,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.radialGradient")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/rect/index.html
+++ b/files/en-us/web/svg/element/rect/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.rect
 ---
 <div>{{SVGRef}}</div>
 
@@ -104,7 +105,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.rect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/script/index.html
+++ b/files/en-us/web/svg/element/script/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - Reference
   - SVG
+browser-compat: svg.elements.script
 ---
 <p>The SVG <code>script</code> element allows to add scripts to an SVG document.</p>
 
@@ -97,7 +98,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.script")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/set/index.html
+++ b/files/en-us/web/svg/element/set/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - SVG
   - SVG Animation
+browser-compat: svg.elements.set
 ---
 <div>{{SVGRef}}</div>
 
@@ -93,7 +94,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.set")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/stop/index.html
+++ b/files/en-us/web/svg/element/stop/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Gradient
+browser-compat: svg.elements.stop
 ---
 <div>{{SVGRef}}</div>
 
@@ -89,4 +90,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.stop")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/style/index.html
+++ b/files/en-us/web/svg/element/style/index.html
@@ -5,6 +5,7 @@ tags:
   - Element
   - Reference
   - SVG
+browser-compat: svg.elements.style
 ---
 <div>{{SVGRef}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.style")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/svg/index.html
+++ b/files/en-us/web/svg/element/svg/index.html
@@ -7,6 +7,7 @@ tags:
   - SVG
   - SVG Container
   - Web
+browser-compat: svg.elements.svg
 ---
 <div>{{SVGRef}}</div>
 
@@ -119,4 +120,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.svg")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/switch/index.html
+++ b/files/en-us/web/svg/element/switch/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - SVG
   - SVG Container
+browser-compat: svg.elements.switch
 ---
 <div>{{SVGRef}}</div>
 
@@ -89,4 +90,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.switch")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/symbol/index.html
+++ b/files/en-us/web/svg/element/symbol/index.html
@@ -4,6 +4,7 @@ slug: Web/SVG/Element/symbol
 tags:
   - SVG
   - SVG Container
+browser-compat: svg.elements.symbol
 ---
 <div>{{SVGRef}}</div>
 
@@ -113,4 +114,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.symbol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/text/index.html
+++ b/files/en-us/web/svg/element/text/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.text
 ---
 <div>{{SVGRef}}</div>
 
@@ -110,7 +111,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.text")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Related">Related</h2>
 

--- a/files/en-us/web/svg/element/textpath/index.html
+++ b/files/en-us/web/svg/element/textpath/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.textPath
 ---
 <div>{{SVGRef}}</div>
 
@@ -113,4 +114,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.textPath")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/title/index.html
+++ b/files/en-us/web/svg/element/title/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Descriptive
+browser-compat: svg.elements.title
 ---
 <div>{{SVGRef}}</div>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.title")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/tref/index.html
+++ b/files/en-us/web/svg/element/tref/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.tref
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -85,7 +86,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.tref")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/svg/element/tspan/index.html
+++ b/files/en-us/web/svg/element/tspan/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Text Content
+browser-compat: svg.elements.tspan
 ---
 <div>{{SVGRef}}</div>
 
@@ -105,4 +106,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.tspan")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/use/index.html
+++ b/files/en-us/web/svg/element/use/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - SVG
   - SVG Graphics
+browser-compat: svg.elements.use
 ---
 <div>{{SVGRef}}</div>
 
@@ -123,4 +124,4 @@ That's why the circles have different x positions, but the same stroke value.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.use")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/view/index.html
+++ b/files/en-us/web/svg/element/view/index.html
@@ -6,6 +6,7 @@ tags:
   - NeedsExample
   - Reference
   - SVG
+browser-compat: svg.elements.view
 ---
 <div>{{SVGRef}}</div>
 
@@ -100,4 +101,4 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("svg.elements.view")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/svg/element/vkern/index.html
+++ b/files/en-us/web/svg/element/vkern/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG Font
+browser-compat: svg.elements.vkern
 ---
 <div>{{SVGRef}}{{deprecated_header}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("svg.elements.vkern")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers svg/* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

277 files in svg/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
