### PR TITLE
remove an anchor element from a heading

### DIFF
--- a/files/en-us/web/html/element/dl/index.html
+++ b/files/en-us/web/html/element/dl/index.html
@@ -146,7 +146,7 @@ browser-compat: html.elements.dl
   content: ": ";
 }</pre>
 
-<h3 id="Wrapping_name-value_groups_in_HTMLElementdiv_elements">Wrapping name-value groups in {{HTMLElement("div")}} elements</h3>
+<h3 id="Wrapping_name-value_groups_in_HTMLElementdiv_elements">Wrapping name-value groups in <code>div</code> elements</h3>
 
 <p><a href="/en-US/docs/Glossary/WHATWG">WHATWG</a> HTML allows wrapping each name-value group in a {{HTMLElement("dl")}} element in a {{HTMLElement("div")}} element. This can be useful when using <a href="/en-US/docs/Web/HTML/Microdata">microdata</a>, or when <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a> apply to a whole group, or for styling purposes.</p>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

There is an anchor element in a heading.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl

