### PR TITLE
Punctuation fixes in “Client-side form validation” code comments

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.html
+++ b/files/en-us/learn/forms/form_validation/index.html
@@ -585,15 +585,15 @@ form.addEventListener('submit', function (event) {
 
 function showError() {
   if(email.validity.valueMissing) {
-    // If the field is empty
+    // If the field is empty,
     // display the following error message.
     emailError.textContent = 'You need to enter an e-mail address.';
   } else if(email.validity.typeMismatch) {
-    // If the field doesn't contain an email address
+    // If the field doesn't contain an email address,
     // display the following error message.
     emailError.textContent = 'Entered value needs to be an e-mail address.';
   } else if(email.validity.tooShort) {
-    // If the data is too short
+    // If the data is too short,
     // display the following error message.
     emailError.textContent = `Email should be at least ${ email.minLength } characters; you entered ${ email.value.length }.`;
   }


### PR DESCRIPTION
Made punctuation changes to end of line comments (inserted commas) starting in line 588. No code changes were made.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

> MDN URL of the main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
