### PR TITLE
Put browser-compat in front-runner for webextensions (remaining special cases)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.BookmarkTreeNode
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNode", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.BookmarkTreeNodeType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -27,6 +28,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeType", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Type
   - WebExtensions
+browser-compat: webextensions.api.bookmarks.CreateDetails
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.bookmarks.CreateDetails", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - getBadgeBackgroundColor
+browser-compat: webextensions.api.browserAction.getBadgeBackgroundColor
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.getBadgeBackgroundColor",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - getBadgeText
+browser-compat: webextensions.api.browserAction.getBadgeText
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.getBadgeText",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserAction
   - getBadgeTextColor
+browser-compat: webextensions.api.browserAction.getBadgeTextColor
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.getBadgeTextColor",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - getPopup
+browser-compat: webextensions.api.browserAction.getPopup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.getPopup",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - getTitle
+browser-compat: webextensions.api.browserAction.getTitle
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.getTitle",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserAction
   - isEnabled
+browser-compat: webextensions.api.browserAction.isEnabled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.isEnabled",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - openPopup
+browser-compat: webextensions.api.browserAction.openPopup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.openPopup", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - setBadgeBackgroundColor
+browser-compat: webextensions.api.browserAction.setBadgeBackgroundColor
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.setBadgeBackgroundColor",2)}}</p>
+<p>{{Compat}}</p>
 
 <p>The default color in Firefox is: <code>[217, 0, 0, 255]</code>.</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - setBadgeText
+browser-compat: webextensions.api.browserAction.setBadgeText
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.setBadgeText",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserAction
   - setBadgeTextColor
+browser-compat: webextensions.api.browserAction.setBadgeTextColor
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.setBadgeTextColor",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - setIcon
+browser-compat: webextensions.api.browserAction.setIcon
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.setIcon",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - browserAction
   - setPopup
+browser-compat: webextensions.api.browserAction.setPopup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.setPopup",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserAction
   - setTitle
+browser-compat: webextensions.api.browserAction.setTitle
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserAction.setTitle", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - homepageOverride
+browser-compat: webextensions.api.browserSettings.homepageOverride
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -19,7 +20,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.homepageOverride", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - browserSettings
   - imageAnimationBehavior
+browser-compat: webextensions.api.browserSettings.imageAnimationBehavior
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -24,7 +25,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.imageAnimationBehavior", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - newTabPageOverride
+browser-compat: webextensions.api.browserSettings.newTabPageOverride
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -19,7 +20,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.newTabPageOverride", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browserSettings
   - newTabPosition
+browser-compat: webextensions.api.browserSettings.newTabPosition
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -25,7 +26,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browserSettings.newTabPosition", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - browsingData
+browser-compat: webextensions.api.browsingData
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData", 2)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note hidden">
 <p>The "Chrome incompatibilities" section is included from <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - browsingData
+browser-compat: webextensions.api.browsingData.RemovalOptions
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.RemovalOptions", 2)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removeHistory
+browser-compat: webextensions.api.browsingData.removeHistory
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removeHistory", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - browsingData
   - removeLocalStorage
+browser-compat: webextensions.api.browsingData.removeLocalStorage
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.browsingData.removeLocalStorage", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - setImageData
+browser-compat: webextensions.api.clipboard.setImageData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.clipboard.setImageData", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.html
@@ -10,6 +10,7 @@ tags:
   - Update
   - WebExtensions
   - commands
+browser-compat: webextensions.api.commands.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.commands.update", 5)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.html
@@ -8,6 +8,7 @@ tags:
   - Interface
   - WebExtensions
   - contentScripts
+browser-compat: webextensions.api.contentScripts
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -39,6 +40,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contentScripts", 10, 1)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - contentScripts
   - register
+browser-compat: webextensions.api.contentScripts.register
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contentScripts.register", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.html
@@ -8,6 +8,7 @@ tags:
   - RegisteredContentScript
   - Type
   - contentScripts
+browser-compat: webextensions.api.contentScripts.RegisteredContentScript
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contentScripts.RegisteredContentScript", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - RegisteredContentScript.unregister
   - contentScripts
