### PR TITLE
updating release notes for 89 yesterday

### DIFF
--- a/files/en-us/mozilla/firefox/releases/89/index.html
+++ b/files/en-us/mozilla/firefox/releases/89/index.html
@@ -9,7 +9,12 @@ tags:
 ---
 <p>{{FirefoxSidebar}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 89 that will affect developers. Firefox 89 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">June 1, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 89 that will affect developers. Firefox 89 was released on June 1, 2021.</p>
+
+<div class="note notecard">
+  <h4>Note</h4>
+  <p>See also <a href="https://hacks.mozilla.org/2021/06/looking-fine-with-firefox-89/">Looking fine with Firefox 89</a> on Mozilla Hacks.</p>
+</div>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 

--- a/files/en-us/mozilla/firefox/releases/91/index.html
+++ b/files/en-us/mozilla/firefox/releases/91/index.html
@@ -1,23 +1,19 @@
 ---
-title: Firefox 90 for developers
-slug: Mozilla/Firefox/Releases/90
+title: Firefox 91 for developers
+slug: Mozilla/Firefox/Releases/91
 tags:
-  - '90'
+  - '91'
   - Firefox
   - Mozilla
   - Release
 ---
 <p>{{FirefoxSidebar}}{{draft}}</p>
 
-<p class="summary">This article provides information about the changes in Firefox 90 that will affect developers. Firefox 90 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta">Beta version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">July 13, 2021</a>.</p>
+<p class="summary">This article provides information about the changes in Firefox 91 that will affect developers. Firefox 91 is the current <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Nightly version of Firefox</a>, and will ship on <a href="https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates">August 8, 2021</a>.</p>
 
 <h2 id="Changes_for_web_developers">Changes for web developers</h2>
 
 <h3 id="Developer_Tools">Developer Tools</h3>
-
-<ul>
-  <li>The response view now shows a <a href="/en-US/docs/Tools/Network_Monitor/request_details#response_tab">preview for web fonts</a> ({{bug(872078)}}).</li>
-</ul>
 
 <h3 id="HTML">HTML</h3>
 
@@ -34,10 +30,6 @@ tags:
 <h3 id="HTTP">HTTP</h3>
 
 <h4 id="removals_http">Removals</h4>
-
-<ul>
-  <li>FTP has now been removed from Firefox ({{bug(1574475)}}). This follows <a href="/en-US/docs/Mozilla/Firefox/Releases/88#http">deprecation in Firefox 88</a>. Note that web extensions can still register themselves as <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers">FTP protocol handlers</a>.</li>
-</ul>
 
 <h3 id="Security">Security</h3>
 
@@ -65,4 +57,4 @@ tags:
 
 <h2 id="Older_versions">Older versions</h2>
 
-<p>{{Firefox_for_developers(89)}}</p>
+<p>{{Firefox_for_developers(90)}}</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Updating release notes for 89 release yesterday

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases -> should include 91 & updates to 89 & 90

