### PR TITLE
fix minor typo in a notecard

### DIFF
--- a/files/en-us/web/css/repeating-conic-gradient()/index.html
+++ b/files/en-us/web/css/repeating-conic-gradient()/index.html
@@ -62,7 +62,7 @@ background: repeating-conic-gradient(
 <p>Because <code>&lt;gradient&gt;</code>s belong to the <code>&lt;image&gt;</code> data type, they can only be used where <code>&lt;image&gt;</code>s can be used. For this reason, <code>repeating-conic-gradient()</code> won't work on {{CSSxRef("background-color")}} and other properties that use the {{CSSxRef("&lt;color&gt;")}} data type.</p>
 
 <div class="notecard note">
-<p>To create a conic gradient that doe not repeat, make the gradient a full 360 degree rotation, or use the {{CSSxRef("conic-gradient()")}} function instead.</p>
+<p>To create a conic gradient that does not repeat, make the gradient a full 360 degree rotation, or use the {{CSSxRef("conic-gradient()")}} function instead.</p>
 </div>
 
 <h3 id="Understanding_repeating_conic_gradients">Understanding repeating conic gradients</h3>


### PR DESCRIPTION
I replaced “doe not” with “does not.”

**What was wrong/why is this fix needed? (quick summary only)**
There was a simple typo in the notecard in the description.

**MDN URL of the main page changed**
[/en-US/docs/Web/CSS/repeating-conic-gradient()](https://developer.Mozilla.org/en-US/docs/Web/CSS/repeating-conic-gradient()#description)
