### PR TITLE
Mark ShadowRoot.mode as read-only (#5539)

### DIFF
--- a/files/en-us/web/api/shadowroot/mode/index.html
+++ b/files/en-us/web/api/shadowroot/mode/index.html
@@ -12,7 +12,7 @@ browser-compat: api.ShadowRoot.mode
 ---
 <div>{{APIRef("Shadow DOM")}}</div>
 
-<p>The <strong><code>mode</code></strong> property of the {{domxref("ShadowRoot")}}
+<p>The <strong><code>mode</code></strong> read-only property of the {{domxref("ShadowRoot")}}
 	specifies its mode — either <code>open</code> or <code>closed</code>. This defines
 	whether or not the shadow root's internal features are accessible from JavaScript.</p>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

ShadowRoot.mode was not marked as read-only.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/mode

> Issue number (if there is an associated issue)

Fixes #5539.

> Anything else that could help us review it

The parent's page and Mozilla's weidl confirms it is read-only.