### PR TITLE
Fix broken link to TDZ

### DIFF
--- a/files/en-us/web/javascript/reference/statements/let/index.html
+++ b/files/en-us/web/javascript/reference/statements/let/index.html
@@ -50,7 +50,7 @@ browser-compat: javascript.statements.let
   declares a variable globally, or locally to an entire function regardless of block
   scope. The other difference between {{jsxref("statements/var", "var")}} and
   <code>let</code> is that the latter is initialized to a value only when a <a
-    href="#Temporal_dead_zone_tdz">parser evaluates it (see below)</a>.</p>
+    href="#temporal_dead_zone_tdz">parser evaluates it (see below)</a>.</p>
 
 <p>Just like {{jsxref("statements/const", "const", "Description")}} the <code>let</code>
   does <em>not</em> create properties of the {{domxref("window")}} object when declared

--- a/files/en-us/web/javascript/reference/statements/let/index.html
+++ b/files/en-us/web/javascript/reference/statements/let/index.html
@@ -50,7 +50,7 @@ browser-compat: javascript.statements.let
   declares a variable globally, or locally to an entire function regardless of block
   scope. The other difference between {{jsxref("statements/var", "var")}} and
   <code>let</code> is that the latter is initialized to a value only when a <a
-    href="#Temporal_dead_zone">parser evaluates it (see below)</a>.</p>
+    href="#Temporal_dead_zone_tdz">parser evaluates it (see below)</a>.</p>
 
 <p>Just like {{jsxref("statements/const", "const", "Description")}} the <code>let</code>
   does <em>not</em> create properties of the {{domxref("window")}} object when declared


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

In https://github.com/mdn/content/commit/92a9b04bf11236a0cbad2ebeb23492d5a3e2a2f9#diff-89a3708d223d1000c33e17fe227dac7cdc5b3c20df0246a15ef29ed742eb3002 H3 ID was changed without updating link.
> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
