### PR TITLE
Put browser-compat in front-runner for <h1>, <iframe>, <link> & <script>

### DIFF
--- a/files/en-us/web/html/element/heading_elements/index.html
+++ b/files/en-us/web/html/element/heading_elements/index.html
@@ -7,6 +7,7 @@ tags:
   - HTML sections
   - Reference
   - Web
+browser-compat: html.elements.h1
 ---
 <div>{{HTMLRef}}</div>
 
@@ -245,7 +246,7 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("html.elements.h1")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/iframe/index.html
+++ b/files/en-us/web/html/element/iframe/index.html
@@ -14,6 +14,7 @@ tags:
   - Web
   - embedded
   - iframe
+browser-compat: html.elements.iframe
 ---
 <div>{{HTMLRef}}</div>
 
@@ -257,7 +258,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.iframe", 3)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/link/index.html
+++ b/files/en-us/web/html/element/link/index.html
@@ -10,6 +10,7 @@ tags:
   - Web
   - Web Performance
   - metadata
+browser-compat: html.elements.link
 ---
 <div>{{HTMLRef}}</div>
 
@@ -363,7 +364,7 @@ myStylesheet.onerror = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("html.elements.link", 3)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/html/element/script/index.html
+++ b/files/en-us/web/html/element/script/index.html
@@ -13,6 +13,7 @@ tags:
   - Script
   - Web
   - tag
+browser-compat: html.elements.script
 ---
 <p>{{HTMLRef}}</p>
 
@@ -207,7 +208,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("html.elements.script", 2)}}</div>
+<div>{{Compat}}</div>
 
 <h3 id="Compatibility_notes">Compatibility notes</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers 4 html elements that were unusual. I modified them manually and double checked the results locally.
> MDN URL of the main page changed

4 files in html/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it

With these, the whole html/* hierarchy has been converted to bcd in front-runner.