### PR TITLE
Update templates for BCD in front-runner

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.html
@@ -7,6 +7,7 @@ tags:
   - Template
   - constructor subpage
   - reference page
+browser-compat: path.to.feature.NameOfTheConstructor
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -111,7 +112,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheConstructor")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_event_handler_subpage_template/index.html
@@ -7,6 +7,7 @@ tags:
   - Template
   - event handler subpage
   - reference page
+browser-compat: path.to.feature.NameOfTheProperty
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -89,7 +90,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheProperty")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.html
@@ -7,6 +7,7 @@ tags:
   - Event subpage
   - Template
   - reference page
+browser-compat: path.to.feature.NameOfTheEvent_event
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -118,7 +119,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheEvent_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Landing
   - Template
+browser-compat: path.to.feature.NameOfAPI
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -123,7 +124,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfAPI")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.html
@@ -7,6 +7,7 @@ tags:
   - Template
   - method subpage
   - reference page
+browser-compat: path.to.feature.NameOfTheMethod
 ---
 <p>{{MDNSidebar}}</p>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheMethod")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.html
@@ -7,6 +7,7 @@ tags:
   - Template
   - property subpage
   - reference page
+browser-compat: path.to.feature.NameOfTheProperty
 ---
 <p>{{MDNSidebar}}</p>
 
@@ -91,7 +92,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheProperty")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.html
@@ -5,6 +5,7 @@ tags:
   - API
   - Template
   - reference page
+browser-compat: path.to.feature.NameOfTheInterface
 ---
 <p>{{MDNSidebar}}</p>
 
@@ -133,7 +134,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheInterface")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.html
@@ -6,6 +6,7 @@ tags:
   - Property
   - Reference
   - Template
+browser-compat: path.to.feature.NameOfTheProperty
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -110,7 +111,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheProperty")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - Selector
   - Template
+browser-compat: css.selectors.NameOfTheSelector
 ---
 <p>{{MDNSidebar}}</p>
 
@@ -92,7 +93,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("css.selectors.NameOfTheSelector")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.html
@@ -6,6 +6,7 @@ tags:
   - HTML
   - Template
   - reference page
+browser-compat: path.to.feature.NameOfTheElement
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -160,7 +161,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - Template
   - reference page
+browser-compat: path.to.feature.NameOfTheHeader
 ---
 <div>{{MDNSidebar}}</div>
 
@@ -113,7 +114,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheHeader")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.html
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.html
@@ -6,6 +6,7 @@ tags:
   - SVG
   - Template
   - reference page
+browser-compat: path.to.feature.NameOfTheElement
 ---
 <div>{{FirefoxSidebar}}</div>
 
@@ -114,7 +115,7 @@ tags:
 
 <h2 id="Browser_compatibility_2">Browser compatibility</h2>
 
-<p>{{Compat("path.to.feature.NameOfTheElement")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We have updated most of MDN to use BCD in front-runner. It is important that new pages abide by this convention. We have template pages that we invite author to use. We need to update them.

> MDN URL of the main page changed

Subpages of https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types

> Issue number (if there is an associated issue)

Part of openwebdocs/project#36

> Anything else that could help us review it
