### PR TITLE
Updated sizes of live embedded examples

### DIFF
--- a/files/en-us/web/html/element/input/number/index.html
+++ b/files/en-us/web/html/element/input/number/index.html
@@ -255,7 +255,7 @@ browser-compat: html.elements.input.input-number
   &lt;/div&gt;
 &lt;/form&gt;</pre>
 
-<p>{{EmbedLiveSample("Validation", 600, 80)}}</p>
+<p>{{EmbedLiveSample("Validation", 600, 110)}}</p>
 
 <p>Try submitting the form with different invalid values entered — e.g., no value; a value below 0 or above 100; a value that is not a multiple of 10; or a non-numerical value — and see how the error messages the browser gives you differ with different ones.</p>
 
@@ -299,7 +299,7 @@ input:valid+span:after {
 
 <p>In the following example is a form for entering the user's height. It defaults to accepting a height in meters, but you can click the relevant button to change the form to accept feet and inches instead. The input for the height in meters accepts decimals to two places.</p>
 
-<p>{{EmbedLiveSample("Examples", 600, 100)}}</p>
+<p>{{EmbedLiveSample("Examples", 600, 150)}}</p>
 
 <p>The HTML looks like this:</p>
 


### PR DESCRIPTION
Updated sizes of live embedded examples so that there are no scroll bars. 

Previously there were vertical scroll bars on the live examples because they were not tall enough. I increased the height so that there are no scroll bars anymore.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
There were scroll bars on the live examples. 
> MDN URL of the main page changed
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number
> Issue number (if there is an associated issue)
None yet
> Anything else that could help us review it
Nope