### PR TITLE
Fix typo in grid-template-columns

### DIFF
--- a/files/en-us/web/css/grid-template-columns/index.html
+++ b/files/en-us/web/css/grid-template-columns/index.html
@@ -71,7 +71,7 @@ grid-template-columns: unset;
  <dt id="auto"><code>auto</code></dt>
  <dd><p>As a maximum represents the largest {{cssxref("max-content")}} size of the items in that track.</p>
   <p>As a minimum represents the largest minimum size of items in that track (specified by the {{cssxref("min-width")}}/{{cssxref("min-height")}} of the items). This is often, though not always, the {{cssxref("min-content")}} size.</p>
-  <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maxium described above. This behaves similarly to <code>minmax(min-content,max-content)</code> in most cases.</p>
+  <p>If used outside of {{cssxref("minmax()", "minmax()")}} notation, <code>auto</code> represents the range between the minimum and maximum described above. This behaves similarly to <code>minmax(min-content,max-content)</code> in most cases.</p>
 
  <div class="notecard note">
    <h4>Note:</h4>


### PR DESCRIPTION
As the author closed PR #5612, I open this one with the typo to be fixed.

Thanks @nataliecardot for finding it!