### PR TITLE
Cite some concrete cases in intro of the Same Origin Policy doc

### DIFF
--- a/files/en-us/web/security/same-origin_policy/index.html
+++ b/files/en-us/web/security/same-origin_policy/index.html
@@ -13,7 +13,9 @@ tags:
 ---
 <div>{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}</div>
 
-<p><span class="seoSummary">The <strong>same-origin policy</strong> is a critical security mechanism that restricts how a document or script loaded from one {{Glossary("origin")}} can interact with a resource from another origin.</span> It helps isolate potentially malicious documents, reducing possible attack vectors.</p>
+<p><span class="seoSummary">The <strong>same-origin policy</strong> is a critical security mechanism that restricts how a document or script loaded by one {{Glossary("origin")}} can interact with a resource from another origin.</span></p>
+
+<p>It helps isolate potentially malicious documents, reducing possible attack vectors. For example, it prevents a malicious website on the Internet from running JS in a browser to read data from a third-party webmail service (which the user is signed into) or a company intranet (which is protected from direct access by the attacker by not having a public IP address) and relaying that data to the attacker.</p>
 
 <h2 id="Definition_of_an_origin">Definition of an origin</h2>
 


### PR DESCRIPTION
This adds an example of how the Same Origin Policy is useful to the introduction of the page.

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

The introductory paragraph lacked an example which demonstrated why the Same Origin Policy is needed.

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy

> Issue number (if there is an associated issue)

#4628

> Anything else that could help us review it
