### PR TITLE
removing BCD for flex layout

### DIFF
--- a/files/en-us/web/css/justify-self/index.html
+++ b/files/en-us/web/css/justify-self/index.html
@@ -211,10 +211,6 @@ article {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<h3 id="Support_in_Flex_layout">Support in Flex layout</h3>
-
-<p>{{Compat("css.properties.justify-self.flex_context")}}</p>
-
 <h3 id="Support_in_Grid_layout">Support in Grid layout</h3>
 
 <p>{{Compat("css.properties.justify-self.grid_context")}}</p>


### PR DESCRIPTION
Fixes #5506 

It doesn't make sense to have the BCD for this property for flexbox, as it isn't specified for flex layouts.
