### PR TITLE
More correct example of use for ShadowRoot.mode

### DIFF
--- a/files/en-us/web/api/shadowroot/mode/index.html
+++ b/files/en-us/web/api/shadowroot/mode/index.html
@@ -34,14 +34,18 @@ browser-compat: api.ShadowRoot.mode
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js">let customElem = document.querySelector('my-shadow-dom-element');
-let shadow = customElem.shadowRoot;
+<pre class="brush: js">
+  // We create a closed shadow root, that is not accessible
+  let element = document.createElement("div");
+  element.attachShadow({ mode: "closed" });
+  element.shadowRoot // null as the shadow root is closed
 
-// Another way to check whether the shadow root is open; it will return null if not
-if(shadow) {
-  // If it is open, close it to stop people stealing our secrets!
-  shadow.mode = 'closed';
-}</pre>
+  // We create an open shadow root, that is accessible
+  let element2 = document.createElement("div");
+  element2.attachShadow({ mode: "open" });
+  console.log("The shadow is" + element2.shadowRoot.mode) // logs "The shadow is open"
+  element2.shadowRoot.innerHTML("<p>Opened shadow</p>") // The shadow is open, we can access it from outside
+</pre>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The example of ShadowRoot.mode was modifying this attribute while it was read-only.

This create a new example, correct and a bit more useful.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/mode

> Issue number (if there is an associated issue)

Fix #5539 

> Anything else that could help us review it
