### PR TITLE
Fix Table user agent info for Firefox for Android

### DIFF
--- a/files/en-us/web/http/headers/user-agent/firefox/index.html
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.html
@@ -52,7 +52,7 @@ tags:
 <h2 id="Mobile_and_Tablet_indicators">Mobile and Tablet indicators</h2>
 
 <div class="note">
-<p>Only from Firefox 11 onwards.</p>
+<p>Only from Firefox 11 to 68.</p>
 </div>
 
 <p>The <code><var>platform</var></code> part of the UA string indicates if Firefox is running on a phone-sized or tablet device. When Firefox runs on a device that has the phone form factor, there is a <code>Mobile;</code> token in the <code><var>platform</var></code> part of the UA string. When Firefox runs on a tablet device, there is a <code>Tablet;</code> token in the <code><var>platform</var></code> part of the UA string instead. For example:</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Firefox for Android does not send a tablet user agent in versions 69 or newer.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox

> Issue number (if there is an associated issue)

> Anything else that could help us review it
