### PR TITLE
Provide link for more detail on two's complement

### DIFF
--- a/files/en-us/web/javascript/reference/operators/bitwise_not/index.html
+++ b/files/en-us/web/javascript/reference/operators/bitwise_not/index.html
@@ -11,7 +11,7 @@ browser-compat: javascript.operators.bitwise_not
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>The bitwise NOT operator (<code>~</code>) inverts the bits of its operand.</p>
+<p>The bitwise NOT operator (<code>~</code>) inverts the bits of its operand. Like other bitwise operators, it converts the operand to a 32-bit signed integer</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-bitwise-not.html")}}</div>
 
@@ -22,9 +22,9 @@ browser-compat: javascript.operators.bitwise_not
 
 <h2 id="Description">Description</h2>
 
-<p>The operand is converted to a 32-bit integer and expressed as a series of bits (zeroes
+<p>The operand is converted to a 32-bit signed integer and expressed as a series of bits (zeroes
   and ones). Numbers with more than 32 bits get their most significant bits discarded. For
-  example, the following integer, with more than 32 bits, will be converted to a 32 bit
+  example, the following integer, with more than 32 bits, will be converted to a 32-bit signed
   integer:</p>
 
 <pre class="brush: js">Before: 11100110111110100000000000000110000000000001
@@ -58,6 +58,10 @@ After:              10100000000000000110000000000001</pre>
                --------------------------------
 ~9 (base 10) = 11111111111111111111111111110110 (base 2) = -10 (base 10)
 </pre>
+
+<p>The 32-bit signed integer operand is inverted according to
+  <a href="https://en.wikipedia.org/wiki/Two%27s_complement">two's complement</a>. That is, the
+  presence of the most significant bit is used to express negative integers.</p>
 
 <p>Bitwise NOTing any number <code>x</code> yields <code>-(x + 1)</code>. For example,
   <code>~-5</code> yields <code>4</code>.</p>


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

It is not clear to beginners that the most significant bit is used to represent negative numbers in two's complement, so a link was added to provide detail.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT

> Issue number (if there is an associated issue)

#5599 

> Anything else that could help us review it
