### PR TITLE
Move BCD in front-runner (remaining api/[d-q]*; manual)

### DIFF
--- a/files/en-us/web/api/dommatrix/index.html
+++ b/files/en-us/web/api/dommatrix/index.html
@@ -10,6 +10,7 @@ tags:
   - Interface
   - Reference
   - matrix
+browser-compat: api.DOMMatrix
 ---
 <p>{{APIRef("Geometry Interfaces")}}</p>
 
@@ -160,7 +161,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMMatrix")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{Compat("api.WebKitCSSMatrix")}}</p>
 

--- a/files/en-us/web/api/domparser/index.html
+++ b/files/en-us/web/api/domparser/index.html
@@ -10,6 +10,7 @@ tags:
   - HTMLDocument
   - Parsing
   - Reference
+browser-compat: api.DOMParser
 ---
 <p>{{APIRef("DOM")}}</p>
 
@@ -97,7 +98,7 @@ console.log(doc3.body.firstChild.textContent);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMParser", 3)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompoint/frompoint/index.html
+++ b/files/en-us/web/api/dompoint/frompoint/index.html
@@ -14,6 +14,7 @@ tags:
 - Static
 - Static Method
 - fromPoint
+browser-compat: api.DOMPoint.fromPoint
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -89,4 +90,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.fromPoint")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/dompoint/w/index.html
+++ b/files/en-us/web/api/dompoint/w/index.html
@@ -12,6 +12,7 @@ tags:
 - Reference
 - W
 - perspective
+browser-compat: api.DOMPoint.w
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.w")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompoint/x/index.html
+++ b/files/en-us/web/api/dompoint/x/index.html
@@ -12,6 +12,7 @@ tags:
 - Property
 - Reference
 - x
+browser-compat: api.DOMPoint.x
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -51,7 +52,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.x")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompoint/y/index.html
+++ b/files/en-us/web/api/dompoint/y/index.html
@@ -11,7 +11,8 @@ tags:
 - Point
 - Property
 - Reference
-- 'y'
+- y
+browser-compat: api.DOMPoint.y
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -50,7 +51,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.y")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/dompoint/z/index.html
+++ b/files/en-us/web/api/dompoint/z/index.html
@@ -14,6 +14,7 @@ tags:
 - Property
 - Reference
 - z
+browser-compat: api.DOMPoint.z
 ---
 <div>{{APIRef("DOM")}}</div>
 
@@ -53,7 +54,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DOMPointReadOnly.z")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/effecttiming/easing/index.html
+++ b/files/en-us/web/api/effecttiming/easing/index.html
@@ -15,6 +15,7 @@ tags:
   - easing
   - waapi
   - web animations api
+browser-compat: api.EffectTiming.easing
 ---
 <div>{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}</div>
 
@@ -149,7 +150,7 @@ spriteFrames, {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.EffectTiming.easing", 2)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/element/mozmousepixelscroll/index.html
+++ b/files/en-us/web/api/element/mozmousepixelscroll/index.html
@@ -14,6 +14,7 @@ tags:
   - mouse
   - wheel
   - Deprecated
+browser-compat: api.Element.MozMousePixelScroll_event
 ---
 <p>{{APIRef}}{{deprecated_header}}{{ Non-standard_header() }}</p>
 
@@ -54,7 +55,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Element.MozMousePixelScroll_event")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.html
@@ -18,6 +18,7 @@ tags:
   - attachEvent
   - events
   - mselementresize
+browser-compat: api.EventTarget.addEventListener
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
@@ -1078,7 +1079,7 @@ window.addEventListener('scroll', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.EventTarget.addEventListener", 3)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.html
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.html
@@ -11,6 +11,7 @@ tags:
   - Reference
   - browser compatibility
   - removeEventListener
+browser-compat: api.EventTarget.removeEventListener
 ---
 <div>{{APIRef("DOM Events")}}</div>
 
@@ -204,7 +205,7 @@ mouseOverTarget.addEventListener('mouseover', function () {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.EventTarget.removeEventListener", 3)}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Polyfill_to_support_older_browsers">Polyfill to support older browsers</h2>
 

--- a/files/en-us/web/api/interventionreportbody/index.html
+++ b/files/en-us/web/api/interventionreportbody/index.html
@@ -8,6 +8,7 @@ tags:
   - InterventionReportBody
   - Reference
   - Reporting API
+browser-compat: api.InterventionReportBody
 ---
 <div>{{SeeCompatTable}}{{APIRef("Reporting API")}}</div>
 
@@ -66,7 +67,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.DeprecationReportBody")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/keyboard/unlock/index.html
+++ b/files/en-us/web/api/keyboard/unlock/index.html
@@ -8,7 +8,8 @@ tags:
 - Method
 - Reference
 - keyboard
-- unLock()
+- unLock
+browser-compat: api.Keyboard.unlocks
 ---
 <div>{{APIRef("Keyboard API")}}{{SeeCompatTable}}</div>
 
@@ -52,4 +53,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Keyboard.unlock()")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/notificationaction/index.html
+++ b/files/en-us/web/api/notificationaction/index.html
@@ -1,6 +1,7 @@
 ---
 title: NotificationAction
 slug: Web/API/NotificationAction
+browser-compat: api.NotificationAction
 ---
 <div>{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}</div>
 
@@ -67,7 +68,7 @@ self.addEventListener('notificationclick', function(event) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Notification")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/pointerevent/pointertype/index.html
+++ b/files/en-us/web/api/pointerevent/pointertype/index.html
@@ -8,6 +8,7 @@ tags:
 - PointerEvent
 - Property
 - Reference
+browser-compat: api.PointerEvent.pointerType
 ---
 <div>{{ APIRef("Pointer Events") }}</div>
 
@@ -99,4 +100,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.PointerEvent.pointerType", 2)}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/[d-q]* for the cases refused by the script (that is defensive).

> MDN URL of the main page changed

15 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
- there was a couple of cases with useless param
- and a few case with a wrong parameter (I moved it and fixed it).