### PR TITLE
DeviceMotionEvent(): Relax "type" parameter requirements

### DIFF
--- a/files/en-us/web/api/devicemotionevent/devicemotionevent/index.html
+++ b/files/en-us/web/api/devicemotionevent/devicemotionevent/index.html
@@ -28,7 +28,7 @@ browser-compat: api.DeviceMotionEvent.DeviceMotionEvent
 
 <dl>
   <dt><code>type</code></dt>
-  <dd>Must be <code>"devicemotion"</code>.</dd>
+  <dd>A {{domxref("DOMString")}} representing the name of the event.</dd>
   <dt><code>options</code>{{Optional_Inline}}</dt>
   <dd>Options are as follows:
     <ul>


### PR DESCRIPTION
There was some confusion in https://crbug.com/1213041 over the previous
text, which said that the `type` parameter must always be "devicemotion".
While it does not make much sense to use a different value, it is possible
to do so, just like with any other Event-derived interface.

Write a more generic description for the parameter based on what we have in
the description of the `MouseEvent` constructor.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent/DeviceMotionEvent

> Issue number (if there is an associated issue)

> Anything else that could help us review it
