### PR TITLE
fix: minor typo

### DIFF
--- a/files/en-us/web/api/file_and_directory_entries_api/index.html
+++ b/files/en-us/web/api/file_and_directory_entries_api/index.html
@@ -58,7 +58,7 @@ tags:
 
 <h2 id="Synchronous_API">Synchronous API</h2>
 
-<p>The synchronous API is should only be used in {{domxref("Worker")}}s; these calls block until they're finished executing, and return the results instead of using callbacks. Using them on the main thread will block the browser, which is naughty. The interfaces below otherwise mirror the ones from the asynchronous API.</p>
+<p>The synchronous API should only be used in {{domxref("Worker")}}s; these calls block until they're finished executing, and return the results instead of using callbacks. Using them on the main thread will block the browser, which is naughty. The interfaces below otherwise mirror the ones from the asynchronous API.</p>
 
 <dl>
  <dt>{{domxref("FileSystemSync")}}</dt>


### PR DESCRIPTION
Fix a minor typo - extra `is`.