### PR TITLE
Remove spec table for {set,clear}Immediate

### DIFF
--- a/files/en-us/web/api/window/clearimmediate/index.html
+++ b/files/en-us/web/api/window/clearimmediate/index.html
@@ -42,25 +42,9 @@ document.getElementById("button")
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://w3c.github.io/setImmediate/#si-setImmediate"
-          hreflang="en" lang="en">Efficient Script Yielding<br>
-          <small lang="en-US">The definition of '<code>setImmediate</code>' in that
-            specification.</small></a></td>
-      <td><span class="spec-ED">Editor's Draft</span></td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>Not part of any current specifications. The
+<a href="https://w3c.github.io/setImmediate/#si-setImmediate">Efficient Script Yielding</a>
+specification is no longer being worked on.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/window/setimmediate/index.html
+++ b/files/en-us/web/api/window/setimmediate/index.html
@@ -69,25 +69,9 @@ var <em>immediateID</em> = setImmediate(<em>func</em>);
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://w3c.github.io/setImmediate/#si-setImmediate"
-          hreflang="en" lang="en">Efficient Script Yielding<br>
-          <small lang="en-US">The definition of '<code>setImmediate</code>' in that
-            specification.</small></a></td>
-      <td><span class="spec-ED">Editor's Draft</span></td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+<p>Not part of any current specifications. The
+<a href="https://w3c.github.io/setImmediate/#si-setImmediate">Efficient Script Yielding</a>
+specification is no longer being worked on.</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
Removing the spec table so it doesn't make it look like there is an actual specification for these things.

See https://github.com/w3c/browser-specs/issues/306
BCD https://github.com/mdn/browser-compat-data/pull/10746