### PR TITLE
Fix links in HTML references

### DIFF
--- a/files/en-us/web/html/element/s/index.html
+++ b/files/en-us/web/html/element/s/index.html
@@ -91,7 +91,7 @@ s::after {
 
 <ul>
  <li><a href="https://developer.paciellogroup.com/blog/2017/12/short-note-on-making-your-mark-more-accessible/">Short note on making your mark (more accessible) | The Paciello Group</a></li>
- <li><a href="http://adrianroselli.com/2017/12/tweaking-text-level-styles.html">Tweaking Text Level Styles | Adrian Roselli</a></li>
+ <li><a href="https://adrianroselli.com/2017/12/tweaking-text-level-styles.html">Tweaking Text Level Styles | Adrian Roselli</a></li>
 </ul>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/mathml/element/math/index.html
+++ b/files/en-us/web/mathml/element/math/index.html
@@ -35,7 +35,7 @@ tags:
 	<p>If not present, its default value is <code>inline</code>.</p>
 	</dd>
 	<dt id="attr-mode">mode {{deprecated_inline}}</dt>
-	<dd>Deprecated in favor of the <a href="/en-US/docs/Web/MathML/Element/math#attr-display">display attribute</a>.<br>
+	<dd>Deprecated in favor of the <a href="#attr-display">display attribute</a>.<br>
 	Possible values are: <code>display</code> (which has the same effect as <code>display="block"</code>) and <code>inline</code>.</dd>
 </dl>
 
@@ -111,7 +111,7 @@ tags:
 &lt;/body&gt;
 &lt;/html&gt;</pre>
 
-<p><strong>Notes</strong>: XHTML documents with MathML must be served as <code>application/xhtml+xml</code>. You can achieve that easily by adding the <code>.xhtml</code> extension to your local files. For Apache servers you can <a href="http://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype">configure your <code>.htaccess</code> file</a> to map extensions to the correct Mime type. Since you notate your MathML in an XML document, also be sure you write a well-formed XML document.</p>
+<p><strong>Notes</strong>: XHTML documents with MathML must be served as <code>application/xhtml+xml</code>. You can achieve that easily by adding the <code>.xhtml</code> extension to your local files. For Apache servers you can <a href="https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype">configure your <code>.htaccess</code> file</a> to map extensions to the correct Mime type. Since you notate your MathML in an XML document, also be sure you write a well-formed XML document.</p>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

fix links
- http to https scheme
- remove unnecessary part of a link

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/math
