### PR TITLE
Fix indentation for the code sample

### DIFF
--- a/files/en-us/web/css/css_container_queries/index.html
+++ b/files/en-us/web/css/css_container_queries/index.html
@@ -52,7 +52,7 @@ tags:
 <pre class="brush:css">@container (min-width: 700px){
   .card {
     display: grid;
-	  grid-template-columns: 2fr 1fr;
+    grid-template-columns: 2fr 1fr;
   }
 }</pre>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The indentation is off because of the tab character.

<img width="443" alt="image" src="https://user-images.githubusercontent.com/105274/120243760-1e471500-c271-11eb-9fa5-eb2a1f289c7c.png">

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries