### PR TITLE
Fix incorrectly ended code block in Window.devicePixelRatio

### DIFF
--- a/files/en-us/web/api/window/devicepixelratio/index.html
+++ b/files/en-us/web/api/window/devicepixelratio/index.html
@@ -115,7 +115,7 @@ const updatePixelRatio = () =&gt; {
 }
 
 updatePixelRatio();
-
+</pre>
 <p>The string <code>mqString</code> is set up to be the media query itself. The media
   query, which begins as <code>(resolution: 1dppx)</code> (for standard  displays) or
   <code>(resolution: 2dppx)</code> (for Retina/HiDPI displays), checks to see if the
@@ -147,11 +147,9 @@ updatePixelRatio();
   &lt;/div&gt;
     &lt;div class="pixel-ratio"&gt;&lt;/div&gt;
 &lt;/div&gt;</pre>
+</pre>
 
-<details>
-  <summary>
-    <h4 id="CSS">CSS</h4>
-  </summary>
+<h4 id="CSS">CSS</h4>
 
   <pre class="brush: css">body {
   font: 22px arial, sans-serif;
@@ -181,8 +179,8 @@ updatePixelRatio();
   bottom: 0;
   right: 1em;
   font-weight: bold;
-}</pre>
-</details>
+}
+</pre>
 
 <h4 id="Result">Result</h4>
 


### PR DESCRIPTION
Fix #5625.

A missing `<\pre>` was borking all the end of the article.