### PR TITLE
Put browser-compat in front-runner for remaining http pages (manual)

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.html
+++ b/files/en-us/web/http/headers/set-cookie/index.html
@@ -8,6 +8,7 @@ tags:
   - Response
   - header
   - samesite
+browser-compat: http.headers.Set-Cookie
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -202,7 +203,7 @@ Set-Cookie: __Host-id=1; Secure; Path=/; Domain=example.com
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Set-Cookie", 5)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Compatibility_notes">Compatibility notes</h2>
 

--- a/files/en-us/web/http/headers/set-cookie/samesite/index.html
+++ b/files/en-us/web/http/headers/set-cookie/samesite/index.html
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Reference
   - samesite
+browser-compat: http.headers.Set-Cookie.SameSite
 ---
 <div>{{HTTPSidebar}}</div>
 
@@ -122,7 +123,7 @@ RewriteRule "^admin/(.*)\.html$" "admin/index.php?nav=$1 [NC,L,QSA,CO=RewriteRul
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("http.headers.Set-Cookie", 5)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers http/* where the script requested a manual edition. (one file was incorrect, the other had a useless paramete)

> MDN URL of the main page changed

2 files in http/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it

http:/ will be done (except non-existent BCD) after this PR lands.