### PR TITLE
Fix extra space appearing in link to "sloppy mode"

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.html
+++ b/files/en-us/web/javascript/reference/strict_mode/index.html
@@ -12,10 +12,7 @@ tags:
 <h2>Strict Mode Overview</h2>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> Sometimes you'll see the default, non-strict mode referred to as <strong>"<a
-      href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">
-      sloppy mode</a>"</strong>. This isn't an official term, but be
-  aware of it, just in case.</p>
+  <p><strong>Note:</strong> Sometimes you'll see the default, non-strict mode referred to as <strong>"<a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">sloppy mode</a>"</strong>. This isn't an official term, but beaware of it, just in case.</p>
 </div>
 
 <p>JavaScript's strict mode, introduced in ECMAScript 5, is a way to <em>opt in</em> to a restricted variant of JavaScript, thereby implicitly opting-out of "<a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">sloppy mode</a>". Strict mode isn't just a subset: it <em>intentionally</em> has different semantics from normal code. Browsers not supporting strict mode will run strict mode code with different behavior from browsers that do, so don't rely on strict mode without feature-testing for support for the relevant aspects of strict mode. Strict mode code and non-strict mode code can coexist, so scripts can opt into strict mode incrementally.</p>

--- a/files/en-us/web/javascript/reference/strict_mode/index.html
+++ b/files/en-us/web/javascript/reference/strict_mode/index.html
@@ -12,7 +12,7 @@ tags:
 <h2>Strict Mode Overview</h2>
 
 <div class="notecard note">
-  <p><strong>Note:</strong> Sometimes you'll see the default, non-strict mode referred to as <strong>"<a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">sloppy mode</a>"</strong>. This isn't an official term, but beaware of it, just in case.</p>
+  <p><strong>Note:</strong> Sometimes you'll see the default, non-strict mode referred to as <strong>"<a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">sloppy mode</a>"</strong>. This isn't an official term, but be aware of it, just in case.</p>
 </div>
 
 <p>JavaScript's strict mode, introduced in ECMAScript 5, is a way to <em>opt in</em> to a restricted variant of JavaScript, thereby implicitly opting-out of "<a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode">sloppy mode</a>". Strict mode isn't just a subset: it <em>intentionally</em> has different semantics from normal code. Browsers not supporting strict mode will run strict mode code with different behavior from browsers that do, so don't rely on strict mode without feature-testing for support for the relevant aspects of strict mode. Strict mode code and non-strict mode code can coexist, so scripts can opt into strict mode incrementally.</p>


### PR DESCRIPTION
From what I can tell, the result of putting the quoted text on a new line.


<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Fix extra space appearing in link to "sloppy mode"

> MDN URL of the main page changed

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

> Issue number (if there is an associated issue)

N/A

> Anything else that could help us review it

I did not test this but it should be correct.
