### PR TITLE
Adds WebOTP API and OTPCredential

### DIFF
--- a/files/en-us/web/api/credential_management_api/index.html
+++ b/files/en-us/web/api/credential_management_api/index.html
@@ -36,7 +36,7 @@ tags:
  <dt>{{domxref("CredentialsContainer")}}</dt>
  <dd>Exposes methods to request credentials and notify the user agent when interesting events occur such as successful sign in or sign out. This interfaces is accessible from <code>navigator.credentials</code>.</dd>
  <dt>{{domxref("FederatedCredential")}}</dt>
- <dd>Provides information about credentials from a federated identity provider, which is an entity that a website trusts to correctly authenticate a user, and which provides an API for that purpose. <a href="http://openid.net/developers/specs/">OpenID Connect</a> is an example of such a framework.</dd>
+ <dd>Provides information about credentials from a federated identity provider, which is an entity that a website trusts to correctly authenticate a user, and which provides an API for that purpose. <a href="https://openid.net/developers/specs/">OpenID Connect</a> is an example of such a framework.</dd>
  <dt>{{domxref("PasswordCredential")}}</dt>
  <dd>Provides information about a username/password pair.</dd>
  <dt>{{domxref("PublicKeyCredential")}}</dt>

--- a/files/en-us/web/api/otpcredential/code/index.html
+++ b/files/en-us/web/api/otpcredential/code/index.html
@@ -1,0 +1,46 @@
+---
+title: OTPCredential.code
+slug: Web/API/OTPCredential/code
+tags:
+  - API
+  - Property
+  - Reference
+  - code
+  - OTPCredential
+browser-compat: api.OTPCredential.code
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}</div>
+
+<p class="summary">The <strong><code>code</code></strong> property of the {{domxref("OTPCredential")}} interface returns the one-time password.</p>
+
+<h2 id="Syntax">Syntax</h2>
+
+<pre class="brush: js">let code = OTPCredential.code;
+</pre>
+
+<h3>Value</h3>
+<p>A {{domxref("DOMString","string")}} containing the one-time password.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The below code uses the value of <code>code</code> to complete an input form element. <a href="https://glitch.com/edit/#!/web-otp?path=views%2Findex.html%3A55%3A8">See this code as part of a simple demo</a>.</p>
+
+<pre class="brush: js">navigator.credentials.get({
+  otp: { transport:['sms'] },
+  signal: ac.signal
+}).then(otp => {
+  input.value = otp.code;
+  if (form) form.submit();
+}).catch(err => {
+  console.log(err);
+});</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/otpcredential/index.html
+++ b/files/en-us/web/api/otpcredential/index.html
@@ -1,0 +1,57 @@
+---
+title: OTPCredential
+slug: Web/API/OTPCredential
+tags:
+  - API
+  - Interface
+  - Reference
+  - OTPCredential
+browser-compat: api.OTPCredential
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}</div>
+
+<p class="summary">The <strong><code>OTPCredential</code></strong> interface of the {{domxref('WebOTP API','','',' ')}} contains the attributes that are returned when a new one-time password is retreived.</p>
+
+{{InheritanceDiagram}}
+
+<h2 id="Properties">Properties</h2>
+
+<p><em>This interface also inherits properties from {{domxref("Credential")}}.</em></p>
+
+<dl>
+  <dt>{{domxref("OTPCredential.code")}}</dt>
+  <dd>The one-time password.</dd>
+</dl>
+
+<h3 id="Event_handlers">Event handlers</h3>
+
+<p>None.</p>
+
+<h2 id="Methods">Methods</h2>
+
+<p>None.</p>
+
+<h2 id="Examples">Examples</h2>
+
+<p>The below code triggers the browser's permission flow when an SMS message arrives. If permission is granted then the promise resolves with an <code>OTPCredential</code> object. <a href="https://glitch.com/edit/#!/web-otp?path=views%2Findex.html%3A55%3A8">See this code as part of a simple demo</a>.</p>
+
+<pre class="brush: js">navigator.credentials.get({
+  otp: { transport:['sms'] },
+  signal: ac.signal
+}).then(otp => {
+  input.value = otp.code;
+  if (form) form.submit();
+}).catch(err => {
+  console.log(err);
+});</pre>
+
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat}}</p>
+
+

--- a/files/en-us/web/api/webotp_api/index.html
+++ b/files/en-us/web/api/webotp_api/index.html
@@ -13,7 +13,7 @@ tags:
 
 <h2> Concepts and Usage</h2>
 
