### PR TITLE
Fix typo in browser-compat

### DIFF
--- a/files/en-us/web/api/keyboard/unlock/index.html
+++ b/files/en-us/web/api/keyboard/unlock/index.html
@@ -9,7 +9,7 @@ tags:
 - Reference
 - keyboard
 - unLock
-browser-compat: api.Keyboard.unlocks
+browser-compat: api.Keyboard.unlock
 ---
 <div>{{APIRef("Keyboard API")}}{{SeeCompatTable}}</div>
 


### PR DESCRIPTION
Typo in BCD (follow-up of #5568, already closed). Thanks @wbamberg for finding it.