### PR TITLE
Move BCD in front-runner (remaining api/[r-z]*; manual)

### DIFF
--- a/files/en-us/web/api/report/type/index.html
+++ b/files/en-us/web/api/report/type/index.html
@@ -9,6 +9,7 @@ tags:
 - Report
 - Reporting API
 - Type
+browser-compat: api.Report.type
 ---
 <div>{{APIRef("Reporting API")}}{{SeeCompatTable}}</div>
 
@@ -59,7 +60,7 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Report.body")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/rtcicetransportstate/index.html
+++ b/files/en-us/web/api/rtcicetransportstate/index.html
@@ -16,6 +16,7 @@ tags:
   - WebRTC
   - WebRTC API
   - state
+browser-compat: api.rtcicetransportstate
 ---
 <div>{{APIRef("WebRTC")}}</div>
 
@@ -80,4 +81,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCIceRole")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/rtcrtpparameters/index.html
+++ b/files/en-us/web/api/rtcrtpparameters/index.html
@@ -15,6 +15,7 @@ tags:
   - WebRTC API
   - WebRTC Device API
   - parameters
+browser-compat: api.RTCRtpParameters
 ---
 <p>{{DefaultAPISidebar("WebRTC")}}</p>
 
@@ -68,4 +69,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.RTCRtpReceiveParameters")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/scrolltooptions/index.html
+++ b/files/en-us/web/api/scrolltooptions/index.html
@@ -7,6 +7,7 @@ tags:
   - Dictionary
   - Reference
   - ScrollToOptions
+browser-compat: api.ScrollToOptions
 ---
 <div>{{ APIRef("CSSOM View") }}</div>
 
@@ -72,5 +73,5 @@ tags:
 
 <div>
 
-<p>{{Compat("api.ScrollToOptions", 10)}}</p>
+<p>{{Compat}}</p>
 </div>

--- a/files/en-us/web/api/serialport/close/index.html
+++ b/files/en-us/web/api/serialport/close/index.html
@@ -7,6 +7,7 @@ tags:
   - Reference
   - close
   - SerialPort
+browser-compat: api.SerialPort.close
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}</div>
 
@@ -43,4 +44,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.SerialPort.close()")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
@@ -8,6 +8,7 @@ tags:
   - contentdelete
   - delete
   - events
+  browser-compat: api.ServiceWorkerGlobalScope.contentdelete_event
 ---
 <div>{{draft}}{{DefaultAPISidebar("Service Worker API")}}</div>
 
@@ -76,7 +77,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ServiceWorkerGlobalScope.contentdelete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.html
@@ -8,7 +8,7 @@ tags:
   - contentdelete
   - delete
   - events
-  browser-compat: api.ServiceWorkerGlobalScope.contentdelete_event
+browser-compat: api.ServiceWorkerGlobalScope.contentdelete_event
 ---
 <div>{{draft}}{{DefaultAPISidebar("Service Worker API")}}</div>
 

--- a/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.html
+++ b/files/en-us/web/api/serviceworkerglobalscope/oncontentdelete/index.html
@@ -7,6 +7,7 @@ tags:
   - ServiceWorkerGlobalScope
   - content indexing
   - delete
+browser-compat: api.ServiceWorkerGlobalScope.oncontentdelete
 ---
 <div>{{draft}}{{DefaultAPISidebar("Service Worker API")}}</div>
 
@@ -52,7 +53,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.ServiceWorkerGlobalScope.contentdelete")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.html
@@ -6,6 +6,7 @@ tags:
   - Constructor
   - Reference
   - USBConnectionEvent
+browser-compat: api.USBConnectionEvent.USBConnectionEvent
 ---
 <div>{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}</div>
 
@@ -63,4 +64,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.USBConnectionEvent")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - WebGL
 - WebGL2
