### PR TITLE
fix fixable flaws in some bad <pre> tags

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.html
@@ -54,22 +54,24 @@ browser-compat: webextensions.api.runtime.sendNativeMessage
 
 <p>Here's a background script that sends a "ping" message to the "ping_pong" app and logs the response, whenever the user clicks the browser action:</p>
 
-<pre class="brush: js line-numbers  language-js"><code class="language-js"><span class="keyword token">function</span> <span class="function token">onResponse</span><span class="punctuation token">(</span>response<span class="punctuation token">)</span> <span class="punctuation token">{</span>
-  console<span class="punctuation token">.</span><span class="function token">log</span><span class="punctuation token">(</span><span class="string token">`Received ${</span>response}<span class="punctuation token">`)</span><span class="punctuation token">;</span>
-<span class="punctuation token">}
+<pre class="brush: js line-numbers">function onResponse(response) {
+  console.log(`Received ${response}`);
+}
 
-</span></code>function onError(error) {
-  console.log(`Error: ${error}`);
-}<code class="language-js">
+function onError(error) {
+  console.log(`Error: ${error}`);
+}
 
-<span class="comment token">/*
+/*
 On a click on the browser action, send the app a message.
-*/</span>
-browser<span class="punctuation token">.</span>browserAction<span class="punctuation token">.</span>onClicked<span class="punctuation token">.</span><span class="function token">addListener</span><span class="punctuation token">(</span><span class="punctuation token">(</span><span class="punctuation token">)</span> <span class="operator token">=</span><span class="operator token">&gt;</span> <span class="punctuation token">{</span>
-  console<span class="punctuation token">.</span><span class="function token">log</span><span class="punctuation token">(</span><span class="string token">"Sending:  ping"</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-  var sending = browser<span class="punctuation token">.</span>runtime<span class="punctuation token">.</span><span class="function token">sendNativeMessage</span><span class="punctuation token">(</span><span class="string token">"ping_pong"</span><span class="punctuation token">,</span> <span class="string token">"ping"</span><span class="punctuation token">)</span><span class="punctuation token">;
-  sending.then(onResponse, onError);</span>
-<span class="punctuation token">}</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code></pre>
+*/
+browser.browserAction.onClicked.addListener(() => {
+  console.log("Sending:  ping");
+  var sending = browser.runtime.sendNativeMessage("ping_pong", "ping");
+  sending.then(onResponse, onError);
+});
+</pre>
+
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/en-us/web/api/node/insertbefore/index.html
+++ b/files/en-us/web/api/node/insertbefore/index.html
@@ -2,11 +2,11 @@
 title: Node.insertBefore()
 slug: Web/API/Node/insertBefore
 tags:
-- API
-- DOM
-- Method
-- Node
-- Reference
+  - API
+  - DOM
+  - Method
+  - Node
+  - Reference
 browser-compat: api.Node.insertBefore
 ---
 <div>{{APIRef("DOM")}}</div>
@@ -125,7 +125,7 @@ parentDiv.insertBefore(sp1, sp2)
 <p>In the previous example, <code>sp1</code> could be inserted after <code>sp2</code>
   using:</p>
 
-<pre class="brush: js"><code>parentDiv.insertBefore(sp1, sp2.nextSibling)</code></pre>
+<pre class="brush: js">parentDiv.insertBefore(sp1, sp2.nextSibling)</pre>
 
 <p>If <code>sp2</code> does not have a next sibling, then it must be the last child —
   <code>sp2.nextSibling</code> returns <code>null</code>, and <code>sp1</code> is inserted

--- a/files/en-us/web/api/selection/index.html
+++ b/files/en-us/web/api/selection/index.html
@@ -53,8 +53,6 @@ browser-compat: api.Selection
  <dd>Indicates if a certain node is part of the selection.</dd>
  <dt>{{DOMxRef("Selection.deleteFromDocument()")}}</dt>
  <dd>Deletes the selection's content from the document.</dd>
- <dt>{{DOMxRef("Selection.removeAllRanges")}}</dt>
- <dd>Removes all ranges from the selection. This is an alias for <code>removeAllRanges()</code> — See {{DOMxRef("Selection.removeAllRanges()")}} for more details.</dd>
  <dt>{{DOMxRef("Selection.extend()")}}</dt>
  <dd>Moves the focus of the selection to a specified point.</dd>
  <dt>{{DOMxRef("Selection.getRangeAt()")}}</dt>
@@ -69,8 +67,6 @@ browser-compat: api.Selection
  <dd>Adds all the children of the specified node to the selection.</dd>
  <dt>{{DOMxRef("Selection.setBaseAndExtent()")}}</dt>
  <dd>Sets the selection to be a range including all or parts of two specified DOM nodes, and any content located between them.</dd>
- <dt>{{DOMxRef("Selection.collapse")}}</dt>
- <dd>Collapses the current selection to a single point. This is an alias for <code>collapse()</code> — See {{DOMxRef("Selection.collapse()")}} for more details.</dd>
  <dt>{{DOMxRef("Selection.toString()")}}</dt>
  <dd>Returns a string currently being represented by the selection object, i.e. the currently selected text.</dd>
 </dl>

--- a/files/en-us/web/api/selection/index.html
+++ b/files/en-us/web/api/selection/index.html
@@ -53,7 +53,7 @@ browser-compat: api.Selection
  <dd>Indicates if a certain node is part of the selection.</dd>
  <dt>{{DOMxRef("Selection.deleteFromDocument()")}}</dt>
  <dd>Deletes the selection's content from the document.</dd>
- <dt>{{DOMxRef("Selection.empty()")}}</dt>
+ <dt>{{DOMxRef("Selection.removeAllRanges")}}</dt>
  <dd>Removes all ranges from the selection. This is an alias for <code>removeAllRanges()</code> — See {{DOMxRef("Selection.removeAllRanges()")}} for more details.</dd>
  <dt>{{DOMxRef("Selection.extend()")}}</dt>
  <dd>Moves the focus of the selection to a specified point.</dd>
@@ -69,7 +69,7 @@ browser-compat: api.Selection
  <dd>Adds all the children of the specified node to the selection.</dd>
  <dt>{{DOMxRef("Selection.setBaseAndExtent()")}}</dt>
  <dd>Sets the selection to be a range including all or parts of two specified DOM nodes, and any content located between them.</dd>
- <dt>{{DOMxRef("Selection.setPosition()")}}</dt>
+ <dt>{{DOMxRef("Selection.collapse")}}</dt>
  <dd>Collapses the current selection to a single point. This is an alias for <code>collapse()</code> — See {{DOMxRef("Selection.collapse()")}} for more details.</dd>
  <dt>{{DOMxRef("Selection.toString()")}}</dt>
  <dd>Returns a string currently being represented by the selection object, i.e. the currently selected text.</dd>
@@ -92,8 +92,8 @@ window.alert(selObj);
 <p>A selection object represents the {{DOMxRef("Range")}}s that the user has selected. Typically, it holds only one range, accessed as follows:</p>
 
 <div style="overflow: hidden;">
-<pre class="brush:js"><code>var selObj = window.getSelection();
-var range  = selObj.getRangeAt(0);</code></pre>
+<pre class="brush:js">var selObj = window.getSelection();
+var range  = selObj.getRangeAt(0);</pre>
 </div>
 
 <ul>
@@ -203,5 +203,5 @@ var range  = selObj.getRangeAt(0);</code></pre>
  <li>{{DOMxRef("Window.getSelection")}}, {{DOMxRef("Document.getSelection")}}, {{DOMxRef("Range")}}</li>
  <li>Selection-related events: {{Event("selectionchange")}} and {{Event("selectstart")}}</li>
  <li>HTML inputs provide simpler helper APIs for working with selection (see {{DOMxRef("HTMLInputElement.setSelectionRange()")}})</li>
- <li>{{DOMxRef("Document.activeElement")}}, {{DOMxRef("HTMLElement.focus()")}}, and {{DOMxRef("HTMLElement.blur()")}}</li>
+ <li>{{DOMxRef("Document.activeElement")}}, {{DOMxRef("HTMLOrForeignElement.focus")}}, and {{DOMxRef("HTMLOrForeignElement.blur")}}</li>
 </ul>

--- a/files/en-us/web/api/storage/removeitem/index.html
+++ b/files/en-us/web/api/storage/removeitem/index.html
@@ -52,11 +52,11 @@ browser-compat: api.Storage.removeItem
 <p>We can do the same for the session storage.</p>
 
 <pre class="brush: js">function populateStorage() {
-  <code>sessionStorage</code>.setItem('bgcolor', 'red');
-  <code>sessionStorage</code>.setItem('font', 'Helvetica');
-  <code>sessionStorage</code>.setItem('image', 'myCat.png');
+  sessionStorage.setItem('bgcolor', 'red');
+  sessionStorage.setItem('font', 'Helvetica');
+  sessionStorage.setItem('image', 'myCat.png');
 
-  <code>sessionStorage</code>.removeItem('image');
+  sessionStorage.removeItem('image');
 }</pre>
 
 <div class="note">

--- a/files/en-us/web/api/subtlecrypto/digest/index.html
+++ b/files/en-us/web/api/subtlecrypto/digest/index.html
@@ -2,12 +2,12 @@
 title: SubtleCrypto.digest()
 slug: Web/API/SubtleCrypto/digest
 tags:
-- API
-- Method
-- Reference
-- SubtleCrypto
-- WebCrypto API
-- digest
+  - API
+  - Method
+  - Reference
+  - SubtleCrypto
+  - WebCrypto API
+  - digest
 browser-compat: api.SubtleCrypto.digest
 ---
 <p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
@@ -23,7 +23,7 @@ browser-compat: api.SubtleCrypto.digest
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">const digest = <var>crypto</var><code>.subtle.digest(<var>algorithm</var>, <var>data</var>)</code>;
+<pre class="brush: js">const digest = crypto.subtle.digest(algorithm, data);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -108,7 +108,7 @@ browser-compat: api.SubtleCrypto.digest
  <div class="notecard note">
   <p>Hint: If you are looking here for how to create an keyed-hash message authentication
     code (<a href="/en-US/docs/Glossary/HMAC">HMAC</a>), you need to use the <a
-      href="/en-US/docs/Web/API/SubtleCrypto/sign#HMAC">SubtleCrypto.sign()</a> instead.
+      href="/en-US/docs/Web/API/SubtleCrypto/sign#hmac">SubtleCrypto.sign()</a> instead.
   </p>
 </div>
 

--- a/files/en-us/web/api/subtlecrypto/generatekey/index.html
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.html
@@ -2,12 +2,12 @@
 title: SubtleCrypto.generateKey()
 slug: Web/API/SubtleCrypto/generateKey
 tags:
-- API
-- Method
-- Reference
-- SubtleCrypto
-- Web Crypto API
-- generateKey
+  - API
+  - Method
+  - Reference
+  - SubtleCrypto
+  - Web Crypto API
+  - generateKey
 browser-compat: api.SubtleCrypto.generateKey
 ---
 <p>{{APIRef("Web Crypto API")}}{{SecureContext_header}}</p>
@@ -18,7 +18,7 @@ browser-compat: api.SubtleCrypto.generateKey
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: js">const <em>result</em> = <em>crypto.subtle</em><code>.generateKey(<em>algorithm</em>, <em>extractable</em>, <em>keyUsages</em>)</code>;
+<pre class="brush: js">const result = crypto.subtle.generateKey(algorithm, extractable, keyUsages);
 </pre>
 
 <h3 id="Parameters">Parameters</h3>
@@ -29,22 +29,22 @@ browser-compat: api.SubtleCrypto.generateKey
 
     <ul>
       <li>For <a
-          href="/en-US/docs/Web/API/SubtleCrypto/sign#RSASSA-PKCS1-v1_5">RSASSA-PKCS1-v1_5</a>, <a
-          href="/en-US/docs/Web/API/SubtleCrypto/sign#RSA-PSS">RSA-PSS</a>, or <a
-          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#RSA-OAEP">RSA-OAEP</a>: pass an
+          href="/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5">RSASSA-PKCS1-v1_5</a>, <a
+          href="/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss">RSA-PSS</a>, or <a
+          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep">RSA-OAEP</a>: pass an
         <code><a href="/en-US/docs/Web/API/RsaHashedKeyGenParams">RsaHashedKeyGenParams</a></code>
         object.</li>
-      <li>For <a href="/en-US/docs/Web/API/SubtleCrypto/sign#ECDSA">ECDSA</a> or <a
-          href="/en-US/docs/Web/API/SubtleCrypto/deriveKey#ECDH">ECDH</a>: pass
+      <li>For <a href="/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa">ECDSA</a> or <a
+          href="/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh">ECDH</a>: pass
         an <code><a href="/en-US/docs/Web/API/EcKeyGenParams">EcKeyGenParams</a></code>
         object.</li>
-      <li>For <a href="/en-US/docs/Web/API/SubtleCrypto/sign#HMAC">HMAC</a>: pass an
+      <li>For <a href="/en-US/docs/Web/API/SubtleCrypto/sign#hmac">HMAC</a>: pass an
         <code><a href="/en-US/docs/Web/API/HmacKeyGenParams">HmacKeyGenParams</a></code>
         object.</li>
-      <li>For <a href="/en-US/docs/Web/API/SubtleCrypto/encrypt#AES-CTR">AES-CTR</a>, <a
-          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#AES-CBC">AES-CBC</a>, <a
-          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#AES-GCM">AES-GCM</a>, or <a
-          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#AES-KW">AES-KW</a>: pass an
+      <li>For <a href="/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr">AES-CTR</a>, <a
+          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc">AES-CBC</a>, <a
+          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm">AES-GCM</a>, or <a
+          href="/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw">AES-KW</a>: pass an
         <code><a href="/en-US/docs/Web/API/AesKeyGenParams">AesKeyGenParams</a></code>
         object.</li>
     </ul>

--- a/files/en-us/web/api/xmlhttprequest/send/index.html
+++ b/files/en-us/web/api/xmlhttprequest/send/index.html
@@ -2,17 +2,17 @@
 title: XMLHttpRequest.send()
 slug: Web/API/XMLHttpRequest/send
 tags:
-- AJAX
-- API
-- HTTP request
-- Method
-- NeedsContent
-- NeedsExample
-- Reference
-- XHR
-- XHR Request
-- XMLHttpRequest
-- send
+  - AJAX
+  - API
+  - HTTP request
+  - Method
+  - NeedsContent
+  - NeedsExample
+  - Reference
+  - XHR
+  - XHR Request
+  - XMLHttpRequest
+  - send
 browser-compat: api.XMLHttpRequest.send
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
@@ -89,7 +89,7 @@ browser-compat: api.XMLHttpRequest.send
 
 <h2 id="Example_GET">Example: GET</h2>
 
-<pre class="brush: js"><code>var xhr = new XMLHttpRequest();
+<pre class="brush: js">var xhr = new XMLHttpRequest();
 xhr.open('GET', '/server', true);
 
 xhr.onload = function () {
@@ -98,27 +98,27 @@ xhr.onload = function () {
 
 xhr.send(null);
 // xhr.send('string');
-</code>// <code>xhr.send(new Blob());
+// xhr.send(new Blob());
 // xhr.send(new Int8Array());
-// xhr.send(document);</code>
+// xhr.send(document);
 </pre>
 
 <h2 id="Example_POST">Example: POST</h2>
 
-<pre class="brush: js"><code>var xhr = new XMLHttpRequest();
-xhr.open("POST", '/server', true);
+<pre class="brush: js">var xhr = new XMLHttpRequest();
+xhr.open(&quot;POST&quot;, '/server', true);
 
 //Send the proper header information along with the request
-xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+xhr.setRequestHeader(&quot;Content-Type&quot;, &quot;application/x-www-form-urlencoded&quot;);
 
 xhr.onreadystatechange = function() { // Call a function when the state changes.
     if (this.readyState === XMLHttpRequest.DONE &amp;&amp; this.status === 200) {
         // Request finished. Do processing here.
     }
 }
-xhr.send("foo=bar&amp;lorem=ipsum");
+xhr.send(&quot;foo=bar&amp;lorem=ipsum&quot;);
 // xhr.send(new Int8Array());
-// xhr.send(document);</code>
+// xhr.send(document);
 </pre>
 
 <h2 id="Specifications">Specifications</h2>

--- a/files/en-us/web/css/font-language-override/index.html
+++ b/files/en-us/web/css/font-language-override/index.html
@@ -8,7 +8,7 @@ tags:
   - Reference
   - font-language-override
   - l10n
-  - 'recipe:css-property'
+  - recipe:css-property
 browser-compat: css.properties.font-language-override
 ---
 <div>{{CSSRef}}</div>
@@ -42,7 +42,7 @@ font-language-override: unset;
  <dt><code>normal</code></dt>
  <dd>Tells the browser to use font glyphs that are appropriate for the language specified by the <code>lang</code> attribute. This is the default value.</dd>
  <dt>{{cssxref("string")}}</dt>
- <dd>Tells the browser to use font glyphs that are appropriate for the language specified by the string. The string must match a language tag found in the <a href="http://www.microsoft.com/typography/otspec/languagetags.htm">OpenType language system</a>. For example, "ENG" is English, and "KOR" is Korean.</dd>
+ <dd>Tells the browser to use font glyphs that are appropriate for the language specified by the string. The string must match a language tag found in the <a href="https://www.microsoft.com/typography/otspec/languagetags.htm">OpenType language system</a>. For example, "ENG" is English, and "KOR" is Korean.</dd>
 </dl>
 
 <h2 id="Formal_definition">Formal definition</h2>
@@ -59,8 +59,8 @@ font-language-override: unset;
 
 <h4 id="HTML">HTML</h4>
 
-<pre class="brush: html">&lt;p class="para1"&gt;Default language setting.&lt;/p&gt;
-&lt;p class="para2"&gt;This is a string with the &lt;code&gt;font-language-override&lt;/code&gt; set to <code>Danish.</code>&lt;/p&gt;
+<pre class="brush: html">&lt;p class=&quot;para1&quot;&gt;Default language setting.&lt;/p&gt;
+&lt;p class=&quot;para2&quot;&gt;This is a string with the &lt;code&gt;font-language-override&lt;/code&gt; set to Danish.&lt;/p&gt;
 </pre>
 
 <h4 id="CSS">CSS</h4>

--- a/files/en-us/web/css/max-content/index.html
+++ b/files/en-us/web/css/max-content/index.html
@@ -13,14 +13,14 @@ browser-compat: css.properties.width.max-content
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: css"><code>/* Used as a length */
+<pre class="brush: css">/* Used as a length */
 width: max-content;
 inline-size: max-content;
 height: max-content;
 block-size: max-content;
 
 /* used in grid tracks */
-grid-template-columns: 200px 1fr max-content;</code>
+grid-template-columns: 200px 1fr max-content;
 </pre>
 
 <h2 id="Examples">Examples</h2>

--- a/files/en-us/web/css/min-content/index.html
+++ b/files/en-us/web/css/min-content/index.html
@@ -13,14 +13,14 @@ browser-compat: css.properties.width.min-content
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="brush: css"><code>/* Used as a length */
+<pre class="brush: css">/* Used as a length */
 width: min-content;
 inline-size: min-content;
 height: min-content;
 block-size: min-content;
 
 /* used in grid tracks */
-grid-template-columns: 200px 1fr min-content;</code>
+grid-template-columns: 200px 1fr min-content;
 </pre>
 
 <h2 id="Examples">Examples</h2>


### PR DESCRIPTION
I sorted popularity on all the documents that had the `bad_pre_tags` flaw and fixed the flaws. In one or two documents, I had to manually correct the HTML. But there's absolutely not visual difference from what it was before. Just no more unnecessary HTML inside the `<pre>` tags. 