+browser-compat: webextensions.api.contentScripts.RegisteredContentScript.unregister
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.contentScripts.RegisteredContentScript.unregister", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools.panels
+browser-compat: webextensions.api.devtools.panels.elements
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -17,7 +18,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.elements", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - createSidebarPane
   - devtools.panels
+browser-compat: webextensions.api.devtools.panels.ElementsPanel.createSidebarPane
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ElementsPanel.createSidebarPane", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - devtools.panels.ElementsPanel
+browser-compat: webextensions.api.devtools.panels.ElementsPanel
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -32,7 +33,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ElementsPanel", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - devtools.panelsElementsPanel
+browser-compat: webextensions.api.devtools.panels.ElementsPanel.onSelectionChanged
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ browser.devtools.panels.elements.onSelectionChanged.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ElementsPanel.onSelectionChanged", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - devtools.panels.ExtensionSidebarPane
+browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -48,7 +49,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - onHidden
+browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.onHidden
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -48,7 +49,7 @@ browser.devtools.panels.onHidden.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.onHidden", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - onShown
+browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.onShown
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -47,7 +48,7 @@ browser.devtools.panels.onShown.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.onShown", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - setExpression
+browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setExpression
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setExpression", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - devtools.panels
   - setObject
+browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setObject
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -43,7 +44,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setObject", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - setPage
+browser-compat: webextensions.api.devtools.panels.ExtensionSidebarPane.setPage
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -49,7 +50,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setPage", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - devtools.panels
+browser-compat: webextensions.api.devtools.panels
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.devtools.panels", 2)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - find
+browser-compat: webextensions.api.find.find
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -117,7 +118,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.find.find", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - find
   - highlightResults
+browser-compat: webextensions.api.find.highlightResults
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.find.highlightResults", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/removehighlighting/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - find
   - removeHighlighting
+browser-compat: webextensions.api.find.removeHighlighting
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -30,7 +31,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.find.removeHighlighting", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - contextMenus
+browser-compat: webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
@@ -12,6 +12,7 @@ tags:
   - WebExtensions
   - contextMenus
   - menus
+browser-compat: webextensions.api.menus.ContextType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -62,7 +63,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.ContextType", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - contextMenus
+browser-compat: webextensions.api.menus.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -184,7 +185,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.create", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/createproperties/index.html
@@ -8,6 +8,7 @@ tags:
   - WebExtensions
   - contextMenus
   - createProperties
+browser-compat: webextensions.api.menus.createProperties
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -94,7 +95,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.createProperties", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - contextMenus
   - itemtype
+browser-compat: webextensions.api.menus.ItemType
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.ItemType", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - contextMenus
+browser-compat: webextensions.api.menus.OnClickData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -61,7 +62,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.OnClickData", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - contextMenus
   - onClicked
+browser-compat: webextensions.api.menus.onClicked
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -59,7 +60,7 @@ browser.menus.onClicked.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.onClicked", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onhidden/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - menus
   - onHidden
+browser-compat: webextensions.api.menus.onHidden
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ browser.menus.onHidden.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.onHidden", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - menus
   - onShown
+browser-compat: webextensions.api.menus.onShown
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -124,7 +125,7 @@ browser.menus.onShown.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.onShown", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/refresh/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - menus
   - refresh
+browser-compat: webextensions.api.menus.refresh
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.refresh", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - contextMenus
   - remove
+browser-compat: webextensions.api.menus.remove
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -68,7 +69,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.remove", 10)}}</p>
+<p>{{Compat}}</p>
 
 
 <div class="note"><strong>Acknowledgements</strong>

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.html
@@ -12,6 +12,7 @@ tags:
   - contextMenus
   - menus
   - removeAll
+browser-compat: webextensions.api.menus.removeAll
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.removeAll", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.html
@@ -11,6 +11,7 @@ tags:
   - Update
   - WebExtensions
   - contextMenus
+browser-compat: webextensions.api.menus.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -151,7 +152,7 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.menus.update", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - close
   - sidebarAction
+browser-compat: webextensions.api.pageAction.openPopup
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -35,7 +36,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pageAction.openPopup", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - installModule
   - pkcs11
+browser-compat: webextensions.api.pkcs11.installModule
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pkcs11.installModule", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - isModuleInstalled
   - pkcs11