+browser-compat: api.WebGL2RenderingContext.clearBufferiv
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -87,7 +88,7 @@ gl.clearBufferfi(gl.DEPTH_STENCIL, 0, 1.0, 0);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGL2RenderingContext.clearBufferiv")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - WebGL
 - WebGL2
+browser-compat: api.WebGL2RenderingContext.samplerParameteri
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -65,7 +66,7 @@ gl.samplerParameteri(sampler, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
 <h2 id="Specifications">Specifications</h2>
 
-<p>{{Compat("api.WebGL2RenderingContext.samplerParameteri")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniform/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniform/index.html
@@ -8,6 +8,7 @@ tags:
 - WebGL
 - WebGL2
 - WebGL2RenderingContext
+browser-compat: api.WebGL2RenderingContext.uniform1ui
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -88,7 +89,7 @@ void gl.uniform4uiv(location, data, optional srcOffset, optional srcLength);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGL2RenderingContext.uniform1ui")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - WebGL
 - WebGL2
+browser-compat: api.WebGL2RenderingContext.uniformMatrix2fv
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -78,7 +79,7 @@ void gl.uniformMatrix4fv(location, transpose, data, optional srcOffset, optional
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGL2RenderingContext.uniformMatrix2fv")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - WebGL
 - WebGL2
+browser-compat: api.WebGL2RenderingContext.vertexAttribI4i
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -71,7 +72,7 @@ void <var>gl</var>.vertexAttribI4uiv(<var>index</var>, <var>value</var>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGL2RenderingContext.vertexAttribI4i")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl_draw_buffers/index.html
+++ b/files/en-us/web/api/webgl_draw_buffers/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.WEBGL_draw_buffers
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -132,7 +133,7 @@ void main(void) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WEBGL_draw_buffers.drawBuffersWEBGL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl_lose_context/index.html
+++ b/files/en-us/web/api/webgl_lose_context/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.WEBGL_lose_context
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -61,7 +62,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WEBGL_lose_context.loseContext")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - WebGL
   - WebGL extension
+browser-compat: api.WEBGL_multi_draw
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -137,7 +138,7 @@ ext.multiDrawElementsInstancedWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("WEBGL_multi_draw")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.html
@@ -6,6 +6,7 @@ tags:
 - Reference
 - WebGL
 - WebGL extension
+browser-compat: api.WEBGL_multi_draw.multiDrawArraysInstancedWEBGL
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -130,7 +131,7 @@ ext.multiDrawArraysInstancedWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WEBGL_multi_draw.multiDrawArraysWEBGL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.html
@@ -6,6 +6,7 @@ tags:
 - Reference
 - WebGL
 - WebGL extension
+browser-compat: api.WEBGL_multi_draw.multiDrawElementsInstancedWEBGL
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -142,7 +143,7 @@ ext.multiDrawElementsInstancedWEBGL(
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WEBGL_multi_draw.multiDrawElementsWEBGL")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.html
@@ -9,6 +9,7 @@ tags:
 - WebGL
 - WebGL extension
 - WebGLRenderingContext
+broser-compat: api.WebGLRenderingContext.compressedTexImage2D
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -248,7 +249,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 
 <h3 id="compressedTexImage2D">compressedTexImage2D</h3>
 
-<p>{{Compat("api.WebGLRenderingContext.compressedTexImage2D")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="compressedTexImage3D">compressedTexImage3D</h3>
 

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.html
@@ -8,6 +8,7 @@ tags:
 - Textures
 - WebGL
 - WebGLRenderingContext
+browser-compat: api.WebGLRenderingContext.texParameterf
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -182,7 +183,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST)
 <h3 id="WebGLRenderingContext.texParameterf">
   <code>WebGLRenderingContext.texParameterf()</code></h3>
 
-<p>{{Compat("api.WebGLRenderingContext.texParameterf")}}</p>
+<p>{{Compat}}</p>
 
 <h3 id="WebGLRenderingContext.texParameteri">
   <code>WebGLRenderingContext.texParameteri()</code></h3>

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - WebGL
 - WebGLRenderingContext
+browser-compat: api.WebGLRenderingContext.uniform1f
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -99,7 +100,7 @@ void <var>gl</var>.uniform4iv(<var>location</var>, <var>value</var>);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGLRenderingContext.uniform1f")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.html
@@ -15,6 +15,7 @@ tags:
 - uniformMatrix2fv
 - uniformMatrix3fv
 - uniformMatrix4fv
+browser-compat: api.WebGLRenderingContext.uniformMatrix2fv
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -83,7 +84,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGLRenderingContext.uniformMatrix2fv")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.html
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.html
@@ -7,6 +7,7 @@ tags:
 - Reference
 - WebGL
 - WebGLRenderingContext
+browser-compat: api.WebGLRenderingContext.vertexAttrib1f
 ---
 <div>{{APIRef("WebGL")}}</div>
 
@@ -112,7 +113,7 @@ gl.vertexAttrib3f(matrix3x3Location + 2, 2, 5, 8);
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.WebGLRenderingContext.vertexAttrib1f")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/window/appinstalled_event/index.html
+++ b/files/en-us/web/api/window/appinstalled_event/index.html
@@ -9,6 +9,7 @@ tags:
   - appinstalled
   - events
   - web manifest
+browser-compat: api.Window.appinstalled_event
 ---
 <div>{{deprecated_header}}</div>
 
@@ -50,7 +51,7 @@ tags:
 };</pre>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
-<p>{{Compat("api.Window.onappinstalled")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/window/applicationcache/index.html
+++ b/files/en-us/web/api/window/applicationcache/index.html
@@ -11,6 +11,7 @@ tags:
 - Property
 - Reference
 - Window
+browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
 <p>{{Deprecated_Header}}{{Non-standard_Header}}</p>
 
@@ -39,7 +40,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.SharedWorkerGlobalScope.applicationCache")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/api/xpathevaluator/evaluate/index.html
+++ b/files/en-us/web/api/xpathevaluator/evaluate/index.html
@@ -9,6 +9,7 @@ tags:
 - Reference
 - XPath
 - XPathEvaluator
+browser-compat: api.XPathEvaluator.evaluate
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -119,4 +120,4 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathEvaluator.evaluate()")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathexpression/evaluate/index.html
+++ b/files/en-us/web/api/xpathexpression/evaluate/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathExpression
+browser-compat: api.XPathExpression.evaluate
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -115,4 +116,4 @@ document.querySelector("output").textContent = result.snapshotLength;
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathExpression.evaluate()")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/iteratenext/index.html
+++ b/files/en-us/web/api/xpathresult/iteratenext/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.iterateNext
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -83,4 +84,4 @@ document.querySelector("output").textContent = tagNames.join(", ");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.iterateNext()")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xpathresult/snapshotitem/index.html
+++ b/files/en-us/web/api/xpathresult/snapshotitem/index.html
@@ -8,6 +8,7 @@ tags:
 - Reference
 - XPath
 - XPathResult
+browser-compat: api.XPathResult.snapshotItem
 ---
 <div>{{APIRef("DOM XPath")}}</div>
 
@@ -82,4 +83,4 @@ document.querySelector("output").textContent = tagNames.join(", ");
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XPathResult.snapshotItem()")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.html
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.html
@@ -14,6 +14,7 @@ tags:
 - WebXR Device API
 - XR
 - depthFar
+browser-compat: api.XRRenderState.depthFar
 ---
 <div>{{draft}}{{securecontext_header}}{{APIRef("WebXR")}}</div>
 
@@ -49,4 +50,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.XRRenderState.XRRenderState.depthFar")}}</p>
+<p>{{Compat}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers api/[r-z]* for the cases refused by the script (that is defensive).

> MDN URL of the main page changed

30 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
- there was a few of cases with useless parenthesis
- a few wrong parameters (bad cut and paste at page creation) for Compat
- and a few case where the page was for a set of parameters, and named strangely