### PR TITLE
Remove redundant classes from HTML main page elements

### DIFF
--- a/files/en-us/web/html/index.html
+++ b/files/en-us/web/html/index.html
@@ -10,7 +10,7 @@ tags:
 ---
 <div>{{HTMLSidebar}}</div>
 
-<p class="summary"><span class="seoSummary"><strong>HTML</strong> (HyperText Markup Language) is the most basic building block of the Web. It defines the meaning and structure of web content. Other technologies besides HTML are generally used to describe a web page's appearance/presentation (<a href="/en-US/docs/Web/CSS">CSS</a>) or functionality/behavior (<a href="/en-US/docs/Web/JavaScript">JavaScript</a>).</span></p>
+<p><strong>HTML</strong> (HyperText Markup Language) is the most basic building block of the Web. It defines the meaning and structure of web content. Other technologies besides HTML are generally used to describe a web page's appearance/presentation (<a href="/en-US/docs/Web/CSS">CSS</a>) or functionality/behavior (<a href="/en-US/docs/Web/JavaScript">JavaScript</a>).</p>
 
 <p>"Hypertext" refers to links that connect web pages to one another, either within a single website or between websites. Links are a fundamental aspect of the Web. By uploading content to the Internet and linking it to pages created by other people, you become an active participant in the World Wide Web.</p>
 
@@ -42,7 +42,7 @@ tags:
 
 </div>
 
-<h2 class="Tools" id="Beginners_tutorials">Beginner's tutorials</h2>
+<h2 id="Beginners_tutorials">Beginner's tutorials</h2>
 
 <p>Our <a href="/en-US/docs/Learn/HTML">HTML Learning Area</a> features multiple modules that teach HTML from the ground up — no previous knowledge required.</p>
 
@@ -62,38 +62,38 @@ tags:
 <h2 id="Advanced_topics">Advanced topics</h2>
 
 <dl>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/CORS_enabled_image">CORS enabled image</a></dt>
- <dd class="landingPageList">The {{htmlattrxref("crossorigin", "img")}} attribute, in combination with an appropriate {{glossary("CORS")}} header, allows images defined by the {{HTMLElement("img")}} element to be loaded from foreign origins and used in a {{HTMLElement("canvas")}} element as if they were being loaded from the current origin.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Attributes/crossorigin">CORS settings attributes</a></dt>
- <dd class="landingPageList">Some HTML elements that provide support for <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>, such as {{HTMLElement("img")}} or {{HTMLElement("video")}}, have a <code>crossorigin</code> attribute (<code>crossOrigin</code> property), which lets you configure the CORS requests for the element's fetched data.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Preloading_content">Preloading content with rel="preload"</a></dt>
- <dd class="landingPageList">The <code>preload</code> value of the {{htmlelement("link")}} element's {{htmlattrxref("rel", "link")}} attribute allows you to write declarative fetch requests in your HTML {{htmlelement("head")}}, specifying resources that your pages will need very soon after loading, which you therefore want to start preloading early in the lifecycle of a page load, before the browser's main rendering machinery kicks in. This ensures that they are made available earlier and are less likely to block the page's first render, leading to performance improvements. This article provides a basic guide to how <code>preload</code> works.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/CORS_enabled_image">CORS enabled image</a></dt>
+ <dd>The {{htmlattrxref("crossorigin", "img")}} attribute, in combination with an appropriate {{glossary("CORS")}} header, allows images defined by the {{HTMLElement("img")}} element to be loaded from foreign origins and used in a {{HTMLElement("canvas")}} element as if they were being loaded from the current origin.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Attributes/crossorigin">CORS settings attributes</a></dt>
+ <dd>Some HTML elements that provide support for <a href="/en-US/docs/Web/HTTP/CORS">CORS</a>, such as {{HTMLElement("img")}} or {{HTMLElement("video")}}, have a <code>crossorigin</code> attribute (<code>crossOrigin</code> property), which lets you configure the CORS requests for the element's fetched data.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Preloading_content">Preloading content with rel="preload"</a></dt>
+ <dd>The <code>preload</code> value of the {{htmlelement("link")}} element's {{htmlattrxref("rel", "link")}} attribute allows you to write declarative fetch requests in your HTML {{htmlelement("head")}}, specifying resources that your pages will need very soon after loading, which you therefore want to start preloading early in the lifecycle of a page load, before the browser's main rendering machinery kicks in. This ensures that they are made available earlier and are less likely to block the page's first render, leading to performance improvements. This article provides a basic guide to how <code>preload</code> works.</dd>
 </dl>
 
-<h2 class="Documentation" id="References">References</h2>
+<h2 id="References">References</h2>
 
 <dl>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Reference">HTML reference</a></dt>
