### PR TITLE
Update description on types of shaders to be more accurate

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.html
+++ b/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.html
@@ -12,7 +12,7 @@ tags:
 ---
 <div>{{GamesSidebar}}</div>
 
-<p class="summary"><span class="seosummary">Shaders use GLSL (</span><span class="ILfuVd">OpenGL Shading Language</span>)<span class="seosummary">, a special OpenGL Shading Language with syntax similar to C. GLSL is executed directly by the graphics pipeline. There are two types of shaders: Vertex Shaders and Fragment (Pixel) Shaders. Vertex Shaders transform shape positions into 3D drawing coordinates. Fragment Shaders compute the renderings of a shape's colors and other attributes.</span></p>
+<p class="summary"><span class="seosummary">Shaders use GLSL (</span><span class="ILfuVd">OpenGL Shading Language</span>)<span class="seosummary">, a special OpenGL Shading Language with syntax similar to C. GLSL is executed directly by the graphics pipeline. There are <a href="https://www.khronos.org/opengl/wiki/Shader">several different kinds of shaders</a>, but two are commonly used to create graphics on the web: Vertex Shaders and Fragment (Pixel) Shaders. Vertex Shaders transform shape positions into 3D drawing coordinates. Fragment Shaders compute the renderings of a shape's colors and other attributes.</span></p>
 
 <p>GLSL is not as intuitive as JavaScript. GLSL is strongly typed and there is a lot of math involving vectors and matrices. It can get very complicated — very quickly. In this article we will make a simple code example that renders a cube. To speed up the background code we will be using the Three.js API.</p>
 


### PR DESCRIPTION
The docs say that there are two types of shaders, but the OpenGL Shading Language wiki specifies several other shaders: https://www.khronos.org/opengl/wiki/Shader. This edit addresses this discrepancy.