### PR TITLE
fix incorrect reference of dir anchor tag in Manifest “lang” doc

### DIFF
--- a/files/en-us/web/manifest/lang/index.html
+++ b/files/en-us/web/manifest/lang/index.html
@@ -22,7 +22,7 @@ browser-compat: html.manifest.lang
  </tbody>
 </table>
 
-<p>The <dfn><code>lang</code></dfn> member is a string containing a single <a href="/en-US/docs/Web/HTML/Global_attributes/lang">language tag</a>. It specifies the primary language for the values of the manifest's directionality-capable members, and together with <code><a href="/en-US/docs/Web/HTML/Global_attributes/dir">dir</a></code> determines their directionality.</p>
+<p>The <dfn><code>lang</code></dfn> member is a string containing a single <a href="/en-US/docs/Web/HTML/Global_attributes/lang">language tag</a>. It specifies the primary language for the values of the manifest's directionality-capable members, and together with <code><a href="/en-US/docs/Web/Manifest/dir">dir</a></code> determines their directionality.</p>
 
 <h2 id="Examples">Examples</h2>
 


### PR DESCRIPTION
fix #5569

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
