### PR TITLE
Adds kumascript macro to show promise-finally interactive example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.html
@@ -22,6 +22,8 @@ browser-compat: javascript.builtins.Promise.finally
 <p>This helps to avoid duplicating code in both the promise's {{jsxref("Promise.then",
   "then()")}} and {{jsxref("Promise.catch", "catch()")}} handlers.</p>
 
+<div>{{EmbedInteractiveExample("pages/js/promise-finally.html", "taller")}}</div>
+
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="brush: js"><var>p</var>.finally(<var>onFinally</var>);


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Missing interactive example.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally 

> Issue number (if there is an associated issue)

[#1653](https://github.com/mdn/interactive-examples/issues/1653) in `mdn/interactive-examples`
