### PR TITLE
Move BCD in front-runner for webdriver/*

### DIFF
--- a/files/en-us/web/webdriver/commands/closewindow/index.html
+++ b/files/en-us/web/webdriver/commands/closewindow/index.html
@@ -6,6 +6,7 @@ tags:
   - Command
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.CloseWindow
 ---
 <p>The <em>Close Window</em> <a href="/en-US/docs/Web/WebDriver/Command">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API closes the current top-level browsing context (window or tab) and returns with the list of currently open <code><a href="/en-US/docs/Web/WebDriver/WebWindow">WebWindow</a></code>s. If it is the last window that is being closed, the WebDriver session will implicitly be deleted. Subsequent commands after the session is ended will therefore cause <a href="/en-US/docs/Web/WebDriver/Errors/InvalidSessionID">invalid session ID</a> errors.</p>
 
@@ -103,7 +104,7 @@ namespace MDNWebDriverExamples
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.CloseWindow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/getelementattribute/index.html
+++ b/files/en-us/web/webdriver/commands/getelementattribute/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Element Tag Name
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.GetElementAttribute
 ---
 <p>The <em>Get Element Attribute</em> <a href="/en-US/docs/Web/WebDriver/Command">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the attribute of the referenced <a href="/en-US/docs/Web/WebDriver/WebElement">web element</a>. If for example the element is an {{HTMLElement("img")}}, the returned attribute is <code>"//TODO"</code>, which is equivalent to calling {{domxref("Element.getAttribute")}} on the element. For XML/XHTML documents it may be cased differently.</p>
 
@@ -84,4 +85,4 @@ print(search_box.get_attribute("id"))
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.GetElementAttribute")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/webdriver/commands/getelementproperty/index.html
+++ b/files/en-us/web/webdriver/commands/getelementproperty/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Element Property
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.GetElementProperty
 ---
 <p>The <em>Get Element Property</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the property of the referenced <a href="/en-US/docs/Web/WebDriver/WebElement">web element</a>. Given <code>&lt;input value=foo&gt;</code> where the user changes the value to <code>bar</code>, the returned property is <code>bar</code> rather than the initial value <code>foo</code>. This is equivalent to calling {{domxref("Element.getProperty")}} on the element.</p>
 
@@ -93,7 +94,7 @@ bar
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.GetElementProperty")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/getelementtagname/index.html
+++ b/files/en-us/web/webdriver/commands/getelementtagname/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Element Tag Name
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.GetElementTagName
 ---
 <p>The <em>Get Element Tag Name</em> <a href="/en-US/docs/Web/WebDriver/Command">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the tag name of the referenced <a href="/en-US/docs/Web/WebDriver/WebElement">web element</a>. If for example the element is an {{HTMLElement("img")}}, the returned tag name is <code>"IMG"</code>, which is equivalent to calling {{domxref("Element.tagName")}} on the element. For XML/XHTML documents it may be cased differently.</p>
 
@@ -82,4 +83,4 @@ print(search_box.tag_name)
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.GetElementTagName")}}</p>
+<p>{{Compat}}</p>

--- a/files/en-us/web/webdriver/commands/gettimeouts/index.html
+++ b/files/en-us/web/webdriver/commands/gettimeouts/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Timeouts
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.GetTimeouts
 ---
 <p>The <em>Get Timeouts</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the timeouts associated with the current session. The <a href="/en-US/docs/Web/WebDriver/Timeouts">session timeout</a> durations control such behavior as timeouts on <a href="/en-US/docs/Web/WebDriver/Timeouts#script">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageload">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit">element retrieval</a>.</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.GetTimeouts")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/getwindowhandles/index.html
+++ b/files/en-us/web/webdriver/commands/getwindowhandles/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Window Handles
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.GetWindowHandles
 ---
 <p>The <em>Get Window Handles</em> <a href="/en-US/docs/Web/WebDriver/Command">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns a list of all <code><a href="/en-US/docs/Web/WebDriver/WebWindow">WebWindow</a></code>s. Each tab or window, depending on whether you are using a tabbed browser, is associated by a <em>window handle</em> that is used as a reference when <a href="/en-US/docs/Web/WebDriver/Commands/SwitchToWindow">switching to the window</a>.</p>
 
@@ -85,7 +86,7 @@ namespace MDNWebDriverExamples
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.GetWindowHandles")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/getwindowrect/index.html
+++ b/files/en-us/web/webdriver/commands/getwindowrect/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Window Rect
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.GetWindowRect
 ---
 <p>The <em>Get Window Rect</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API returns the size and position of the given <code><a href="/en-US/docs/Web/WebDriver/WebElement">WebElement</a></code>. Many <a href="/en-US/docs/Web/WebDriver/Clients">WebDriver clients</a> present separate API methods for getting an element’s location and dimensions, but as an optimization they both use this primitive.</p>
 
@@ -78,7 +79,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.GetWindowRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/index.html
+++ b/files/en-us/web/webdriver/commands/index.html
@@ -6,6 +6,7 @@ tags:
   - Web
   - WebDriver
   - commands
+browser-compat: webdriver.commands
 ---
 <p>The following is a list of the available WebDriver commands.</p>
 
@@ -13,6 +14,6 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands")}}</p>
+<p>{{Compat}}</p>
 
 <p>{{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver")}}</p>

--- a/files/en-us/web/webdriver/commands/new_window/index.html
+++ b/files/en-us/web/webdriver/commands/new_window/index.html
@@ -1,6 +1,7 @@
 ---
 title: New Window
 slug: Web/WebDriver/Commands/New_Window
+browser-compat: webdriver.commands.NewWindow
 ---
 <p>The <em>New Window</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API opens a new top-level browsing context of type <em>window</em> or <em>tab</em>, and returns with a dictionary containing the <em>handle</em> of the new <a href="/en-US/docs/Web/WebDriver/WebWindow">WebWindow</a> and its created <em>type</em>. If the requested <em>type</em> cannot be created by the browser, the alternative type will be tried to create.</p>
 
@@ -82,7 +83,7 @@ slug: Web/WebDriver/Commands/New_Window
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.NewWindow")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/settimeouts/index.html
+++ b/files/en-us/web/webdriver/commands/settimeouts/index.html
@@ -6,6 +6,7 @@ tags:
   - Get Timeouts
   - Reference
   - WebDriver
+browser-compat: webdriver.commands.SetTimeouts
 ---
 <p>The <em>Set Timeouts</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API sets the timeouts associated with the current session. The <a href="/en-US/docs/Web/WebDriver/Timeouts">session timeout</a> durations control such behavior as timeouts on <a href="/en-US/docs/Web/WebDriver/Timeouts#script">script injection</a>, <a href="/en-US/docs/Web/WebDriver/Timeouts#pageload">document navigation</a>, and <a href="/en-US/docs/Web/WebDriver/Timeouts#implicit">element retrieval</a>.</p>
 
@@ -72,7 +73,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.SetTimeouts")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 

--- a/files/en-us/web/webdriver/commands/setwindowrect/index.html
+++ b/files/en-us/web/webdriver/commands/setwindowrect/index.html
@@ -6,6 +6,7 @@ tags:
   - Reference
   - Set Window Rect
   - WebDriver
+browser-compat: webdriver.commands.SetWindowRect
 ---
 <p>The <em>Set Window Rect</em> <a href="/en-US/docs/Web/WebDriver/Commands">command</a> of the <a href="/en-US/docs/Web/WebDriver">WebDriver</a> API alters the size and position of the operating system window associated with the current <code><a href="/en-US/docs/Web/API/Window">window</a></code>. The command acts as the setter of <a href="/en-US/docs/Web/WebDriver/Commands/GetWindowRect">Get Window Rect</a>, which return object you can pass directly as this command’s payload.</p>
 
@@ -109,7 +110,7 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("webdriver.commands.SetWindowRect")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

We want to have browser-compat in front-runner: this allows us to write {{Compat}} without parameter, and in the future, {{Spec}} (and likely more).

This PR covers all of webdriver/* .

> MDN URL of the main page changed

11 files in api/* 

> Issue number (if there is an associated issue)

openwebdocs/project#36

> Anything else that could help us review it
Done manually, but all were straightforward.