### PR TITLE
Fix typo in “Overview of accessible web applications & widgets”

### DIFF
--- a/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.html
+++ b/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.html
@@ -129,7 +129,7 @@ tags:
 
 <p>The JavaScript to update the <strong><code>aria-hidden</code></strong> property has the form shown in Example 2c. Note that the script only updates the <strong><code>aria-hidden</code></strong> attribute (line 2); it does not need to also add or remove a custom classname.</p>
 
-<p><em>Example 2c. JavaScript to update the aria-checked attribute </em></p>
+<p><em>Example 2c. JavaScript to update the aria-hidden attribute </em></p>
 
 <pre class="brush: js">var showTip = function(el) {
   el.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
Replaced "aria-checkbox" with "aria-hidden" in Example 2c.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed
[https://developer.mozilla.org/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets](https://developer.mozilla.org/en-US/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets)

> Issue number (if there is an associated issue)

> Anything else that could help us review it
