### PR TITLE
Add a note that windows can be tabs

### DIFF
--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -111,7 +111,7 @@ function openRequestedPopup() {
 <p>To open a <em>new</em> window on every call of <code>window.open()</code>, use the
   special value <code>_blank</code> for <code><var>windowName</var></code>.</p>
 
-<div class="note">
+<div class="notecard note">
   <p id="Note_on_use_of_window_open">Note on the use of <code>window.open()</code> to
     reopen an existing window with name <code><var>windowName</var></code> : This
     functionality is not valid for all browsers and more with variable conditions.
@@ -138,7 +138,7 @@ function openRequestedPopup() {
   an empty string), then the new secondary window will render the default toolbars of the
   main window.</p>
 
-<div class="note">
+<div class="notecard note">
   <p><strong>Tip</strong>: Note that in some browsers, users can override the
     <code><var>windowFeatures</var></code> settings and enable (or prevent the disabling
     of) features. Further, control of some window features is available only on some browsers
@@ -275,7 +275,7 @@ function openRequestedPopup() {
     <br>
     If <code><var>windowFeatures</var></code> is non-empty, <code>resizable</code>
     defaults to on.
-    <div class="note">
+    <div class="notecard note">
       <p><strong>Tip</strong>: For accessibility reasons, it is strongly recommended to
         set this feature always on</p>
     </div>
@@ -288,7 +288,7 @@ function openRequestedPopup() {
     defaults to off.<br>
     <br>
     See <a href="#note_on_scrollbars">note on scrollbars</a>.
-    <div class="note">
+    <div class="notecard note">
       <p><strong>Tip</strong>: For accessibility reasons, it is strongly encouraged to set
         this feature always on</p>
     </div>

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -20,6 +20,11 @@ browser-compat: api.Window.open
   then a new browsing context is opened in a new tab or a new window, and the specified
   resource is loaded into it.</p>
 
+<div class="note">
+   <p>Note that for brevity, this document will generally use the term "window" as a
+   shorthand for "a browsing context in a tab or window".</p>
+</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre

--- a/files/en-us/web/api/window/open/index.html
+++ b/files/en-us/web/api/window/open/index.html
@@ -20,7 +20,7 @@ browser-compat: api.Window.open
   then a new browsing context is opened in a new tab or a new window, and the specified
   resource is loaded into it.</p>
 
-<div class="note">
+<div class="notecard note">
    <p>Note that for brevity, this document will generally use the term "window" as a
    shorthand for "a browsing context in a tab or window".</p>
 </div>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

At least one person ( https://stackoverflow.com/questions/67810545/window-open-does-not-always-opens-a-new-window ) found the use of the term "window" confusing. This attempts to make it clear that new tabs can be opened instead.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/Window/open

> Issue number (if there is an associated issue)

n/a

> Anything else that could help us review it