-<p>Phone numbers are often used as a way to identify the user of an app, and in order to verify that the number belongs to the user, SMS is frequently deployed. A typical scenario would involve a message being sent to the user with a one-time password. They would then need to copy and paste that password into a form to verify that they did own the number.</p>
+<p>Phone numbers are often used as a way to identify the user of an app, and to verify that the number belongs to the user, SMS is frequently deployed. A typical scenario would involve a message being sent to the user with a one-time password. They would then need to copy and paste that password into a form to verify that the user owns the number.</p>
 
 <p>The WebOTP API removes friction from this process, by allowing the password to be received by the app and verified automatically, with no need to copy and paste any codes.</p>
 

--- a/files/en-us/web/api/webotp_api/index.html
+++ b/files/en-us/web/api/webotp_api/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p>Phone numbers are often used as a way to identify the user of an app, and to verify that the number belongs to the user, SMS is frequently deployed. A typical scenario would involve a message being sent to the user with a one-time password. They would then need to copy and paste that password into a form to verify that the user owns the number.</p>
 
-<p>The WebOTP API removes friction from this process, by allowing the password to be received by the app and verified automatically, with no need to copy and paste any codes.</p>
+<p>The WebOTP API removes friction from this process by allowing the password to be received by the app and verified automatically, with no need to copy and paste any codes.</p>
 
 <h2 id="Interfaces"> Interfaces</h2>
 

--- a/files/en-us/web/api/webotp_api/index.html
+++ b/files/en-us/web/api/webotp_api/index.html
@@ -1,0 +1,67 @@
+---
+title: WebOTP API
+slug: Web/API/WebOTP_API
+tags:
+  - API
+  - WebOTP
+  - Overview
+  - Reference
+---
+<div>{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}</div>
+
+<p class="summary">The <strong>WebOTP API</strong> provides a method for verifying that a phone number belongs to the user, by generating a one-time password on receipt of a specially formatted SMS message.</p>
+
+<h2> Concepts and Usage</h2>
+
+<p>Phone numbers are often used as a way to identify the user of an app, and in order to verify that the number belongs to the user, SMS is frequently deployed. A typical scenario would involve a message being sent to the user with a one-time password. They would then need to copy and paste that password into a form to verify that they did own the number.</p>
+
+<p>The WebOTP API removes friction from this process, by allowing the password to be received by the app and verified automatically, with no need to copy and paste any codes.</p>
+
+<h2 id="Interfaces"> Interfaces</h2>
+
+<dl>
+  <dt>{{domxref("OTPCredential")}}</dt>
+  <dd>Extends {{domxref("Credential")}} and contains the attributes that are returned when a new one-time password is created.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<p>In this example, when an SMS message arrives, and the user grants permission, an {{domxref("OTPCredential")}} object is returned with a one-time password. This password is then prefilled into the form field, and the form submitted.</p>
+
+<p><a href="https://glitch.com/edit/#!/web-otp?path=views%2Findex.html%3A55%3A8">Try the demo using a phone here</a>.</p>
+
+<pre class="brush: html">&lt;input type="text" autocomplete="one-time-code" inputmode="numeric"&gt;</pre>
+
+<pre class="brush: js">if ('OTPCredential' in window) {
+  window.addEventListener('DOMContentLoaded', e => {
+    const input = document.querySelector('input[autocomplete="one-time-code"]');
+    if (!input) return;
+    const ac = new AbortController();
+    const form = input.closest('form');
+    if (form) {
+      form.addEventListener('submit', e => {
+        ac.abort();
+      });
+    }
+    navigator.credentials.get({
+      otp: { transport:['sms'] },
+      signal: ac.signal
+    }).then(otp => {
+      input.value = otp.code;
+      if (form) form.submit();
+    }).catch(err => {
+      console.log(err);
+    });
+  });
+}</pre>
+
+<h2 id="Specifications">Specifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="See_also">See also</h2>
+
+<ul>
+  <li><a href="https://web.dev/web-otp/">Verify phone numbers on the web with WebOTP</a></li>
+  <li><a href="https://web.dev/web-otp-iframe/">Fill OTP forms within cross-origin iframes with WebOTP API</a></li>
+</ul>


### PR DESCRIPTION
Adds the overview page for the WebOTP API, and the OTPCredential Interface.

I have added the spec, plus add the spec data into BCD:

- https://github.com/mdn/yari/pull/3964
- https://github.com/mdn/browser-compat-data/pull/10742 

I also fixed a link on Credential, which is why it's in there, as I had it open.

Reviewer @jpmedley 