### PR TITLE
Put browser-compat in front-runner for api/[opq]

### DIFF
--- a/files/en-us/web/api/oes_element_index_uint/index.html
+++ b/files/en-us/web/api/oes_element_index_uint/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_element_index_uint
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -51,7 +52,7 @@ gl.drawElements(gl.POINTS, 8, gl.UNSIGNED_INT, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_element_index_uint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_fbo_render_mipmap/index.html
+++ b/files/en-us/web/api/oes_fbo_render_mipmap/index.html
@@ -7,6 +7,7 @@ tags:
   - WebGL
   - WebGL extension
   - WebGL extensions
+browser-compat: api.OES_fbo_render_mipmap
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_fbo_render_mipmap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_standard_derivatives/index.html
+++ b/files/en-us/web/api/oes_standard_derivatives/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_standard_derivatives
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -76,7 +77,7 @@ void main(){
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_standard_derivatives")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_texture_float/index.html
+++ b/files/en-us/web/api/oes_texture_float/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_texture_float
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -65,7 +66,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, image);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_texture_float")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_texture_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_float_linear/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_texture_float_linear
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -54,7 +55,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, image);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_texture_float_linear")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_texture_half_float/index.html
+++ b/files/en-us/web/api/oes_texture_half_float/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_texture_half_float
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -71,7 +72,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, ext.HALF_FLOAT_OES, image);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_texture_half_float")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_texture_half_float_linear/index.html
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_texture_half_float_linear
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -54,7 +55,7 @@ gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, halfFloat.HALF_FLOAT_OES, imag
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_texture_half_float_linear")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.html
@@ -8,6 +8,7 @@ tags:
 - VAO
 - WebGL
 - WebGL extension
+browser-compat: api.OES_vertex_array_object.bindVertexArrayOES
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -62,7 +63,7 @@ ext.bindVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_vertex_array_object.bindVertexArrayOES")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.html
@@ -8,6 +8,7 @@ tags:
 - VAO
 - WebGL
 - WebGL extension
+browser-compat: api.OES_vertex_array_object.createVertexArrayOES
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -62,7 +63,7 @@ ext.bindVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_vertex_array_object.createVertexArrayOES")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.html
@@ -8,6 +8,7 @@ tags:
 - VAO
 - WebGL
 - WebGL extension
+browser-compat: api.OES_vertex_array_object.deleteVertexArrayOES
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -61,7 +62,7 @@ ext.deleteVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_vertex_array_object.deleteVertexArrayOES")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.OES_vertex_array_object
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -80,7 +81,7 @@ oes_vao_ext.bindVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_vertex_array_object")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.html
+++ b/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.html
@@ -8,6 +8,7 @@ tags:
   - VAO
   - WebGL
   - WebGL extension
+browser-compat: api.OES_vertex_array_object.isVertexArrayOES
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -63,7 +64,7 @@ ext.isVertexArrayOES(vao);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OES_vertex_array_object.isVertexArrayOES")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.html
@@ -7,6 +7,7 @@ tags:
   - OfflineAudioCompletionEvent
   - Reference
   - Web Audio API
+browser-compat: api.OfflineAudioCompletionEvent
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -55,7 +56,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioCompletionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.html
@@ -8,6 +8,7 @@ tags:
 - OfflineAudioCompletionEvent
 - Reference
 - Web Audio API
+browser-compat: api.OfflineAudioCompletionEvent.OfflineAudioCompletionEvent
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -66,5 +67,5 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.OfflineAudioCompletionEvent.OfflineAudioCompletionEvent")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
+++ b/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - Web Audio API
+browser-compat: api.OfflineAudioCompletionEvent.renderedBuffer
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioCompletionEvent.renderedBuffer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/offlineaudiocontext/complete_event/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/complete_event/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - complete
+browser-compat: api.OfflineAudioContext.complete_event
 ---
 <p>{{DefaultAPISidebar("Web Audio API")}}</p>
 
@@ -79,7 +80,7 @@ offlineAudioCtx.oncomplete = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.complete_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/index.html
@@ -8,6 +8,7 @@ tags:
   - OfflineAudioContext
   - Reference
   - Web Audio API
+browser-compat: api.OfflineAudioContext
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -151,7 +152,7 @@ getData();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/length/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/length/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - Web Audio API
+browser-compat: api.OfflineAudioContext.length
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -42,4 +43,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.length")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.html
@@ -9,6 +9,7 @@ tags:
   - OfflineAudioContext
   - Reference
   - Web Audio API
+browser-compat: api.OfflineAudioContext.OfflineAudioContext
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
@@ -106,4 +107,4 @@ const source = offlineCtx.createBufferSource();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.OfflineAudioContext")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/offlineaudiocontext/oncomplete/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/oncomplete/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - oncomplete
+browser-compat: api.OfflineAudioContext.oncomplete
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -49,7 +50,7 @@ offlineAudioCtx.oncomplete = function() { ... }</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.oncomplete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Audio API
 - resume
+browser-compat: api.OfflineAudioContext.resume
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.resume")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/offlineaudiocontext/startrendering/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/startrendering/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - startRendering
+browser-compat: api.OfflineAudioContext.startRendering
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -146,7 +147,7 @@ getData();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.startRendering")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.html
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Web Audio API
 - suspend
+browser-compat: api.OfflineAudioContext.suspend
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OfflineAudioContext.suspend")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.html
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - OffscreenCanvas
   - Reference
+browser-compat: api.OffscreenCanvas.convertToBlob
 ---
 <p>{{APIRef("Canvas API")}} {{SeeCompatTable}}</p>
 