+browser-compat: webextensions.api.pkcs11.isModuleInstalled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pkcs11.isModuleInstalled", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - pkcs11
   - uninstallModule
+browser-compat: webextensions.api.pkcs11.uninstallModule
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.pkcs11.uninstallModule", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.html
@@ -8,6 +8,7 @@ tags:
   - Privacy
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.privacy
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -28,7 +29,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.privacy", 10, 1)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Services
+browser-compat: webextensions.api.privacy.services
 ---
 <div>{{AddonSidebar}}
 <p>The {{WebExtAPIRef("privacy.services")}} property contains privacy-related settings controlling services offered by the browser or by third parties. Each property is a {{WebExtAPIRef("types.BrowserSetting")}} object.</p>
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.privacy.services", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/onrequest/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - onRequest
+browser-compat: webextensions.api.proxy.onRequest
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -81,7 +82,7 @@ browser.proxy.onRequest.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.onRequest", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Settings
   - WebExtensions
+browser-compat: webextensions.api.proxy.settings
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -65,4 +66,4 @@ browser.proxy.settings.set({value: proxySettings});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.proxy.settings", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onInstalled
   - runtime
+browser-compat: webextensions.api.runtime.onInstalled
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -66,7 +67,7 @@ browser.runtime.onInstalled.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.runtime.onInstalled", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.html
@@ -10,6 +10,7 @@ tags:
   - Search
   - WebExtensions
   - get
+browser-compat: webextensions.api.search.search
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.search.search", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.html
@@ -9,6 +9,7 @@ tags:
   - Search
   - Search Engines
   - WebExtensions
+browser-compat: webextensions.api.search.search
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.search.search", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getTabValue
   - sessions
+browser-compat: webextensions.api.sessions.getTabValue
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.getTabValue", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getWindowValue
   - sessions
+browser-compat: webextensions.api.sessions.getWindowValue
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -42,7 +43,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.getWindowValue", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - removeTabValue
   - sessions
+browser-compat: webextensions.api.sessions.removeTabValue
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.removeTabValue", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - removeWindowValue
   - sessions
+browser-compat: webextensions.api.sessions.removeWindowValue
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.removeWindowValue", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - sessions
   - setTabValue
+browser-compat: webextensions.api.sessions.setTabValue
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.setTabValue", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - sessions
   - setWindowValue
