### PR TITLE
Make kitchensink file attachment a link to

### DIFF
--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -365,7 +365,6 @@ rect2.bind("EnterFrame", function () {
 {{Non-standard_Header}}
 {{Deprecated_Header}}
 
-<p>Small change just to trigger a build</p>
 <a href="iceberg.jpg"><img src="iceberg.jpg" alt="Iceberg pic"></a>
 
 <p><code>geckoRelease:</code> {{ geckoRelease("1.9.3") }}</p>

--- a/files/en-us/mdn/kitchensink/index.html
+++ b/files/en-us/mdn/kitchensink/index.html
@@ -366,6 +366,6 @@ rect2.bind("EnterFrame", function () {
 {{Deprecated_Header}}
 
 <p>Small change just to trigger a build</p>
-<img src="iceberg.jpg" alt="Iceberg pic">
+<a href="iceberg.jpg"><img src="iceberg.jpg" alt="Iceberg pic"></a>
 
 <p><code>geckoRelease:</code> {{ geckoRelease("1.9.3") }}</p>

--- a/files/en-us/web/javascript/reference/global_objects/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/index.html
@@ -11,6 +11,10 @@ tags:
 
 <p><span class="seoSummary">This chapter documents all of JavaScript's standard, built-in objects, including their methods and properties.</span></p>
 
+<pre class="brush:js">
+const f = function() {return undefined;}
+</pre>
+
 <p>The term "global objects" (or standard built-in objects) here is not to be confused with <strong>the global object</strong>. Here, "global objects" refer to <strong>objects in the global scope</strong>.</p>
 
 <p>The <strong>global object</strong> itself can be accessed using the {{JSxRef("Operators/this", "this")}} operator in the global scope. In fact, the global scope <strong>consists of</strong> the properties of the global object, including inherited properties, if any.</p>

--- a/files/en-us/web/javascript/reference/global_objects/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/index.html
@@ -11,10 +11,6 @@ tags:
 
 <p><span class="seoSummary">This chapter documents all of JavaScript's standard, built-in objects, including their methods and properties.</span></p>
 
-<pre class="brush:js">
-const f = function() {return undefined;}
-</pre>
-
 <p>The term "global objects" (or standard built-in objects) here is not to be confused with <strong>the global object</strong>. Here, "global objects" refer to <strong>objects in the global scope</strong>.</p>
 
 <p>The <strong>global object</strong> itself can be accessed using the {{JSxRef("Operators/this", "this")}} operator in the global scope. In fact, the global scope <strong>consists of</strong> the properties of the global object, including inherited properties, if any.</p>


### PR DESCRIPTION
I needed this for the end-to-end tests in https://github.com/mdn/yari/pull/3887
Now, this becomes a reliable page to test the ability to link directly to a file attachment and not just use it as an `<img>`. 