### PR TITLE
Remove references to SVGUnknownElement

### DIFF
--- a/files/en-us/web/api/document_object_model/index.html
+++ b/files/en-us/web/api/document_object_model/index.html
@@ -200,7 +200,6 @@ tags:
  <li>{{DOMxRef("SVGTRefElement")}} {{Deprecated_Inline}}</li>
  <li>{{DOMxRef("SVGTSpanElement")}}</li>
  <li>{{DOMxRef("SVGUseElement")}}</li>
- <li>{{DOMxRef("SVGUnknownElement")}} {{Experimental_Inline}}</li>
  <li>{{DOMxRef("SVGViewElement")}}</li>
  <li>{{DOMxRef("SVGVKernElement")}} {{Deprecated_Inline}}</li>
 </ul>

--- a/files/en-us/web/api/htmlunknownelement/index.html
+++ b/files/en-us/web/api/htmlunknownelement/index.html
@@ -46,10 +46,3 @@ tags:
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <p>{{Compat("api.HTMLUnknownElement")}}</p>
-
-<h2 id="See_also">See also</h2>
-
-<ul>
-	<li>Obsolete or non-standard HTML elements implementing this interface: {{HTMLElement("bgsound")}}, {{HTMLElement("blink")}}, {{HTMLElement("isindex")}}, {{HTMLElement("nextid")}}, {{HTMLElement("rb")}}, {{HTMLElement("spacer")}}</li>
-	<li>{{DOMxRef("SVGUnknownElement")}}</li>
-</ul>

--- a/files/en-us/web/svg/svg_2_support_in_mozilla/index.html
+++ b/files/en-us/web/svg/svg_2_support_in_mozilla/index.html
@@ -254,7 +254,7 @@ tags:
    <td><code>SVGSVGElement.currentView</code> was never implemented, <code>SVGSVGElement.useCurrentView</code> not removed yet ({{bug("1174097")}})</td>
   </tr>
   <tr style="color: black; background-color: salmon;">
-   <td>{{domxref("SVGUnknownElement")}}</td>
+   <td><code>SVGUnknownElement</code></td>
    <td>Not implemented ({{bug("1239218")}})</td>
   </tr>
   <tr style="color: black; background-color: lightgreen;">


### PR DESCRIPTION
The "See also" in HTMLUnknownElement is removed entirely, as it's just a
random subset of elements which aren't supported.