### PR TITLE
Moving a stray sentence

### DIFF
--- a/files/en-us/web/html/element/caption/index.html
+++ b/files/en-us/web/html/element/caption/index.html
@@ -85,6 +85,8 @@ browser-compat: html.elements.caption
 
 <p>When the <code>&lt;table&gt;</code> element that contains the <code>&lt;caption&gt;</code> is the only descendant of a {{HTMLElement("figure")}} element, you should use the {{HTMLElement("figcaption")}} element instead of <code>&lt;caption&gt;</code>.</p>
 
+<p>A {{cssxref("background-color")}} on the table will not include the caption. Add a <code>background-color</code> to the <code>&lt;caption&gt;</code> element as well if you want the same color to be behind both.</p>
+
 <h2 id="Example">Example</h2>
 
 <p>This simple example presents a table that includes a caption.</p>
@@ -108,7 +110,6 @@ browser-compat: html.elements.caption
 <div class="hidden">
 <pre class="brush: css">caption {
   caption-side: top;
-  align: right;
 }
 table {
   border-collapse: collapse;
@@ -121,8 +122,6 @@ table, th, td {
 </div>
 
 <p>{{EmbedLiveSample('Example', 650, 100)}}</p>
-
-<p><code>table {background: red;}</code> do not alter caption. For that you need <code>display: block</code>.</p>
 
 <h2 id="Specifications">Specifications</h2>
 

--- a/files/en-us/web/html/element/caption/index.html
+++ b/files/en-us/web/html/element/caption/index.html
@@ -16,7 +16,7 @@ browser-compat: html.elements.caption
 ---
 <div>{{HTMLRef}}</div>
 
-<p><span class="seoSummary">The <strong>HTML <code>&lt;caption&gt;</code> element</strong> specifies the caption (or title) of a table.</span></p>
+<p>The <strong><code>&lt;caption&gt;</code></strong> <a href="/en-US/docs/Web/HTML">HTML</a> element specifies the caption (or title) of a table.</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/caption.html", "tabbed-taller")}}</div>
 


### PR DESCRIPTION
Fixes #5452 by moving the sentence and clarifying it so it makes better sense.

I also removed some deprecated CSS from the example as it wasn't useful to the demo and might be confusing.
