### PR TITLE
Move BCD in front-runner (remaining api/[abc]*; manual)

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -6991,6 +6991,8 @@
 /en-US/docs/Web/API/Blob.type	/en-US/docs/Web/API/Blob/type
 /en-US/docs/Web/API/BlobEvent.BlobEvent	/en-US/docs/Web/API/BlobEvent/BlobEvent
 /en-US/docs/Web/API/BlobEvent.data	/en-US/docs/Web/API/BlobEvent/data
+/en-US/docs/Web/API/BluetoothCharacteristicProperties/writableAuxiliar	/en-US/docs/Web/API/BluetoothCharacteristicProperties/writableAuxiliaries
+/en-US/docs/Web/API/BluetoothCharacteristicProperties/writeWithoutRespponse	/en-US/docs/Web/API/BluetoothCharacteristicProperties/writeWithoutResponse
 /en-US/docs/Web/API/BluetoothDevice.name	/en-US/docs/Web/API/BluetoothDevice/name
 /en-US/docs/Web/API/BluetoothDevice.paired	/en-US/docs/Web/API/BluetoothDevice/paired
 /en-US/docs/Web/API/BluetoothDevice.uuids	/en-US/docs/Web/API/BluetoothDevice/uuids

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - writableAuxiliaries
+browser-compat: api.BluetoothCharacteristicProperties.writableAuxiliaries
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.writableAuxiliaries")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writableauxiliaries/index.html
@@ -1,6 +1,6 @@
 ---
 title: BluetoothCharacteristicProperties.writableAuxiliaries
-slug: Web/API/BluetoothCharacteristicProperties/writableAuxiliar
+slug: Web/API/BluetoothCharacteristicProperties/writableAuxiliaries
 tags:
 - API
 - Bluetooth

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
@@ -11,6 +11,7 @@ tags:
 - Reference
 - Web Bluetooth API
 - writeWithoutResponse
+browser-compat: api.BluetoothCharacteristicProperties.writeWithoutResponse
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("Bluetooth API")}}</div>
 
@@ -48,4 +49,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.BluetoothCharacteristicProperties.writeWithoutResponse")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/writewithoutresponse/index.html
@@ -1,6 +1,6 @@
 ---
 title: BluetoothCharacteristicProperties.writeWithoutResponse
-slug: Web/API/BluetoothCharacteristicProperties/writeWithoutRespponse
+slug: Web/API/BluetoothCharacteristicProperties/writeWithoutResponse
 tags:
 - API
 - Bluetooth

--- a/files/en-us/web/api/clipboarditem/presentationstyle/index.html
+++ b/files/en-us/web/api/clipboarditem/presentationstyle/index.html
@@ -13,6 +13,7 @@ tags:
 - presentationStyle
 - copy
 - paste
+browser-compat: api.ClipboardItem.presentationStyle
 ---
 <div>{{DefaultAPISidebar("Clipboard API")}}</div>
 
@@ -68,7 +69,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ClipboardItem.types")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/css/index.html
+++ b/files/en-us/web/api/css/index.html
@@ -7,6 +7,7 @@ tags:
   - Interface
   - Painting
   - Reference
+browser-compat: api.CSS
 ---
 <div>{{APIRef("CSSOM")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSS", 1)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/css/registerproperty/index.html
+++ b/files/en-us/web/api/css/registerproperty/index.html
@@ -5,6 +5,7 @@ tags:
 - CSS
 - Houdini
 - Reference
+browser-compat: api.CSS.registerProperty
 ---
 <div>{{SeeCompatTable}}</div>
 
@@ -130,7 +131,7 @@ button {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSS.registerProperty", 1)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/cssnumericvalue/sum/index.html
+++ b/files/en-us/web/api/cssnumericvalue/sum/index.html
@@ -10,6 +10,7 @@ tags:
 - Method
 - Reference
 - sum()
+browser-compat: api.CSSNumericValue.sum
 ---
 <div>{{draft}}{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}</div>
 
@@ -67,4 +68,4 @@ console.log(mathSum.toString());</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSNumericValue.sub")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/csspseudoelement/element/index.html
+++ b/files/en-us/web/api/csspseudoelement/element/index.html
@@ -8,6 +8,7 @@ tags:
 - Experimental
 - Property
 - Reference
+browser-compat: api.CSSPseudoElement.element
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
@@ -61,7 +62,7 @@ console.log(myElement.nextSibling === cssPseudoElement);        // Outputs false
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('api.CSSPseudoElement.element')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csspseudoelement/index.html
+++ b/files/en-us/web/api/csspseudoelement/index.html
@@ -8,6 +8,7 @@ tags:
   - Experimental
   - Interface
   - Reference
+browser-compat: api.CSSPseudoElement
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
@@ -66,7 +67,7 @@ console.log(cssPseudoElement.type); // Outputs '::before'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('api.CSSPseudoElement')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csspseudoelement/type/index.html
+++ b/files/en-us/web/api/csspseudoelement/type/index.html
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - Type
+browser-compat: api.CSSPseudoElement.type
 ---
 <p>{{APIRef}}{{SeeCompatTable}}</p>
 
@@ -63,7 +64,7 @@ console.log(mySelector === typeOfPseudoElement); // Outputs true
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat('api.CSSPseudoElement.type')}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/csstransition/transitionproperty/index.html
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.html
@@ -7,6 +7,7 @@ tags:
 - CSSTransition
 - Property
 - Reference
+browser-compat: api.CSSTransition.transitionProperty
 ---
 <div>{{APIRef("Web Animations API")}}{{SeeCompatTable}}</div>
 
@@ -72,4 +73,4 @@ item.addEventListener('transitionrun', () => {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.CSSAnimation.transitionProperty")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/[abc]* for the cases refused by the script (that is defensive).

> MDN URL of the main page changed

10 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
- 2 files had a wrong name; I renamed them
- there was a couple of cases with useless param
- and a few case with a wrong parameter (I moved it and fixed it).