- <dd class="landingPageList">HTML consists of <strong>elements</strong>, each of which may be modified by some number of <strong>attributes</strong>. HTML documents are connected to each other with <a href="/en-US/docs/Web/HTML/Link_types">links</a>.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Element">HTML element reference</a></dt>
- <dd class="landingPageList">Browse a list of all {{glossary("HTML")}} {{glossary("Element", "elements")}}.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Attributes">HTML attribute reference</a></dt>
- <dd class="landingPageList">Elements in HTML have <strong>attributes</strong>. These are additional values that configure the elements or adjust their behavior in various ways.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Global_attributes">Global attributes</a></dt>
- <dd class="landingPageList">Global attributes may be specified on all <a href="/en-US/docs/Web/HTML/Element">HTML elements</a>, <em>even those not specified in the standard</em>. This means that any non-standard elements must still permit these attributes, even though those elements make the document HTML5-noncompliant.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Inline_elements">Inline elements</a> and <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level elements</a></dt>
- <dd class="landingPageList">HTML elements are usually "inline" or "block-level" elements. An inline element occupies only the space bounded by the tags that define it. A block-level element occupies the entire space of its parent element (container), thereby creating a "block."</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Link_types">Link types</a></dt>
- <dd class="landingPageList">In HTML, various link types can be used to establish and define the relationship between two documents. Link elements that types can be set on include {{HTMLElement("a")}}, {{HTMLElement("area")}} and {{HTMLElement("link")}}.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Media/Formats">Guide to media types and formats on the web</a></dt>
- <dd class="landingPageList">The {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements allow you to play audio and video media natively within your content without the need for external software support.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/Guide/HTML/Content_categories">HTML content categories</a></dt>
- <dd class="landingPageList">HTML is comprised of several kinds of content, each of which is allowed to be used in certain contexts and is disallowed in others. Similarly, each has a set of other content categories they can contain and elements that can or can't be used in them. This is a guide to these categories.</dd>
- <dt class="landingPageList"><a href="/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode">Quirks mode and standards mode</a></dt>
- <dd class="landingPageList">Historical information on quirks mode and standards mode.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Reference">HTML reference</a></dt>
+ <dd>HTML consists of <strong>elements</strong>, each of which may be modified by some number of <strong>attributes</strong>. HTML documents are connected to each other with <a href="/en-US/docs/Web/HTML/Link_types">links</a>.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Element">HTML element reference</a></dt>
+ <dd>Browse a list of all {{glossary("HTML")}} {{glossary("Element", "elements")}}.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Attributes">HTML attribute reference</a></dt>
+ <dd>Elements in HTML have <strong>attributes</strong>. These are additional values that configure the elements or adjust their behavior in various ways.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Global_attributes">Global attributes</a></dt>
+ <dd>Global attributes may be specified on all <a href="/en-US/docs/Web/HTML/Element">HTML elements</a>, <em>even those not specified in the standard</em>. This means that any non-standard elements must still permit these attributes, even though those elements make the document HTML5-noncompliant.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Inline_elements">Inline elements</a> and <a href="/en-US/docs/Web/HTML/Block-level_elements">block-level elements</a></dt>
+ <dd>HTML elements are usually "inline" or "block-level" elements. An inline element occupies only the space bounded by the tags that define it. A block-level element occupies the entire space of its parent element (container), thereby creating a "block."</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Link_types">Link types</a></dt>
+ <dd>In HTML, various link types can be used to establish and define the relationship between two documents. Link elements that types can be set on include {{HTMLElement("a")}}, {{HTMLElement("area")}} and {{HTMLElement("link")}}.</dd>
+ <dt><a href="/en-US/docs/Web/Media/Formats">Guide to media types and formats on the web</a></dt>
+ <dd>The {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements allow you to play audio and video media natively within your content without the need for external software support.</dd>
+ <dt><a href="/en-US/docs/Web/Guide/HTML/Content_categories">HTML content categories</a></dt>
+ <dd>HTML is comprised of several kinds of content, each of which is allowed to be used in certain contexts and is disallowed in others. Similarly, each has a set of other content categories they can contain and elements that can or can't be used in them. This is a guide to these categories.</dd>
+ <dt><a href="/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode">Quirks mode and standards mode</a></dt>
+ <dd>Historical information on quirks mode and standards mode.</dd>
 </dl>
 
-<h2 class="landingPageList" id="Related_topics">Related topics</h2>
+<h2 id="Related_topics">Related topics</h2>
 
 <dl>
  <dt><a href="/en-US/docs/Web/HTML/Applying_color">Applying color to HTML elements using CSS</a></dt>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Removes redundant summary classes along with legacy style classes.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTML

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it

For summary:

As I understand, only one element, or the very first paragraph from a selector `span.seoSummary, .summary`, gets used as a document summary. https://github.com/mdn/yari/blob/95114a1f32e02eb14d30b650db0f0e411568a759/build/document-extractor.js#L533

Since `p.summary` _is_ the first paragraph, and the `span.seoSummary` encompasses whole said paragraph, they are all same.

For style classes:

Even though Yari renderer is already stripping the legacy style classes from headings and dls, I think this should help translation efforts a bit by cleaning the source code.