### PR TITLE
Codify <th> in Learn/HTML/Tables/Advanced

### DIFF
--- a/files/en-us/learn/html/tables/advanced/index.html
+++ b/files/en-us/learn/html/tables/advanced/index.html
@@ -413,7 +413,7 @@ tfoot {
 
 <ol>
  <li>You add a unique <code>id</code> to each <code>&lt;th&gt;</code> element.</li>
- <li>You add a <code>headers</code> attribute to each <code>&lt;td&gt;</code> element. Each <code>headers</code> attribute has to contain a list of the <code>id</code>s of all the &lt;th&gt; elements that act as a header for that cell, separated by spaces.</li>
+ <li>You add a <code>headers</code> attribute to each <code>&lt;td&gt;</code> element. Each <code>headers</code> attribute has to contain a list of the <code>id</code>s of all the <code>&lt;th&gt;</code> elements that act as a header for that cell, separated by spaces.</li>
 </ol>
 
 <p>This gives your HTML table an explicit definition of the position of each cell in the table, defined by the header(s) for each column and row it is part of, kind of like a spreadsheet. For it to work well, the table really needs both column and row headers.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

A `<th>` was not marked as code.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced

> Issue number (if there is an associated issue)

Fix #5497

> Anything else that could help us review it
