### PR TITLE
Remove duplicated 'the'

### DIFF
--- a/files/en-us/web/api/svganimationelement/index.html
+++ b/files/en-us/web/api/svganimationelement/index.html
@@ -21,9 +21,9 @@ browser-compat: api.SVGAnimationElement
 
 <dl>
  <dt>{{domxref("SVGAnimationElement.requiredExtensions")}} {{ReadOnlyInline}}</dt>
- <dd>An {{domxref("SVGStringList")}} reflecting the the {{SVGAttr("requiredExtensions")}} attribute of the given element.</dd>
+ <dd>An {{domxref("SVGStringList")}} reflecting the {{SVGAttr("requiredExtensions")}} attribute of the given element.</dd>
  <dt>{{domxref("SVGAnimationElement.systemLanguage")}} {{ReadOnlyInline}}</dt>
- <dd>An {{domxref("SVGStringList")}} reflecting the the {{SVGAttr("systemLanguage")}} attribute of the given element.</dd>
+ <dd>An {{domxref("SVGStringList")}} reflecting the {{SVGAttr("systemLanguage")}} attribute of the given element.</dd>
  <dt>{{domxref("SVGAnimationElement.targetElement")}} {{ReadOnlyInline}}</dt>
  <dd>An {{domxref("SVGElement")}} representing the element which is being animated. If no target element is being animated (for example, because the {{SVGAttr("href")}} specifies an unknown element) the value returned is <code>null</code>.</dd>
 </dl>

--- a/files/en-us/web/api/svggraphicselement/index.html
+++ b/files/en-us/web/api/svggraphicselement/index.html
@@ -21,9 +21,9 @@ browser-compat: api.SVGGraphicsElement
 
 <dl>
  <dt>{{domxref("SVGGraphicsElement.requiredExtensions")}} {{ReadOnlyInline}}</dt>
- <dd>An {{domxref("SVGStringList")}} reflecting the the {{SVGAttr("requiredExtensions")}} attribute of the given element.</dd>
+ <dd>An {{domxref("SVGStringList")}} reflecting the {{SVGAttr("requiredExtensions")}} attribute of the given element.</dd>
  <dt>{{domxref("SVGGraphicsElement.systemLanguage")}} {{ReadOnlyInline}}</dt>
- <dd>An {{domxref("SVGStringList")}} reflecting the the {{SVGAttr("systemLanguage")}} attribute of the given element.</dd>
+ <dd>An {{domxref("SVGStringList")}} reflecting the {{SVGAttr("systemLanguage")}} attribute of the given element.</dd>
  <dt>{{domxref("SVGGraphicsElement.transform")}} {{ReadOnlyInline}}</dt>
  <dd>An {{domxref("SVGAnimatedTransformList")}} reflecting the computed value of the {{cssxref("transform")}} property and its corresponding {{SVGAttr("transform")}} attribute of the given element.</dd>
 </dl>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

There are a few 'the the' in 2 files introduced in PR #5533

> MDN URL of the main page changed

> Issue number (if there is an associated issue)
N/A
> Anything else that could help us review it