+browser-compat: webextensions.api.sessions.setWindowValue
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sessions.setWindowValue", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/close/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - close
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.close
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.close", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getPanel
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.getPanel
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.getPanel",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getTitle
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.getTitle
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.getTitle",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - isOpen
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.isOpen
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.isOpen",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/open/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - open
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.open
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.open", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - setIcon
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.setIcon
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -100,7 +101,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.setIcon",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - setPanel
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.setPanel
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -88,7 +89,7 @@ browser.browserAction.onClicked.addListener(() =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.setPanel",2)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - setTitle
   - sidebarAction
+browser-compat: webextensions.api.sidebarAction.setTitle
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.setTitle",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - sidebarAction
   - toggle
+browser-compat: webextensions.api.sidebarAction.toggle
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.sidebarAction.toggle", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -103,7 +104,7 @@ browser.browserAction.onClicked.addListener(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.create", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - discard
   - tabs
+browser-compat: webextensions.api.tabs.discard
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -74,7 +75,7 @@ discarding.then(onDiscarded, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.discard", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - highlight
   - tabs
+browser-compat: webextensions.api.tabs.highlight
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.highlight",2)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.moveInSuccession
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.moveInSuccession", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onUpdated
   - tabs
+browser-compat: webextensions.api.tabs.onUpdated
 ---
 <p>Fired when a tab is updated.</p>
 
@@ -239,7 +240,7 @@ browser.tabs.onUpdated.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.onUpdated", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.html
@@ -11,6 +11,7 @@ tags:
   - Type
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.Tab
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -87,7 +88,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.Tab", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.html
@@ -11,6 +11,7 @@ tags:
   - Update
   - WebExtensions
   - tabs
+browser-compat: webextensions.api.tabs.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -125,7 +126,7 @@ querying.then(updateFirstTab, onError);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.tabs.update", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.html
@@ -10,6 +10,7 @@ tags:
   - Theme
   - WebExtensions
   - getCurrent
+browser-compat: webextensions.api.theme.getCurrent
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.theme.getCurrent", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.html
@@ -7,6 +7,7 @@ tags:
   - Extensions
   - Theme
   - WebExtensions
+browser-compat: webextensions.api.theme.onUpdated
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -65,7 +66,7 @@ browser.theme.onUpdated.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.theme.onUpdated", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.html
@@ -10,6 +10,7 @@ tags:
   - Theme
   - Update
   - WebExtensions
+browser-compat: webextensions.api.theme.update
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.theme.update", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - WebExtensions
   - userScripts
+browser-compat: webextensions.api.userScripts
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.userScripts", 10, 1)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/register/index.html
@@ -9,6 +9,7 @@ tags:
   - WebExtensions
   - register
   - userScripts
+browser-compat: webextensions.api.userScripts.register
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -70,7 +71,7 @@ await registeredUserScript.unregister();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.userScripts.register", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.html
@@ -8,6 +8,7 @@ tags:
   - RegisteredUserScript
   - Type
   - userScripts
+browser-compat: webextensions.api.userScripts.RegisteredUserScript
 ---
 <p>{{AddonSidebar()}}</p>
 
@@ -28,4 +29,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.userScripts.RegisteredUserScript", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.CertificateInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -71,6 +72,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.CertificateInfo", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - filterResponseData
   - webRequest
+browser-compat: webextensions.api.webRequest.filterResponseData
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -73,4 +74,4 @@ browser.webRequest.onBeforeRequest.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.filterResponseData", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.html
@@ -10,6 +10,7 @@ tags:
   - WebExtensions
   - getSecurityInfo
   - webRequest
+browser-compat: webextensions.api.webRequest.getSecurityInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.getSecurityInfo", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onAuthRequired
   - webRequest
+browser-compat: webextensions.api.webRequest.onAuthRequired
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -228,7 +229,7 @@ browser.webRequest.onAuthRequired.hasListener(<var>listener</var>)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onAuthRequired", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onBeforeRedirect
   - webRequest
+browser-compat: webextensions.api.webRequest.onBeforeRedirect
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -166,7 +167,7 @@ browser.webRequest.onBeforeRedirect.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onBeforeRedirect", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onBeforeRequest
   - webRequest
+browser-compat: webextensions.api.webRequest.onBeforeRequest
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -193,7 +194,7 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onBeforeRequest", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="DNS_resolution_ordering_when_BlockingResponse_is_used">DNS resolution ordering when BlockingResponse is used</h3>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onBeforeSendHeaders
   - webRequest
+browser-compat: webextensions.api.webRequest.onBeforeSendHeaders
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -179,7 +180,7 @@ browser.webRequest.onBeforeSendHeaders.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onBeforeSendHeaders", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onCompleted
   - webRequest
+browser-compat: webextensions.api.webRequest.onCompleted
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -164,7 +165,7 @@ browser.webRequest.onCompleted.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onCompleted", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onErrorOccurred
   - webRequest
+browser-compat: webextensions.api.webRequest.onErrorOccurred
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -156,7 +157,7 @@ browser.webRequest.onErrorOccurred.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onErrorOccurred", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onHeadersReceived
   - webRequest
+browser-compat: webextensions.api.webRequest.onHeadersReceived
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -185,7 +186,7 @@ browser.webRequest.onHeadersReceived.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onHeadersReceived", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onResponseStarted
   - webRequest
+browser-compat: webextensions.api.webRequest.onResponseStarted
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -164,7 +165,7 @@ browser.webRequest.onResponseStarted.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onResponseStarted", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - onSendHeaders
   - webRequest
+browser-compat: webextensions.api.webRequest.onSendHeaders
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -156,7 +157,7 @@ browser.webRequest.onSendHeaders.hasListener(listener)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onSendHeaders", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.html
@@ -9,6 +9,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.SecurityInfo
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -90,6 +91,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.SecurityInfo", 10)}}</p>
+<p>{{Compat}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.html
@@ -8,6 +8,7 @@ tags:
   - StreamFilter.close
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.close
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -34,7 +35,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.close", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.html
@@ -8,6 +8,7 @@ tags:
   - StreamFilter.disconnect
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.disconnect
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.disconnect", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.error
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.error
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -16,7 +17,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.error", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.html
@@ -10,6 +10,7 @@ tags:
   - Type
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.html
@@ -11,6 +11,7 @@ tags:
   - TextEncoder
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.ondata
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -318,4 +319,4 @@ browser.webRequest.onBeforeRequest.addListener(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.ondata", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.onerror
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.onerror
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -22,7 +23,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.onerror", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.onstart
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.onstart
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -16,7 +17,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.onstart", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.onstop
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.onstop
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -16,7 +17,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.onstop", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.resume()
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.resume
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.resume", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.status
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.status
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.status", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.suspend()
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.suspend
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -31,7 +32,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.suspend", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.html
@@ -9,6 +9,7 @@ tags:
   - StreamFilter.write()
   - WebExtensions
   - webRequest
+browser-compat: webextensions.api.webRequest.StreamFilter.write
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -36,7 +37,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.webRequest.StreamFilter.write", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - WebExtensions
   - Windows
+browser-compat: webextensions.api.windows.create
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -148,7 +149,7 @@ browser.browserAction.onClicked.addListener((tab) =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.create", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="note"><strong>Acknowledgements</strong>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - get
+browser-compat: webextensions.api.windows.get
 ---
 <div><span class="diff_add">{{AddonSidebar()}}</span></div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.get",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - getCurrent
+browser-compat: webextensions.api.windows.getCurrent
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.getCurrent",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.html
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - Windows
   - getLastFocused
+browser-compat: webextensions.api.windows.getLastFocused
 ---
 <div>{{AddonSidebar()}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.api.windows.getLastFocused",2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Examples">Examples</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.html
@@ -7,6 +7,7 @@ tags:
   - Manifest
   - Reference
   - WebExtensions
+browser-compat: webextensions.manifest.background
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -109,4 +110,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.background", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_action/index.html
@@ -5,6 +5,7 @@ tags:
   - Add-ons
   - Extensions
   - WebExtensions
+browser-compat: webextensions.manifest.browser_action
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -245,7 +246,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.browser_action", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
@@ -7,6 +7,7 @@ tags:
   - WebExtensions
   - chrome_settings_overrides
   - manifest.json
+browser-compat: webextensions.manifest.chrome_settings_overrides
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -130,4 +131,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.chrome_settings_overrides", 10)}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.html
@@ -7,6 +7,7 @@ tags:
   - Overview
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest
 ---
 <p>{{AddonSidebar}}</p>
 
@@ -128,7 +129,7 @@ tags:
 
 <p>For a full overview of all manifest keys and their sub-keys, see the<a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json"> full <code>manifest.json</code> browser compatibility table</a>.</p>
 
-<p>{{Compat("webextensions.manifest")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.html
@@ -7,6 +7,7 @@ tags:
   - Manifest
   - Reference
   - WebExtensions
+browser-compat: webextensions.manifest.storage
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.storage", 10)}}</p>
+<p>{{Compat}}</p>
 
 <div class="notecard note">
 <p><strong>Acknowledgements</strong></p>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -11,6 +11,7 @@ tags:
   - Themes
   - colors
   - theme manifest
+browser-compat: webextensions.manifest.theme
 ---
 <div>{{AddonSidebar}}</div>
 
@@ -1337,19 +1338,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webextensions.manifest.theme")}}</p>
-
-<h3 id="Colors">Colors</h3>
-
-<p>{{Compat("webextensions.manifest.theme.colors", 10)}}</p>
-
-<h3 id="Images">Images</h3>
-
-<p>{{Compat("webextensions.manifest.theme.images", 10)}}</p>
-
-<h3 id="Properties">Properties</h3>
-
-<p>{{Compat("webextensions.manifest.theme.properties", 10)}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="Chrome_compatibility">Chrome compatibility</h3>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers special cases under webextensions (macros with more than one parameters, as well as several macros on the page)

With this one (and the two previous ones), we should be done moving BCD in front-runner for webextensions

> MDN URL of the main page changed

131 files in webextensions/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