@@ -75,7 +76,7 @@ offscreen.convertToBlob().then(function(blob) {
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.OffscreenCanvas.convertToBlob")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.html
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - OffscreenCanvas
   - Reference
+browser-compat: api.OffscreenCanvas.getContext
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -158,7 +159,7 @@ gl.canvas; // OffscreenCanvas</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas.getContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/height/index.html
+++ b/files/en-us/web/api/offscreencanvas/height/index.html
@@ -8,6 +8,7 @@ tags:
 - OffscreenCanvas
 - Property
 - Reference
+browser-compat: api.OffscreenCanvas.height
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ offscreen.height = 512;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/index.html
+++ b/files/en-us/web/api/offscreencanvas/index.html
@@ -7,6 +7,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.OffscreenCanvas
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -130,7 +131,7 @@ worker.postMessage({canvas: offscreen}, [offscreen]);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/offscreencanvas/index.html
+++ b/files/en-us/web/api/offscreencanvas/offscreencanvas/index.html
@@ -9,6 +9,7 @@ tags:
 - OffscreenCanvas
 - Reference
 - WebGL
+browser-compat: api.OffscreenCanvas.OffscreenCanvas
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ let gl = offscreen.getContext('webgl');
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas.OffscreenCanvas")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/toblob/index.html
+++ b/files/en-us/web/api/offscreencanvas/toblob/index.html
@@ -8,6 +8,7 @@ tags:
 - Method
 - OffscreenCanvas
 - Reference
+browser-compat: api.OffscreenCanvas.convertToBlob
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -72,7 +73,7 @@ offscreen.convertToBlob().then(function(blob) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas.convertToBlob")}}</p>
+<p>{{Compat}}</p>
 
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.html
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.html
@@ -8,6 +8,7 @@ tags:
   - Method
   - OffscreenCanvas
   - Reference
+browser-compat: api.OffscreenCanvas.transferToImageBitmap
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -54,7 +55,7 @@ offscreen.transferToImageBitmap();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas.transferToImageBitmap")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/offscreencanvas/width/index.html
+++ b/files/en-us/web/api/offscreencanvas/width/index.html
@@ -8,6 +8,7 @@ tags:
 - OffscreenCanvas
 - Property
 - Reference
+browser-compat: api.OffscreenCanvas.width
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -49,7 +50,7 @@ offscreen.width = 512;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OffscreenCanvas.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/orientationsensor/index.html
+++ b/files/en-us/web/api/orientationsensor/index.html
@@ -11,6 +11,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.OrientationSensor
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -99,4 +100,4 @@ Promise.all([navigator.permissions.query({ name: "accelerometer" }),
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OrientationSensor")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/orientationsensor/populatematrix/index.html
+++ b/files/en-us/web/api/orientationsensor/populatematrix/index.html
@@ -12,6 +12,7 @@ tags:
   - Sensor APIs
   - Sensors
   - populateMatrix()
+browser-compat: api.OrientationSensor.populateMatrix
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -78,4 +79,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OrientationSensor.populateMatrix")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/orientationsensor/quaternion/index.html
+++ b/files/en-us/web/api/orientationsensor/quaternion/index.html
@@ -11,6 +11,7 @@ tags:
 - Sensor
 - Sensor APIs
 - Sensors
+browser-compat: api.OrientationSensor.quaternion
 ---
 <div>{{APIRef("Generic Sensor API")}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OrientationSensor.quaternion")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/oscillatornode/detune/index.html
+++ b/files/en-us/web/api/oscillatornode/detune/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - detune
+browser-compat: api.OscillatorNode.detune
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -62,7 +63,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.detune")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/frequency/index.html
+++ b/files/en-us/web/api/oscillatornode/frequency/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - frequency
+browser-compat: api.OscillatorNode.frequency
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,7 +62,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.frequency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/index.html
@@ -9,6 +9,7 @@ tags:
   - OscillatorNode
   - Reference
   - Web Audio API
+browser-compat: api.OscillatorNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -115,7 +116,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/onended/index.html
+++ b/files/en-us/web/api/oscillatornode/onended/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - onended
+browser-compat: api.OscillatorNode.onended
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -62,7 +63,7 @@ oscillator.onended = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.onended")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.html
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio
   - Web Audio API
+browser-compat: api.OscillatorNode.OscillatorNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -81,5 +82,5 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.OscillatorNode.OscillatorNode")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/oscillatornode/setperiodicwave/index.html
+++ b/files/en-us/web/api/oscillatornode/setperiodicwave/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - setPeriodicWave
+browser-compat: api.OscillatorNode.setPeriodicWave
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -92,7 +93,7 @@ osc.stop(2);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.setPeriodicWave")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/start/index.html
+++ b/files/en-us/web/api/oscillatornode/start/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - start
+browser-compat: api.OscillatorNode.start
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -70,7 +71,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.start")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/stop/index.html
+++ b/files/en-us/web/api/oscillatornode/stop/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - stop
+browser-compat: api.OscillatorNode.stop
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -72,7 +73,7 @@ oscillator.stop(audioCtx.currentTime + 2); // stop 2 seconds after the current t
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.stop")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/oscillatornode/type/index.html
+++ b/files/en-us/web/api/oscillatornode/type/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Type
   - Web Audio API
+browser-compat: api.OscillatorNode.type
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -92,7 +93,7 @@ oscillator.start();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OscillatorNode.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/overconstrainederror/constraint/index.html
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Video
 - constraint
+browser-compat: api.OverconstrainedError.constraint
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Media Capture and
   Streams")}}{{SeeCompatTable}}</div>
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OverconstrainedError.constraint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/index.html
@@ -11,6 +11,7 @@ tags:
   - OverconstrainedError
   - Reference
   - Video
+browser-compat: api.OverconstrainedError
 ---
 <div>{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OverconstrainedError")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.html
@@ -11,6 +11,7 @@ tags:
 - OverconstrainedError
 - Reference
 - Video
+browser-compat: api.OverconstrainedError.OverconstrainedError
 ---
 <div>{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
 </div>
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OverconstrainedError.OverconstrainedError")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.html
+++ b/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.html
@@ -10,6 +10,7 @@ tags:
   - WebGL extensions
   - WebVR
   - WebXR
+browser-compat: api.OVR_multiview2.framebufferTextureMultiviewOVR
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -154,7 +155,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OVR_multiview2.framebufferTextureMultiviewOVR")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/ovr_multiview2/index.html
+++ b/files/en-us/web/api/ovr_multiview2/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - WebGL
   - WebGL extensions
+browser-compat: api.OVR_multiview2
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -102,7 +103,7 @@ void main() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.OVR_multiview2")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/page_visibility_api/index.html
+++ b/files/en-us/web/api/page_visibility_api/index.html
@@ -14,6 +14,7 @@ tags:
   - Tutorials
   - Visibility
   - Visible Pages
+browser-compat: api.Document.visibilityState
 ---
 <div>{{DefaultAPISidebar("Page Visibility API")}}</div>
 
@@ -188,7 +189,7 @@ document.addEventListener("visibilitychange", handleVisibilityChange, false);
 
 <div>
 
-<p>{{Compat("api.Document.visibilityState")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/page_visibility_api/index.html
+++ b/files/en-us/web/api/page_visibility_api/index.html
@@ -14,7 +14,6 @@ tags:
   - Tutorials
   - Visibility
   - Visible Pages
-browser-compat: api.Document.visibilityState
 ---
 <div>{{DefaultAPISidebar("Page Visibility API")}}</div>
 
@@ -189,7 +188,7 @@ document.addEventListener("visibilitychange", handleVisibilityChange, false);
 
 <div>
 
-<p>{{Compat}}</p>
+<p>{{Compat("api.Document.visibilityState")}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/pagetransitionevent/index.html
+++ b/files/en-us/web/api/pagetransitionevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - PageTransitionEvent
   - Reference
+browser-compat: api.PageTransitionEvent
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -66,7 +67,7 @@ function myFunction(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PageTransitionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pagetransitionevent/persisted/index.html
+++ b/files/en-us/web/api/pagetransitionevent/persisted/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - Web API
+browser-compat: api.PageTransitionEvent.persisted
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PageTransitionEvent.persisted")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paintworklet/devicepixelratio/index.html
+++ b/files/en-us/web/api/paintworklet/devicepixelratio/index.html
@@ -13,6 +13,7 @@ tags:
   - Worklet
   - devicePixelRatio
   - paintWorklet
+browser-compat: api.PaintWorkletGlobalScope.devicePixelRatio
 ---
 <p>{{draft}}{{APIRef("CSS Painting API")}}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaintWorkletGlobalScope.devicePixelRatio")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paintworklet/index.html
+++ b/files/en-us/web/api/paintworklet/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Worklet
   - paintWorklet
+browser-compat: api.PaintWorkletGlobalScope
 ---
 <p>{{APIRef("CSS Painting API")}} {{SeeCompatTable}}</p>
 
@@ -113,7 +114,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaintWorkletGlobalScope")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paintworklet/registerpaint/index.html
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.html
@@ -12,6 +12,7 @@ tags:
   - Worklet
   - paintWorklet
   - registerPaint
+browser-compat: api.PaintWorkletGlobalScope.registerPaint
 ---
 <div>{{draft}}{{APIRef("CSS Painting API")}}</div>
 
@@ -111,7 +112,7 @@ registerPaint('checkerboard', CheckerboardPainter);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaintWorkletGlobalScope.registerPaint")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/coneinnerangle/index.html
+++ b/files/en-us/web/api/pannernode/coneinnerangle/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - coneInnerAngle
+browser-compat: api.PannerNode.coneInnerAngle
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -50,7 +51,7 @@ panner.coneInnerAngle = 360;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.coneInnerAngle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/coneouterangle/index.html
+++ b/files/en-us/web/api/pannernode/coneouterangle/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - coneOuterAngle
+browser-compat: api.PannerNode.coneOuterAngle
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -50,7 +51,7 @@ panner.coneOuterAngle = 0;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.coneOuterAngle")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/coneoutergain/index.html
+++ b/files/en-us/web/api/pannernode/coneoutergain/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - coneOuterGain
+browser-compat: api.PannerNode.coneOuterGain
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -57,7 +58,7 @@ panner.coneOuterGain = 0;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.coneOuterGain")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/distancemodel/index.html
+++ b/files/en-us/web/api/pannernode/distancemodel/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - distanceModel
+browser-compat: api.PannerNode.distanceModel
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -61,7 +62,7 @@ panner.distanceModel = 'inverse';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.distanceModel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/index.html
@@ -7,6 +7,7 @@ tags:
   - PannerNode
   - Reference
   - Web Audio API
+browser-compat: api.PannerNode
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -125,7 +126,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/maxdistance/index.html
+++ b/files/en-us/web/api/pannernode/maxdistance/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - maxDistance
+browser-compat: api.PannerNode.maxDistance
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -57,7 +58,7 @@ panner.maxDistance = 10000;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.maxDistance")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/orientationx/index.html
+++ b/files/en-us/web/api/pannernode/orientationx/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Web Audio API
   - orientationX
+browser-compat: api.PannerNode.orientationX
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -163,7 +164,7 @@ osc.start(0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.orientationX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/orientationy/index.html
+++ b/files/en-us/web/api/pannernode/orientationy/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - orientationY
+browser-compat: api.PannerNode.orientationY
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.orientationY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/orientationz/index.html
+++ b/files/en-us/web/api/pannernode/orientationz/index.html
@@ -6,6 +6,7 @@ tags:
   - PannerNode
   - Property
   - Web Audio
+browser-compat: api.PannerNode.orientationZ
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -71,7 +72,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.orientationZ")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/pannernode/index.html
+++ b/files/en-us/web/api/pannernode/pannernode/index.html
@@ -8,6 +8,7 @@ tags:
   - PannerNode
   - Reference
   - Web Audio API
+browser-compat: api.PannerNode.PannerNode
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -88,4 +89,4 @@ var myPanner = new PannerNode(ctx, options);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.PannerNode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pannernode/panningmodel/index.html
+++ b/files/en-us/web/api/pannernode/panningmodel/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - panningModel
+browser-compat: api.PannerNode.panningModel
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -55,7 +56,7 @@ panner.panningModel = 'HRTF';</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.panningModel")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/positionx/index.html
+++ b/files/en-us/web/api/pannernode/positionx/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - positionX
+browser-compat: api.PannerNode.positionX
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -89,7 +90,7 @@ osc.start(0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.positionX")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/positiony/index.html
+++ b/files/en-us/web/api/pannernode/positiony/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - positionY
+browser-compat: api.PannerNode.positionY
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -91,7 +92,7 @@ osc.start(0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.positionY")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/positionz/index.html
+++ b/files/en-us/web/api/pannernode/positionz/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - positionZ
+browser-compat: api.PannerNode.positionZ
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -91,7 +92,7 @@ osc.start(0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.positionZ")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/refdistance/index.html
+++ b/files/en-us/web/api/pannernode/refdistance/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - refDistance
+browser-compat: api.PannerNode.refDistance
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -94,7 +95,7 @@ scheduleTestTone(7, context.currentTime + NOTE_LENGTH * 2);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.refDistance")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/rollofffactor/index.html
+++ b/files/en-us/web/api/pannernode/rollofffactor/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - rollOffFactor
+browser-compat: api.PannerNode.rolloffFactor
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -107,7 +108,7 @@ scheduleTestTone(0.1, context.currentTime + NOTE_LENGTH * 2);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.rolloffFactor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/setorientation/index.html
+++ b/files/en-us/web/api/pannernode/setorientation/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - setOrientation
+browser-compat: api.PannerNode.setOrientation
 ---
 <p>{{ APIRef("Web Audio API") }} {{Deprecated_Header}}</p>
 
@@ -63,7 +64,7 @@ panner.setOrientation(1,0,0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.setOrientation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/setposition/index.html
+++ b/files/en-us/web/api/pannernode/setposition/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Audio API
   - setPosition
+browser-compat: api.PannerNode.setPosition
 ---
 <p>{{ APIRef("Web Audio API") }} {{Deprecated_Header}}</p>
 
@@ -61,7 +62,7 @@ panner.setPosition(0,0,0);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.setPosition")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pannernode/setvelocity/index.html
+++ b/files/en-us/web/api/pannernode/setvelocity/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Web Audio API
   - setVelocity
+browser-compat: api.PannerNode.setVelocity
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -51,7 +52,7 @@ panner.setVelocity(0,0,17);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PannerNode.setVelocity")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/passwordcredential/iconurl/index.html
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - credential management
+browser-compat: api.PasswordCredential.iconURL
 ---
 <p>{{SeeCompatTable}}{{APIRef("")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PasswordCredential.iconURL")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/index.html
@@ -8,6 +8,7 @@ tags:
   - PasswordCredential
   - Reference
   - credential management
+browser-compat: api.PasswordCredential
 ---
 <p>{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}</p>
 
@@ -79,4 +80,4 @@ navigator.credentials.store(cred)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PasswordCredential")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/passwordcredential/name/index.html
+++ b/files/en-us/web/api/passwordcredential/name/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - credential management
+browser-compat: api.PasswordCredential.name
 ---
 <p>{{SeeCompatTable}}{{APIRef("")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PasswordCredential.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/passwordcredential/password/index.html
+++ b/files/en-us/web/api/passwordcredential/password/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - credential management
+browser-compat: api.PasswordCredential.password
 ---
 <p>{{SeeCompatTable}}{{APIRef("")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PasswordCredential.password")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.html
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.html
@@ -8,6 +8,7 @@ tags:
   - PasswordCredential
   - Reference
   - credential management
+browser-compat: api.PasswordCredential.PasswordCredential
 ---
 <p>{{APIRef("")}}{{Non-standard_header}}</p>
 
@@ -85,4 +86,4 @@ navigator.credentials.store(creds)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PasswordCredential.PasswordCredential")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/path2d/addpath/index.html
+++ b/files/en-us/web/api/path2d/addpath/index.html
@@ -8,6 +8,7 @@ tags:
 - Path2D
 - Path2D.addPath
 - Reference
+browser-compat: api.Path2D.addPath
 ---
 <div>{{APIRef("Canvas API")}}</div>
 
@@ -98,7 +99,7 @@ ctx.fill(p1);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Path2D.addPath")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/path2d/index.html
+++ b/files/en-us/web/api/path2d/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Path2D
   - Reference
+browser-compat: api.Path2D
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Path2D")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/path2d/path2d/index.html
+++ b/files/en-us/web/api/path2d/path2d/index.html
@@ -10,6 +10,7 @@ tags:
 - Path2D
 - Paths
 - Reference
+browser-compat: api.Path2D.Path2D
 ---
 <div>{{APIRef("Canvas API")}} {{SeeCompatTable}}</div>
 
@@ -102,7 +103,7 @@ ctx.fill(p);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Path2D.Path2D")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/payererrors/email/index.html
+++ b/files/en-us/web/api/payererrors/email/index.html
@@ -13,6 +13,7 @@ tags:
 - Shopping
 - Validation
 - payment
+browser-compat: api.PayerErrors.email
 ---
 <div>{{APIRef("Payment Request API")}} {{Deprecated_header}} {{Non-standard_header}}</div>
 
@@ -61,4 +62,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PayerErrors.email")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/payererrors/index.html
+++ b/files/en-us/web/api/payererrors/index.html
@@ -14,6 +14,7 @@ tags:
   - Reference
   - payment
   - paymentAddress
+browser-compat: api.PayerErrors
 ---
 <div>{{APIRef("Payment Request API")}} {{Deprecated_header}} {{Non-standard_header}}</div>
 
@@ -34,4 +35,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PayerErrors")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/payererrors/name/index.html
+++ b/files/en-us/web/api/payererrors/name/index.html
@@ -15,6 +15,7 @@ tags:
 - Validation
 - name
 - payment
+browser-compat: api.PayerErrors.name
 ---
 <div>{{APIRef("Payment Request API")}} {{Deprecated_header}} {{Non-standard_header}}</div>
 
@@ -66,4 +67,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PayerErrors.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/payererrors/phone/index.html
+++ b/files/en-us/web/api/payererrors/phone/index.html
@@ -16,6 +16,7 @@ tags:
 - Response
 - Validation
 - payment
+browser-compat: api.PayerErrors.phone
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PayerErrors.phone")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/addressline/index.html
+++ b/files/en-us/web/api/paymentaddress/addressline/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - payment
 - paymentAddress
+browser-compat: api.PaymentAddress.addressLine
 ---
 <p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.addressLine")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/city/index.html
+++ b/files/en-us/web/api/paymentaddress/city/index.html
@@ -15,6 +15,7 @@ tags:
 - paymentAddress
 - town
 - village
+browser-compat: api.PaymentAddress.city
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}}</div>
 
@@ -34,4 +35,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.city")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/country/index.html
+++ b/files/en-us/web/api/paymentaddress/country/index.html
@@ -12,6 +12,7 @@ tags:
 - country
 - payment
 - paymentAddress
+browser-compat: api.PaymentAddress.country
 ---
 <p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -49,7 +50,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.PaymentAddress.country")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentaddress/dependentlocality/index.html
+++ b/files/en-us/web/api/paymentaddress/dependentlocality/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - paymentAddress
+browser-compat: api.PaymentAddress.dependentLocality
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -37,4 +38,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.dependentLocality")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/index.html
+++ b/files/en-us/web/api/paymentaddress/index.html
@@ -9,6 +9,7 @@ tags:
   - PaymentRequest
   - Reference
   - paymentAddress
+browser-compat: api.PaymentAddress
 ---
 <div>{{APIRef("Payment Request API")}}{{SecureContext_Header}} {{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -124,4 +125,4 @@ doPaymentRequest();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/languagecode/index.html
+++ b/files/en-us/web/api/paymentaddress/languagecode/index.html
@@ -16,6 +16,7 @@ tags:
 - WebRTC
 - WebRTC API
 - rtc
+browser-compat: api.PaymentAddress.languageCode
 ---
 <p>{{deprecated_header}}{{APIRef("Payment Request API")}}{{Non-standard_header}}</p>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.languageCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/organization/index.html
+++ b/files/en-us/web/api/paymentaddress/organization/index.html
@@ -15,6 +15,7 @@ tags:
 - institution
 - organization
 - paymentAddress
+browser-compat: api.PaymentAddress.organization
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -36,4 +37,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.organization")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/phone/index.html
+++ b/files/en-us/web/api/paymentaddress/phone/index.html
@@ -15,6 +15,7 @@ tags:
 - Téléphone
 - payment
 - paymentAddress
+browser-compat: api.PaymentAddress.phone
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -35,4 +36,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.phone")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/postalcode/index.html
+++ b/files/en-us/web/api/paymentaddress/postalcode/index.html
@@ -19,6 +19,7 @@ tags:
 - payment
 - paymentAddress
 - postalCode
+browser-compat: api.PaymentAddress.postalCode
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.PaymentAddress.postalCode")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentaddress/recipient/index.html
+++ b/files/en-us/web/api/paymentaddress/recipient/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - paymentAddress
+browser-compat: api.PaymentAddress.recipient
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -29,4 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.recipient")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/region/index.html
+++ b/files/en-us/web/api/paymentaddress/region/index.html
@@ -17,6 +17,7 @@ tags:
 - paymentAddress
 - region
 - state
+browser-compat: api.PaymentAddress.region
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.region")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/sortingcode/index.html
+++ b/files/en-us/web/api/paymentaddress/sortingcode/index.html
@@ -13,6 +13,7 @@ tags:
 - payment
 - paymentAddress
 - sortingCode
+browser-compat: api.PaymentAddress.sortingCode
 ---
 <div>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.sortingCode")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentaddress/tojson/index.html
+++ b/files/en-us/web/api/paymentaddress/tojson/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - paymentAddress
 - toJSON
+browser-compat: api.PaymentAddress.toJSON
 ---
 <p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -34,4 +35,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentAddress.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentcurrencyamount/currency/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currency/index.html
@@ -12,6 +12,7 @@ tags:
 - PaymentCurrencySystem
 - Reference
 - payment
+browser-compat: api.PaymentCurrencyAmount.currency
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentCurrencyAmount.currency")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/currencysystem/index.html
@@ -14,6 +14,7 @@ tags:
 - Property
 - Reference
 - payment
+browser-compat: api.PaymentCurrencyAmount.currencySystem
 ---
 <p> {{APIRef("Payment Request API")}} {{Deprecated_Header}}</p>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentCurrencyAmount.currencySystem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentcurrencyamount/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/index.html
@@ -15,6 +15,7 @@ tags:
   - cost
   - payment
   - value
+browser-compat: api.PaymentCurrencyAmount
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -59,4 +60,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentCurrencyAmount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentcurrencyamount/value/index.html
+++ b/files/en-us/web/api/paymentcurrencyamount/value/index.html
@@ -14,6 +14,7 @@ tags:
 - cost
 - payment
 - value
+browser-compat: api.PaymentCurrencyAmount.value
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -117,7 +118,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentCurrencyAmount.value")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentdetailsbase/index.html
+++ b/files/en-us/web/api/paymentdetailsbase/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Web Payments
   - Web Payments API
+browser-compat: api.PaymentDetailsBase
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentDetailsBase")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentdetailsupdate/error/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/error/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - payment
+browser-compat: api.PaymentDetailsUpdate.error
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentDetailsUpdate.error")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentdetailsupdate/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - details
   - payment
+browser-compat: api.PaymentDetailsUpdate
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}{{draft}}</div>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentDetailsUpdate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentdetailsupdate/shippingaddresserrors/index.html
+++ b/files/en-us/web/api/paymentdetailsupdate/shippingaddresserrors/index.html
@@ -14,6 +14,7 @@ tags:
 - Validation
 - payment
 - shippingAddressErrors
+browser-compat: api.PaymentDetailsUpdate.shippingAddressErrors
 ---
 <div>{{APIRef("Payment Request API")}}{{securecontext_header}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentDetailsUpdate.shippingAddressErrors")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentitem/index.html
+++ b/files/en-us/web/api/paymentitem/index.html
@@ -10,6 +10,7 @@ tags:
   - PaymentItem
   - Reference
   - payment
+browser-compat: api.PaymentItem
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentItem")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentmethodchangeevent/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - payment
+browser-compat: api.PaymentMethodChangeEvent
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentMethodChangeEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.html
@@ -13,6 +13,7 @@ tags:
 - methodDetails
 - payment
 - paymentmethodchange
+browser-compat: api.PaymentMethodChangeEvent.methodDetails
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -87,4 +88,4 @@ const response = await request.show();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentMethodChangeEvent.methodDetails")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentmethodchangeevent/methodname/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/methodname/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - methodName
 - payment
+browser-compat: api.PaymentMethodChangeEvent.methodName
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -84,4 +85,4 @@ const response = await request.show();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentMethodChangeEvent.methodName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.html
+++ b/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.html
@@ -10,6 +10,7 @@ tags:
 - PaymentMethodChangeEvent
 - Reference
 - payment
+browser-compat: api.PaymentMethodChangeEvent.PaymentMethodChangeEvent
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentMethodChangeEvent.PaymentMethodChangeEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/abort/index.html
+++ b/files/en-us/web/api/paymentrequest/abort/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Secure context
   - abort
+browser-compat: api.PaymentRequest.abort
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -65,7 +66,7 @@ var paymentTimeout = window.setTimeout(() =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.abort")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.html
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - canMakePayment
+browser-compat: api.PaymentRequest.canMakePayment
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -118,7 +119,7 @@ async function initPaymentRquest() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.canMakePayment")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/id/index.html
+++ b/files/en-us/web/api/paymentrequest/id/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Secure context
 - id
+browser-compat: api.PaymentRequest.id
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -77,4 +78,4 @@ console.log(json.requestId,response.requestId, request.id);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/index.html
@@ -13,6 +13,7 @@ tags:
   - Payments
   - Reference
   - Secure context
+browser-compat: api.PaymentRequest
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -85,4 +86,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.html
+++ b/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.html
@@ -15,6 +15,7 @@ tags:
   - events
   - merchantvalidation
   - payment
+browser-compat: api.PaymentRequest.merchantvalidation_event
 ---
 <div>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</div>
 
@@ -85,7 +86,7 @@ const response = await request.show();</pre>
 
 <div>
 
-<p>{{Compat("api.PaymentRequest.merchantvalidation_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/onmerchantvalidation/index.html
+++ b/files/en-us/web/api/paymentrequest/onmerchantvalidation/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - onmerchantvalidation
 - payment
+browser-compat: api.PaymentRequest.onmerchantvalidation
 ---
 <p>{{deprecated_header}}{{non-standard_header}}{{securecontext_header}}</p>
 
@@ -59,4 +60,4 @@ const response = await request.show();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.onmerchantvalidation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/onpaymentmethodchange/index.html
+++ b/files/en-us/web/api/paymentrequest/onpaymentmethodchange/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - onpaymentmethodchange
 - payment
+browser-compat: api.PaymentRequest.onpaymentmethodchange
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -85,4 +86,4 @@ const response = await request.show();</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.onpaymentmethodchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.html
+++ b/files/en-us/web/api/paymentrequest/onshippingaddresschange/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - onshippingaddresschange
+browser-compat: api.PaymentRequest.onshippingaddresschange
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -52,4 +53,4 @@ payment.show().then(function(paymentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.onshippingaddresschange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.html
+++ b/files/en-us/web/api/paymentrequest/onshippingoptionchange/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Secure context
   - onshippingoptionchange
+browser-compat: api.PaymentRequest.onshippingoptionchange
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -79,4 +80,4 @@ request.addEventListener('shippingaddresschange', e =&gt; {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.onshippingoptionchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.html
@@ -9,6 +9,7 @@ tags:
   - events
   - payment
   - paymentmethodchange
+browser-compat: api.PaymentRequest.paymentmethodchange_event
 ---
 <div>{{APIRef}}</div>
 
@@ -99,7 +100,7 @@ paymentRequest.show()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.paymentmethodchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/paymentrequest/index.html
+++ b/files/en-us/web/api/paymentrequest/paymentrequest/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Secure context
 - payment
+browser-compat: api.PaymentRequest.PaymentRequest
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -187,4 +188,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.PaymentRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/shippingaddress/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingaddress/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - shippingAddress
+browser-compat: api.PaymentRequest.shippingAddress
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -81,4 +82,4 @@ function updateDetails(details, shippingAddress, resolve) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.shippingAddress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/shippingaddresschange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingaddresschange_event/index.html
@@ -14,6 +14,7 @@ tags:
   - events
   - payment
   - shippingaddresschange
+browser-compat: api.PaymentRequest.shippingaddresschange_event
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -76,7 +77,7 @@ const checkAddress = theAddress =&gt; {
 
 <div>
 
-<p>{{Compat("api.PaymentRequest.shippingaddresschange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingoption/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingoption/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Secure context
   - shippingOption
+browser-compat: api.PaymentRequest.shippingOption
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -71,4 +72,4 @@ async function checkShipping(request) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.shippingOption")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/shippingoptionchange_event/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingoptionchange_event/index.html
@@ -13,6 +13,7 @@ tags:
   - onshippingoptionchange
   - payment
   - shippingoptionchange
+browser-compat: api.PaymentRequest.shippingoptionchange_event
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <div>
 
-<p>{{Compat("api.PaymentRequest.shippingoptionchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequest/shippingtype/index.html
+++ b/files/en-us/web/api/paymentrequest/shippingtype/index.html
@@ -10,6 +10,7 @@ tags:
 - Reference
 - Secure context
 - shippingType
+browser-compat: api.PaymentRequest.shippingType
 ---
 <p>{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -30,4 +31,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.shippingType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequest/show/index.html
+++ b/files/en-us/web/api/paymentrequest/show/index.html
@@ -13,6 +13,7 @@ tags:
 - Reference
 - Secure context
 - show
+browser-compat: api.PaymentRequest.show
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}</div>
 
@@ -295,7 +296,7 @@ document.getElementById("buyButton").onclick = requestPayment;</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequest.show")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequestevent/index.html
+++ b/files/en-us/web/api/paymentrequestevent/index.html
@@ -9,6 +9,7 @@ tags:
   - PaymentRequestEvent
   - Reference
   - payment
+browser-compat: api.PaymentRequestEvent
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -67,4 +68,4 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.PaymentRequestEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/instrumentkey/index.html
+++ b/files/en-us/web/api/paymentrequestevent/instrumentkey/index.html
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.instrumentKey
 slug: Web/API/PaymentRequestEvent/instrumentKey
+browser-compat: api.PaymentRequestEvent.instrumentKey
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -39,4 +40,4 @@ slug: Web/API/PaymentRequestEvent/instrumentKey
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.instrumentKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/methoddata/index.html
+++ b/files/en-us/web/api/paymentrequestevent/methoddata/index.html
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.methodData
 slug: Web/API/PaymentRequestEvent/methodData
+browser-compat: api.PaymentRequestEvent.methodData
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -38,4 +39,4 @@ slug: Web/API/PaymentRequestEvent/methodData
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.methodData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/modifiers/index.html
+++ b/files/en-us/web/api/paymentrequestevent/modifiers/index.html
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.modifiers
 slug: Web/API/PaymentRequestEvent/modifiers
+browser-compat: api.PaymentRequestEvent.modifiers
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -36,4 +37,4 @@ slug: Web/API/PaymentRequestEvent/modifiers
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.modifiers")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/openwindow/index.html
+++ b/files/en-us/web/api/paymentrequestevent/openwindow/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - openWindow()
 - payment
+browser-compat: api.PaymentRequestEvent.openWindow
 ---
 <p>{{APIRef("Payment Request API")}}{{SeeCompatTable}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.openWindow")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestevent/index.html
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestevent/index.html
@@ -8,6 +8,7 @@ tags:
 - PaymentRequestEvent
 - Reference
 - payment
+browser-compat: api.PaymentRequestEvent.PaymentRequestEvent
 ---
 <p>{{APIRef("Payment Request API")}}{{Non-standard_header}}</p>
 
@@ -50,4 +51,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.PaymentRequestEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.html
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - payment
 - paymentRequestId
+browser-compat: api.PaymentRequestEvent.paymentRequestId
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.paymentRequestId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.html
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - payment
 - paymentRequestOrigin
+browser-compat: api.PaymentRequestEvent.paymentRequestOrigin
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.paymentRequestOrigin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.html
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - payment
 - respondWith()
+browser-compat: api.PaymentRequestEvent.respondWith
 ---
 <p>{{APIRef("Payment Request API")}}{{SeeCompatTable}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.respondWith")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/toporigin/index.html
+++ b/files/en-us/web/api/paymentrequestevent/toporigin/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - payment
 - topLevelOrigin
+browser-compat: api.PaymentRequestEvent.topOrigin
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.topOrigin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestevent/total/index.html
+++ b/files/en-us/web/api/paymentrequestevent/total/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - payment
 - total
+browser-compat: api.PaymentRequestEvent.total
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestEvent.total")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestupdateevent/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/index.html
@@ -10,6 +10,7 @@ tags:
   - PaymentRequestUpdateEvent
   - Reference
   - Secure context
+browser-compat: api.PaymentRequestUpdateEvent
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -65,7 +66,7 @@ tags:
 
 <div>
 
-<p>{{Compat("api.PaymentRequestUpdateEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.html
@@ -10,6 +10,7 @@ tags:
 - PaymentRequestUpdateEvent
 - Reference
 - Secure context
+browser-compat: api.PaymentRequestUpdateEvent.PaymentRequestUpdateEvent
 ---
 <p>{{APIRef("Payment Request API")}}{{securecontext_header}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestUpdateEvent.PaymentRequestUpdateEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.html
+++ b/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.html
@@ -15,6 +15,7 @@ tags:
 - Web Payments
 - payment
 - updateWith
+browser-compat: api.PaymentRequestUpdateEvent.updateWith
 ---
 <p>{{APIRef("Payment Request API")}}{{securecontext_header}}</p>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentRequestUpdateEvent.updateWith")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/complete/index.html
+++ b/files/en-us/web/api/paymentresponse/complete/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Secure context
 - complete
+browser-compat: api.PaymentResponse.complete
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -125,4 +126,4 @@ payment.show().then(function(paymentResponse) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.complete")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/details/index.html
+++ b/files/en-us/web/api/paymentresponse/details/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - details
+browser-compat: api.PaymentResponse.details
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.details")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/index.html
+++ b/files/en-us/web/api/paymentresponse/index.html
@@ -9,6 +9,7 @@ tags:
   - PaymentResponse
   - Reference
   - Secure context
+browser-compat: api.PaymentResponse
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -73,4 +74,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/methodname/index.html
+++ b/files/en-us/web/api/paymentresponse/methodname/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Secure context
 - methodName
+browser-compat: api.PaymentResponse.methodName
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -71,4 +72,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.methodName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/onpayerdetailchange/index.html
+++ b/files/en-us/web/api/paymentresponse/onpayerdetailchange/index.html
@@ -15,6 +15,7 @@ tags:
 - onpayerdetailchange
 - payment
 - validate
+browser-compat: api.PaymentResponse.onpayerdetailchange
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -113,4 +114,4 @@ await response.retry({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.onpayerdetailchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/payerdetailchange_event/index.html
+++ b/files/en-us/web/api/paymentresponse/payerdetailchange_event/index.html
@@ -12,6 +12,7 @@ tags:
   - payerdetail
   - payment
   - validate
+browser-compat: api.PaymentResponse.payerdetailchange_event
 ---
 <div>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</div>
 
@@ -124,7 +125,7 @@ await response.retry({
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.payerdetailchange_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentresponse/payeremail/index.html
+++ b/files/en-us/web/api/paymentresponse/payeremail/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - payerEmail
+browser-compat: api.PaymentResponse.payerEmail
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -27,4 +28,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.payerEmail")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/payername/index.html
+++ b/files/en-us/web/api/paymentresponse/payername/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - Secure context
+browser-compat: api.PaymentResponse.payerName
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -30,4 +31,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.payerName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/payerphone/index.html
+++ b/files/en-us/web/api/paymentresponse/payerphone/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Secure context
   - payerPhone
+browser-compat: api.PaymentResponse.payerPhone
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -27,4 +28,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.payerPhone")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/requestid/index.html
+++ b/files/en-us/web/api/paymentresponse/requestid/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Secure context
 - requestId
+browser-compat: api.PaymentResponse.requestId
 ---
 <p>{{SeeCompatTable}}{{APIRef("Payment Request API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.requestId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/retry/index.html
+++ b/files/en-us/web/api/paymentresponse/retry/index.html
@@ -12,6 +12,7 @@ tags:
   - Web Payments
   - payment
   - retry
+browser-compat: api.PaymentResponse.retry
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -165,7 +166,7 @@ doPaymentRequest();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.retry")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.html
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Secure context
 - shippingAddress
+browser-compat: api.PaymentResponse.shippingAddress
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -86,4 +87,4 @@ function updateDetails(details, shippingAddress, resolve) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.shippingAddress")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentresponse/shippingoption/index.html
+++ b/files/en-us/web/api/paymentresponse/shippingoption/index.html
@@ -11,6 +11,7 @@ tags:
   - Request Payment API
   - Secure context
   - shippingOption
+browser-compat: api.PaymentResponse.shippingOption
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}</p>
 
@@ -71,4 +72,4 @@ function updateDetails(details, shippingOption, resolve, reject) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentResponse.shippingOption")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/paymentvalidationerrors/index.html
+++ b/files/en-us/web/api/paymentvalidationerrors/index.html
@@ -12,6 +12,7 @@ tags:
   - Reference
   - Validation
   - payment
+browser-compat: api.PaymentValidationErrors
 ---
 <p>{{securecontext_header}}{{APIRef("Payment Request API")}}</p>
 
@@ -57,7 +58,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PaymentValidationErrors")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/clearmarks/index.html
+++ b/files/en-us/web/api/performance/clearmarks/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.clearMarks
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
@@ -95,4 +96,4 @@ logMarkCount() // "Found this many entries: 0"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.clearMarks")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/clearmeasures/index.html
+++ b/files/en-us/web/api/performance/clearmeasures/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.clearMeasures
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
@@ -97,4 +98,4 @@ logMeasureCount() // "Found this many entries: 0"
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.clearMeasures")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/clearresourcetimings/index.html
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.clearResourceTimings
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -88,4 +89,4 @@ function clear_performance_timings() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.clearResourceTimings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/getentries/index.html
+++ b/files/en-us/web/api/performance/getentries/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.getEntries
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -107,4 +108,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.getEntries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/getentriesbyname/index.html
+++ b/files/en-us/web/api/performance/getentriesbyname/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.getEntriesByName
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -122,4 +123,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.getEntriesByName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/getentriesbytype/index.html
+++ b/files/en-us/web/api/performance/getentriesbytype/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.getEntriesByType
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -119,4 +120,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.getEntriesByType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/index.html
+++ b/files/en-us/web/api/performance/index.html
@@ -8,6 +8,7 @@ tags:
   - Performance
   - Reference
   - Web Performance
+browser-compat: api.Performance
 ---
 <div>{{APIRef("High Resolution Time")}}</div>
 
@@ -130,4 +131,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/mark/index.html
+++ b/files/en-us/web/api/performance/mark/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.mark
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
@@ -97,4 +98,4 @@ performance.clearMarks();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.mark")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/measure/index.html
+++ b/files/en-us/web/api/performance/measure/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - Web Performance
 - Web Workers
+browser-compat: api.Performance.measure
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
@@ -124,4 +125,4 @@ setTimeout(function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.measure")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/memory/index.html
+++ b/files/en-us/web/api/performance/memory/index.html
@@ -1,6 +1,7 @@
 ---
 title: Performance.memory
 slug: Web/API/Performance/memory
+browser-compat: api.Performance.memory
 ---
 <p>{{APIRef}}</p>
 
@@ -28,7 +29,7 @@ slug: Web/API/Performance/memory
 
 <div>
 
-    <p>{{Compat("api.Performance.memory")}}</p>
+    <p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/performance/navigation/index.html
+++ b/files/en-us/web/api/performance/navigation/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.Performance.navigation
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.navigation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/now/index.html
+++ b/files/en-us/web/api/performance/now/index.html
@@ -7,6 +7,7 @@ tags:
   - Performance
   - Reference
   - Web Performance API
+browser-compat: api.Performance.now
 ---
 <div>{{APIRef("High Resolution Timing")}}</div>
 
@@ -128,7 +129,7 @@ Cross-Origin-Embedder-Policy: require-corp
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.now")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/onresourcetimingbufferfull/index.html
+++ b/files/en-us/web/api/performance/onresourcetimingbufferfull/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Peformance
+browser-compat: api.Performance.onresourcetimingbufferfull
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -65,7 +66,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.onresourcetimingbufferfull")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.html
+++ b/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Performance
   - onresourcetimingbufferfull
+browser-compat: api.Performance.resourcetimingbufferfull_event
 ---
 <div>{{APIRef}}</div>
 
@@ -73,7 +74,7 @@ function init() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div>{{Compat("api.Performance.resourcetimingbufferfull_event")}}</div>
+<div>{{Compat}}</div>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/setresourcetimingbuffersize/index.html
+++ b/files/en-us/web/api/performance/setresourcetimingbuffersize/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.Performance.setResourceTimingBufferSize
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -77,4 +78,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.setResourceTimingBufferSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performance/timeorigin/index.html
+++ b/files/en-us/web/api/performance/timeorigin/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - timeOrigin
+browser-compat: api.Performance.timeOrigin
 ---
 <p>{{SeeCompatTable}}{{APIRef("High Resolution Time")}}</p>
 
@@ -46,5 +47,5 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.Performance.timeOrigin")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/performance/timing/index.html
+++ b/files/en-us/web/api/performance/timing/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.Performance.timing
 ---
 <p>{{APIRef("Navigation Timing")}}{{deprecated_header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.timing")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performance/tojson/index.html
+++ b/files/en-us/web/api/performance/tojson/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Performance
 - Reference
+browser-compat: api.Performance.toJSON
 ---
 <div>{{APIRef("High Resolution Timing")}}</div>
 
@@ -62,4 +63,4 @@ console.log("json = " + JSON.stringify(js));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Performance.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/element/index.html
+++ b/files/en-us/web/api/performanceelementtiming/element/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - element
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.element
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -55,4 +56,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.element")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/id/index.html
+++ b/files/en-us/web/api/performanceelementtiming/id/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - id
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.id
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -55,4 +56,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.html
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - identifier
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.identifier
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -55,4 +56,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.identifier")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/index.html
+++ b/files/en-us/web/api/performanceelementtiming/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -76,4 +77,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - intersectionRect
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.intersectionRect
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -57,4 +58,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.intersectionRect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - loadTime
   - PerformanceElementTimingnull
+browser-compat: api.PerformanceElementTiming.loadTime
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -55,4 +56,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.loadTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - naturalHeight
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.naturalHeight
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -55,4 +56,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.naturalHeight")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - naturalWidth
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.naturalWidth
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -54,4 +55,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.naturalWidth")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.html
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - renderTime
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.renderTime
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -59,4 +60,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.renderTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.html
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - toJSON()
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.toJSON
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -59,4 +60,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceelementtiming/url/index.html
+++ b/files/en-us/web/api/performanceelementtiming/url/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - url
   - PerformanceElementTiming
+browser-compat: api.PerformanceElementTiming.url
 ---
 <div>{{DefaultAPISidebar("Element Timing")}}</div>
 
@@ -55,4 +56,4 @@ observer.observe({ entryTypes: ["element"] });</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceElementTiming.url")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceentry/duration/index.html
+++ b/files/en-us/web/api/performanceentry/duration/index.html
@@ -6,6 +6,7 @@ tags:
   - Property
   - Reference
   - Web Performance
+browser-compat: api.PerformanceEntry.duration
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -131,4 +132,4 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEntry.duration")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceentry/entrytype/index.html
+++ b/files/en-us/web/api/performanceentry/entrytype/index.html
@@ -8,6 +8,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceEntry.entryType
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -142,4 +143,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEntry.entryType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceentry/index.html
+++ b/files/en-us/web/api/performanceentry/index.html
@@ -8,6 +8,7 @@ tags:
   - PerformanceEntry
   - Reference
   - Web Performance
+browser-compat: api.PerformanceEntry
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -141,4 +142,4 @@ function print_PerformanceEntry(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEntry")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceentry/name/index.html
+++ b/files/en-us/web/api/performanceentry/name/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceEntry.name
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -147,4 +148,4 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEntry.name")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceentry/starttime/index.html
+++ b/files/en-us/web/api/performanceentry/starttime/index.html
@@ -6,6 +6,7 @@ tags:
   - Property
   - Reference
   - Web Performance
+browser-compat: api.PerformanceEntry.startTime
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -126,4 +127,4 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEntry.startTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceentry/tojson/index.html
+++ b/files/en-us/web/api/performanceentry/tojson/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.PerformanceEntry.toJSON
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -104,4 +105,4 @@ function check_PerformanceEntry(obj) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEntry.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceeventtiming/index.html
+++ b/files/en-us/web/api/performanceeventtiming/index.html
@@ -9,6 +9,7 @@ tags:
   - PerformanceEventTiming
   - Reference
   - Web Performance
+browser-compat: api.PerformanceEventTiming
 ---
 <p>The <code>PerformanceEventTiming</code> interface of the Event Timing API provides timing information for the event types listed below.</p>
 
@@ -162,4 +163,4 @@ try {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceEventTiming")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceframetiming/index.html
+++ b/files/en-us/web/api/performanceframetiming/index.html
@@ -9,6 +9,7 @@ tags:
   - PerformanceFrameTiming
   - Reference
   - Web Performance
+browser-compat: api.PerformanceFrameTiming
 ---
 <div>{{APIRef("Frame Timing API")}}{{SeeCompatTable}}</div>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceFrameTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancelongtasktiming/attribution/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/attribution/index.html
@@ -1,6 +1,7 @@
 ---
 title: PerformanceLongTaskTiming.attribution
 slug: Web/API/PerformanceLongTaskTiming/attribution
+browser-compat: api.PerformanceLongTaskTiming.attribution
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -36,4 +37,4 @@ slug: Web/API/PerformanceLongTaskTiming/attribution
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceLongTaskTiming.attribution")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancelongtasktiming/index.html
+++ b/files/en-us/web/api/performancelongtasktiming/index.html
@@ -7,6 +7,7 @@ tags:
   - Long Tasks API
   - PerformanceLongTaskTiming
   - Reference
+browser-compat: api.PerformanceLongTaskTiming
 ---
 <p>{{SeeCompatTable}}{{APIRef("Long Tasks")}}</p>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceLongTaskTiming")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancemark/index.html
+++ b/files/en-us/web/api/performancemark/index.html
@@ -7,6 +7,7 @@ tags:
   - Performance Timing API
   - Reference
   - Web Performance
+browser-compat: api.PerformanceMark
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceMark")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancemeasure/index.html
+++ b/files/en-us/web/api/performancemeasure/index.html
@@ -7,6 +7,7 @@ tags:
   - Performance Timeline API
   - Reference
   - Web Performance
+browser-compat: api.PerformanceMeasure
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceMeasure")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancenavigation/index.html
+++ b/files/en-us/web/api/performancenavigation/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Timing
   - legacy
+browser-compat: api.PerformanceNavigation
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -75,7 +76,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceNavigation.redirectCount
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigation.redirectCount")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancenavigation/type/index.html
+++ b/files/en-us/web/api/performancenavigation/type/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceNavigation.type
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigation.type")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.domComplete
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -76,4 +77,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.domComplete")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.domContentLoadedEventEnd
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -75,4 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.domContentLoadedEventEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.domContentLoadedEventStart
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -75,4 +76,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.domContentLoadedEventStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.domInteractive
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -74,4 +75,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.domInteractive")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/index.html
@@ -8,6 +8,7 @@ tags:
   - Performance Timeline API
   - Reference
   - Web Performance
+browser-compat: api.PerformanceNavigationTiming
 ---
 <p>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</p>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.loadEventEnd
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.loadEventEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.loadEventStart
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -70,4 +71,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.loadEventStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.redirectCount
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.redirectCount")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.toJSON
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -63,4 +64,4 @@ console.log("PerformanceNavigationTiming.toJSON() = " + s);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/type/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.type
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -86,4 +87,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.type")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.unloadEventEnd
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.unloadEventEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceNavigationTiming.unloadEventStart
 ---
 <div>{{APIRef("Navigation Timing")}}{{SeeCompatTable}}</div>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceNavigationTiming.unloadEventStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserver/disconnect/index.html
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.html
@@ -10,6 +10,7 @@ tags:
 - Web Performance
 - disconnect()
 - observers
+browser-compat: api.PerformanceObserver.disconnect
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -63,4 +64,4 @@ observer2.observe({entryTypes: ["measure"]});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserver.disconnect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Performance
   - observers
+browser-compat: api.PerformanceObserver
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -68,7 +69,7 @@ observer.observe({entryTypes: ["measure"]});</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceobserver/observe/index.html
+++ b/files/en-us/web/api/performanceobserver/observe/index.html
@@ -8,6 +8,7 @@ tags:
 - PerformanceObserver
 - Reference
 - Web Performance
+browser-compat: api.PerformanceObserver.observe
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -93,4 +94,4 @@ observer2.observe({entryTypes: ["measure"]});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserver.observe")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.html
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.html
@@ -7,6 +7,7 @@ tags:
 - PerformanceObserver
 - Reference
 - Web Performance
+browser-compat: api.PerformanceObserver.PerformanceObserver
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -75,4 +76,4 @@ observer2.observe({entryTypes: ["measure"]});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserver.PerformanceObserver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.html
@@ -8,6 +8,7 @@ tags:
 - Web Performance
 - PerformanceObserver
 - supportedEntryTypes
+browser-compat: api.PerformanceObserver.supportedEntryTypes
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -69,4 +70,4 @@ detectSupport(["resource", "mark", "frame"]);</pre>
 
  <h2 id="Browser_compatibility">Browser compatibility</h2>
 
- <p>{{Compat("api.PerformanceObserver.supportedEntryTypes")}}</p>
+ <p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserver/takerecords/index.html
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - observers
 - takeRecords()
+browser-compat: api.PerformanceObserver.takeRecords
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -65,4 +66,4 @@ console.log(records[0].duration);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserver.takeRecords")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserverentrylist/getentries/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentries/index.html
@@ -7,6 +7,7 @@ tags:
 - PerformanceObserverEntryList
 - Reference
 - Web Performance
+browser-compat: api.PerformanceObserverEntryList.getEntries
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -127,4 +128,4 @@ observe_frame.observe({entryTypes: ['frame']});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserverEntryList.getEntries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.html
@@ -7,6 +7,7 @@ tags:
 - PerformanceObserverEntryList
 - Reference
 - Web Performance
+browser-compat: api.PerformanceObserverEntryList.getEntriesByName
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -114,4 +115,4 @@ observe_frame.observe({entryTypes: ['frame']});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserverEntryList.getEntriesByName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.html
@@ -7,6 +7,7 @@ tags:
   - PerformanceObserverEntryList
   - Reference
   - Web Performance
+browser-compat: api.PerformanceObserverEntryList.getEntriesByType
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -94,4 +95,4 @@ observe_frame.observe({entryTypes: ['frame']});
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserverEntryList.getEntriesByType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceobserverentrylist/index.html
+++ b/files/en-us/web/api/performanceobserverentrylist/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - Web Performance
+browser-compat: api.PerformanceObserverEntryList
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
@@ -55,4 +56,4 @@ var observe_all = new PerformanceObserver(function(list, obs) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceObserverEntryList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancepainttiming/index.html
+++ b/files/en-us/web/api/performancepainttiming/index.html
@@ -9,6 +9,7 @@ tags:
   - PerformancePaintTiming
   - Reference
   - Web Performance
+browser-compat: api.PerformancePaintTiming
 ---
 <p>{{APIRef("Performance Timeline API")}}</p>
 
@@ -75,4 +76,4 @@ The time to first-contentful-paint was 2787.460 milliseconds.</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformancePaintTiming")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.connectEnd
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -83,4 +84,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.connectEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.connectStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -81,4 +82,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.connectStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.decodedBodySize
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -79,4 +80,4 @@ function check_PerformanceEntries() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.decodedBodySize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.domainLookupEnd
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -86,4 +87,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.domainLookupEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.domainLookupStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -81,4 +82,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.domainLookupStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.encodedBodySize
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -81,4 +82,4 @@ function check_PerformanceEntries() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.encodedBodySize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.fetchStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -84,4 +85,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.fetchStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - Web Performance
+browser-compat: api.PerformanceResourceTiming
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -103,7 +104,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.initiatorType
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -77,4 +78,4 @@ function print_initiatorType(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.initiatorType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - Resource Timing API
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.nextHopProtocol
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -73,4 +74,4 @@ function print_nextHopProtocol(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.nextHopProtocol")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.redirectEnd
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -87,4 +88,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.redirectEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.redirectStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -86,4 +87,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.redirectStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.requestStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -85,4 +86,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.requestStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.responseEnd
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -83,4 +84,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.responseEnd")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.responseStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -81,4 +82,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.responseStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.secureConnectionStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -85,4 +86,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.secureConnectionStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/servertiming/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/servertiming/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - SecureContextOnly
 - ServerTiming
+browser-compat: api.PerformanceResourceTiming.serverTiming
 ---
 <div>{{APIRef("Resource Timing API")}} {{securecontext_header}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.PerformanceResourceTiming.serverTiming")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.html
@@ -6,6 +6,7 @@ tags:
 - Method
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.toJSON
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -62,4 +63,4 @@ console.log("PerformanceEntry.toJSON = " + s);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - Web Performance
+browser-compat: api.PerformanceResourceTiming.transferSize
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -83,4 +84,4 @@ function check_PerformanceEntries() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.transferSize")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.html
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Performance
 - workerStart
+browser-compat: api.PerformanceResourceTiming.workerStart
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -86,4 +87,4 @@ function print_start_and_end_properties(perfEntry) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceResourceTiming.workerStart")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performanceservertiming/description/index.html
+++ b/files/en-us/web/api/performanceservertiming/description/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - ServerTiming
+browser-compat: api.PerformanceServerTiming.description
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -40,7 +41,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.PerformanceServerTiming.description")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceservertiming/duration/index.html
+++ b/files/en-us/web/api/performanceservertiming/duration/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - ServerTiming
+browser-compat: api.PerformanceServerTiming.duration
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -37,7 +38,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceServerTiming.duration")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceservertiming/index.html
+++ b/files/en-us/web/api/performanceservertiming/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - ServerTiming
+browser-compat: api.PerformanceServerTiming
 ---
 <div>{{APIRef("Resource Timing API")}} {{AvailableInWorkers}} {{securecontext_header}}</div>
 
@@ -82,7 +83,7 @@ console.log(entries[0].serverTiming);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceServerTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceservertiming/name/index.html
+++ b/files/en-us/web/api/performanceservertiming/name/index.html
@@ -6,6 +6,7 @@ tags:
 - Property
 - Reference
 - ServerTiming
+browser-compat: api.PerformanceServerTiming.name
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -38,7 +39,7 @@ tags:
 
 <div>
 
-  <p>{{Compat("api.PerformanceServerTiming.name")}}</p>
+  <p>{{Compat}}</p>
 
   <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performanceservertiming/tojson/index.html
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - ServerTiming
 - toJSON
+browser-compat: api.PerformanceServerTiming.toJSON
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceServerTiming.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/performancetiming/connectend/index.html
+++ b/files/en-us/web/api/performancetiming/connectend/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.connectEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.connectEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/connectstart/index.html
+++ b/files/en-us/web/api/performancetiming/connectstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.connectStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.connectStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - fetchStart
 - legacy
+browser-compat: api.PerformanceTiming.domainLookupEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domainLookupEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.html
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.domainLookupStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domainLookupStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/domcomplete/index.html
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.domComplete
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domComplete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - domContentLoadedEventEnd
 - legacy
+browser-compat: api.PerformanceTiming.domContentLoadedEventEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domContentLoadedEventEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - domContentLoadedEventStart
 - legacy
+browser-compat: api.PerformanceTiming.domContentLoadedEventStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domContentLoadedEventStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/dominteractive/index.html
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - domInteractive
 - legacy
+browser-compat: api.PerformanceTiming.domInteractive
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -60,7 +61,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domInteractive")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/domloading/index.html
+++ b/files/en-us/web/api/performancetiming/domloading/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - domxref
 - legacy
+browser-compat: api.PerformanceTiming.domLoading
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.domLoading")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/fetchstart/index.html
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.html
@@ -12,6 +12,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.fetchStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.fetchStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/index.html
+++ b/files/en-us/web/api/performancetiming/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Timing
   - legacy
+browser-compat: api.PerformanceTiming
 ---
 <div>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</div>
 
@@ -106,7 +107,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/loadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.html
@@ -12,6 +12,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.loadEventEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.loadEventEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.loadEventStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.loadEventStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/navigationstart/index.html
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.html
@@ -12,6 +12,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.navigationStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.navigationStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/redirectend/index.html
+++ b/files/en-us/web/api/performancetiming/redirectend/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.redirectEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.redirectEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/redirectstart/index.html
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.redirectStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.redirectStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/requeststart/index.html
+++ b/files/en-us/web/api/performancetiming/requeststart/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.requestStart
 ---
 <p>{{ APIRef("PerformanceTiming") }} {{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.requestStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/responseend/index.html
+++ b/files/en-us/web/api/performancetiming/responseend/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.responseEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.responseEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/responsestart/index.html
+++ b/files/en-us/web/api/performancetiming/responsestart/index.html
@@ -11,6 +11,7 @@ tags:
 - Read-only
 - Reference
 - legacy
+browser-compat: api.PerformanceTiming.responseStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.responseStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.secureConnectionStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.secureConnectionStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.unloadEventEnd
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.unloadEventEnd")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.html
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Read-only
 - legacy
+browser-compat: api.PerformanceTiming.unloadEventStart
 ---
 <p>{{APIRef("Navigation Timing")}}{{Deprecated_Header}}</p>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PerformanceTiming.unloadEventStart")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - ServiceWorker
   - Workers
+browser-compat: api.PeriodicSyncEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -69,7 +70,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
+++ b/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.html
@@ -9,6 +9,7 @@ tags:
 - Service Worker
 - Web Periodic Background Synchronization API
 - periodic sync
+browser-compat: api.PeriodicSyncEvent.PeriodicSyncEvent
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -74,7 +75,7 @@ psEvent.tag; // should return 'unique-tag'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncEvent.PeriodicSyncEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncevent/tag/index.html
+++ b/files/en-us/web/api/periodicsyncevent/tag/index.html
@@ -9,6 +9,7 @@ tags:
 - Service Worker
 - Web Periodic Background Synchronization API
 - periodic sync
+browser-compat: api.PeriodicSyncEvent.tag
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -56,7 +57,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncEvent.tag")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/gettags/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/gettags/index.html
@@ -10,6 +10,7 @@ tags:
 - Service Worker
 - Web Periodic Background Synchronization API
 - periodic sync
+browser-compat: api.PeriodicSyncManager.getTags
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -70,7 +71,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncManager.getTags")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/index.html
@@ -10,6 +10,7 @@ tags:
   - PeriodicSyncManager
   - Reference
   - ServiceWorker
+browser-compat: api.PeriodicSyncManager
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -90,7 +91,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncManager")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/register/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.html
@@ -9,6 +9,7 @@ tags:
 - PeriodicSyncManager
 - Service Worker
 - Web Periodic Background Synchronization API
+browser-compat: api.PeriodicSyncManager.register
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -88,7 +89,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncManager.register")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicsyncmanager/unregister/index.html
+++ b/files/en-us/web/api/periodicsyncmanager/unregister/index.html
@@ -9,6 +9,7 @@ tags:
 - PeriodicSyncManager
 - Service Worker
 - Web Periodic Background Synchronization API
+browser-compat: api.PeriodicSyncManager.unregister
 ---
 <div>{{draft}}{{DefaultAPISidebar("Periodic Background Sync")}}</div>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicSyncManager.unregister")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/index.html
@@ -11,6 +11,7 @@ tags:
   - Web Audio
   - Web Audio API
   - waveform
+browser-compat: api.PeriodicWave
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicWave")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/periodicwave/periodicwave/index.html
+++ b/files/en-us/web/api/periodicwave/periodicwave/index.html
@@ -8,6 +8,7 @@ tags:
   - PeriodicWave
   - Reference
   - Web Audio API
+browser-compat: api.PeriodicWave.PeriodicWave
 ---
 <p>{{APIRef("Web Audio API")}}</p>
 
@@ -88,4 +89,4 @@ var wave = new PeriodicWave(ac, options);</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PeriodicWave.PeriodicWave")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/permissions/index.html
+++ b/files/en-us/web/api/permissions/index.html
@@ -8,6 +8,7 @@ tags:
   - Permissions
   - Permissions API
   - Reference
+browser-compat: api.Permissions
 ---
 <p>{{APIRef("Permissions API")}}{{SeeCompatTable}}</p>
 
@@ -56,4 +57,4 @@ tags:
 
 <h2 id="Browser_Support">Browser Support</h2>
 
-<p>{{Compat("api.Permissions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/permissions/query/index.html
+++ b/files/en-us/web/api/permissions/query/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - Permissions
   - Reference
+browser-compat: api.Permissions.query
 ---
 <p>{{APIRef("Permissions API")}}{{SeeCompatTable}}</p>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Permissions.query")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/permissions/revoke/index.html
+++ b/files/en-us/web/api/permissions/revoke/index.html
@@ -9,6 +9,7 @@ tags:
 - Permissions API
 - Reference
 - revoke
+browser-compat: api.Permissions.revoke
 ---
 <p>{{APIRef("Permissions API")}}{{deprecated_header}}</p>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Permissions.revoke")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/permissions_api/index.html
+++ b/files/en-us/web/api/permissions_api/index.html
@@ -9,6 +9,7 @@ tags:
   - Permissions API
   - Web
   - access
+browser-compat: api.Permissions
 ---
 <p>{{DefaultAPISidebar("Permissions API")}}</p>
 
@@ -80,7 +81,7 @@ tags:
 
 <div>
 
-<p>{{Compat("api.Permissions")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/permissions_api/index.html
+++ b/files/en-us/web/api/permissions_api/index.html
@@ -9,7 +9,6 @@ tags:
   - Permissions API
   - Web
   - access
-browser-compat: api.Permissions
 ---
 <p>{{DefaultAPISidebar("Permissions API")}}</p>
 
@@ -81,7 +80,7 @@ browser-compat: api.Permissions
 
 <div>
 
-<p>{{Compat}}</p>
+<p>{{Compat("api.Permissions")}}</p>
 </div>
 </div>
 

--- a/files/en-us/web/api/permissionstatus/index.html
+++ b/files/en-us/web/api/permissionstatus/index.html
@@ -9,6 +9,7 @@ tags:
   - Permissions
   - Permissions API
   - Reference
+browser-compat: api.PermissionStatus
 ---
 <div>{{APIRef("Permissions API")}}{{SeeCompatTable}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PermissionStatus")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/permissionstatus/onchange/index.html
+++ b/files/en-us/web/api/permissionstatus/onchange/index.html
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - onchange
+browser-compat: api.PermissionStatus.onchange
 ---
 <p>{{APIRef("Permissions API")}}{{SeeCompatTable}}</p>
 
@@ -48,4 +49,4 @@ PermissionStatus.addEventListener('change', function() { ... })</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PermissionStatus.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/permissionstatus/state/index.html
+++ b/files/en-us/web/api/permissionstatus/state/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - status
+browser-compat: api.PermissionStatus.state
 ---
 <p>{{APIRef("Permissions API")}}{{SeeCompatTable}}</p>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PermissionStatus.state")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/photocapabilities/filllightmode/index.html
+++ b/files/en-us/web/api/photocapabilities/filllightmode/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.PhotoCapabilities.fillLightMode
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -59,5 +60,5 @@ tags:
 
 <div>
 
-	<p>{{Compat("api.PhotoCapabilities.fillLightMode")}}</p>
+	<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/photocapabilities/imageheight/index.html
+++ b/files/en-us/web/api/photocapabilities/imageheight/index.html
@@ -11,6 +11,7 @@ tags:
 - PhotoCapabilities
 - Property
 - Reference
+browser-compat: api.PhotoCapabilities.imageHeight
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Image")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PhotoCapabilities.imageHeight")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/photocapabilities/imagewidth/index.html
+++ b/files/en-us/web/api/photocapabilities/imagewidth/index.html
@@ -11,6 +11,7 @@ tags:
 - PhotoCapabilities
 - Property
 - Reference
+browser-compat: api.PhotoCapabilities.imageWidth
 ---
 <p>{{SeeCompatTable}}{{APIRef("MediaStream Image")}}</p>
 
@@ -46,4 +47,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PhotoCapabilities.imageWidth")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/photocapabilities/index.html
+++ b/files/en-us/web/api/photocapabilities/index.html
@@ -11,6 +11,7 @@ tags:
   - MediaStream Image Capture API
   - PhotoCapabilities
   - Reference
+browser-compat: api.PhotoCapabilities
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -79,4 +80,4 @@ navigator.mediaDevices.getUserMedia({video: true})
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PhotoCapabilities")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/photocapabilities/redeyereduction/index.html
+++ b/files/en-us/web/api/photocapabilities/redeyereduction/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Read-only
 - Reference
+browser-compat: api.PhotoCapabilities.redEyeReduction
 ---
 <div>{{APIRef("MediaStream Image")}}</div>
 
@@ -57,4 +58,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PhotoCapabilities.redEyeReduction")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pictureinpictureevent/index.html
+++ b/files/en-us/web/api/pictureinpictureevent/index.html
@@ -7,6 +7,7 @@ tags:
   - DOM Events
   - Event
   - Reference
+browser-compat: api.PictureInPictureEvent
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pictureinpictureevent/pictureinpictureevent/index.html
+++ b/files/en-us/web/api/pictureinpictureevent/pictureinpictureevent/index.html
@@ -1,6 +1,7 @@
 ---
 title: PictureInPictureEvent()
 slug: Web/API/PictureInPictureEvent/PictureInPictureEvent
+browser-compat: api.PictureInPictureEvent.PictureInPictureEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -53,7 +54,7 @@ slug: Web/API/PictureInPictureEvent/PictureInPictureEvent
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureEvent.PictureInPictureEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/height/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/height/index.html
@@ -9,6 +9,7 @@ tags:
 - Picture-in-Picture API
 - Video
 - pip
+browser-compat: api.PictureInPictureWindow.height
 ---
 <div>{{APIRef}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureWindow.height")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/index.html
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Video
   - pip
+browser-compat: api.PictureInPictureWindow
 ---
 <div>{{APIRef("Picture-in-Picture API")}}</div>
 
@@ -83,7 +84,7 @@ button.onclick = function() {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureWindow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/onresize/index.html
@@ -9,6 +9,7 @@ tags:
 - Picture-in-Picture API
 - Video
 - pip
+browser-compat: api.PictureInPictureWindow.onresize
 ---
 <div>{{ ApiRef() }}</div>
 
@@ -78,7 +79,7 @@ video.requestPictureInPicture()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureWindow.onresize")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.html
@@ -9,6 +9,7 @@ tags:
   - Video
   - pip
   - resize
+browser-compat: api.PictureInPictureWindow.resize_event
 ---
 <div>{{APIRef}}</div>
 
@@ -82,7 +83,7 @@ video.requestPictureInPicture()
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureWindow.resize_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pictureinpicturewindow/width/index.html
+++ b/files/en-us/web/api/pictureinpicturewindow/width/index.html
@@ -9,6 +9,7 @@ tags:
 - Picture-in-Picture API
 - Video
 - pip
+browser-compat: api.PictureInPictureWindow.width
 ---
 <div>{{APIRef}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PictureInPictureWindow.width")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/plugin/index.html
+++ b/files/en-us/web/api/plugin/index.html
@@ -8,6 +8,7 @@ tags:
   - NeedsContent
   - Plug-in
   - Plugins
+browser-compat: api.Plugin
 ---
 <div>{{ApiRef("HTML DOM")}}{{deprecated_header}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Plugin")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pluginarray/index.html
+++ b/files/en-us/web/api/pluginarray/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - NeedsContent
   - Plugins
+browser-compat: api.PluginArray
 ---
 <p>{{APIRef("HTML DOM")}}{{deprecated_header}}</p>
 
@@ -99,6 +100,6 @@ for(var i = 0; i &lt; pluginsLength; i++) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PluginArray")}}</p>
+<p>{{Compat}}</p>
 
 <p>In addition to listing each plugin as a pseudo-array by zero-indexed numeric properties, Firefox provides properties that are the plugin name directly on the PluginArray object.</p>

--- a/files/en-us/web/api/point/index.html
+++ b/files/en-us/web/api/point/index.html
@@ -9,6 +9,7 @@ tags:
   - Non-standard
   - Point
   - Reference
+browser-compat: api.Point
 ---
 <div>{{APIRef("CSS3 Transforms")}}{{Deprecated_Header}}{{Non-standard_header}}</div>
 
@@ -33,7 +34,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Point")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -9,7 +9,6 @@ tags:
   - Pointer Events
   - Web
   - events
-browser-compat: api.PointerEvent
 ---
 <p>{{DefaultAPISidebar("Pointer Events")}}</p>
 
@@ -485,7 +484,7 @@ browser-compat: api.PointerEvent
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat}}</p>
+<p>{{Compat("api.PointerEvent")}}</p>
 
 <p>Some new values have been defined for the {{cssxref("touch-action", "CSS touch-action")}} property as part of the {{SpecName('Pointer Events 3')}} specification but currently those new values have limited implementation support.</p>
 

--- a/files/en-us/web/api/pointer_events/index.html
+++ b/files/en-us/web/api/pointer_events/index.html
@@ -9,6 +9,7 @@ tags:
   - Pointer Events
   - Web
   - events
+browser-compat: api.PointerEvent
 ---
 <p>{{DefaultAPISidebar("Pointer Events")}}</p>
 
@@ -484,7 +485,7 @@ tags:
 </table>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.PointerEvent")}}</p>
+<p>{{Compat}}</p>
 
 <p>Some new values have been defined for the {{cssxref("touch-action", "CSS touch-action")}} property as part of the {{SpecName('Pointer Events 3')}} specification but currently those new values have limited implementation support.</p>
 

--- a/files/en-us/web/api/pointer_lock_api/index.html
+++ b/files/en-us/web/api/pointer_lock_api/index.html
@@ -8,7 +8,6 @@ tags:
   - Reference
   - mouse lock
   - pointer lock
-browser-compat: api.Element.requestPointerLock
 ---
 <div>{{DefaultAPISidebar("Pointer Lock API")}}</div>
 
@@ -239,7 +238,7 @@ function updatePosition(e) {
 
 <div>
 
-<p>{{Compat}}</p>
+<p>{{Compat("api.Element.requestPointerLock"}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pointer_lock_api/index.html
+++ b/files/en-us/web/api/pointer_lock_api/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - mouse lock
   - pointer lock
+browser-compat: api.Element.requestPointerLock
 ---
 <div>{{DefaultAPISidebar("Pointer Lock API")}}</div>
 
@@ -238,7 +239,7 @@ function updatePosition(e) {
 
 <div>
 
-<p>{{Compat("api.Element.requestPointerLock")}}</p>
+<p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pointer_lock_api/index.html
+++ b/files/en-us/web/api/pointer_lock_api/index.html
@@ -238,7 +238,7 @@ function updatePosition(e) {
 
 <div>
 
-<p>{{Compat("api.Element.requestPointerLock"}}</p>
+<p>{{Compat("api.Element.requestPointerLock")}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.html
@@ -8,6 +8,7 @@ tags:
 - Pointer Events
 - PointerEvent
 - Reference
+browser-compat: api.PointerEvent.getCoalescedEvents
 ---
 <p>{{APIRef("Pointer Events")}}{{SeeCompatTable}}</p>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.getCoalescedEvents")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/height/index.html
+++ b/files/en-us/web/api/pointerevent/height/index.html
@@ -8,6 +8,7 @@ tags:
   - PointerEvent
   - Property
   - Reference
+browser-compat: api.PointerEvent.height
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -62,4 +63,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.height")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/index.html
+++ b/files/en-us/web/api/pointerevent/index.html
@@ -9,6 +9,7 @@ tags:
   - PointerEvent
   - Reference
   - events
+browser-compat: api.PointerEvent
 ---
 <p>{{ APIRef("Pointer Events") }}</p>
 
@@ -148,7 +149,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pointerevent/isprimary/index.html
+++ b/files/en-us/web/api/pointerevent/isprimary/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.isPrimary
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -88,4 +89,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.isPrimary")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/pointerevent/index.html
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - PointerEvent
   - Reference
+browser-compat: api.PointerEvent.PointerEvent
 ---
 <p>{{APIRef("Pointer Events")}}</p>
 
@@ -86,4 +87,4 @@ var downEvent = new PointerEvent("pointerdown",
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.PointerEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/pointerid/index.html
+++ b/files/en-us/web/api/pointerevent/pointerid/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.pointerId
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -68,4 +69,4 @@ target.addEventListener('pointerdown', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.pointerId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/pressure/index.html
+++ b/files/en-us/web/api/pointerevent/pressure/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.pressure
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.pressure")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pointerevent/tangentialpressure/index.html
+++ b/files/en-us/web/api/pointerevent/tangentialpressure/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - tangentialPressure
+browser-compat: api.PointerEvent.tangentialPressure
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.tangentialPressure")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pointerevent/tiltx/index.html
+++ b/files/en-us/web/api/pointerevent/tiltx/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.tiltX
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.tiltX")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/tilty/index.html
+++ b/files/en-us/web/api/pointerevent/tilty/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.tiltY
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.tiltY")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pointerevent/twist/index.html
+++ b/files/en-us/web/api/pointerevent/twist/index.html
@@ -9,6 +9,7 @@ tags:
 - Property
 - Reference
 - twist
+browser-compat: api.PointerEvent.twist
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.twist")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pointerevent/width/index.html
+++ b/files/en-us/web/api/pointerevent/width/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.width
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.width")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/popstateevent/index.html
+++ b/files/en-us/web/api/popstateevent/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Interface
   - Reference
+browser-compat: api.PopStateEvent
 ---
 <p id="Summary">{{APIRef("HTML DOM")}}</p>
 
@@ -86,7 +87,7 @@ history.go(2);  // alerts "location: http://example.com/example.html?page=3, sta
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 
-<p>{{Compat("api.PopStateEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionoptions/enablehighaccuracy/index.html
+++ b/files/en-us/web/api/positionoptions/enablehighaccuracy/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Secure context
+browser-compat: api.PositionOptions.enableHighAccuracy
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -47,7 +48,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionOptions.enableHighAccuracy")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionoptions/index.html
+++ b/files/en-us/web/api/positionoptions/index.html
@@ -8,6 +8,7 @@ tags:
   - PositionOptions
   - Reference
   - Secure context
+browser-compat: api.PositionOptions
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -45,7 +46,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionoptions/maximumage/index.html
+++ b/files/en-us/web/api/positionoptions/maximumage/index.html
@@ -8,6 +8,7 @@ tags:
   - PositionOptions
   - Property
   - Secure context
+browser-compat: api.PositionOptions.maximumAge
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionOptions.maximumAge")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionoptions/timeout/index.html
+++ b/files/en-us/web/api/positionoptions/timeout/index.html
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - Secure context
+browser-compat: api.PositionOptions.timeout
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
@@ -46,7 +47,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionOptions.timeout")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.html
@@ -11,6 +11,7 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+browser-compat: api.PositionSensorVRDevice.getImmediateState
 ---
 <p>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</p>
 
@@ -66,7 +67,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionSensorVRDevice.getImmediateState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/getstate/index.html
@@ -11,6 +11,7 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+browser-compat: api.PositionSensorVRDevice.getState
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionSensorVRDevice.getState")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionsensorvrdevice/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/index.html
@@ -11,6 +11,7 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+browser-compat: api.PositionSensorVRDevice
 ---
 <p>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</p>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionSensorVRDevice")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.html
@@ -12,6 +12,7 @@ tags:
   - Virtual Reality
   - WebVR
   - resetSensor
+browser-compat: api.PositionSensorVRDevice.resetSensor
 ---
 <div>{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}</div>
 
@@ -41,7 +42,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PositionSensorVRDevice.resetSensor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/presentation/defaultrequest/index.html
+++ b/files/en-us/web/api/presentation/defaultrequest/index.html
@@ -7,6 +7,7 @@ tags:
   - Property
   - Reference
   - Web
+browser-compat: api.Presentation.defaultRequest
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{APIRef("Presentation API")}}</p>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Presentation.defaultRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentation/index.html
+++ b/files/en-us/web/api/presentation/index.html
@@ -8,6 +8,7 @@ tags:
   - Presentation
   - Presentation API
   - Reference
+browser-compat: api.Presentation
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{APIRef("Presentation API")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Presentation")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentation/receiver/index.html
+++ b/files/en-us/web/api/presentation/receiver/index.html
@@ -9,6 +9,7 @@ tags:
 - Read-only
 - Reference
 - receiver
+browser-compat: api.Presentation.receiver
 ---
 <p>{{APIRef("Presentation")}}</p>
 
@@ -100,7 +101,7 @@ navigator.presentation.receiver.connectionList
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Presentation.receiver")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/presentation_api/index.html
+++ b/files/en-us/web/api/presentation_api/index.html
@@ -7,6 +7,7 @@ tags:
   - NeedsContent
   - Presentation API
   - Reference
+browser-compat: api.Presentation
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Presentation API")}}</p>
 
@@ -283,7 +284,7 @@ tags:
 
 <div>
 
-<p>{{Compat("api.Presentation")}}</p>
+<p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/presentation_api/index.html
+++ b/files/en-us/web/api/presentation_api/index.html
@@ -7,7 +7,6 @@ tags:
   - NeedsContent
   - Presentation API
   - Reference
-browser-compat: api.Presentation
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Presentation API")}}</p>
 
@@ -284,7 +283,7 @@ browser-compat: api.Presentation
 
 <div>
 
-<p>{{Compat}}</p>
+<p>{{Compat("api.Presentation")}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/presentationavailability/index.html
+++ b/files/en-us/web/api/presentationavailability/index.html
@@ -8,6 +8,7 @@ tags:
   - Presentation API
   - PresentationAvailability
   - Reference
+browser-compat: api.PresentationAvailability
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{APIRef("Presentation API")}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationAvailability")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationavailability/onchange/index.html
+++ b/files/en-us/web/api/presentationavailability/onchange/index.html
@@ -1,9 +1,10 @@
 ---
 title: PresentationAvailability.onchange
 slug: Web/API/PresentationAvailability/onchange
+browser-compat: api.PresentationAvailability.onchange
 ---
 <p><span class="seoSummary">The <dfn><code>onchange</code></dfn> attribute is an <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-event-handler">event handler</a> whose corresponding <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-event-handler-event-type">event handler event type</a> is <dfn><code>change</code></dfn>.</span></p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationAvailability.onchange")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationavailability/value/index.html
+++ b/files/en-us/web/api/presentationavailability/value/index.html
@@ -1,6 +1,7 @@
 ---
 title: PresentationAvailability.value
 slug: Web/API/PresentationAvailability/value
+browser-compat: api.PresentationAvailability.value
 ---
 <p><span class="seoSummary">The <dfn><code>value</code></dfn> attribute <em>MUST</em> return the last value from which it was set. The value is updated by the <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-monitor-the-list-of-available-presentation-displays">monitor the list of available presentation displays</a> algorithm.</span></p>
 
@@ -8,4 +9,4 @@ slug: Web/API/PresentationAvailability/value
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationAvailability.value")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/binarytype/index.html
+++ b/files/en-us/web/api/presentationconnection/binarytype/index.html
@@ -13,6 +13,7 @@ tags:
   - Property
   - Reference
   - binaryType
+browser-compat: api.PresentationConnection.binaryType
 ---
 <div>{{APIRef("Presentation API")}}</div>
 
@@ -24,4 +25,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.binaryType")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/close/index.html
+++ b/files/en-us/web/api/presentationconnection/close/index.html
@@ -10,6 +10,7 @@ tags:
   - Presentation
   - PresentationConnection
   - Reference
+browser-compat: api.PresentationConnection.close
 ---
 <div>{{APIRef("Presentation API")}}</div>
 
@@ -17,4 +18,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.close")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/id/index.html
+++ b/files/en-us/web/api/presentationconnection/id/index.html
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Web
   - id
+browser-compat: api.PresentationConnection.id
 ---
 <div>{{APIRef("Presentation API")}}</div>
 
@@ -20,4 +21,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.id")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/index.html
+++ b/files/en-us/web/api/presentationconnection/index.html
@@ -8,6 +8,7 @@ tags:
   - Presentation API
   - PresentationConnection
   - Reference
+browser-compat: api.PresentationConnection
 ---
 <div>{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("Presentation API")}}</div>
 
@@ -69,4 +70,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/send/index.html
+++ b/files/en-us/web/api/presentationconnection/send/index.html
@@ -11,6 +11,7 @@ tags:
 - PresentationConnection
 - Reference
 - send
+browser-compat: api.PresentationConnection.send
 ---
 <div>{{APIRef("Presentation")}}</div>
 
@@ -58,4 +59,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.send")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/state/index.html
+++ b/files/en-us/web/api/presentationconnection/state/index.html
@@ -12,6 +12,7 @@ tags:
   - Property
   - Reference
   - state
+browser-compat: api.PresentationConnection.state
 ---
 <div>{{APIRef("Presentation API")}}</div>
 
@@ -26,4 +27,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.state")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/terminate/index.html
+++ b/files/en-us/web/api/presentationconnection/terminate/index.html
@@ -12,6 +12,7 @@ tags:
   - PresentationConnection
   - Reference
   - terminate
+browser-compat: api.PresentationConnection.terminate
 ---
 <div>{{APIRef("Presentation API")}}</div>
 
@@ -19,4 +20,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.terminate")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnection/url/index.html
+++ b/files/en-us/web/api/presentationconnection/url/index.html
@@ -10,6 +10,7 @@ tags:
 - Property
 - Reference
 - URL
+browser-compat: api.PresentationConnection.url
 ---
 <p>{{SeeCompatTable}}{{APIRef("Presentation API")}}</p>
 
@@ -44,4 +45,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnection.url")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnectionavailableevent/connection/index.html
+++ b/files/en-us/web/api/presentationconnectionavailableevent/connection/index.html
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnectionAvailableEvent.connection
 slug: Web/API/PresentationConnectionAvailableEvent/connection
+browser-compat: api.PresentationConnectionAvailableEvent.connection
 ---
 <p>When an incoming connection is created, a <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-receiving-user-agent">receiving user agent</a> <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-firing-an-event">fires</a> a <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-trusted-event">trusted event</a>, named <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-connectionavailable"><code>connectionavailable</code></a>, on a <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#idl-def-presentationreceiver"><code>PresentationReceiver</code></a>. The <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-trusted-event">trusted event</a> is fired at the <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-presentation-controllers-monitor">presentation controller's monitor</a>, using the <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#idl-def-presentationconnectionavailableevent"><code>PresentationConnectionAvailableEvent</code></a> interface, with the <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#idl-def-presentationconnectionavailableevent-connection"><code>connection</code></a> attribute set to the <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#idl-def-presentationconnection"><code>PresentationConnection</code></a> object that was created.</p>
 
@@ -8,4 +9,4 @@ slug: Web/API/PresentationConnectionAvailableEvent/connection
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnectionAvailableEvent.connection")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnectionavailableevent/index.html
+++ b/files/en-us/web/api/presentationconnectionavailableevent/index.html
@@ -9,6 +9,7 @@ tags:
   - PresentationRequest
   - Reference
   - events
+browser-compat: api.PresentationConnectionAvailableEvent
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("Presentation API")}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnectionAvailableEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.html
+++ b/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.html
@@ -9,6 +9,7 @@ tags:
   - Presentation API
   - PresentationConnectionAvailableEvent
   - Reference
+browser-compat: api.PresentationConnectionAvailableEvent.PresentationConnectionAvailableEvent
 ---
 <p>The <strong><code>PresentationConnectionAvailableInit()</code></strong> constructor creates a new {{domxref("PresentationConnectionAvailableEvent")}}.</p>
 
@@ -31,4 +32,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnectionAvailableEvent.PresentationConnectionAvailableEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnectioncloseevent/index.html
+++ b/files/en-us/web/api/presentationconnectioncloseevent/index.html
@@ -9,6 +9,7 @@ tags:
   - PresentationRequest
   - Reference
   - events
+browser-compat: api.PresentationConnectionCloseEvent
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("Presentation API")}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnectionCloseEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationconnectionlist/index.html
+++ b/files/en-us/web/api/presentationconnectionlist/index.html
@@ -9,6 +9,7 @@ tags:
   - Presentation API
   - PresentationConnectionList
   - Reference
+browser-compat: api.PresentationConnectionList
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Presentation API")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationConnectionList")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationreceiver/index.html
+++ b/files/en-us/web/api/presentationreceiver/index.html
@@ -9,6 +9,7 @@ tags:
   - Presentation API
   - PresentationReceiver
   - Reference
+browser-compat: api.PresentationReceiver
 ---
 <p>{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Presentation API")}}</p>
 
@@ -40,4 +41,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationReceiver")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationrequest/getavailability/index.html
+++ b/files/en-us/web/api/presentationrequest/getavailability/index.html
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest.getAvailability()
 slug: Web/API/PresentationRequest/getAvailability
+browser-compat: api.PresentationRequest.getAvailability
 ---
 <p><span class="seoSummary">When the <code><dfn>getAvailability</dfn>()</code> method is called, the user agent <em>MUST</em> run the following steps:</span></p>
 
@@ -58,4 +59,4 @@ slug: Web/API/PresentationRequest/getAvailability
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationRequest.getAvailability")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/index.html
@@ -8,6 +8,7 @@ tags:
   - Presentation API
   - PresentationRequest
   - Reference
+browser-compat: api.PresentationRequest
 ---
 <p>{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("Presentation API")}}</p>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationrequest/onconnectionavailable/index.html
+++ b/files/en-us/web/api/presentationrequest/onconnectionavailable/index.html
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest.onconnectionavailable
 slug: Web/API/PresentationRequest/onconnectionavailable
+browser-compat: api.PresentationRequest.onconnectionavailable
 ---
 <p><span class="seoSummary">The following are event handlers (and their corresponding event handler event types) which must be supported, as event handler IDL attributes, by objects implementing the <a class="internalDFN" href="https://www.w3.org/TR/2016/CR-presentation-api-20160714/#idl-def-presentationrequest"><code>PresentationRequest</code></a> interface:</span></p>
 
@@ -38,4 +39,4 @@ slug: Web/API/PresentationRequest/onconnectionavailable
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationRequest.onconnectionavailable")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationrequest/presentationrequest/index.html
+++ b/files/en-us/web/api/presentationrequest/presentationrequest/index.html
@@ -8,6 +8,7 @@ tags:
 - Presentation API
 - PresentationRequest
 - Reference
+browser-compat: api.PresentationRequest.PresentationRequest
 ---
 <p>{{APIRef("Presentation API")}}{{Non-standard_header}}</p>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationRequest.PresentationRequest")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationrequest/reconnect/index.html
+++ b/files/en-us/web/api/presentationrequest/reconnect/index.html
@@ -5,6 +5,7 @@ tags:
   - Promise
   - controlled presentations
   - presentation identifier
+browser-compat: api.PresentationRequest.reconnect
 ---
 <p>When the <code><dfn>reconnect</dfn>(presentationId)</code> method is called on a <code>PresentationRequest</code> <var>presentationRequest</var>, the <a class="internalDFN" href="https://www.w3.org/TR/presentation-api/#dfn-user-agents">user agent</a> <em>MUST</em> run the following steps to <dfn>reconnect to a presentation</dfn>:</p>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationRequest.reconnect")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/presentationrequest/start/index.html
+++ b/files/en-us/web/api/presentationrequest/start/index.html
@@ -8,6 +8,7 @@ tags:
 - PresentationRequest
 - Reference
 - start()
+browser-compat: api.PresentationRequest.start
 ---
 <p>{{APIRef("Presentation API")}}{{SeeCompatTable}}</p>
 
@@ -51,4 +52,4 @@ promise.then(function(PresentationConnection) { ... })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PresentationRequest.start")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/processinginstruction/index.html
+++ b/files/en-us/web/api/processinginstruction/index.html
@@ -4,6 +4,7 @@ slug: Web/API/ProcessingInstruction
 tags:
   - API
   - DOM
+browser-compat: api.ProcessingInstruction
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProcessingInstruction")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/index.html
@@ -7,6 +7,7 @@ tags:
   - Progress Events
   - ProgressEvent
   - Reference
+browser-compat: api.ProgressEvent
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -80,7 +81,7 @@ client.send()</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProgressEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/progressevent/initprogressevent/index.html
+++ b/files/en-us/web/api/progressevent/initprogressevent/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Progress Events
 - ProgressEvent
+browser-compat: api.ProgressEvent.initProgressEvent
 ---
 <div>{{apiref("DOM Events")}} {{deprecated_header}}{{non-standard_header}}</div>
 
@@ -97,7 +98,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProgressEvent.initProgressEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/progressevent/lengthcomputable/index.html
+++ b/files/en-us/web/api/progressevent/lengthcomputable/index.html
@@ -6,6 +6,7 @@ tags:
 - Progress Events
 - ProgressEvent
 - Property
+browser-compat: api.ProgressEvent.lengthComputable
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProgressEvent.lengthComputable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/progressevent/loaded/index.html
+++ b/files/en-us/web/api/progressevent/loaded/index.html
@@ -6,6 +6,7 @@ tags:
 - Progress Event
 - ProgressEvent
 - Property
+browser-compat: api.ProgressEvent.loaded
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -40,7 +41,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProgressEvent.loaded")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/progressevent/progressevent/index.html
+++ b/files/en-us/web/api/progressevent/progressevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - DOM Events
   - ProgressEvent
+browser-compat: api.ProgressEvent.ProgressEvent
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -63,7 +64,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProgressEvent.ProgressEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/progressevent/total/index.html
+++ b/files/en-us/web/api/progressevent/total/index.html
@@ -7,6 +7,7 @@ tags:
 - ProgressEvent
 - Property
 - Reference
+browser-compat: api.ProgressEvent.total
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -44,7 +45,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ProgressEvent.total")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/index.html
+++ b/files/en-us/web/api/promiserejectionevent/index.html
@@ -10,6 +10,7 @@ tags:
   - Promises
   - Reference
   - events
+browser-compat: api.PromiseRejectionEvent
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -79,7 +80,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PromiseRejectionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/promise/index.html
+++ b/files/en-us/web/api/promiserejectionevent/promise/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - events
+browser-compat: api.PromiseRejectionEvent.promise
 ---
 <div>{{APIRef("HTML DOM") }}</div>
 
@@ -73,7 +74,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PromiseRejectionEvent.promise")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.html
+++ b/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.html
@@ -10,6 +10,7 @@ tags:
 - Promises
 - Reference
 - events
+browser-compat: api.PromiseRejectionEvent.PromiseRejectionEvent
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PromiseRejectionEvent.PromiseRejectionEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/promiserejectionevent/reason/index.html
+++ b/files/en-us/web/api/promiserejectionevent/reason/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - events
 - reason
+browser-compat: api.PromiseRejectionEvent.reason
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -58,7 +59,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PromiseRejectionEvent.reason")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredential/getclientextensionresults/index.html
+++ b/files/en-us/web/api/publickeycredential/getclientextensionresults/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredential.getClientExtensionResults
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -118,7 +119,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredential.getClientExtensionResults")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredential/id/index.html
+++ b/files/en-us/web/api/publickeycredential/id/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredential.id
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -98,7 +99,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredential.id")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredential/index.html
+++ b/files/en-us/web/api/publickeycredential/index.html
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredential
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -112,7 +113,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredential")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.html
+++ b/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -95,7 +96,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredential/rawid/index.html
+++ b/files/en-us/web/api/publickeycredential/rawid/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredential.rawId
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -87,4 +88,4 @@ navigator.credentials.create({  publickey: options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredential.rawId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/publickeycredential/response/index.html
+++ b/files/en-us/web/api/publickeycredential/response/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredential.response
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -115,4 +116,4 @@ navigator.credentials.create({  publickey: options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredential.response")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/publickeycredentialcreationoptions/attestation/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/attestation/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.attestation
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -98,7 +99,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.attestation")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/authenticatorselection/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/authenticatorselection/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.authenticatorSelection
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -118,7 +119,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.authenticatorSelection")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/challenge/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/challenge/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.challenge
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -97,7 +98,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.challenge")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/excludecredentials/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/excludecredentials/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.excludeCredentials
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -118,4 +119,4 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.excludeCredentials")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/publickeycredentialcreationoptions/extensions/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/extensions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.extensions
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -178,7 +179,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.extensions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -135,7 +136,7 @@ navigator.credentials.create(createCredentialOptions)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/pubkeycredparams/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/pubkeycredparams/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.pubKeyCredParams
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -105,7 +106,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.pubKeyCredParams")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/rp/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/rp/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.rp
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -89,4 +90,4 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.rp")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/publickeycredentialcreationoptions/timeout/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/timeout/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.timeout
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -89,7 +90,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.timeout")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialcreationoptions/user/index.html
+++ b/files/en-us/web/api/publickeycredentialcreationoptions/user/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialCreationOptions.user
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -97,7 +98,7 @@ navigator.credentials.create({ publicKey })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialCreationOptions.user")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/allowcredentials/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/allowcredentials/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions.allowCredentials
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -112,7 +113,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions.allowCredentials")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/challenge/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/challenge/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions.challenge
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -84,7 +85,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions.challenge")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/extensions/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/extensions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions.extensions
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -171,7 +172,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions.extensions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/index.html
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions
 ---
 <div>{{APIRef("Web Authentication API")}}{{securecontext_header}}</div>
 
@@ -92,7 +93,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/rpid/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/rpid/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions.rpId
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -78,7 +79,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions.rpId")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/timeout/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/timeout/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions.timeout
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -75,7 +76,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions.timeout")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/publickeycredentialrequestoptions/userverification/index.html
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/userverification/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - Web Authentication API
 - WebAuthn
+browser-compat: api.PublicKeyCredentialRequestOptions.userVerification
 ---
 <p>{{APIRef("Web Authentication API")}}{{securecontext_header}}</p>
 
@@ -85,7 +86,7 @@ navigator.credentials.get({ "publicKey": options })
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PublicKeyCredentialRequestOptions.userVerification")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushevent/data/index.html
+++ b/files/en-us/web/api/pushevent/data/index.html
@@ -9,6 +9,7 @@ tags:
   - PushEvent
   - Reference
   - data
+browser-compat: api.PushEvent.data
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushEvent.data")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Service Workers
   - Workers
+browser-compat: api.PushEvent
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -86,7 +87,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushevent/pushevent/index.html
+++ b/files/en-us/web/api/pushevent/pushevent/index.html
@@ -10,6 +10,7 @@ tags:
 - PushEvent
 - Reference
 - Service Workers
+browser-compat: api.PushEvent.PushEvent
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -55,7 +56,7 @@ myPushEvent.data.text(); // should return 'Some sample text'</pre>
 
 <div>
 
-	<p>{{Compat("api.PushEvent.PushEvent")}}</p>
+	<p>{{Compat}}</p>
 </div>
 
 <h2 id="See_also">See also</h2>

--- a/files/en-us/web/api/pushmanager/getsubscription/index.html
+++ b/files/en-us/web/api/pushmanager/getsubscription/index.html
@@ -8,6 +8,7 @@ tags:
   - PushManager
   - Reference
   - Service Workers
+browser-compat: api.PushManager.getSubscription
 ---
 <p>{{SeeCompatTable}}{{ApiRef("Push API")}}</p>
 
@@ -85,6 +86,6 @@ tags:
 <div>
 <div>
 
-<p>{{Compat("api.PushManager.getSubscription")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>

--- a/files/en-us/web/api/pushmanager/haspermission/index.html
+++ b/files/en-us/web/api/pushmanager/haspermission/index.html
@@ -7,6 +7,7 @@ tags:
   - Method
   - PushManager
   - Reference
+browser-compat: api.PushManager.hasPermission
 ---
 <div>{{deprecated_header}}{{ApiRef("Push API")}}</div>
 
@@ -42,6 +43,6 @@ tags:
 <div>
 <div>
 
-<p>{{Compat("api.PushManager.hasPermission")}}</p>
+<p>{{Compat}}</p>
 </div>
 </div>

--- a/files/en-us/web/api/pushmanager/index.html
+++ b/files/en-us/web/api/pushmanager/index.html
@@ -9,6 +9,7 @@ tags:
   - Push API
   - Reference
   - Service Workers
+browser-compat: api.PushManager
 ---
 <p>{{ApiRef("Push API")}}</p>
 
@@ -96,7 +97,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushmanager/permissionstate/index.html
+++ b/files/en-us/web/api/pushmanager/permissionstate/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - permissionState
+browser-compat: api.PushManager.permissionState
 ---
 <p>{{SeeCompatTable}}{{ApiRef("Push API")}}</p>
 
@@ -72,4 +73,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager.permissionState")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmanager/register/index.html
+++ b/files/en-us/web/api/pushmanager/register/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - Simple Push API
+browser-compat: api.PushManager.register
 ---
 <div>{{deprecated_header}}{{ ApiRef("Push API")}}</div>
 
@@ -66,7 +67,7 @@ req.onerror = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager.register")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushmanager/registrations/index.html
+++ b/files/en-us/web/api/pushmanager/registrations/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - Simple Push API
+browser-compat: api.PushManager.registrations
 ---
 <div>{{deprecated_header}}{{ApiRef("Push API")}}</div>
 
@@ -78,7 +79,7 @@ req.onsuccess = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager.registrations")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushmanager/subscribe/index.html
+++ b/files/en-us/web/api/pushmanager/subscribe/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - WebAPI
 - subscribe
+browser-compat: api.PushManager.subscribe
 ---
 <p>{{SeeCompatTable}}{{ApiRef("Push API")}}</p>
 
@@ -127,4 +128,4 @@ navigator.serviceWorker.ready.then(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager.subscribe")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - Service Workers
 - supportedContentEncodings
+browser-compat: api.PushManager.supportedContentEncodings
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -45,4 +46,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager.supportedContentEncodings")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmanager/unregister/index.html
+++ b/files/en-us/web/api/pushmanager/unregister/index.html
@@ -7,6 +7,7 @@ tags:
 - Method
 - Reference
 - Simple Push API
+browser-compat: api.PushManager.unregister
 ---
 <div>{{deprecated_header}}{{ ApiRef("Push API")}}</div>
 
@@ -81,7 +82,7 @@ req.onerror = function(e) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushManager.unregister")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.html
@@ -10,6 +10,7 @@ tags:
   - PushMessageData
   - Reference
   - Service Workers
+browser-compat: api.PushMessageData.arrayBuffer
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushMessageData.arrayBuffer")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmessagedata/blob/index.html
+++ b/files/en-us/web/api/pushmessagedata/blob/index.html
@@ -10,6 +10,7 @@ tags:
   - PushMessageData
   - Reference
   - Service Workers
+browser-compat: api.PushMessageData.blob
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushMessageData.blob")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmessagedata/index.html
+++ b/files/en-us/web/api/pushmessagedata/index.html
@@ -10,6 +10,7 @@ tags:
   - PushMessageData
   - Reference
   - Service Workers
+browser-compat: api.PushMessageData
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushMessageData")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmessagedata/json/index.html
+++ b/files/en-us/web/api/pushmessagedata/json/index.html
@@ -10,6 +10,7 @@ tags:
   - PushMessageData
   - Reference
   - Service Workers
+browser-compat: api.PushMessageData.json
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushMessageData.json")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushmessagedata/text/index.html
+++ b/files/en-us/web/api/pushmessagedata/text/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - Service Workers
   - Text
+browser-compat: api.PushMessageData.text
 ---
 <p>{{APIRef("Push API")}}{{SeeCompatTable()}}</p>
 
@@ -55,4 +56,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushMessageData.text")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushregistrationmanager/index.html
+++ b/files/en-us/web/api/pushregistrationmanager/index.html
@@ -9,6 +9,7 @@ tags:
   - NeedsExample
   - PushRegistrationManager
   - Reference
+browser-compat: api.PushRegistrationManager
 ---
 <div>{{deprecated_header}}{{APIRef("Push API")}}</div>
 
@@ -29,4 +30,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushRegistrationManager")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/endpoint/index.html
+++ b/files/en-us/web/api/pushsubscription/endpoint/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Service Workers
 - endPoint
+browser-compat: api.PushSubscription.endpoint
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -64,4 +65,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.endpoint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/expirationtime/index.html
+++ b/files/en-us/web/api/pushsubscription/expirationtime/index.html
@@ -10,6 +10,7 @@ tags:
 - PushSubscription
 - Reference
 - Service Worker
+browser-compat: api.PushSubscription.expirationTime
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -47,4 +48,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.expirationTime")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/getkey/index.html
+++ b/files/en-us/web/api/pushsubscription/getkey/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Service Workers
 - getKey
+browser-compat: api.PushSubscription.getKey
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -95,4 +96,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.getKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/index.html
+++ b/files/en-us/web/api/pushsubscription/index.html
@@ -10,6 +10,7 @@ tags:
   - PushSubscription
   - Reference
   - Service Workers
+browser-compat: api.PushSubscription
 ---
 <div>{{SeeCompatTable}}{{ApiRef("Push API")}} </div>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushsubscription/options/index.html
+++ b/files/en-us/web/api/pushsubscription/options/index.html
@@ -9,6 +9,7 @@ tags:
 - PushManager
 - Reference
 - Service Worker
+browser-compat: api.PushSubscription.options
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -53,4 +54,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.options")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.html
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - Service Workers
 - subscriptionId
+browser-compat: api.PushSubscription.subscriptionId
 ---
 <div>{{APIRef("Push API")}}{{Deprecated_header}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.subscriptionId")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/tojson/index.html
+++ b/files/en-us/web/api/pushsubscription/tojson/index.html
@@ -12,6 +12,7 @@ tags:
 - Serializer
 - Service Workers
 - toJSON
+browser-compat: api.PushSubscription.toJSON
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -60,4 +61,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.toJSON")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscription/unsubscribe/index.html
+++ b/files/en-us/web/api/pushsubscription/unsubscribe/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Service Workers
 - unsubscribe
+browser-compat: api.PushSubscription.unsubscribe
 ---
 <p>{{SeeCompatTable}}{{APIRef("Push API")}}</p>
 
@@ -64,7 +65,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscription.unsubscribe")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - applicationServerKey
   - PushSubscriptionOptions
+browser-compat: api.PushSubscriptionOptions.applicationServerKey
 ---
 <div>{{DefaultAPISidebar("Push API")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscriptionOptions.applicationServerKey")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscriptionoptions/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.html
@@ -6,6 +6,7 @@ tags:
   - Interface
   - Reference
   - PushSubscriptionOptions
+browser-compat: api.PushSubscriptionOptions
 ---
 <div>{{DefaultAPISidebar("Push API")}}</div>
 
@@ -54,4 +55,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscriptionOptions")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - userVisibleOnly
   - PushSubscriptionOptions
+browser-compat: api.PushSubscriptionOptions.userVisibleOnly
 ---
 <div>{{DefaultAPISidebar("Push API")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PushSubscriptionOptions.userVisibleOnly")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/[opq]* for the case without problem: 1 macro Compat in the page and its parameter matching the slug. Other cases (no Compat macros on a page, multiple Compat macros, macro not matching the slug, will be done at a later stage).

> MDN URL of the main page changed

414 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it

This is a replacement for #5420 where I didn't handle the merge conflicts adequately.