### PR TITLE
Move IME example into own example section

### DIFF
--- a/files/en-us/web/api/document/keydown_event/index.html
+++ b/files/en-us/web/api/document/keydown_event/index.html
@@ -40,16 +40,6 @@ browser-compat: api.Document.keydown_event
 
 <p>The <code>keydown</code> and {{domxref("Document/keyup_event", "keyup")}} events provide a code indicating which key is pressed, while {{domxref("Document/keypress_event", "keypress")}} indicates which <em>character</em> was entered. For example, a lowercase "a" will be reported as 65 by <code>keydown</code> and <code>keyup</code>, but as 97 by <code>keypress</code>. An uppercase "A" is reported as 65 by all events.</p>
 
-<p>Since Firefox 65, the <code>keydown</code> and {{domxref("Document/keyup_event", "keyup")}} events are now fired during IME composition ({{bug(354358)}}). To ignore all <code>keydown</code> events that are part of composition, do something like this (229 is a special value set for a <code>keyCode</code> relating to an event that has been processed by an IME):</p>
-
-<pre class="brush: js">eventTarget.addEventListener("keydown", event =&gt; {
-  if (event.isComposing || event.keyCode === 229) {
-    return;
-  }
-  // do something
-});
-</pre>
-
 <h2 id="Examples">Examples</h2>
 
 <h3 id="addEventListener_keydown_example">addEventListener keydown example</h3>
@@ -71,22 +61,25 @@ function logKey(e) {
 
 <pre class="brush: js">document.onkeydown = logKey;</pre>
 
+
+<h3 id="Ignoring_keydown_during_ime_composition">Ignoring keydown during IME composition</h3>
+
+<p>An <em>Input Method Editor (IME)</em> is a program that enables users to enter characters that are not supported by their keyboard using some other key combination.</p>
+
+<p>Since Firefox 65, the <code>keydown</code> and {{domxref("Document/keyup_event", "keyup")}} events are now fired during IME composition ({{bug(354358)}}). To ignore all <code>keydown</code> events that are part of composition, do something like this (229 is a special value set for a <code>keyCode</code> relating to an event that has been processed by an IME):</p>
+
+<pre class="brush: js">eventTarget.addEventListener("keydown", event =&gt; {
+  if (event.isComposing || event.keyCode === 229) {
+    return;
+  }
+  // do something
+});
+</pre>
+
+
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('UI Events', '#event-type-keydown')}}</td>
-   <td>{{Spec2('UI Events')}}</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/en-us/web/api/document/keyup_event/index.html
+++ b/files/en-us/web/api/document/keyup_event/index.html
@@ -41,16 +41,6 @@ browser-compat: api.Document.keyup_event
 <p><strong>Note:</strong> If you're looking for a way to react to changes in an input's value, you should use the <a href="/en-US/docs/Web/API/HTMLElement/input_event"><code>input</code> event</a>. Some changes are not detectable by <code>keyup</code>, for example pasting text from the context menu in a text input.</p>
 </div>
 
-<p>Since Firefox 65, the {{domxref("Document/keydown_event", "keydown")}} and <code>keyup</code> events are now fired during IME composition, to improve cross-browser compatibility for CJKT users ({{bug(354358)}}, also see <a href="https://www.fxsitecompat.com/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/">keydown and keyup events are now fired during IME composition</a> for more useful details). To ignore all <code>keyup</code> events that are part of composition, do something like this (229 is a special value set for a <code>keyCode</code> relating to an event that has been processed by an IME):</p>
-
-<pre class="brush: js">eventTarget.addEventListener("keyup", event =&gt; {
-  if (event.isComposing || event.keyCode === 229) {
-    return;
-  }
-  // do something
-});
-</pre>
-
 <h2 id="Examples">Examples</h2>
 
 <p>This example logs the {{domxref("KeyboardEvent.code")}} value whenever you release a key.</p>
@@ -74,22 +64,26 @@ function logKey(e) {
 
 <pre class="brush: js">document.onkeyup = logKey;</pre>
 
+
+<h3 id="Ignoring_keyup_during_ime_composition">Ignoring keyup during IME composition</h3>
+
+<p>An <em>Input Method Editor (IME)</em> is a program that enables users to enter characters that are not supported by their keyboard using some other key combination.</p>
+
+<p>Since Firefox 65, the {{domxref("Document/keydown_event", "keydown")}} and <code>keyup</code> events are now fired during IME composition, to improve cross-browser compatibility for CJKT users ({{bug(354358)}}, also see <a href="https://www.fxsitecompat.com/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/">keydown and keyup events are now fired during IME composition</a> for more useful details). To ignore all <code>keyup</code> events that are part of composition, do something like this (229 is a special value set for a <code>keyCode</code> relating to an event that has been processed by an IME):</p>
+
+<pre class="brush: js">eventTarget.addEventListener("keyup", event =&gt; {
+  if (event.isComposing || event.keyCode === 229) {
+    return;
+  }
+  // do something
+});
+</pre>
+
+
+
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("UI Events", "#event-type-keyup")}}</td>
-   <td>{{Spec2("UI Events")}}</td>
-  </tr>
- </tbody>
-</table>
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event and https://developer.mozilla.org/en-US/docs/Web/API/Document/keyup_event start with a note about how FF65 sends keyup and keydown events for IMEs and shows how they should be ignored.

This feels like the wrong place for this information. What I have done is moved this section down as an example, and included information about what an IME is. So now at least it is obvious that this is something that you do to handle key(up/down) and work properly with IMEs. I also added specifications macro, since I was here.

Fixes #5532 

#5532 reports a bug that the IME part of the code uses the deprecated keyCode . However for IMEs I don't think you have any choice but to use this. So while this doesn't fix the bug, because it is not a bug, it does make it a little more clear that this is related purely to IMEs.

I guess I could have a note "note this is deprecated, but you don't have any choice" as well. Let me know if you think necessary.