### PR TITLE
Put browser-compat in front-runner for xpath & xslt

### DIFF
--- a/files/en-us/web/xpath/axes/child/index.html
+++ b/files/en-us/web/xpath/axes/child/index.html
@@ -4,6 +4,7 @@ slug: Web/XPath/Axes/child
 tags:
   - Axe
   - XPath
+browser-compat: xpath.axes.child
 ---
 <p>The <code>child</code> axis indicates the children of the context node. If an XPath expression does not specify an axis, the <code>child</code> axis is understood by default. Since only the root node or element nodes have children, any other use will select nothing.</p>
 
@@ -43,6 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("xpath.axes.child")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/XPath")}}</p>

--- a/files/en-us/web/xpath/axes/self/index.html
+++ b/files/en-us/web/xpath/axes/self/index.html
@@ -4,6 +4,7 @@ slug: Web/XPath/Axes/self
 tags:
   - Axe
   - XPath
+browser-compat: xpath.axes.self
 ---
 <p>The <code>self</code> axis indicates the context node itself. It can be abbreviated as a single period (<code>.</code>).</p>
 
@@ -43,6 +44,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("xpath.axes.self")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/XPath")}}</p>

--- a/files/en-us/web/xslt/element/stylesheet/index.html
+++ b/files/en-us/web/xslt/element/stylesheet/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - StyleSheet
   - XSLT
+browser-compat: xslt.elements.stylesheet
 ---
 <div>{{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/XSLT")}}</div>
 
@@ -93,4 +94,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("xslt.elements.stylesheet")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers xpath & xslt for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

3 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
